### PR TITLE
Add PikaPods hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ tool gives you the powers of a developer without leaving your browser.
 * Uses popular frameworks and tools like [Django](https://www.djangoproject.com/), 
   [Vue.js](https://vuejs.org/) and [PostgreSQL](https://www.postgresql.org/).
 
-[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/bram2w/baserow/tree/master)
+[![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/bram2w/baserow/tree/master) [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=baserow)
 
 ```bash
 docker run -v baserow_data:/baserow/data -p 80:80 -p 443:443 baserow/baserow:1.10.0

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ how to become a contributor.
 * [**Docker Compose** ](docs/installation/install-with-docker-compose.md)
 * [**Heroku**: Easily install and scale up Baserow on Heroku.](docs/installation/install-on-heroku.md)
 * [**Cloudron**: Install and update Baserow on your own Cloudron server.](docs/installation/install-on-cloudron.md)
+* [**PikaPods**: Single-click managed Baserow hosting](https://www.pikapods.com/pods?run=baserow)
 
 ## Official documentation
 


### PR DESCRIPTION
Given the recent security leaks, the pricing, the need for a separate template and years of stagnation over at Heroku (recent [HN discussion](https://news.ycombinator.com/item?id=31372675)), I'm not sure it should be recommended as the only hosting option right at the start.

So I'm suggesting to add [PikaPods.com](https://www.pikapods.com/) as additional install option to run Baserow. We already offer Baserow in our “app store” and someone from your team even suggested some env var optimizations. Currently we have about two dozen users running Baserow and about 2000 potential active users (ran at least one pod).

PikaPods is seeking active collaboration with upstream project, which sometimes means setting up the first Docker publishing workflow, or adding an app as "featured" on the frontpage or our newsletter. Since Baserow fills an interesting niche, the latter two could be suitable. A little vision or background story would be nice for this to make it more personal, especially in the newsletter.

Looking forward to hearing the team’s opinion on this. Thanks for the consideration!

[Rendered preview](https://github.com/m3nu/baserow/tree/add-pikapods-button)