### PR TITLE
Update install-with-helm.md to reflect correct chart

### DIFF
--- a/docs/installation/install-with-helm.md
+++ b/docs/installation/install-with-helm.md
@@ -45,8 +45,8 @@ helm ls --all-namespaces
 4. Install Baserow using Helm
 
 ```bash
-helm repo add christianknell https://christianknell.github.io/helm-charts
+helm repo add christianhuth https://charts.christianhuth.de
 helm repo update
-helm install 1.5.3 christianknell/baserow
+helm install my-baserow christianhuth/baserow
 # Finally follow the printed instructions.
 ```


### PR DESCRIPTION
The helm chart for baserow is now at a new location.