### PR TITLE
Replaced star on GitLab with GitHub

### DIFF
--- a/web-frontend/modules/core/components/dashboard/DashboardHelp.vue
+++ b/web-frontend/modules/core/components/dashboard/DashboardHelp.vue
@@ -22,13 +22,13 @@
     <template #actions>
       <Button
         tag="a"
-        href="https://gitlab.com/baserow/baserow"
+        href="https://github.com/baserow/baserow"
         target="_blank"
         rel="noopener noreferrer"
         type="secondary"
-        icon="baserow-icon-gitlab"
+        icon="iconoir-github"
       >
-        {{ $t('dashboard.starOnGitlab') }}</Button
+        {{ $t('dashboard.starOnGitHub') }}</Button
       >
       <ButtonIcon
         v-tooltip="$t('dashboard.shareOnTwitter')"
@@ -76,7 +76,7 @@
 </template>
 
 <script>
-const helpDisplayCookieName = 'baserow_dashboard_alert_closed'
+const helpDisplayCookieName = 'baserow_dashboard_alert_closed_v2'
 
 export default {
   name: 'DashboardHelp',

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -423,7 +423,7 @@
     "tweetContent": "Check out @baserow an open source no-code database tool and Airtable alternative!",
     "redditTitle": "'Baserow - An open source no-code database",
     "becomeGithubSponsor": "Become a GitHub sponsor",
-    "starOnGitlab": "Star us on GitLab",
+    "starOnGitHub": "Star us on GitHub",
     "shareOnTwitter": "Tweet about Baserow",
     "shareOnReddit": "Share on Reddit",
     "shareOnFacebook": "Share on Facebook",


### PR DESCRIPTION
### What is in this PR

Small change that replaced start on GitLab with GitLab, and changed the name of the help cookie name so that it resurfaces for all our users again.

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
