### PR TITLE
Lazy load dspy to save memory on startup

### DIFF
--- a/enterprise/backend/src/baserow_enterprise/assistant/adapter.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/adapter.py
@@ -1,14 +1,21 @@
-import dspy
-
 from .prompts import ASSISTANT_SYSTEM_PROMPT
 
 
-class ChatAdapter(dspy.ChatAdapter):
-    def format_field_description(self, signature: type[dspy.Signature]) -> str:
-        """
-        This is the first part of the prompt the LLM sees, so we prepend our custom
-        system prompt to it to give it the personality and context of Baserow.
-        """
+def get_chat_adapter():
+    import dspy  # local import to save memory when not used
 
-        field_description = super().format_field_description(signature)
-        return ASSISTANT_SYSTEM_PROMPT + "## TASK INSTRUCTIONS:\n\n" + field_description
+    class ChatAdapter(dspy.ChatAdapter):
+        def format_field_description(self, signature: type[dspy.Signature]) -> str:
+            """
+            This is the first part of the prompt the LLM sees, so we prepend our custom
+            system prompt to it to give it the personality and context of Baserow.
+            """
+
+            field_description = super().format_field_description(signature)
+            return (
+                ASSISTANT_SYSTEM_PROMPT
+                + "## TASK INSTRUCTIONS:\n\n"
+                + field_description
+            )
+
+    return ChatAdapter()

--- a/enterprise/backend/src/baserow_enterprise/assistant/react.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/react.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import Any, Callable, Literal
 
 import dspy
 from dspy.adapters.types.tool import Tool
@@ -10,10 +10,6 @@ from loguru import logger
 
 from .types import ToolsUpgradeResponse
 
-if TYPE_CHECKING:
-    from dspy.signatures.signature import Signature
-
-
 # Variant of dspy.predict.react.ReAct that accepts a "meta-tool":
 # a callable that can produce tools at runtime (e.g. per-table schemas).
 # This lets a single ReAct instance handle many different table signatures
@@ -21,9 +17,7 @@ if TYPE_CHECKING:
 
 
 class ReAct(Module):
-    def __init__(
-        self, signature: type["Signature"], tools: list[Callable], max_iters: int = 100
-    ):
+    def __init__(self, signature, tools: list[Callable], max_iters: int = 100):
         """
         ReAct stands for "Reasoning and Acting," a popular paradigm for building
         tool-using agents. In this approach, the language model is iteratively provided

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/database/tools.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/database/tools.py
@@ -5,7 +5,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.utils.translation import gettext as _
 
-import dspy
 from loguru import logger
 from pydantic import create_model
 
@@ -25,9 +24,9 @@ from baserow.core.service import CoreService
 from baserow_enterprise.assistant.tools.registries import AssistantToolType, ToolHelpers
 from baserow_enterprise.assistant.types import (
     TableNavigationType,
-    ToolSignature,
     ToolsUpgradeResponse,
     ViewNavigationType,
+    get_tool_signature,
 )
 
 from . import utils
@@ -284,6 +283,8 @@ def get_create_tables_tool(
         - if add_sample_rows is True (default), add some example rows to each table
         """
 
+        import dspy  # local import to save memory when not used
+
         nonlocal user, workspace, tool_helpers
 
         if not tables:
@@ -354,7 +355,7 @@ def get_create_tables_tool(
                     f"- Create 5 example rows for table_{created_table.id}. Fill every relationship with valid data when possible."
                 )
 
-            predictor = dspy.Predict(ToolSignature)
+            predictor = dspy.Predict(get_tool_signature())
             result = predictor(
                 question=("\n".join(instructions)),
                 tools=list(tools.values()),

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/database/utils.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/database/utils.py
@@ -7,8 +7,6 @@ from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext as _
 
-import dspy
-from dspy.adapters.types.tool import _resolve_json_schema_reference
 from pydantic import ConfigDict, Field, create_model
 
 from baserow.contrib.database.fields.actions import CreateFieldActionType
@@ -385,6 +383,9 @@ def get_view(user, view_id: int):
 def get_table_rows_tools(
     user, workspace: Workspace, tool_helpers: ToolHelpers, table: Table
 ):
+    import dspy  # local import to save memory when not used
+    from dspy.adapters.types.tool import _resolve_json_schema_reference
+
     row_model_for_create = get_create_row_model(table)
     row_model_for_update = get_update_row_model(table)
     row_model_for_response = create_model(

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/navigation/utils.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/navigation/utils.py
@@ -1,6 +1,3 @@
-from dspy.dsp.utils.settings import settings
-from dspy.streaming.messages import sync_send_to_stream
-
 from baserow_enterprise.assistant.types import AiNavigationMessage, AnyNavigationType
 
 
@@ -12,6 +9,9 @@ def unsafe_navigate_to(location: AnyNavigationType) -> str:
 
     :param navigation_type: The type of navigation to perform.
     """
+
+    from dspy.dsp.utils.settings import settings
+    from dspy.streaming.messages import sync_send_to_stream
 
     stream = settings.send_stream
     if stream is not None:

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/registries.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/registries.py
@@ -4,9 +4,6 @@ from typing import TYPE_CHECKING, Any, Callable
 from django.contrib.auth.models import AbstractUser
 from django.utils import translation
 
-from dspy.dsp.utils.settings import settings
-from dspy.streaming.messages import sync_send_to_stream
-
 from baserow.core.exceptions import (
     InstanceTypeAlreadyRegistered,
     InstanceTypeDoesNotExist,
@@ -122,6 +119,9 @@ class AssistantToolRegistry(Registry[AssistantToolType]):
 
             :param status: The status message to send.
             """
+
+            from dspy.dsp.utils.settings import settings
+            from dspy.streaming.messages import sync_send_to_stream
 
             nonlocal user
 

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/search_docs/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/search_docs/handler.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core import serializers
 from django.db.models import Q
 
-import dspy
 from httpx import Client as httpxClient
 from pgvector.django import L2Distance
 
@@ -62,11 +61,13 @@ class BaserowEmbedder:
 
 
 class VectorHandler:
-    def __init__(self, embedder: dspy.Embedder | None = None):
+    def __init__(self, embedder=None):
         self._embedder = embedder
 
     @property
-    def embedder(self) -> dspy.Embedder:
+    def embedder(self):
+        import dspy  # local import to save memory when not used
+
         if self._embedder is None:
             self._embedder = dspy.Embedder(
                 BaserowEmbedder(settings.BASEROW_EMBEDDINGS_API_URL)

--- a/enterprise/backend/src/baserow_enterprise/assistant/types.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/types.py
@@ -4,7 +4,6 @@ from typing import Annotated, Any, Callable, Literal, Optional
 
 from django.utils.translation import gettext as _
 
-import dspy
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import ConfigDict, Field
 
@@ -223,12 +222,17 @@ class AiNavigationMessage(BaseModel):
 
 class ToolsUpgradeResponse(BaseModel):
     observation: str
-    new_tools: list[dspy.Tool | Callable[[Any], Any]]
+    new_tools: list[Callable[[Any], Any]]
 
 
-class ToolSignature(dspy.Signature):
-    """Signature for manual tool handling."""
+def get_tool_signature():
+    import dspy  # local import to save memory when not used
 
-    question: str = dspy.InputField()
-    tools: list[dspy.Tool] = dspy.InputField()
-    outputs: dspy.ToolCalls = dspy.OutputField()
+    class ToolSignature(dspy.Signature):
+        """Signature for manual tool handling."""
+
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        outputs: dspy.ToolCalls = dspy.OutputField()
+
+    return ToolSignature

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant.py
@@ -15,7 +15,7 @@ from asgiref.sync import async_to_sync
 from dspy.primitives.prediction import Prediction
 from dspy.streaming import StreamResponse
 
-from baserow_enterprise.assistant.assistant import Assistant, AssistantCallbacks
+from baserow_enterprise.assistant.assistant import Assistant, get_assistant_callbacks
 from baserow_enterprise.assistant.models import AssistantChat, AssistantChatMessage
 from baserow_enterprise.assistant.types import (
     AiMessageChunk,
@@ -38,7 +38,7 @@ class TestAssistantCallbacks:
     def test_extend_sources_deduplicates(self):
         """Test that sources are deduplicated when extended"""
 
-        callbacks = AssistantCallbacks()
+        callbacks = get_assistant_callbacks()
 
         # Add initial sources
         callbacks.extend_sources(
@@ -64,7 +64,7 @@ class TestAssistantCallbacks:
     def test_extend_sources_preserves_order(self):
         """Test that source order is preserved (first occurrence wins)"""
 
-        callbacks = AssistantCallbacks()
+        callbacks = get_assistant_callbacks()
 
         callbacks.extend_sources(["https://example.com/a"])
         callbacks.extend_sources(["https://example.com/b"])
@@ -76,7 +76,7 @@ class TestAssistantCallbacks:
     def test_on_tool_end_extracts_sources_from_outputs(self):
         """Test that sources are extracted from tool outputs"""
 
-        callbacks = AssistantCallbacks()
+        callbacks = get_assistant_callbacks()
 
         # Mock tool instance and inputs
         tool_instance = MagicMock()
@@ -107,7 +107,7 @@ class TestAssistantCallbacks:
     def test_on_tool_end_handles_missing_sources(self):
         """Test that tool outputs without sources don't cause errors"""
 
-        callbacks = AssistantCallbacks()
+        callbacks = get_assistant_callbacks()
 
         tool_instance = MagicMock()
         tool_instance.name = "some_tool"

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_lazy_loading.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_lazy_loading.py
@@ -1,0 +1,143 @@
+"""
+Test that dspy is lazy-loaded only when the Assistant is actually used.
+
+This prevents unnecessary memory usage when the AI Assistant feature is not being used.
+"""
+import sys
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestDspyLazyLoading:
+    """Verify that dspy is only loaded when Assistant is instantiated."""
+
+    def test_dspy_not_loaded_on_django_startup(self):
+        """
+        Test that dspy is NOT loaded when Django starts up.
+
+        This is critical for memory efficiency - dspy should only be loaded
+        when the AI Assistant feature is actually used.
+        """
+
+        # Remove dspy and litellm from sys.modules if already loaded
+        # (this can happen if other tests ran first)
+        modules_to_remove = [
+            key
+            for key in sys.modules
+            if key.startswith("dspy") or key.startswith("litellm")
+        ]
+        for module in modules_to_remove:
+            del sys.modules[module]
+
+        # Import the handler module (which is what gets imported at Django startup)
+        from baserow_enterprise.assistant import handler  # noqa: F401
+
+        # Verify dspy and litellm are NOT loaded yet
+        assert "dspy" not in sys.modules, (
+            "dspy should not be loaded on import. "
+            "Check for top-level dspy imports in assistant module files."
+        )
+
+        assert "litellm" not in sys.modules, (
+            "litellm should not be loaded on import. "
+            "Check for top-level litellm imports in assistant module files."
+        )
+
+    def test_dspy_loaded_when_assistant_created(
+        self, data_fixture, enterprise_data_fixture
+    ):
+        """
+        Test that dspy IS loaded when an Assistant object is created.
+
+        This verifies that lazy loading works correctly and dspy is available
+        when needed.
+        """
+
+        # Remove dspy and litellm from sys.modules to start fresh
+        modules_to_remove = [
+            key
+            for key in sys.modules
+            if key.startswith("dspy") or key.startswith("litellm")
+        ]
+        for module in modules_to_remove:
+            del sys.modules[module]
+
+        # Create necessary fixtures
+        user = data_fixture.create_user()
+        workspace = data_fixture.create_workspace(user=user)
+        enterprise_data_fixture.enable_enterprise()
+
+        # Import and use handler (should not load dspy yet)
+        from baserow_enterprise.assistant.handler import AssistantHandler
+        from baserow_enterprise.assistant.models import AssistantChat
+
+        # Verify dspy and litellm are still not loaded
+        assert (
+            "dspy" not in sys.modules
+        ), "dspy should not be loaded after importing handler"
+
+        assert (
+            "litellm" not in sys.modules
+        ), "litellm should not be loaded after importing handler"
+
+        # Create a chat
+        chat = AssistantChat.objects.create(
+            user=user,
+            workspace=workspace,
+        )
+
+        # Create Assistant - this SHOULD trigger dspy loading
+        handler = AssistantHandler()
+        assistant = handler.get_assistant(chat)
+
+        # Now dspy and litellm  should be loaded
+        assert "dspy" in sys.modules, (
+            "dspy should be loaded after creating Assistant instance. "
+            "Check that Assistant.__init__ imports dspy."
+        )
+
+        assert "litellm" in sys.modules, (
+            "litellm should be loaded after creating Assistant instance. "
+            "Check that Assistant.__init__ imports dspy."
+        )
+
+        assert assistant is not None
+
+    def test_assistant_handler_does_not_load_dspy(self, data_fixture):
+        """
+        Test that using AssistantHandler methods (other than get_assistant)
+        does not load dspy.
+        """
+
+        # Remove dspy and litellm from sys.modules
+        modules_to_remove = [
+            key
+            for key in sys.modules
+            if key.startswith("dspy") or key.startswith("litellm")
+        ]
+        for module in modules_to_remove:
+            del sys.modules[module]
+
+        # Create fixtures
+        user = data_fixture.create_user()
+        workspace = data_fixture.create_workspace(user=user)
+
+        from baserow_enterprise.assistant.handler import AssistantHandler
+
+        handler = AssistantHandler()
+
+        # These operations should not load dspy
+        chats = handler.list_chats(user, workspace.id)
+        assert chats is not None
+
+        # Verify dspy and litellm are still not loaded
+        assert "dspy" not in sys.modules, (
+            "dspy should not be loaded by AssistantHandler methods "
+            "(except get_assistant)"
+        )
+
+        assert "litellm" not in sys.modules, (
+            "litellm should not be loaded by AssistantHandler methods "
+            "(except get_assistant)"
+        )


### PR DESCRIPTION
### Problem 

dspy and litellm consume ~200MB of memory on import, significantly impacting startup performance and resource usage.

### Solution

Move dspy and litellm imports inside functions to defer loading until actually needed. This ensures the libraries are only loaded when their functionality is required.

### Trade-offs
While this increases code verbosity by moving imports into function scope, the memory savings justify the approach until upstream improvements are made for all the cases where users don't want or need the AI Assistant 

### How to test this PR
- Verify the memory consumption on startup is back to normal. 
- Verify dspy is loaded after the first message is sent to the Assistant
- Verify the test can catch the problem if someone adds an import to dspy or litellm causing these changes to not work anymore



### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
