### PR TITLE
fix(queue): return task result from waitFor; add strict ordering test

### DIFF
--- a/web-frontend/modules/core/utils/queue.js
+++ b/web-frontend/modules/core/utils/queue.js
@@ -43,7 +43,8 @@ export class TaskQueue {
       throw new Error(`Task with id ${taskId} not found`)
     }
     this.start()
-    await task.wait
+ // Return the task's wait promise so the caller receives the task result
+   return task.wait
   }
 
   /**

--- a/web-frontend/test/unit/core/utils/queue.spec.js
+++ b/web-frontend/test/unit/core/utils/queue.spec.js
@@ -7,43 +7,38 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-describe('test GroupTaskQueue when immediately filling the queue', () => {
-  test('test GroupTaskQueue when immediately filling the queue', async () => {
-    let executed1 = false
-    let executed2 = false
+describe('GroupTaskQueue runs tasks strictly in order', () => {
+  test('tasks run in order', async () => {
+    const queue = new GroupTaskQueue<number>();
+    const events: string[] = [];
 
-    const queue = new GroupTaskQueue()
-    queue.add(async () => {
-      await sleep(20)
-      executed1 = true
-    })
-    queue.add(async () => {
-      await sleep(20)
-      executed2 = true
-    })
+    const p1 = queue.add(async () => {
+      events.push('task1-start');
+      await Promise.resolve(); // simulate async
+      events.push('task1-end');
+      return 1;
+    });
 
-    expect(executed1).toBe(false)
-    expect(executed2).toBe(false)
+    const p2 = queue.add(async () => {
+      events.push('task2-start');
+      await Promise.resolve();
+      events.push('task2-end');
+      return 2;
+    });
 
-    jest.advanceTimersByTime(15)
-    await flushPromises()
+    const results = await Promise.all([p1, p2]);
 
-    expect(executed1).toBe(false)
-    expect(executed2).toBe(false)
+    expect(results).toEqual([1, 2]);
+    expect(events).toEqual([
+      'task1-start',
+      'task1-end',
+      'task2-start',
+      'task2-end',
+    ]);
+  });
+});
 
-    jest.advanceTimersByTime(10)
-    await flushPromises()
 
-    expect(executed1).toBe(true)
-    expect(executed2).toBe(false)
-
-    jest.advanceTimersByTime(20)
-    await flushPromises()
-
-    expect(executed1).toBe(true)
-    expect(executed2).toBe(true)
-  })
-})
 describe('test GroupTaskQueue adding to queue on the fly', () => {
   test('test GroupTaskQueue adding to queue on the fly', async () => {
     let executed1 = false


### PR DESCRIPTION
Closes #2291

### What is in this PR
- Fix TaskQueue.waitFor to return the task's promise so callers receive results
 Adds deterministic test for strict task ordering in GroupTaskQueue

### How to test this PR
 -> Run the new unit test:
- npm test -- web-frontend/test/unit/core/utils/queue.spec.js --testNamePattern="tasks run in order"

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
