### PR TITLE
Fix formula migration issue in get error messages

### DIFF
--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -1304,7 +1304,7 @@ export class HeadingElementType extends ElementType {
    * is empty to indicate an error, otherwise return false.
    */
   getErrorMessage({ workspace, page, element, builder }) {
-    if (element.value.formula.length === 0) {
+    if (!element.value.formula) {
       return this.app.i18n.t('elementType.errorValueMissing')
     }
     return super.getErrorMessage({
@@ -1357,7 +1357,7 @@ export class TextElementType extends ElementType {
    * is empty to indicate an error, otherwise return false.
    */
   getErrorMessage({ workspace, page, element, builder }) {
-    if (element.value.formula.length === 0) {
+    if (!element.value.formula) {
       return this.app.i18n.t('elementType.errorValueMissing')
     }
     return super.getErrorMessage({
@@ -1414,7 +1414,7 @@ export class LinkElementType extends ElementType {
    */
   getErrorMessage({ workspace, page, element, builder }) {
     // A Link without any text isn't usable
-    if (element.value.formula.length === 0) {
+    if (!element.value.formula) {
       return this.app.i18n.t('elementType.errorValueMissing')
     }
 
@@ -1577,7 +1577,7 @@ export class ButtonElementType extends ElementType {
    */
   getErrorMessage({ workspace, page, element, builder }) {
     // If Button without any label should be considered invalid
-    if (element.value.formula.length === 0) {
+    if (!element.value.formula) {
       return this.app.i18n.t('elementType.errorValueMissing')
     }
 


### PR DESCRIPTION
### What is in this PR

A fix for the last sentry bug after the release.

### How to test this PR

Create an application with these elements:
- heading
- Text
- Likn element
- Button element

It shouldn't break the application even if the value is empty.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
