### PR TITLE
Show workspace settings modal if clicked on deactivated AI field

### DIFF
--- a/changelog/entries/unreleased/feature/workspace_modal_deactivated_ai_field.json
+++ b/changelog/entries/unreleased/feature/workspace_modal_deactivated_ai_field.json
@@ -1,0 +1,8 @@
+{
+  "type": "feature",
+  "message": "Show workspace settings modal if clicked on deactivated AI field.",
+  "domain": "database",
+  "issue_number": null,
+  "bullet_points": [],
+  "created_at": "2025-10-29"
+}

--- a/premium/web-frontend/modules/baserow_premium/fieldTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/fieldTypes.js
@@ -13,6 +13,7 @@ import PremiumFeatures from '@baserow_premium/features'
 import PaidFeaturesModal from '@baserow_premium/components/PaidFeaturesModal'
 import { AIPaidFeature } from '@baserow_premium/paidFeatures'
 import _ from 'lodash'
+import WorkspaceSettingsModal from '@baserow/modules/core/components/workspace/WorkspaceSettingsModal.vue'
 
 export class AIFieldType extends FieldType {
   static getType() {
@@ -194,6 +195,14 @@ export class AIFieldType extends FieldType {
     return Object.values(workspace.generative_ai_models_enabled).some(
       (models) => models.length > 0
     )
+  }
+
+  getDisabledClickModal(workspace) {
+    return [WorkspaceSettingsModal, { workspace }]
+  }
+
+  getDisabledTooltip() {
+    return 'Click to configure API key'
   }
 
   isDeactivated(workspaceId) {

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -350,7 +350,7 @@
     "label": "Prompt",
     "labelDescription": "Describe the formula you would like to generate",
     "generate": "Generate",
-    "noModels": "Your Baserow instance and workspace doesn't have any AI models configured. Click on the three dots next to your workspace, then on settings to configure them."
+    "noModels": "Your Baserow instance and workspace doesn't have any AI models configured. Navigate to the homepage, click on the name of your workspace, then on settings to configure them."
   },
   "formulaFieldAI": {
     "generateWithAI": "Generate using AI",

--- a/web-frontend/modules/database/components/field/FieldForm.vue
+++ b/web-frontend/modules/database/components/field/FieldForm.vue
@@ -40,6 +40,13 @@
               <DropdownItem
                 v-for="(fieldType, type) in fieldTypes"
                 :key="type"
+                v-tooltip="
+                  !fieldType.isDeactivated(workspace.id) &&
+                  !fieldType.isEnabled(workspace)
+                    ? fieldType.getDisabledTooltip(workspace)
+                    : null
+                "
+                tooltip-position="top"
                 :icon="fieldType.iconClass"
                 :name="fieldType.getName()"
                 :alias="fieldType.getAlias()"
@@ -49,7 +56,7 @@
                   !fieldType.isEnabled(workspace) ||
                   fieldType.isDeactivated(workspace.id)
                 "
-                @click="clickOnDeactivatedItem($event, fieldType)"
+                @click="clickOnItem($event, fieldType)"
               >
                 <i class="select__item-icon" :class="fieldType.iconClass" />
                 <span
@@ -75,6 +82,24 @@
                   v-bind="
                     fieldType.getDeactivatedClickModal(workspace.id)
                       ? fieldType.getDeactivatedClickModal(workspace.id)[1]
+                      : null
+                  "
+                  :workspace="workspace"
+                ></component>
+                <component
+                  :is="
+                    fieldType.getDisabledClickModal(workspace)
+                      ? fieldType.getDisabledClickModal(workspace)[0]
+                      : null
+                  "
+                  :ref="'disabledClickModal-' + fieldType.type"
+                  :v-if="
+                    !fieldType.isEnabled(workspace) &&
+                    fieldType.getDisabledClickModal(workspace)
+                  "
+                  v-bind="
+                    fieldType.getDisabledClickModal(workspace)
+                      ? fieldType.getDisabledClickModal(workspace)[1]
                       : null
                   "
                   :workspace="workspace"
@@ -394,9 +419,11 @@ export default {
       this.$emit('keydown-enter')
       this.submit()
     },
-    clickOnDeactivatedItem(event, fieldType) {
+    clickOnItem(event, fieldType) {
       if (fieldType.isDeactivated(this.workspace.id)) {
         this.$refs[`deactivatedClickModal-${fieldType.type}`][0].show()
+      } else if (!fieldType.isEnabled(this.workspace)) {
+        this.$refs[`disabledClickModal-${fieldType.type}`][0].show()
       }
     },
     /**

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -961,6 +961,21 @@ export class FieldType extends Registerable {
   }
 
   /**
+   * Can return a modal vue component that's opened when the user clicks in this
+   * field type, but `isEnabled` is false. Should return [component, props as {}]
+   */
+  getDisabledClickModal(workspace) {
+    return null
+  }
+
+  /**
+   * Can return a tooltip text that's shown on hover when the `isEnabled` is False.
+   */
+  getDisabledTooltip(workspace) {
+    return null
+  }
+
+  /**
    * Indicates whether the field is visible, but in a deactivated state.
    */
   isDeactivated(workspaceId) {


### PR DESCRIPTION
### What is in this PR

Small change that automatically opens the workspace settings modal if the user clicks on the deactivated AI field.

Note that there is a small bug that keeps the tooltip visible if the correct settings have been added. Those will be fixed in: https://github.com/baserow/baserow/pull/4061.

https://github.com/user-attachments/assets/593ea535-a90e-4285-ae0b-da8f224f0ae0

### How to test this PR

- Confirm that without a valid license, the AI field is deactivated and shows the paywall modal.
- Confirm that with a valid license, but without any generative AI settings, the AI field is disabled, and on click shows the workspace settings.
- Confirm that if there is a valid license and generative AI settings, that it's possible to choose the AI field.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
