### PR TITLE
Ensure that the CoreHTTPTriggerService.uid is serializable.

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -1407,6 +1407,31 @@ class CoreHTTPTriggerServiceType(TriggerServiceTypeMixin, ServiceType):
             ),
         ]
 
+    def serialize_property(
+        self,
+        service: CoreHTTPTriggerService,
+        prop_name: str,
+        files_zip=None,
+        storage=None,
+        cache=None,
+    ):
+        """
+        Responsible for serializing the trigger's properties.
+
+        :param service: The CoreHTTPTriggerService service.
+        :param prop_name: The property name we're serializing.
+        :param files_zip: The zip file containing the files.
+        :param storage: The storage to use for the files.
+        :param cache: The cache to use for the files.
+        """
+
+        if prop_name == "uid":
+            return str(service.uid)
+
+        return super().serialize_property(
+            service, prop_name, files_zip=files_zip, storage=storage, cache=cache
+        )
+
     def process_webhook_request(
         self, webhook_uid: uuid.uuid4, request_data: Dict[str, Any], simulate: bool
     ) -> None:


### PR DESCRIPTION
### What is in this PR

Ensure that `uid` is serializable by casting it to a string.

### How to test this PR

- Add a workflow with an HTTP trigger node.
- In the dashboard, export the workspace.
- In `develop`: you'll get an error
- In this branch: it'll work.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
