### PR TITLE
Fix CSV import throwing 'no fetchall attribute' error

### DIFF
--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -1808,8 +1808,8 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
             and not field_object["field"].read_only
         ]
 
-        # Sort by order then by id
-        fields.sort(key=lambda f: (f.order, f.id))
+        # Sort by primary first (descending), then by order, then by id
+        fields.sort(key=lambda f: (not f.primary, f.order, f.id))
 
         for index, row in enumerate(data):
             # Check row length

--- a/backend/src/baserow/contrib/database/table/queryset.py
+++ b/backend/src/baserow/contrib/database/table/queryset.py
@@ -22,6 +22,8 @@ class CTEUpdateReturningIdsQueryCompiler(SQLUpdateCompiler):
 
     def execute_sql(self, result_type):
         cursor = super(SQLUpdateCompiler, self).execute_sql(result_type)
+        if cursor is None:
+            return []
         return [res[0] for res in cursor.fetchall()]
 
 

--- a/changelog/entries/unreleased/bug/4163_fix_csv_import_throwing_no_fetchall_attribute_error_and_respect_pr.json
+++ b/changelog/entries/unreleased/bug/4163_fix_csv_import_throwing_no_fetchall_attribute_error_and_respect_pr.json
@@ -1,0 +1,8 @@
+{
+    "type": "bug",
+    "message": "Fix CSV import throwing 'no fetchall attribute' error and respect primary field order",
+    "domain": "database",
+    "issue_number": 4163,
+    "bullet_points": [],
+    "created_at": "2025-11-05"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes two issues

* Ensures that when `SQLCompiler.execute_sql` returns `None` our importer won't fail hard
* Primary field sorting is respected during csv import 

Respecting primary field in field sorting is actual fix for this issue

It also solves different issue.

Importing rows could mis-map values when the table’s primary field was changed and ended up with a higher order than other fields. The import logic sorted fields by order/id, so the primary field wasn’t guaranteed to be first. This caused values to shift into the wrong fields or validation errors during CSV imports.

### How to test this PR
* Import workspace and file provided in #4163 
* Observe that import does not break and values are properly imported

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered

Closes #4163 
