### PR TITLE
Fix formula parsing

### DIFF
--- a/web-frontend/modules/builder/dataProviderTypes.js
+++ b/web-frontend/modules/builder/dataProviderTypes.js
@@ -130,8 +130,10 @@ export class DataSourceDataProviderType extends DataProviderType {
     if (serviceType.returnsList) {
       // if it returns a list let's consume the next path token which is the row
       const [row, ...afterRow] = rest
-      content = getValueAtPath(content, row)
-      path = afterRow
+      if (row !== '*') {
+        content = getValueAtPath(content, row)
+        path = afterRow
+      }
     }
 
     return content

--- a/web-frontend/modules/integrations/localBaserow/serviceTypes.js
+++ b/web-frontend/modules/integrations/localBaserow/serviceTypes.js
@@ -83,19 +83,31 @@ export class LocalBaserowTableServiceType extends ServiceType {
   getValueAtPath(service, content, path) {
     const schema = this.getDataSchema(service)
 
-    const [field, ...rest] = path
-    let humanName = field
+    let field, rest
 
-    if (schema && field.startsWith('field_')) {
-      if (this.returnsList) {
-        if (schema.items?.properties?.[field]?.title) {
-          humanName = schema.items.properties[field].title
-        }
-      } else if (schema.properties[field]?.title) {
+    if (this.returnsList && Array.isArray(content)) {
+      const [rowIndex, fieldName, ...remainingPath] = path
+      field = fieldName
+      rest = remainingPath
+
+      let humanName = field
+      if (schema?.items?.properties?.[field]?.title) {
+        humanName = schema.items.properties[field].title
+      }
+
+      return getValueAtPath(content, [rowIndex, humanName, ...rest].join('.'))
+    } else {
+      ;[field, ...rest] = path
+      let humanName = field
+
+      if (this.returnsList && schema?.items?.properties?.[field]?.title) {
+        humanName = schema.items.properties[field].title
+      } else if (!this.returnsList && schema?.properties?.[field]?.title) {
         humanName = schema.properties[field].title
       }
+
+      return getValueAtPath(content, [humanName, ...rest].join('.'))
     }
-    return getValueAtPath(content, [humanName, ...rest].join('.'))
   }
 }
 


### PR DESCRIPTION
# What is in this PR
In the Application Builder, when using a List Rows data source, the "All" data provider node doesn't work for normal elements. It still works as expected for collection elements.

# How to test this PR
In `develop`:
- Create a List Rows data source
- Create a Heading element and use the data explorer to pick the `[All]` node: 
> <img width="352" height="121" alt="image" src="https://github.com/user-attachments/assets/6900a65f-d33f-4b14-aa3c-c0ff503f14be" />

- Also create a Table element and use the same List Rows data source

You'll notice that while the Table element shows data, the Heading element doesn't resolve the formula.

In this branch, both the Heading element and Table element show the expected data.

# Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
