### PR TITLE
Fix form data scoping issue

### DIFF
--- a/changelog/entries/unreleased/bug/4185_fix_scope_issue_with_form_input_and_repeat_elements.json
+++ b/changelog/entries/unreleased/bug/4185_fix_scope_issue_with_form_input_and_repeat_elements.json
@@ -1,0 +1,8 @@
+{
+    "type": "bug",
+    "message": "Fix scope issue with form input and repeat elements",
+    "domain": "builder",
+    "issue_number": 4185,
+    "bullet_points": [],
+    "created_at": "2025-11-08"
+}

--- a/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
@@ -94,13 +94,12 @@ export default {
      * value is invalid.
      */
     formElementChildrenAreInvalid() {
-      const { recordIndexPath } = this.applicationContext
       return this.getFormElementDescendants.some(
         ({ descendant, descendantType }) => {
-          const uniqueElementId = descendantType.uniqueElementId(
-            descendant,
-            recordIndexPath
-          )
+          const uniqueElementId = descendantType.uniqueElementId({
+            element: descendant,
+            applicationContext: this.applicationContext,
+          })
           return this.$store.getters['formData/getElementInvalid'](
             this.elementPage,
             uniqueElementId
@@ -115,13 +114,12 @@ export default {
      * as touched, or not touched, depending on what we're achieving in validation.
      */
     setFormElementDescendantsTouched(wasTouched) {
-      const { recordIndexPath } = this.applicationContext
       this.getFormElementDescendants.forEach(
         ({ descendant, descendantType }) => {
-          const uniqueElementId = descendantType.uniqueElementId(
-            descendant,
-            recordIndexPath
-          )
+          const uniqueElementId = descendantType.uniqueElementId({
+            element: descendant,
+            applicationContext: this.applicationContext,
+          })
           this.$store.dispatch('formData/setElementTouched', {
             page: this.elementPage,
             wasTouched,
@@ -137,14 +135,13 @@ export default {
      * be left intact.
      */
     resetFormContainerElements() {
-      const { recordIndexPath } = this.applicationContext
       if (this.element.reset_initial_values_post_submission) {
         this.getFormElementDescendants.forEach(
           ({ descendant, descendantType }) => {
-            const uniqueElementId = descendantType.uniqueElementId(
-              descendant,
-              recordIndexPath
-            )
+            const uniqueElementId = descendantType.uniqueElementId({
+              element: descendant,
+              applicationContext: this.applicationContext,
+            })
             const initialValue = descendantType.getInitialFormDataValue(
               descendant,
               this.applicationContext

--- a/web-frontend/modules/builder/components/elements/components/collectionField/ButtonField.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/ButtonField.vue
@@ -24,11 +24,10 @@ export default {
       return `${this.field.uid}_click`
     },
     workflowActionsInProgress() {
-      const { recordIndexPath } = this.applicationContext
-      const dispatchedById = this.elementType.uniqueElementId(
-        this.element,
-        recordIndexPath
-      )
+      const dispatchedById = this.elementType.uniqueElementId({
+        element: this.element,
+        applicationContext: this.applicationContext,
+      })
       const workflowActions = this.$store.getters[
         'builderWorkflowAction/getElementWorkflowActions'
       ](this.elementPage, this.element.id)

--- a/web-frontend/modules/builder/dataProviderTypes.js
+++ b/web-frontend/modules/builder/dataProviderTypes.js
@@ -721,10 +721,12 @@ export class FormDataProviderType extends DataProviderType {
    */
   formElementsInNamespacePath(applicationContext, targetElement) {
     const { page } = applicationContext
+
     const targetNamespacePath =
       this.app.store.getters['element/getElementNamespacePath'](
         targetElement
       ).join('.')
+
     const elements = this.app.store.getters['element/getElementsOrdered'](page)
     return elements.filter((element) => {
       const elementType = this.app.$registry.get('element', element.type)
@@ -736,6 +738,7 @@ export class FormDataProviderType extends DataProviderType {
         this.app.store.getters['element/getElementNamespacePath'](element).join(
           '.'
         )
+
       return targetNamespacePath.startsWith(elementNamespacePath)
     })
   }
@@ -746,19 +749,22 @@ export class FormDataProviderType extends DataProviderType {
   }
 
   getDataContent(applicationContext) {
+    const { element: targetElement } = applicationContext
     const formData = this.app.store.getters['formData/getFormData'](
       applicationContext.page
     )
-    const { element: targetElement, recordIndexPath } = applicationContext
+
     const accessibleFormElements = this.formElementsInNamespacePath(
       applicationContext,
       targetElement
     )
+
     return Object.fromEntries(
       accessibleFormElements.map((element) => {
         const uniqueElementId = this.app.$registry
           .get('element', element.type)
-          .uniqueElementId(element, recordIndexPath)
+          .uniqueElementId({ element, applicationContext })
+
         const formEntry = getValueAtPath(formData, uniqueElementId)
         return [element.id, formEntry?.value]
       })

--- a/web-frontend/modules/builder/eventTypes.js
+++ b/web-frontend/modules/builder/eventTypes.js
@@ -19,10 +19,13 @@ export class Event {
 
   async fire({ workflowActions, applicationContext }) {
     const additionalContext = {}
-    const { element, recordIndexPath, builder, page } = applicationContext
+    const { element, builder, page } = applicationContext
     const pages = [page, this.app.store.getters['page/getSharedPage'](builder)]
     const elementType = this.app.$registry.get('element', element.type)
-    const dispatchedById = elementType.uniqueElementId(element, recordIndexPath)
+    const dispatchedById = elementType.uniqueElementId({
+      element,
+      applicationContext,
+    })
 
     /**
      * The currentDispatchId is used to keep track of chained Workflow Actions.

--- a/web-frontend/modules/builder/mixins/element.js
+++ b/web-frontend/modules/builder/mixins/element.js
@@ -18,11 +18,10 @@ export default {
       const workflowActions = this.$store.getters[
         'builderWorkflowAction/getElementWorkflowActions'
       ](this.elementPage, this.element.id)
-      const { recordIndexPath } = this.applicationContext
-      const dispatchedById = this.elementType.uniqueElementId(
-        this.element,
-        recordIndexPath
-      )
+      const dispatchedById = this.elementType.uniqueElementId({
+        element: this.element,
+        applicationContext: this.applicationContext,
+      })
       return workflowActions.some((workflowAction) =>
         this.$store.getters['builderWorkflowAction/getDispatching'](
           workflowAction,

--- a/web-frontend/modules/builder/mixins/formElement.js
+++ b/web-frontend/modules/builder/mixins/formElement.js
@@ -22,10 +22,10 @@ export default {
   },
   computed: {
     uniqueElementId() {
-      return this.elementType.uniqueElementId(
-        this.element,
-        this.applicationContext.recordIndexPath
-      )
+      return this.elementType.uniqueElementId({
+        element: this.element,
+        applicationContext: this.applicationContext,
+      })
     },
     formElementData() {
       return this.$store.getters['formData/getElementFormEntry'](

--- a/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/ChoiceElement.spec.js
@@ -23,8 +23,8 @@ describe('ChoiceElement', () => {
   }
 
   const mountComponentForElement = async (element) => {
-    const builder = { id: 1, theme: { primary_color: '#ccc' } }
     const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
     const workspace = {}
     const mode = 'public'
     const applicationContext = { builder, page, mode }
@@ -74,6 +74,7 @@ describe('ChoiceElement', () => {
       option_type: 'manual',
       show_as_dropdown: true,
       options: [],
+      page_id: 1,
     })
 
     expect(wrapper.element).toMatchSnapshot()
@@ -92,6 +93,7 @@ describe('ChoiceElement', () => {
         { value: '1', name: 'First' },
         { value: '2', name: 'Second' },
       ],
+      page_id: 1,
     })
 
     expect(wrapper.element).toMatchSnapshot()
@@ -111,6 +113,7 @@ describe('ChoiceElement', () => {
         { value: 'bar_name', name: 'Bar Name' },
         { value: null, name: 'Baz Name' },
       ],
+      page_id: 1,
     })
 
     expect(wrapper.vm.optionsResolved).toEqual([
@@ -136,6 +139,7 @@ describe('ChoiceElement', () => {
         { value: '1', name: 'First' },
         { value: '2', name: 'Second' },
       ],
+      page_id: 1,
     })
 
     expect(wrapper.element).toMatchSnapshot()
@@ -154,6 +158,7 @@ describe('ChoiceElement', () => {
         { value: '1', name: 'First' },
         { value: '2', name: 'Second' },
       ],
+      page_id: 1,
     })
 
     expect(wrapper.element).toMatchSnapshot()

--- a/web-frontend/test/unit/builder/components/elements/components/DateTimePickerElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/DateTimePickerElement.spec.js
@@ -76,6 +76,7 @@ describe('DateTimePickerElement', () => {
       date_format: format.date.name,
       include_time: !!format.time,
       time_format: format.time ? format.time.name : '24',
+      page_id: page.id,
     }
     store.dispatch('element/forceCreate', { page, element })
 

--- a/web-frontend/test/unit/builder/components/elements/components/RecordSelectorElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/RecordSelectorElement.spec.js
@@ -77,6 +77,7 @@ describe('RecordSelectorElement', () => {
       type: 'record_selector',
       data_source_id: page.dataSources[0].id,
       items_per_page: 5,
+      page_id: page.id,
     }
     store.dispatch('element/forceCreate', { page, element })
 
@@ -190,6 +191,7 @@ describe('RecordSelectorElement', () => {
       data_source_id: page.dataSources[0].id,
       items_per_page: 5,
       option_name_suffix: { formula: "'Suffix'", mode: 'simple' },
+      page_id: page.id,
     }
     store.dispatch('element/forceCreate', { page, element })
 


### PR DESCRIPTION
### What is in this PR

Restore the expected form input visibility inside a collection element. In a nutshell, an element should be able to access all form input inside the same collection element or any sibling of a parent collection element.
Check the graph in the issue to see all possibilities.

### How to test this PR

Import the following export: 
[exportFormInputVisibility.zip](https://github.com/user-attachments/files/23434214/exportFormInputVisibility.zip)


First on develop then with this branch. This branch should have access to something similar to what you see in the image from the issue.

Fixes #4185 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
