### PR TITLE
Fix formula recursion when same data source is used twice in one formula

### DIFF
--- a/backend/src/baserow/contrib/builder/data_providers/data_provider_types.py
+++ b/backend/src/baserow/contrib/builder/data_providers/data_provider_types.py
@@ -170,9 +170,6 @@ class DataSourceDataProviderType(BuilderDataProviderType):
             # The data source has probably been deleted
             raise InvalidRuntimeFormula() from exc
 
-        # Declare the call and check for recursion
-        dispatch_context.add_call(data_source.id)
-
         dispatch_result = DataSourceHandler().dispatch_data_source(
             data_source, dispatch_context
         )

--- a/backend/tests/baserow/contrib/builder/data_providers/test_data_provider_types.py
+++ b/backend/tests/baserow/contrib/builder/data_providers/test_data_provider_types.py
@@ -240,8 +240,6 @@ def test_data_source_data_provider_get_data_chunk_with_list_data_source(data_fix
         == "Blue"
     )
 
-    dispatch_context.reset_call_stack()
-
     assert (
         data_source_provider.get_data_chunk(
             dispatch_context, [data_source.id, "2", fields[1].db_column]
@@ -249,16 +247,12 @@ def test_data_source_data_provider_get_data_chunk_with_list_data_source(data_fix
         == "White"
     )
 
-    dispatch_context.reset_call_stack()
-
     assert (
         data_source_provider.get_data_chunk(
             dispatch_context, [data_source.id, "0", "id"]
         )
         == rows[0].id
     )
-
-    dispatch_context.reset_call_stack()
 
     assert data_source_provider.get_data_chunk(
         dispatch_context, [data_source.id, "*", fields[1].db_column]

--- a/changelog/entries/unreleased/bug/4195_fix_formula_recursion_error_when_the_same_data_source_is_use.json
+++ b/changelog/entries/unreleased/bug/4195_fix_formula_recursion_error_when_the_same_data_source_is_use.json
@@ -1,0 +1,8 @@
+{
+    "type": "bug",
+    "message": "Fix formula recursion error when the same data source is used twice in one formula of workflow action",
+    "domain": "builder",
+    "issue_number": 4195,
+    "bullet_points": [],
+    "created_at": "2025-11-10"
+}


### PR DESCRIPTION

### What is in this PR

Fixes #4195 

### How to test this PR

Create a workflow action with a field mapping using the same data source twice. If you try to execute the action it will fail with a formula recursion detected error on develop and should work on this branch.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
