### PR TITLE
Keep login loading spinner

### DIFF
--- a/web-frontend/modules/core/components/auth/PasswordLogin.vue
+++ b/web-frontend/modules/core/components/auth/PasswordLogin.vue
@@ -247,8 +247,6 @@ export default {
         } else {
           throw error
         }
-      } finally {
-        this.loading = false
       }
     },
   },


### PR DESCRIPTION
### What is in this PR

This merge request makes sure that the login button remains in loading state when the new page is being loaded. This was accidentally stopped when introducing the 2fa authentication. It must be like it was before, where it remains spinning.

<img width="704" height="519" alt="image" src="https://github.com/user-attachments/assets/999170d7-f93a-4981-b353-6d4025d936d6" />


### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
