### PR TITLE
Hide empty assistant chats

### DIFF
--- a/enterprise/backend/src/baserow_enterprise/assistant/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/handler.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 from uuid import UUID
 
 from django.contrib.auth.models import AbstractUser
+from django.db.models import Count
 
 from baserow.core.models import Workspace
 
@@ -63,9 +64,16 @@ class AssistantHandler:
         List all AI assistant chats for the user in the specified workspace.
         """
 
-        return AssistantChat.objects.filter(
-            workspace_id=workspace_id, user=user
-        ).order_by("-updated_on", "id")
+        return (
+            AssistantChat.objects.filter(
+                workspace_id=workspace_id,
+                user=user,
+            )
+            .exclude(title="")
+            .annotate(message_count=Count("messages"))
+            .filter(message_count__gt=0)
+            .order_by("-updated_on", "id")
+        )
 
     def get_chat_message_by_id(self, user: AbstractUser, message_id: int) -> AiMessage:
         """


### PR DESCRIPTION
### What is in this PR

Small change that hides chats without a title or that don't have any messages when listing them. This to avoid empty chats in the list.

### How to test this PR

- Create three AI-assistant chats, one without a title, one without any messages, and that does have that.
- Confirm that one the one that has both is visible.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
