### PR TITLE
chore(AI Assistant): add disclaimer to responses

### DIFF
--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/assistant.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/assistant.scss
@@ -334,7 +334,6 @@
   }
 }
 
-
 .assistant__message {
   display: flex;
 
@@ -748,4 +747,13 @@
   justify-content: flex-end;
   gap: 8px;
   margin-top: 10px;
+}
+
+.assistant__disclaimer {
+  margin-top: 8px;
+  margin-left: 8px;
+  font-size: 11px;
+  color: $palette-neutral-600;
+  text-align: left;
+  line-height: 1.4;
 }

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantMessageActions.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantMessageActions.vue
@@ -39,6 +39,10 @@
       </template>
     </div>
 
+    <div v-if="message.can_submit_feedback" class="assistant__disclaimer">
+      {{ $t('assistantMessageActions.disclaimer') }}
+    </div>
+
     <!-- Additional user feedback context for the thumb down button -->
     <Context
       ref="feedbackContext"

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -355,7 +355,8 @@
     "feedbackContextPlaceholder": "What could we improve? (optional)",
     "copiedToClipboard": "Copied to clipboard",
     "copiedContentToast": "The Assistant's response content has been copied to your clipboard",
-    "copyFailed": "Failed to copy to clipboard"
+    "copyFailed": "Failed to copy to clipboard",
+    "disclaimer": "Kuma can make mistakes, please double-check responses"
   },
   "chatwootSupportSidebarWorkspace": {
     "directSupport": "Direct support"


### PR DESCRIPTION
### What is in this PR
A disclaimer below every response to double check responses

<img width="400" height="264" alt="Screenshot 2025-11-13 at 11 33 08" src="https://github.com/user-attachments/assets/9fb3b18c-7a4a-4b29-898c-19ecbe168a74" />


### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

Closes #4234 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
