### PR TITLE
Fix workflow action configuration broken

### DIFF
--- a/changelog/entries/unreleased/bug/fix_workflow_action_configuration_broken.json
+++ b/changelog/entries/unreleased/bug/fix_workflow_action_configuration_broken.json
@@ -1,0 +1,8 @@
+{
+    "type": "bug",
+    "message": "Fix workflow action configuration broken",
+    "domain": "builder",
+    "issue_number": null,
+    "bullet_points": [],
+    "created_at": "2025-11-13"
+}

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -291,10 +291,12 @@ export default {
     },
   },
   watch: {
-    nodesHierarchy() {
+    nodesHierarchy(newValue, oldValue) {
       // fixes reactivity issue with components in tiptap by forcing the input to
       // render.
-      this.key += 1
+      if (!_.isEqual(newValue, oldValue)) {
+        this.key += 1
+      }
     },
     disabled(newValue) {
       this.editor.setOptions({ editable: !newValue && !this.readOnly })


### PR DESCRIPTION
### What is in this PR

Fix workflow configuration that is impossible (because of reactivity).

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
