### PR TITLE
Better fix for workflow action reactivity

### DIFF
--- a/web-frontend/modules/builder/components/event/WorkflowAction.vue
+++ b/web-frontend/modules/builder/components/event/WorkflowAction.vue
@@ -105,7 +105,7 @@ export default {
         await this.actionUpdateWorkflowAction({
           page: this.elementPage,
           workflowAction: this.workflowAction,
-          values,
+          values: differences,
         })
       } catch (error) {
         this.$refs.actionForm?.reset()

--- a/web-frontend/modules/builder/store/builderWorkflowAction.js
+++ b/web-frontend/modules/builder/store/builderWorkflowAction.js
@@ -60,21 +60,19 @@ const mutations = {
       order,
     } = page.workflowActions[index]
 
-    const newValue = overwrite
-      ? populateWorkflowAction({
-          id,
-          page_id: pageId,
-          element_id: elementId,
-          event,
-          order,
-          ...values,
-        })
-      : {
-          ...page.workflowActions[index],
-          ...values,
-        }
-
-    page.workflowActions.splice(index, 1, newValue)
+    if (overwrite) {
+      const newValue = populateWorkflowAction({
+        id,
+        page_id: pageId,
+        element_id: elementId,
+        event,
+        order,
+        ...values,
+      })
+      page.workflowActions.splice(index, 1, newValue)
+    } else {
+      Object.assign(page.workflowActions[index], values)
+    }
   },
   SET_ITEM(state, { page, workflowAction: workflowActionToSet, values }) {
     page.workflowActions = page.workflowActions.map((workflowAction) =>

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -294,9 +294,7 @@ export default {
     nodesHierarchy(newValue, oldValue) {
       // fixes reactivity issue with components in tiptap by forcing the input to
       // render.
-      if (!_.isEqual(newValue, oldValue)) {
-        this.key += 1
-      }
+      this.key += 1
     },
     disabled(newValue) {
       this.editor.setOptions({ editable: !newValue && !this.readOnly })


### PR DESCRIPTION
### What is in this PR

This fixes the worfklow action reactivity issue the good way without comparing equality of big structure which is inneficient...

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
