### PR TITLE
Enhance the changelog command.

### DIFF
--- a/changelog/src/changelog.py
+++ b/changelog/src/changelog.py
@@ -43,7 +43,11 @@ def add(working_dir: Optional[str] = typer.Option(default=default_path)):
         issue_number = None
 
     ChangelogHandler(working_dir).add_entry(
-        domain_type, changelog_type, message, issue_number=issue_number
+        domain_type,
+        changelog_type,
+        message,
+        issue_number=issue_number,
+        issue_origin="github",  # All new changelogs originate from GitHub
     )
 
 

--- a/changelog/src/changelog_entry.py
+++ b/changelog/src/changelog_entry.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional, Union
 
 GITLAB_URL = os.environ.get("GITLAB_URL", "https://gitlab.com/baserow/baserow")
+GITHUB_URL = os.environ.get("GITHUB_URL", "https://github.com/baserow/baserow")
 
 
 class ChangelogEntry(abc.ABC):
@@ -17,6 +18,7 @@ class ChangelogEntry(abc.ABC):
         self,
         domain_type_name: str,
         message: str,
+        issue_origin: str,
         issue_number: Optional[int] = None,
         bullet_points: List[str] = None,
     ) -> Dict[str, any]:
@@ -26,18 +28,24 @@ class ChangelogEntry(abc.ABC):
         return {
             "type": self.type,
             "message": message,
-            "domain": domain_type_name,
+            "issue_origin": issue_origin,
             "issue_number": issue_number,
+            "domain": domain_type_name,
             "bullet_points": bullet_points,
             "created_at": datetime.now(tz=timezone.utc).strftime("%Y-%m-%d"),
         }
 
     @staticmethod
-    def get_markdown_string(message: str, issue_number: Union[int, None] = None) -> str:
+    def get_markdown_string(
+        message: str,
+        issue_number: Union[int, None] = None,
+        issue_origin: Optional[str] = "gitlab",
+    ) -> str:
         string = f"* {message}"
 
         if issue_number is not None:
-            string += f" [#{issue_number}]({GITLAB_URL}/-/issues/{issue_number})"
+            url_prefix = GITLAB_URL if issue_origin == "gitlab" else GITHUB_URL
+            string += f" [#{issue_number}]({url_prefix}/-/issues/{issue_number})"
 
         return string
 

--- a/changelog/src/domains.py
+++ b/changelog/src/domains.py
@@ -35,10 +35,16 @@ class AutomationDomain(BaserowDomain):
     heading = "Automation"
 
 
+class IntegrationDomain(BaserowDomain):
+    type = "integration"
+    heading = "Integration"
+
+
 domain_types: Dict[str, type[BaserowDomain]] = {
     CoreDomain.type: CoreDomain,
     DashboardDomain.type: DashboardDomain,
     DatabaseDomain.type: DatabaseDomain,
     BuilderDomain.type: BuilderDomain,
     AutomationDomain.type: AutomationDomain,
+    IntegrationDomain.type: IntegrationDomain,
 }

--- a/changelog/tests/changelog/test_changelog_handler.py
+++ b/changelog/tests/changelog/test_changelog_handler.py
@@ -18,29 +18,29 @@ def test_add_entry(fs):
 
 def test_get_changelog_entries(fs):
     handler = ChangelogHandler()
-    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "1")
-    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "2")
+    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "msg1")
+    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "msg2")
 
     changelog_entries = handler.get_changelog_entries()
 
     assert BugChangelogEntry.type in changelog_entries
     assert [
-        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "1"),
-        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "2"),
+        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "msg1", "github"),
+        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "msg2", "github"),
     ] in changelog_entries.values()
 
 
 def test_get_changelog_entries_order(fs):
     handler = ChangelogHandler()
-    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "2")
-    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "1")
+    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "msg2")
+    handler.add_entry(DatabaseDomain.type, BugChangelogEntry.type, "msg1")
 
     changelog_entries = handler.get_changelog_entries()
 
     assert BugChangelogEntry.type in changelog_entries
     assert [
-        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "1"),
-        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "2"),
+        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "msg1", "github"),
+        BugChangelogEntry().generate_entry_dict(DatabaseDomain.type, "msg2", "github"),
     ] in changelog_entries.values()
 
 


### PR DESCRIPTION
### What is in this PR

1. Add the new "integration" domain.
2. Introduce `issue_origin` support. By default this will be "github" for new entries, but for compat reasons, when we generate the markdown for entries, if the `issue_origin` isn't present then we'll default to "gitlab".

### How to test this PR

- Create a new changelog, for any domain, and see that it defaults to `issue_origin` of "github".
- Cut a new release and confirm that:
   1. Older entries (before `issue_origin` was being manually added) generate markdown pointing to Gitlab's issue page.
   2. Your new changelog points to Github's issue page.
 
### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
