### PR TITLE
Show specific Jira connection error

### DIFF
--- a/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
@@ -283,8 +283,8 @@ class JiraIssuesDataSyncType(DataSyncType):
                 start_at += max_results
                 if data["total"] <= start_at:
                     break
-        except (RequestException, UnacceptableAddressException, ConnectionError):
-            raise SyncError("Error fetching issues from Jira.")
+        except (RequestException, UnacceptableAddressException, ConnectionError) as e:
+            raise SyncError(f"Error connecting to Jira: {str(e)}")
 
         return issues
 


### PR DESCRIPTION
### What is in this PR

Small pull request that allows showing the Jira data sync connection error.

### How to test this PR

- Create a new jira data sync. Put a now existing domain as `Jira instance URL` and try to create the sync.
- Observe that shows the connection error.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
