### PR TITLE
Move Copy button outside of the code block

### DIFF
--- a/web-frontend/modules/automation/components/sidebar/SampleDataModal.vue
+++ b/web-frontend/modules/automation/components/sidebar/SampleDataModal.vue
@@ -3,16 +3,15 @@
     <h2 class="box__title">{{ title }}</h2>
     <div class="sample-data-modal__sub-title">
       {{ $t('simulateDispatch.sampleDataModalSubTitle') }}
-    </div>
-    <div class="sample-data-modal__code">
       <Button
-        class="sample-data-modal__copy-button"
         type="secondary"
         icon="iconoir-copy simulate-dispatch-node__button-icon"
         @click="copyToClipboard"
       >
         {{ $t('simulateDispatch.sampleDataCopy') }}
       </Button>
+    </div>
+    <div class="sample-data-modal__code">
       <pre><code>{{ sampleData }}</code></pre>
     </div>
   </Modal>

--- a/web-frontend/modules/core/assets/scss/components/automation/workflow/sample_data_modal.scss
+++ b/web-frontend/modules/core/assets/scss/components/automation/workflow/sample_data_modal.scss
@@ -8,6 +8,9 @@
 }
 
 .sample-data-modal__sub-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: 14px;
   margin-bottom: 10px;
 }
@@ -29,11 +32,4 @@
     overflow-wrap: anywhere;
     word-break: break-word;
   }
-}
-
-.sample-data-modal__copy-button {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  z-index: 1;
 }


### PR DESCRIPTION
### What is in this PR
This PR moves the "Copy" button in an Automation's Show error/Show payload modal to be outside the actual error/payload content.

| Before | After |
|--------|---------|
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/ec84a170-86f8-481c-9859-b40720e06a9d" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/57b136a1-d399-47a1-9aaf-930f0137fbb8" />|

### How to test this PR
In Automation, create a node with an invalid formula argument, e.g. `day('foo')` and test it. This should cause the error to be populated.

View the error by clicking the "Show error" button.

In `develop`, you'll notice the "Close" button covers part of the error message. In this branch, since the button is outside the error/payload content area, there should be no occlusion.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
