### PR TITLE
Fix table button collection field loading state

### DIFF
--- a/changelog/entries/unreleased/bug/4268_fix_synchronised_button_loading_state_in_tables.json
+++ b/changelog/entries/unreleased/bug/4268_fix_synchronised_button_loading_state_in_tables.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix synchronised button loading state in tables",
+    "issue_origin": "github",
+    "issue_number": 4268,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2025-11-17"
+}

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -41,6 +41,7 @@
                   row,
                   rowIndex,
                   field,
+                  allowSameElement: true,
                 })
               "
               v-bind="value"

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -782,7 +782,12 @@ export class ElementType extends Registerable {
    *
    */
   uniqueElementId({ element, applicationContext }) {
-    const { recordIndexPath, builder, page } = applicationContext
+    const {
+      recordIndexPath,
+      builder,
+      page,
+      allowSameElement = false,
+    } = applicationContext
 
     const elementPage =
       element.page_id === page.id
@@ -792,7 +797,7 @@ export class ElementType extends Registerable {
     const collectionAncestorLength = this.getCollectionAncestry({
       page: elementPage,
       element,
-      allowSameElement: false,
+      allowSameElement,
     }).length
 
     // We might be asking the uniqueID for an outside element so we don't

--- a/web-frontend/modules/builder/mixins/collectionElement.js
+++ b/web-frontend/modules/builder/mixins/collectionElement.js
@@ -198,9 +198,11 @@ export default {
       row,
       rowIndex,
       field = null,
+      ...rest
     }) {
       const newApplicationContext = {
         recordIndexPath: [...applicationContext.recordIndexPath, rowIndex],
+        ...rest,
       }
       if (field) {
         newApplicationContext.field = field


### PR DESCRIPTION
### What is in this PR

fix bug #4268


### How to test this PR


Create a table with a button that trigger a backend action (like creating a row or something). On develop if you click on the button all buttons show the loading state at the same moment. With this branch only the the clickied button should spin.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
