### PR TITLE
Don't show Kuma if the model is not set

### DIFF
--- a/changelog/entries/unreleased/bug/4280_dont_show_the_assistant_panel_if_the_llm_model_env_variable_.json
+++ b/changelog/entries/unreleased/bug/4280_dont_show_the_assistant_panel_if_the_llm_model_env_variable_.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Don't show the Assistant panel if the LLM_MODEL env variable is not configured",
+  "issue_origin": "github",
+  "issue_number": 4280,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2025-11-18"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantSidebarItem.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantSidebarItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="hasPermission">
+  <div v-if="hasPermission && isConfigured">
     <li class="tree__item">
       <div class="tree__action">
         <a href="#" class="tree__link" @click.prevent="toggleRightSidebar">
@@ -39,10 +39,14 @@ export default {
         this.workspace.id
       )
     },
+    isConfigured() {
+      return this.$config.BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL !== null
+    },
   },
   mounted() {
     if (
       this.hasPermission &&
+      this.isConfigured &&
       localStorage.getItem('baserow.rightSidebarOpen') !== 'false'
     ) {
       // open the right sidebar if the feature is available

--- a/enterprise/web-frontend/modules/baserow_enterprise/module.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/module.js
@@ -48,4 +48,9 @@ export default function () {
   // imports the original. We do this so that we can use the existing variables,
   // mixins, placeholders etc.
   this.options.css[0] = path.resolve(__dirname, 'assets/scss/default.scss')
+
+  if (this.options.publicRuntimeConfig) {
+    this.options.publicRuntimeConfig.BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL =
+      process.env.BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL || null
+  }
 }


### PR DESCRIPTION
### What is in this PR
-A fix to hide the assistant panel if the model is not set 

### How to test this PR
- Clear the `BASEROW_ENTERPRISE_ASSISTANT_LLM_MODEL` if it's set and notice the panel is no longer visible. Also, the sidebar item should no longer be visible.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
