### PR TITLE
Dont prepare serialized rows if there is no trigger associated with the table

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -2283,18 +2283,22 @@ class LocalBaserowRowsSignalServiceType(
         model: "GeneratedTableModel",
         **kwargs,
     ):
-        serializer = get_row_serializer_class(
-            model, RowSerializer, is_response=True, user_field_names=True
-        )
+        def get_data():
+            # Make sure we have an up to date model
+            local_model = model.baserow_table.get_model()
 
-        data_to_process = {
-            "results": serializer(rows, many=True).data,
-            "has_next_page": False,
-        }
+            serializer = get_row_serializer_class(
+                local_model, RowSerializer, is_response=True, user_field_names=True
+            )
+
+            return {
+                "results": serializer(rows, many=True).data,
+                "has_next_page": False,
+            }
 
         self._process_event(
             self.model_class.objects.filter(table=table),
-            data_to_process,
+            get_data,
             user=user,
         )
 

--- a/changelog/entries/unreleased/bug/save_data_preparation_for_table_that_dont_have_trigger_assoc.json
+++ b/changelog/entries/unreleased/bug/save_data_preparation_for_table_that_dont_have_trigger_assoc.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Save data preparation for table that don't have trigger associated to it",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2025-11-18"
+}


### PR DESCRIPTION
### What is in this PR

We now lazily serialize the rows if there is no trigger associated to the table that is updated. It prevents bug and save computation time.

### How to test this PR

The bes way is to add a print inside the method `get_data()` in the `_handle_signal` method of `LocalBaserowRowsSignalServiceType`. This print should be printed only if there is at least one workflow activated for this table.
- Test all triggers. They should work as before
- Test create/update/delete row in table with/without a trigger listening, it should print only if there is a trigger listening.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
