### PR TITLE
Use visibility condition formula for formula generator

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -392,6 +392,24 @@ class ElementType(
             create related objects when the import / export functionality is tested.
         """
 
+    def formula_generator(
+        self, element: Element
+    ) -> Generator[str | Instance, str, None]:
+        """
+        Generator that returns formula fields for the LinkElementType.
+
+        Unlike other Element types, this one has its formula fields in the
+        page_parameters and query_prameters JSON fields.
+        """
+
+        yield from super().formula_generator(element)
+
+        # Deal with visibility_condition
+        new_formula = yield element.visibility_condition
+        if new_formula is not None:
+            element.visibility_condition = new_formula
+            yield element
+
 
 ElementTypeSubClass = TypeVar("ElementTypeSubClass", bound=ElementType)
 

--- a/changelog/entries/unreleased/bug/fix_visibility_condition_not_working_if_data_property_wasnt_.json
+++ b/changelog/entries/unreleased/bug/fix_visibility_condition_not_working_if_data_property_wasnt_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix visibility condition not working if data property wasn't used in page",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2025-11-18"
+}


### PR DESCRIPTION
### What is in this PR

Fix visibility condition issue in preview/publish

### How to test this PR

create a page with an element use a property as visibility condition ( can be a simple boolean field). Don't use this property elswhere in the page.

On develop the element is always unvisible, on this branch it should follow the data source value.


### Checklist

- [y] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
