### PR TITLE
fix: builder-label-html-entities

### DIFF
--- a/web-frontend/modules/builder/components/elements/components/ButtonElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ButtonElement.vue
@@ -10,12 +10,15 @@
       :loading="workflowActionsInProgress"
       @click="fireEvent(elementType.getEventByName(element, 'click'))"
     >
-      {{
-        element.value
-          ? resolvedValue ||
-            (mode === 'editing' ? $t('buttonElement.emptyValue') : '&nbsp;')
-          : $t('buttonElement.missingValue')
-      }}
+      <span
+        v-html="
+          element.value
+            ? resolvedValue ||
+              (mode === 'editing' ? $t('buttonElement.emptyValue') : '&nbsp;')
+            : $t('buttonElement.missingValue')
+        "
+      >
+      </span>
     </ABButton>
   </div>
 </template>
@@ -23,6 +26,7 @@
 <script>
 import element from '@baserow/modules/builder/mixins/element'
 import { ensureString } from '@baserow/modules/core/utils/validator'
+import { decodeHTMLEntities } from '@baserow/modules/core/utils/string'
 
 /**
  * @typedef ButtonElement
@@ -44,7 +48,8 @@ export default {
   },
   computed: {
     resolvedValue() {
-      return ensureString(this.resolveFormula(this.element.value))
+      const raw = ensureString(this.resolveFormula(this.element.value))
+      return decodeHTMLEntities(raw);
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/components/LinkElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/LinkElement.vue
@@ -5,12 +5,15 @@
     :style="getStyleOverride(element.variant)"
   >
     <ABLink :target="element.target" :url="url" :variant="element.variant">
-      {{
-        element.value
-          ? resolvedValue ||
-            (mode === 'editing' ? $t('linkElement.emptyValue') : '&nbsp;')
-          : $t('linkElement.missingValue')
-      }}
+      <span
+        v-html="
+          element.value
+            ? resolvedValue ||
+              (mode === 'editing' ? $t('linkElement.emptyValue') : '&nbsp;')
+            : $t('linkElement.missingValue')
+        "
+      >
+      </span>
     </ABLink>
   </div>
 </template>
@@ -19,6 +22,7 @@
 import element from '@baserow/modules/builder/mixins/element'
 import resolveElementUrl from '@baserow/modules/builder/utils/urlResolution'
 import { ensureString } from '@baserow/modules/core/utils/validator'
+import { decodeHTMLEntities } from '@baserow/modules/core/utils/string'
 
 /**
  * @typedef LinkElement
@@ -45,7 +49,8 @@ export default {
   },
   computed: {
     resolvedValue() {
-      return ensureString(this.resolveFormula(this.element.value))
+      const raw = ensureString(this.resolveFormula(this.element.value))
+      return decodeHTMLEntities(raw);
     },
     pages() {
       return this.$store.getters['page/getVisiblePages'](this.builder)

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -103,6 +103,13 @@ import elementImageText from '@baserow/modules/builder/assets/icons/element-text
 import _ from 'lodash'
 import { getValueAtPath } from '../core/utils/object'
 
+function decodeHTMLEntities(text) {
+  if (typeof document === 'undefined') return text
+  const textarea = document.createElement('textarea')
+  textarea.innerHTML = text
+  return textarea.value
+}
+
 export class ElementType extends Registerable {
   get name() {
     return null
@@ -1650,8 +1657,10 @@ export class LinkElementType extends ElementType {
       this.resolveFormula(element.value, applicationContext)
     ).trim()
 
-    return displayValue
-      ? `${displayValue}${destination}`
+    const decodedValue = decodeHTMLEntities(displayValue)
+
+    return decodedValue
+      ? `${decodedValue}${destination}`
       : `${this.name}${destination}`
   }
 }
@@ -1776,7 +1785,7 @@ export class ButtonElementType extends ElementType {
     const resolvedName = ensureString(
       this.resolveFormula(element.value, applicationContext)
     ).trim()
-    return resolvedName || this.name
+    return decodeHTMLEntities(resolvedName) || this.name
   }
 }
 

--- a/web-frontend/modules/core/utils/string.js
+++ b/web-frontend/modules/core/utils/string.js
@@ -223,3 +223,19 @@ export function collatedStringCompare(stringA, stringB, order) {
     ? stringA.localeCompare(stringB, 'en')
     : stringB.localeCompare(stringA, 'en')
 }
+
+/**
+ * Decodes HTML entities in a string to their literal character equivalents.
+ * For example: "&gt;" becomes ">", "&lt;" becomes "<", "&amp;" becomes "&"
+ *
+ * @param {string} text - The text containing HTML entities
+ * @returns {string} The decoded text with literal characters
+ */
+export function decodeHTMLEntities(text) {
+  if (!text || typeof text !== 'string') return text
+  if (typeof document === 'undefined') return text
+
+  const textarea = document.createElement('textarea')
+  textarea.innerHTML = text
+  return textarea.value
+}


### PR DESCRIPTION
closes: #4266

### What is in this PR

- Replaced mustache interpolation with `v-html` to avoid Vue re-escaping already-decoded entity values.
- Removed duplicated textarea-based decoding logic.
- Ensures characters like <, >, &, ©, ♥ display correctly without being shown as &lt; or &amp;.
