### PR TITLE
Removed unneeded clear_generated_model_cache call #4247

### DIFF
--- a/backend/src/baserow/contrib/database/field_rules/handlers.py
+++ b/backend/src/baserow/contrib/database/field_rules/handlers.py
@@ -12,7 +12,6 @@ from baserow.contrib.database.field_rules.registries import (
     FieldRulesTypeRegistry,
     RowRuleChanges,
 )
-from baserow.contrib.database.table.cache import clear_generated_model_cache
 from baserow.contrib.database.table.models import GeneratedTableModel, Table
 from baserow.core.db import specific_iterator
 
@@ -132,7 +131,6 @@ class FieldRuleHandler:
         self.table.field_rules_validity_column_added = True
         self.table.save(update_fields=["field_rules_validity_column_added"])
 
-        clear_generated_model_cache()
         model = self._get_model()
         return model
 


### PR DESCRIPTION
### What is in this PR
- Removes a call `clear_generated_model_cache` during field rule creation for a table

### How to test this PR
- use a table without date dependencies
- create a date dependency rule
- check if the table can be used (rows edited, filtered, sorted, exported, if date dependency is effective).

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered

fix #4247
