### PR TITLE
do not propagate input event from workspace search

### DIFF
--- a/web-frontend/modules/core/components/workspace/WorkspaceSearchModal.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceSearchModal.vue
@@ -26,7 +26,7 @@
               v-model="searchTerm"
               class="workspace-search__input"
               :placeholder="$t('workspaceSearch.searchEverything')"
-              @keydown="handleKeydown"
+              @keydown.stop="handleKeydown"
               @focusin="focusInput = true"
               @focusout="focusInput = false"
             />


### PR DESCRIPTION
### What is in this PR
A fix for grid cell stealing focus from workspace search input, if selected.

### How to test this PR
Compare with develop:
- open grid view
- select a cell
- open workspace search (ctrl-k)
- type some text
- observe entered text to appear in the selected cell with develop branch
- observe entered text to appear in the search input in this branch

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
