### PR TITLE
feat: add support for fixed ratio and fully custom column layouts

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -142,6 +142,8 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
         column_amount: int
         column_gap: int
         alignment: str
+        layout_type: str
+        column_widths: List
 
     @property
     def serializer_field_names(self):
@@ -149,6 +151,8 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
             "column_amount",
             "column_gap",
             "alignment",
+            "layout_type",
+            "column_widths",
         ]
 
     @property
@@ -157,14 +161,51 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
             "column_amount",
             "column_gap",
             "alignment",
+            "layout_type",
+            "column_widths",
         ]
+
+    @property
+    def serializer_field_overrides(self):
+        return {
+            **super().serializer_field_overrides,
+            "layout_type": serializers.ChoiceField(
+                choices=ColumnElement.LAYOUT_TYPES.choices,
+                default=ColumnElement.LAYOUT_TYPES.AUTO,
+                help_text=ColumnElement._meta.get_field("layout_type").help_text,
+                required=False,
+            ),
+            "column_widths": serializers.JSONField(
+                default=list,
+                help_text=ColumnElement._meta.get_field("column_widths").help_text,
+                required=False,
+            ),
+        }
 
     def get_pytest_params(self, pytest_data_fixture) -> Dict[str, Any]:
         return {
             "column_amount": 2,
             "column_gap": 10,
             "alignment": VerticalAlignments.TOP,
+            "layout_type": ColumnElement.LAYOUT_TYPES.AUTO,
+            "column_widths": [],
         }
+
+    def prepare_value_for_db(
+        self, values: Dict, instance: Optional[ColumnElement] = None
+    ):
+        """Validate column_widths match column_amount for custom layouts."""
+        layout_type = values.get("layout_type", getattr(instance, "layout_type", None))
+        column_widths = values.get("column_widths", getattr(instance, "column_widths", []))
+        column_amount = values.get("column_amount", getattr(instance, "column_amount", None))
+
+        if layout_type == ColumnElement.LAYOUT_TYPES.CUSTOM and column_widths:
+            if len(column_widths) != column_amount:
+                raise DRFValidationError(
+                    f"column_widths must have {column_amount} entries for custom layout"
+                )
+
+        return super().prepare_value_for_db(values, instance)
 
     def get_new_place_in_container(
         self, container_element_before_update: ColumnElement, places_removed: List[str]

--- a/backend/src/baserow/contrib/builder/elements/models.py
+++ b/backend/src/baserow/contrib/builder/elements/models.py
@@ -422,6 +422,14 @@ class ColumnElement(ContainerElement):
     A column element that can contain other elements.
     """
 
+    class LAYOUT_TYPES(models.TextChoices):
+        AUTO = "auto"
+        RATIO_1_2 = "1:2"
+        RATIO_2_1 = "2:1"
+        RATIO_1_1_2 = "1:1:2"
+        RATIO_2_1_1 = "2:1:1"
+        CUSTOM = "custom"
+
     column_amount = models.IntegerField(
         default=3,
         help_text="The amount of columns inside this column element.",
@@ -442,6 +450,16 @@ class ColumnElement(ContainerElement):
         choices=VerticalAlignments.choices,
         max_length=10,
         default=VerticalAlignments.TOP,
+    )
+    layout_type = models.CharField(
+        choices=LAYOUT_TYPES.choices,
+        max_length=20,
+        default=LAYOUT_TYPES.AUTO,
+        help_text="The layout type determining column widths.",
+    )
+    column_widths = models.JSONField(
+        default=list,
+        help_text="Custom width configuration for each column. Used when layout_type is 'custom'. Each item can be a number (pixels), 'auto', or 'dynamic'.",
     )
 
 

--- a/backend/src/baserow/contrib/builder/migrations/0050_column_layout_types.py
+++ b/backend/src/baserow/contrib/builder/migrations/0050_column_layout_types.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("builder", "0019_repeat_element_styling"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="columnelement",
+            name="layout_type",
+            field=models.CharField(
+                choices=[
+                    ("auto", "Auto"),
+                    ("1:2", "Ratio 1 2"),
+                    ("2:1", "Ratio 2 1"),
+                    ("1:1:2", "Ratio 1 1 2"),
+                    ("2:1:1", "Ratio 2 1 1"),
+                    ("custom", "Custom"),
+                ],
+                default="auto",
+                help_text="The layout type determining column widths.",
+                max_length=20,
+            ),
+        ),
+        migrations.AddField(
+            model_name="columnelement",
+            name="column_widths",
+            field=models.JSONField(
+                default=list,
+                help_text="Custom width configuration for each column. Used when layout_type is 'custom'. Each item can be a number (pixels), 'auto', or 'dynamic'.",
+            ),
+        ),
+    ]

--- a/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
@@ -10,7 +10,7 @@
       v-for="(childrenInColumn, columnIndex) in childrenElements"
       :key="columnIndex"
       class="column-element__column"
-      :style="{ '--column-width': `${columnWidth}%` }"
+      :style="getColumnStyle(columnIndex)"
     >
       <template v-if="childrenInColumn.length > 0">
         <div
@@ -130,6 +130,26 @@ export default {
         (columnIndex) => this.childrenByColumnOrdered[columnIndex] || []
       )
     },
+    columnWidths() {
+      const { layout_type: layoutType, column_widths: customWidths } = this.element
+
+      switch (layoutType) {
+        case 'auto':
+          return Array(this.columnAmount).fill(100 / this.columnAmount)
+        case '1:2':
+          return this.columnAmount === 2 ? [33.33, 66.67] : this.getAutoWidths()
+        case '2:1':
+          return this.columnAmount === 2 ? [66.67, 33.33] : this.getAutoWidths()
+        case '1:1:2':
+          return this.columnAmount === 3 ? [25, 25, 50] : this.getAutoWidths()
+        case '2:1:1':
+          return this.columnAmount === 3 ? [50, 25, 25] : this.getAutoWidths()
+        case 'custom':
+          return this.calculateCustomWidths(customWidths)
+        default:
+          return this.getAutoWidths()
+      }
+    },
   },
   mounted() {
     this.dimensions.targetElement = this.$el.parentElement
@@ -140,6 +160,47 @@ export default {
         placeInContainer: `${columnIndex}`,
         parentElementId: this.element.id,
       })
+    },
+    getAutoWidths() {
+      return Array(this.columnAmount).fill(100 / this.columnAmount)
+    },
+    calculateCustomWidths(customWidths) {
+      if (!customWidths || customWidths.length !== this.columnAmount) {
+        return this.getAutoWidths()
+      }
+
+      const fixedTotal = customWidths.reduce((sum, width) => {
+        if (typeof width === 'number') {
+          return sum + width
+        }
+        return sum
+      }, 0)
+
+      const dynamicCount = customWidths.filter(
+        (w) => w === 'dynamic' || w === 'auto'
+      ).length
+
+      if (dynamicCount === 0) {
+        const total = customWidths.reduce((sum, w) => sum + (w || 0), 0)
+        return customWidths.map((w) => ((w || 0) / total) * 100)
+      }
+
+      const containerWidth = this.dimensions.width || 1000
+      const gapTotal = this.element.column_gap * (this.columnAmount - 1)
+      const availableWidth = containerWidth - gapTotal - fixedTotal
+      const dynamicWidth = Math.max(0, availableWidth / dynamicCount)
+
+      const totalPx = fixedTotal + dynamicWidth * dynamicCount
+      return customWidths.map((w) => {
+        const px = typeof w === 'number' ? w : dynamicWidth
+        return (px / totalPx) * 100
+      })
+    },
+    getColumnStyle(columnIndex) {
+      const width = this.columnWidths[columnIndex]
+      return {
+        '--column-width': `${width}%`,
+      }
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/components/forms/general/ColumnElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/ColumnElementForm.vue
@@ -22,6 +22,55 @@
       class="margin-bottom-2"
       small-label
       required
+      :label="$t('columnElementForm.layoutTypeTitle')"
+    >
+      <Dropdown v-model="values.layout_type" :show-search="false">
+        <DropdownItem
+          v-for="layoutType in availableLayoutTypes"
+          :key="layoutType.value"
+          :name="layoutType.name"
+          :value="layoutType.value"
+        >
+          {{ layoutType.name }}
+        </DropdownItem>
+      </Dropdown>
+    </FormGroup>
+
+    <FormGroup
+      v-if="values.layout_type === 'custom'"
+      class="margin-bottom-2"
+      small-label
+      :label="$t('columnElementForm.customWidthsTitle')"
+    >
+      <div
+        v-for="(width, index) in values.column_widths"
+        :key="index"
+        class="margin-bottom-1"
+      >
+        <label class="control__label">
+          {{ $t('columnElementForm.columnLabel', { index: index + 1 }) }}
+        </label>
+        <Dropdown v-model="values.column_widths[index]" :show-search="false">
+          <DropdownItem name="Auto" value="auto">Auto</DropdownItem>
+          <DropdownItem name="Dynamic (fills space)" value="dynamic">
+            Dynamic
+          </DropdownItem>
+          <DropdownItem
+            v-for="px in fixedWidthOptions"
+            :key="px"
+            :name="`${px}px`"
+            :value="px"
+          >
+            {{ px }}px
+          </DropdownItem>
+        </Dropdown>
+      </div>
+    </FormGroup>
+
+    <FormGroup
+      class="margin-bottom-2"
+      small-label
+      required
       :label="$t('columnElementForm.columnGapTitle')"
       :error-message="getFirstErrorMessage('column_gap')"
     >
@@ -70,11 +119,21 @@ export default {
     return {
       values: {
         column_amount: 1,
-        column_gap: 30,
+        column_gap: 20,
         alignment: VERTICAL_ALIGNMENTS.TOP,
+        layout_type: 'auto',
+        column_widths: [],
         styles: {},
       },
-      allowedValues: ['column_amount', 'column_gap', 'alignment', 'styles'],
+      allowedValues: [
+        'column_amount',
+        'column_gap',
+        'alignment',
+        'layout_type',
+        'column_widths',
+        'styles',
+      ],
+      fixedWidthOptions: [100, 150, 200, 250, 300, 350, 400, 500],
     }
   },
   computed: {
@@ -87,12 +146,57 @@ export default {
         value: columnAmount + 1,
       }))
     },
+    availableLayoutTypes() {
+      const amount = this.values.column_amount
+      const types = [
+        { name: 'Auto (equal widths)', value: 'auto' },
+        { name: 'Custom', value: 'custom' },
+      ]
+
+      if (amount === 2) {
+        types.push(
+          { name: '1:2 (narrow:wide)', value: '1:2' },
+          { name: '2:1 (wide:narrow)', value: '2:1' }
+        )
+      }
+
+      if (amount === 3) {
+        types.push(
+          { name: '1:1:2 (narrow:narrow:wide)', value: '1:1:2' },
+          { name: '2:1:1 (wide:narrow:narrow)', value: '2:1:1' }
+        )
+      }
+
+      return types
+    },
+  },
+  watch: {
+    'values.column_amount'(newAmount, oldAmount) {
+      const availableValues = this.availableLayoutTypes.map((t) => t.value)
+      if (!availableValues.includes(this.values.layout_type)) {
+        this.values.layout_type = 'auto'
+      }
+
+      if (this.values.layout_type === 'custom') {
+        this.initializeColumnWidths(newAmount)
+      }
+    },
+    'values.layout_type'(newType) {
+      if (newType === 'custom') {
+        this.initializeColumnWidths(this.values.column_amount)
+      }
+    },
   },
   methods: {
     emitChange(newValues) {
       if (this.isFormValid()) {
         form.methods.emitChange.bind(this)(newValues)
       }
+    },
+    initializeColumnWidths(amount) {
+      if (this.values.column_widths.length === amount) return
+
+      this.values.column_widths = Array(amount).fill('auto')
     },
   },
   validations() {

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
@@ -1,13 +1,16 @@
 .column-element {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: var(--space-between-columns);
   align-items: var(--alignment);
+  flex-wrap: nowrap;
 }
 
 .column-element__column {
+  flex: 0 0 var(--column-width);
   width: var(--column-width);
+  min-width: 0;
 }
 
 .column-element__element {


### PR DESCRIPTION
closes: #3560

### What is in this PR

- Add `layout_type` field with ratio & custom options.
- Add `column_widths` JSON field for custom configuration.
- Update backend element serializer & layout logic.
- Improve ColumnElement.vue to compute dynamic widths.