### PR TITLE
Keep websocket connection open longer by sending ping

### DIFF
--- a/backend/src/baserow/ws/consumers.py
+++ b/backend/src/baserow/ws/consumers.py
@@ -158,8 +158,6 @@ class CoreConsumer(AsyncJsonWebsocketConsumer):
         Processes incoming messages.
         """
 
-        if content.get("type") == "ping":
-            await self.send_json({"type": "pong"})
         if "page" in content:
             await self._add_page_scope(content)
         if "remove_page" in content:

--- a/changelog/entries/unreleased/bug/change_websocket_connection_error.json
+++ b/changelog/entries/unreleased/bug/change_websocket_connection_error.json
@@ -1,8 +1,8 @@
 {
   "type": "bug",
-  "message": "Send ping event during websocket to keep the connection open longer.",
+  "message": "Change WebSocket connection closed error message.",
   "issue_origin": "github",
-  "issue_number": 1924,
+  "issue_number": null,
   "domain": "core",
   "bullet_points": [],
   "created_at": "2025-11-24"

--- a/web-frontend/modules/core/plugins/realTimeHandler.js
+++ b/web-frontend/modules/core/plugins/realTimeHandler.js
@@ -15,7 +15,6 @@ export class RealTimeHandler {
     this.subscribedToPages = true
     this.lastToken = null
     this.authenticationSuccess = true
-    this.heartBeatInterval = null
     this.registerCoreEvents()
   }
 
@@ -62,7 +61,6 @@ export class RealTimeHandler {
       this.context.store.dispatch('toast/setConnecting', false)
       this.connected = true
       this.attempts = 0
-      this.startHeartbeat()
 
       // If the client needs to be subscribed to a page we can do that directly
       // after connecting.
@@ -99,7 +97,6 @@ export class RealTimeHandler {
      */
     this.socket.onclose = () => {
       this.connected = false
-      this.stopHeartbeat()
       // By default the user not subscribed to a page a.k.a `null`, so if the current
       // page is already null we can mark it as subscribed.
       this.subscribedToPages = this.pages.length === 0
@@ -126,34 +123,6 @@ export class RealTimeHandler {
       // After the first try, we want to try again every 5 seconds.
       this.attempts > 1 ? 5000 : 0
     )
-  }
-
-  /**
-   * Starts the heart beat interval. This allows to keep the websocket connection
-   * open longer in some situations. We want to avoid losing the websocket
-   * connection and forcing the user to reload the page.
-   */
-  startHeartbeat() {
-    if (this.heartBeatInterval) {
-      clearInterval(this.heartBeatInterval)
-    }
-
-    this.heartBeatInterval = setInterval(() => {
-      if (
-        this.connected &&
-        this.socket &&
-        this.socket.readyState === WebSocket.OPEN
-      ) {
-        this.socket.send(JSON.stringify({ type: 'ping' }))
-      }
-    }, 1000) // every 30 seconds.
-  }
-
-  stopHeartbeat() {
-    if (this.heartBeatInterval) {
-      clearInterval(this.heartBeatInterval)
-      this.heartBeatInterval = null
-    }
   }
 
   /**
@@ -239,7 +208,6 @@ export class RealTimeHandler {
       this.socket.close()
     }
 
-    this.stopHeartbeat()
     this.context.store.dispatch('toast/setConnecting', false)
     this.context.store.dispatch('toast/setFailedConnecting', false)
     clearTimeout(this.reconnectTimeout)


### PR DESCRIPTION
### What is in this PR

This pull request is related to #1924, but does not 100% fix it. If we want to solve the full problem we would need to introduce some sort of reloading mechanism when a tab becomes idle and doesn't receive real-time events anymore. These changes mitigate the problem by:

* Sending `ping` event to the backend, which responds with `pong` to show that there is still activity going on. I've found some online resources explaining that it could help to prevent the tab from becoming idle.
* Updated the description of the reconnect/failed toast to explain the situation better. It's not about the server connection being lost, but rather not being able to receive real-time updates.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
