### PR TITLE
Prevent always setting LLM model in Helm Chart

### DIFF
--- a/changelog/entries/unreleased/bug/fix_bug_in_helm_chart_where_assistant_llm_always_set.json
+++ b/changelog/entries/unreleased/bug/fix_bug_in_helm_chart_where_assistant_llm_always_set.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fix bug in the Helm chart where the AI-assistant LLM model was always set.",
+  "issue_origin": "core",
+  "issue_number": null,
+  "domain": "builder",
+  "bullet_points": [],
+  "created_at": "2025-11-25"
+}

--- a/deploy/helm/baserow/values.yaml
+++ b/deploy/helm/baserow/values.yaml
@@ -59,7 +59,7 @@ global:
     domain: cluster.local
     backendDomain: api.cluster.local
     objectsDomain: objects.cluster.local
-    assistantLLMModel: "groq/openai/gpt-oss-120b"
+    assistantLLMModel: ""
 
     securityContext:
       enabled: false


### PR DESCRIPTION
### What is in this PR

This merge request fixes a small bug where the LLM model is always set in the Helm chart. The environment variable should be empty or not set, otherwise it shows Kuma as active, even though it does not work.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
