### PR TITLE
chore: fix OpenAPI spec for generate_table_ai_field_value

### DIFF
--- a/changelog/entries/unreleased/bug/4339_fix_openapi_spec_for_generate_table_ai_field_value.json
+++ b/changelog/entries/unreleased/bug/4339_fix_openapi_spec_for_generate_table_ai_field_value.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix OpenAPI spec for generate_table_ai_field_value",
+    "issue_origin": "github",
+    "issue_number": 4339,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2025-11-26"
+}

--- a/premium/backend/src/baserow_premium/api/fields/views.py
+++ b/premium/backend/src/baserow_premium/api/fields/views.py
@@ -79,9 +79,9 @@ class AsyncGenerateAIFieldValuesView(APIView):
             "dynamically constructed prompt configured in the field settings. "
             "\nThis is a **premium** feature."
         ),
-        request=None,
+        request=GenerateAIFieldValueViewSerializer,
         responses={
-            200: str,
+            202: GenerateAIValuesJobType().response_serializer_class,
             400: get_error_schema(
                 [
                     "ERROR_GENERATIVE_AI_DOES_NOT_EXIST",


### PR DESCRIPTION
### What is in this PR
- A fix for #4339 

### How to test this PR
- Verify the OpenAPI spec for the endpoint

Closes #4339 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
