### PR TITLE
Handle exceptions like GenerativeAIPromptError in UI

### DIFF
--- a/backend/src/baserow/contrib/database/ws/rows/signals.py
+++ b/backend/src/baserow/contrib/database/ws/rows/signals.py
@@ -131,7 +131,7 @@ def rows_ai_values_generation_error(
                 "row_ids": [row.id for row in rows],
                 "error": error_message,
             },
-            getattr(user, "web_socket_id", None),
+            None,
             table_id=table.id,
         )
     )

--- a/changelog/entries/unreleased/bug/4350_handle_exceptions_like_generativeaiprompterror_in_ui.json
+++ b/changelog/entries/unreleased/bug/4350_handle_exceptions_like_generativeaiprompterror_in_ui.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Handle exceptions like GenerativeAIPromptError in UI",
+    "issue_origin": "github",
+    "issue_number": 4350,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2025-12-01"
+}

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -738,6 +738,14 @@ export const mutations = {
       Vue.delete(state.pendingFieldOps, key)
     })
   },
+  CLEAR_ALL_PENDING_FIELD_OPERATIONS_FOR_FIELD(state, { fieldId }) {
+    const keysToDelete = Object.keys(state.pendingFieldOps).filter(
+      (key) => state.pendingFieldOps[key][0] === fieldId
+    )
+    keysToDelete.forEach((key) => {
+      Vue.delete(state.pendingFieldOps, key)
+    })
+  },
   UPDATE_ROW_HEIGHT(state, value) {
     state.rowHeight = value
   },
@@ -3459,7 +3467,12 @@ export const actions = {
     commit('SET_PENDING_FIELD_OPERATIONS', { fieldId, rowIds, value })
   },
   AIValuesGenerationError({ commit, dispatch }, { fieldId, rowIds }) {
-    commit('SET_PENDING_FIELD_OPERATIONS', { fieldId, rowIds, value: false })
+    // If rowIds is empty, clear ALL pending operations for this field.
+    if (rowIds.length === 0) {
+      commit('CLEAR_ALL_PENDING_FIELD_OPERATIONS_FOR_FIELD', { fieldId })
+    } else {
+      commit('SET_PENDING_FIELD_OPERATIONS', { fieldId, rowIds, value: false })
+    }
     dispatch(
       'toast/error',
       {


### PR DESCRIPTION
### What is in this PR
This PR fixes issue #4350 

When celery task raise exception it's now handled in UI

https://github.com/user-attachments/assets/5ba489a1-5d91-4de0-8026-30ece4d45bf9



### How to test this PR
- have premium license
- define AI provider/model but setup non existing model
- have  AI field in table
- select range and generate AI values. Observe that toast is shown and spinner is removed

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
