### PR TITLE
Add ability to defer signals/tasks in tests

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -52,3 +52,5 @@ markers =
     data_sync: All tests related to data sync functionality
     replica: All tests related to db replicas
     workspace_search: All tests related to workspace search functionality
+    enable_all_signals: Disables signal deferral for this test (all signals enabled)
+    enable_signals: Enables specific signals for this test (accepts dotted callable paths)

--- a/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
+++ b/backend/tests/baserow/contrib/builder/api/data_sources/test_data_source_views.py
@@ -1183,6 +1183,10 @@ def test_dispatch_data_source_with_adhoc_sortings(api_client, data_fixture):
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_dispatch_data_source_with_adhoc_search(api_client, data_fixture):
     with transaction.atomic():
         user, token = data_fixture.create_user_and_token()

--- a/backend/tests/baserow/contrib/database/api/rows/test_row_views.py
+++ b/backend/tests/baserow/contrib/database/api/rows/test_row_views.py
@@ -3678,6 +3678,10 @@ def test_get_row_adjacent_view_invalid_requests(api_client, data_fixture):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_get_row_adjacent_search(api_client, data_fixture, search_mode):
     user, jwt_token = data_fixture.create_user_and_token(
         email="test@test.nl", password="password", first_name="Test1"

--- a/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
@@ -1249,6 +1249,10 @@ def test_list_rows_public_with_query_param_advanced_filters(api_client, data_fix
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_list_rows_public_only_searches_by_visible_columns(
     api_client, data_fixture, search_mode
 ):

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
@@ -4024,6 +4024,10 @@ def test_list_rows_public_filters_by_visible_and_hidden_columns(
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_list_rows_public_only_searches_by_visible_columns(
     api_client, data_fixture, search_mode
 ):

--- a/backend/tests/baserow/contrib/database/api/views/test_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/test_view_views.py
@@ -1172,6 +1172,9 @@ def test_view_cant_update_allow_public_export(data_fixture, api_client):
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_loading_a_sortable_view_will_create_an_index(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)

--- a/backend/tests/baserow/contrib/database/field/test_field_notification_types.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_notification_types.py
@@ -31,6 +31,11 @@ from baserow.test_utils.helpers import (
     assert_undo_redo_actions_are_valid,
 )
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.core.notifications.tasks.send_queued_notifications_to_users.delay",
+    "baserow.ws.tasks.broadcast_to_users.delay",
+)
+
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")

--- a/backend/tests/baserow/contrib/database/field/test_link_row_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_link_row_field_type.py
@@ -1185,6 +1185,10 @@ def test_link_row_field_type_api_row_views(api_client, data_fixture):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.field_link_row
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_import_export_link_row_field(data_fixture):
     user = data_fixture.create_user()
     imported_workspace = data_fixture.create_workspace(user=user)

--- a/backend/tests/baserow/contrib/database/field/test_multiple_collaborators_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_multiple_collaborators_field_type.py
@@ -832,6 +832,10 @@ def test_multiple_collaborators_field_type_values_can_be_stringified(data_fixtur
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.field_multiple_collaborators
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_multiple_collaborators_field_type_values_can_be_searched(data_fixture):
     mario = data_fixture.create_user(first_name="Mario")
     luigi = data_fixture.create_user(first_name="Luigi")

--- a/backend/tests/baserow/contrib/database/rows/test_row_history.py
+++ b/backend/tests/baserow/contrib/database/rows/test_row_history.py
@@ -1163,6 +1163,7 @@ def test_create_rows_action_row_history_with_undo_redo(
 )
 @pytest.mark.django_db
 @pytest.mark.row_history
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_delete_rows_action_row_history_with_undo_redo(
     data_fixture, action_type: "ActionType", input_values: Callable
 ):

--- a/backend/tests/baserow/contrib/database/search/test_search_compatibility.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_compatibility.py
@@ -11,6 +11,11 @@ from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.table.handler import TableHandler
 from baserow.core.user_files.handler import UserFileHandler
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+
 
 @pytest.mark.django_db(transaction=True)
 def test_search_compatibility_between_current_and_postgres(data_fixture, tmpdir):

--- a/backend/tests/baserow/contrib/database/search/test_search_handler.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_handler.py
@@ -16,6 +16,11 @@ from baserow.core.snapshots.handler import SnapshotHandler
 from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import Progress
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+
 
 def test_escape_query():
     # Spacing is standardized.

--- a/backend/tests/baserow/contrib/database/search/test_search_indexing.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_indexing.py
@@ -14,6 +14,11 @@ from baserow.contrib.database.search.handler import SearchHandler
 from baserow.contrib.database.table.handler import TableHandler
 from baserow.core.user_files.handler import UserFileHandler
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+
 
 @pytest.mark.django_db(transaction=True)
 def test_textfield_get_search_expression(data_fixture):

--- a/backend/tests/baserow/contrib/database/search/test_search_tasks.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_tasks.py
@@ -6,6 +6,11 @@ from baserow.contrib.database.search.handler import SearchHandler
 from baserow.contrib.database.search.models import PendingSearchValueUpdate
 from baserow.contrib.database.search.tasks import periodic_check_pending_search_data
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+
 
 @pytest.mark.django_db(transaction=True)
 def test_periodic_check_pending_search_data(data_fixture):

--- a/backend/tests/baserow/contrib/database/search/test_search_views.py
+++ b/backend/tests/baserow/contrib/database/search/test_search_views.py
@@ -9,6 +9,11 @@ from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.search.handler import SearchMode
 from baserow.test_utils.helpers import setup_interesting_test_table
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
+
 
 @pytest.mark.django_db
 def test_search_grid_with_invalid_mode(api_client, data_fixture):

--- a/backend/tests/baserow/contrib/database/table/test_table_handler.py
+++ b/backend/tests/baserow/contrib/database/table/test_table_handler.py
@@ -1115,6 +1115,9 @@ def test_usage_is_calculated_correctly_when_a_template_is_installed(
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.table.tasks.update_table_usage.delay"
+)
 def test_usage_is_calculated_correctly_when_creating_a_new_table(data_fixture):
     user = data_fixture.create_user()
     database = data_fixture.create_database_application(user=user)

--- a/backend/tests/baserow/contrib/database/table/test_table_usage_types.py
+++ b/backend/tests/baserow/contrib/database/table/test_table_usage_types.py
@@ -9,6 +9,10 @@ from baserow.contrib.database.table.usage_types import (
 from baserow.core.trash.handler import TrashHandler
 from baserow.core.usage.registries import USAGE_UNIT_MB
 
+pytestmark = pytest.mark.enable_signals(
+    "baserow.contrib.database.table.tasks.update_table_usage.delay",
+)
+
 
 @pytest.mark.django_db(transaction=True)
 def test_table_workspace_storage_usage_item_type(data_fixture):

--- a/backend/tests/baserow/contrib/database/view/test_view_handler.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_handler.py
@@ -2275,6 +2275,10 @@ def test_get_public_rows_queryset_and_field_ids_view_filters_applied(data_fixtur
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_get_public_rows_queryset_and_field_ids_view_search(data_fixture, search_mode):
     grid_view = data_fixture.create_grid_view(public=True)
     table = grid_view.table
@@ -3022,6 +3026,9 @@ def test_order_views_ownership_type(data_fixture):
 
 @override_settings(AUTO_INDEX_VIEW_ENABLED=True)
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_creating_view_sort_creates_a_new_index(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
@@ -3052,6 +3059,9 @@ def test_creating_view_sort_creates_a_new_index(data_fixture):
     AUTO_INDEX_VIEW_ENABLED=True,
 )
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_updating_view_sorts_creates_a_new_index_and_delete_the_unused_one(
     data_fixture,
 ):
@@ -3110,6 +3120,9 @@ def test_updating_view_sorts_creates_a_new_index_and_delete_the_unused_one(
 
 @override_settings(AUTO_INDEX_VIEW_ENABLED=True)
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_perm_deleting_view_remove_index_if_unused(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
@@ -3150,6 +3163,9 @@ def test_perm_deleting_view_remove_index_if_unused(data_fixture):
 
 @override_settings(AUTO_INDEX_VIEW_ENABLED=True)
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_duplicating_table_do_not_duplicate_indexes(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
@@ -3179,6 +3195,9 @@ def test_duplicating_table_do_not_duplicate_indexes(data_fixture):
 
 @override_settings(AUTO_INDEX_VIEW_ENABLED=True)
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_deleting_a_field_of_a_view_sort_update_view_indexes(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
@@ -3207,6 +3226,9 @@ def test_deleting_a_field_of_a_view_sort_update_view_indexes(data_fixture):
 
 @override_settings(AUTO_INDEX_VIEW_ENABLED=True)
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_changing_a_field_type_of_a_view_sort_to_non_orderable_one_delete_view_index(
     data_fixture,
 ):
@@ -3231,6 +3253,9 @@ def test_changing_a_field_type_of_a_view_sort_to_non_orderable_one_delete_view_i
 
 @patch("baserow.contrib.database.views.tasks.update_view_index.delay")
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_loading_a_view_checks_for_db_index_without_additional_queries(
     mocked_view_index_update_task,
     data_fixture,
@@ -3291,6 +3316,9 @@ def test_loading_a_view_checks_for_db_index_without_additional_queries(
     AUTO_INDEX_VIEW_ENABLED=True,
 )
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_update_index_replaces_index_with_diff_collation(settings, data_fixture):
     with patch("baserow.core.db.get_collation_name", new=lambda: None):
         user = data_fixture.create_user()
@@ -3328,6 +3356,9 @@ def test_update_index_replaces_index_with_diff_collation(settings, data_fixture)
     AUTO_INDEX_VIEW_ENABLED=True,
 )
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.views.tasks.update_view_index.delay"
+)
 def test_view_loaded_replaces_index_with_diff_collation(settings, data_fixture):
     with patch("baserow.core.db.get_collation_name", new=lambda: None):
         user = data_fixture.create_user()

--- a/backend/tests/baserow/contrib/database/view/test_view_notification_types.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_notification_types.py
@@ -17,6 +17,7 @@ from baserow.test_utils.helpers import AnyInt, setup_interesting_test_table
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_user_receive_notification_on_form_submit(
     mocked_broadcast_to_users, api_client, data_fixture
 ):
@@ -130,6 +131,7 @@ def test_user_receive_notification_on_form_submit(
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_all_interested_users_receive_the_notification_on_form_submit(
     mocked_broadcast_to_users, api_client, data_fixture
 ):
@@ -178,6 +180,7 @@ def test_all_interested_users_receive_the_notification_on_form_submit(
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_only_users_with_access_to_the_table_receive_the_notification_on_form_submit(
     mocked_broadcast_to_users, api_client, data_fixture
 ):
@@ -325,6 +328,7 @@ def test_form_submit_notification_can_be_render_as_email(api_client, data_fixtur
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_can_user_receive_notification_for_all_interesting_field_values(
     mocked_broadcast_to_users, api_client, data_fixture
 ):

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
@@ -420,6 +420,10 @@ def test_local_baserow_aggregate_rows_dispatch_data_with_service_filters(data_fi
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_local_baserow_aggregate_rows_dispatch_data_with_search(data_fixture):
     with transaction.atomic():
         user = data_fixture.create_user()

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_mixins.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_mixins.py
@@ -434,6 +434,10 @@ def test_local_baserow_table_service_sortable_mixin_get_dispatch_sorts_raises_ex
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.enable_signals(
+    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
+    "baserow.contrib.database.search.tasks.update_search_data.delay",
+)
 def test_local_baserow_table_service_searchable_mixin_get_table_queryset(
     data_fixture,
 ):

--- a/backend/tests/baserow/core/notifications/test_notifications_handler.py
+++ b/backend/tests/baserow/core/notifications/test_notifications_handler.py
@@ -299,6 +299,10 @@ def test_queued_notifications_are_not_visible_to_the_users(
 
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals(
+    "baserow.core.notifications.tasks.send_queued_notifications_to_users.delay",
+    "baserow.ws.tasks.broadcast_to_users.delay",
+)
 def test_queued_notifications_are_sent_grouped_by_user(
     mocked_broadcast_to_users,
     data_fixture,

--- a/changelog/entries/unreleased/refactor/4373_optimize_test_suite_by_deferring_heavy_signals_by_default.json
+++ b/changelog/entries/unreleased/refactor/4373_optimize_test_suite_by_deferring_heavy_signals_by_default.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Optimize test suite by deferring heavy signals by default",
+    "issue_origin": "github",
+    "issue_number": 4373,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2025-12-02"
+}

--- a/enterprise/backend/tests/baserow_enterprise_tests/ws/test_database_rbac.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/ws/test_database_rbac.py
@@ -127,6 +127,7 @@ async def test_database_created_message_not_leaking(data_fixture):
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 @pytest.mark.websockets
+@pytest.mark.enable_all_signals
 async def test_workspace_restored_applications_arent_leaked(data_fixture):
     user_excluded, token = data_fixture.create_user_and_token()
     workspace = data_fixture.create_workspace(user=user_excluded)

--- a/enterprise/backend/tests/baserow_enterprise_tests/ws/test_role_signals.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/ws/test_role_signals.py
@@ -449,6 +449,7 @@ async def test_unsubscribe_subject_from_table_teams_multiple_users(
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.websockets
 @pytest.mark.flaky(retries=3, delay=1)
+@pytest.mark.enable_all_signals
 async def test_unsubscribe_user_from_tables_and_rows_when_role_updated(data_fixture):
     channel_layer = get_channel_layer()
     user_1, token_1 = data_fixture.create_user_and_token()
@@ -538,6 +539,7 @@ async def test_unsubscribe_user_from_tables_and_rows_when_role_updated(data_fixt
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.websockets
 @pytest.mark.flaky(retries=3, delay=1)
+@pytest.mark.enable_all_signals
 async def test_unsubscribe_user_from_tables_and_rows_when_team_trashed(
     data_fixture, enterprise_data_fixture
 ):

--- a/enterprise/backend/tests/baserow_enterprise_tests/ws/test_table_rbac.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/ws/test_table_rbac.py
@@ -120,6 +120,7 @@ async def test_table_created_message_not_leaking(data_fixture):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+@pytest.mark.enable_all_signals
 async def test_workspace_restored_tables_not_leaking(data_fixture):
     user = data_fixture.create_user()
     user_excluded, token = data_fixture.create_user_and_token()
@@ -153,6 +154,7 @@ async def test_workspace_restored_tables_not_leaking(data_fixture):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
+@pytest.mark.enable_all_signals
 async def test_database_restored_tables_not_leaking(data_fixture):
     user = data_fixture.create_user()
     user_excluded, token = data_fixture.create_user_and_token()

--- a/premium/backend/tests/baserow_premium_tests/row_comments/test_row_comments_handler.py
+++ b/premium/backend/tests/baserow_premium_tests/row_comments/test_row_comments_handler.py
@@ -255,7 +255,7 @@ def test_row_comment_deleted_signal_called(
     assert args == call(RowCommentHandler, row_comment=c, user=user, mentions=[])
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(DEBUG=True)
 def test_row_comment_mentions_are_created(premium_data_fixture):
     user = premium_data_fixture.create_user(
@@ -277,7 +277,7 @@ def test_row_comment_mentions_are_created(premium_data_fixture):
     assert list(c.mentions.all()) == [user2]
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(DEBUG=True)
 def test_row_comment_cant_mention_user_outside_workspace(premium_data_fixture):
     user = premium_data_fixture.create_user(
@@ -297,7 +297,7 @@ def test_row_comment_cant_mention_user_outside_workspace(premium_data_fixture):
     assert comment.mentions.count() == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @override_settings(DEBUG=True)
 def test_user_change_row_comments_notification_mode(premium_data_fixture):
     user = premium_data_fixture.create_user(

--- a/premium/backend/tests/baserow_premium_tests/row_comments/test_row_comments_notification_types.py
+++ b/premium/backend/tests/baserow_premium_tests/row_comments/test_row_comments_notification_types.py
@@ -274,6 +274,7 @@ def test_email_notifications_are_created_correctly(
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
 @override_settings(DEBUG=True)
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_user_receive_notification_if_subscribed_for_comments_on_a_row(
     mocked_broadcast_to_users, api_client, premium_data_fixture
 ):
@@ -435,6 +436,7 @@ def test_user_receive_notification_if_subscribed_for_comments_on_a_row(
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
 @override_settings(DEBUG=True)
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_all_interested_users_receive_the_notification_when_a_comment_is_posted(
     mocked_broadcast_to_users, api_client, premium_data_fixture
 ):
@@ -516,6 +518,7 @@ def test_all_interested_users_receive_the_notification_when_a_comment_is_posted(
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
 @override_settings(DEBUG=True)
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_only_users_with_access_to_the_table_receive_the_notification_for_new_comments(
     mocked_broadcast_to_users, api_client, premium_data_fixture
 ):

--- a/premium/backend/tests/baserow_premium_tests/views/test_premium_view_notification_types.py
+++ b/premium/backend/tests/baserow_premium_tests/views/test_premium_view_notification_types.py
@@ -14,6 +14,7 @@ from baserow.contrib.database.views.handler import ViewHandler
 @pytest.mark.django_db(transaction=True)
 @override_settings(DEBUG=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_user_stop_receiving_notification_if_another_user_change_view_ownership(
     mocked_broadcast_to_users, api_client, premium_data_fixture
 ):

--- a/premium/backend/tests/baserow_premium_tests/ws/test_ws_row_comments_signals.py
+++ b/premium/backend/tests/baserow_premium_tests/ws/test_ws_row_comments_signals.py
@@ -200,6 +200,7 @@ def test_row_comment_restored(premium_data_fixture):
 @pytest.mark.django_db(transaction=True)
 @patch("baserow.ws.tasks.broadcast_to_users.apply")
 @override_settings(DEBUG=True)
+@pytest.mark.enable_signals("baserow.ws.tasks.broadcast_to_users.delay")
 def test_row_comments_notification_mode_updated(
     mocked_broadcast_to_users,
     premium_data_fixture,


### PR DESCRIPTION
### What is in this PR
Closes #4373


* Add global autouse fixture that defers heavy Celery tasks and WebSocket broadcasts during tests
* Tests that need these signals can opt-out using `@pytest.mark.enable_all_signals` or `@pytest.mark.enable_signals("path.to.callable")`

By default defer:

```
    "baserow.ws.tasks.broadcast_to_channel_group.delay",
    "baserow.ws.tasks.broadcast_to_users.delay",
    "baserow.ws.tasks.broadcast_to_permitted_users.delay",
    "baserow.ws.tasks.broadcast_to_group.delay",
    "baserow.ws.tasks.broadcast_to_groups.delay",
    "baserow.ws.tasks.broadcast_application_created.delay",
    "baserow.contrib.database.search.tasks.schedule_update_search_data.delay",
    "baserow.contrib.database.search.tasks.update_search_data.delay",
    "baserow.contrib.database.table.tasks.update_table_usage.delay",
    "baserow.core.notifications.tasks.send_queued_notifications_to_users.delay",
    "baserow.contrib.database.views.tasks.update_view_index.delay",
```

By defering them we can gain ~10% speed of the tests.


### How to test this PR
* Run tests on develop branch
* Run tests with the same conditions on this branch
* Observe there are passing and they are faster than on develop

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
