### PR TITLE
Fix data node usage in HTML content

### DIFF
--- a/changelog/entries/unreleased/bug/4377_fix_formulainputfield_display_with_mixed_content.json
+++ b/changelog/entries/unreleased/bug/4377_fix_formulainputfield_display_with_mixed_content.json
@@ -1,9 +1,9 @@
 {
     "type": "bug",
-    "message": "Fix FormulaInputField display with mixed content",
+    "message": "Resolved a bug which prevented formula fields from working correctly with HTML content.",
     "issue_origin": "github",
     "issue_number": 4377,
-    "domain": "automation",
+    "domain": "core",
     "bullet_points": [],
     "created_at": "2025-12-03"
 }

--- a/web-frontend/modules/core/components/formula/FormulaInputContext.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputContext.vue
@@ -14,7 +14,7 @@
       @node-selected="$emit('node-selected', $event)"
       @node-unselected="$emit('node-unselected')"
     />
-    <div v-if="enableAdvancedMode" class="formula-input-context__footer">
+    <div v-if="advancedModeEnabled" class="formula-input-context__footer">
       <ButtonText
         type="primary"
         icon="iconoir-input-field"
@@ -59,6 +59,7 @@
 <script>
 import context from '@baserow/modules/core/mixins/context'
 import NodeExplorer from '@baserow/modules/core/components/nodeExplorer/NodeExplorer'
+import { BASEROW_FORMULA_MODES } from '@baserow/modules/core/formula/constants'
 
 export default {
   name: 'FormulaInputContext',
@@ -87,7 +88,7 @@ export default {
       required: false,
       default: 'advanced',
       validator: (value) => {
-        return ['advanced', 'simple'].includes(value)
+        return BASEROW_FORMULA_MODES.includes(value)
       },
     },
     allowNodeSelection: {
@@ -95,10 +96,14 @@ export default {
       required: false,
       default: false,
     },
-    enableAdvancedMode: {
-      type: Boolean,
-      required: false,
-      default: true,
+    /**
+     * An array of Baserow formula modes which the parent formula input
+     * component allows to be used. By default, in `FormulaInputField`,
+     * we will allow all modes.
+     */
+    enabledModes: {
+      type: Array,
+      required: true,
     },
   },
   data() {
@@ -113,6 +118,9 @@ export default {
     }
   },
   computed: {
+    advancedModeEnabled() {
+      return this.enabledModes.includes('advanced')
+    },
     isAdvancedMode() {
       return this.mode === 'advanced'
     },

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -21,7 +21,7 @@
       :mode="mode"
       :allow-node-selection="allowNodeSelection"
       :nodes-hierarchy="nodesHierarchy"
-      :enable-advanced-mode="enableAdvancedMode"
+      :enabled-modes="enabledModes"
       @node-selected="handleNodeSelected"
       @node-unselected="unSelectNode"
       @mode-changed="handleModeChange"
@@ -75,6 +75,7 @@ import FormulaInputContext from '@baserow/modules/core/components/formula/Formul
 import { isFormulaValid } from '@baserow/modules/core/formula'
 import NodeHelpTooltip from '@baserow/modules/core/components/nodeExplorer/NodeHelpTooltip'
 import { fixPropertyReactivityForProvide } from '@baserow/modules/core/utils/object'
+import { BASEROW_FORMULA_MODES } from '@baserow/modules/core/formula/constants'
 
 export default {
   name: 'FormulaInputField',
@@ -139,7 +140,7 @@ export default {
       required: false,
       default: 'simple',
       validator: (value) => {
-        return ['advanced', 'simple', 'raw'].includes(value)
+        return BASEROW_FORMULA_MODES.includes(value)
       },
     },
     contextPosition: {
@@ -150,10 +151,14 @@ export default {
         return ['bottom', 'left', 'right'].includes(value)
       },
     },
-    enableAdvancedMode: {
-      type: Boolean,
+    /**
+     * An array of Baserow formula modes which the parent formula input
+     * component allows to be used. By default, we will allow all modes.
+     */
+    enabledModes: {
+      type: Array,
       required: false,
-      default: true,
+      default: () => BASEROW_FORMULA_MODES,
     },
   },
   data() {
@@ -452,7 +457,6 @@ export default {
     emitChange() {
       const functions = new RuntimeFunctionCollection(this.$registry)
       const formula = this.toFormula(this.wrapperContent)
-      console.log(formula)
       this.isFormulaInvalid = !isFormulaValid(formula, functions)
 
       if (!this.isFormulaInvalid) {

--- a/web-frontend/modules/core/components/formula/InjectedFormulaInput.vue
+++ b/web-frontend/modules/core/components/formula/InjectedFormulaInput.vue
@@ -2,7 +2,6 @@
   <component
     :is="formulaComponent"
     :data-providers-allowed="dataProvidersAllowed || []"
-    :enable-advanced-mode="enableAdvancedMode"
     v-bind="$attrs"
     @input="$emit('input', $event)"
   >
@@ -16,12 +15,5 @@
 export default {
   name: 'InjectedFormulaInput',
   inject: ['formulaComponent', 'dataProvidersAllowed'],
-  props: {
-    enableAdvancedMode: {
-      type: Boolean,
-      required: false,
-      default: true,
-    },
-  },
 }
 </script>

--- a/web-frontend/modules/core/formula/constants.js
+++ b/web-frontend/modules/core/formula/constants.js
@@ -1,0 +1,1 @@
+export const BASEROW_FORMULA_MODES = ['raw', 'simple', 'advanced']

--- a/web-frontend/modules/integrations/core/components/services/CoreHTTPRequestServiceForm.vue
+++ b/web-frontend/modules/integrations/core/components/services/CoreHTTPRequestServiceForm.vue
@@ -168,7 +168,11 @@
     >
       <InjectedFormulaInput
         v-model="values.body_content"
-        :enable-advanced-mode="values.body_type === 'html' ? false : true"
+        :enabled-modes="
+          values.body_type === 'plain'
+            ? BASEROW_FORMULA_MODES
+            : ['raw', 'simple']
+        "
         :placeholder="$t('coreHTTPRequestServiceForm.bodyPlaceholder')"
       />
     </FormGroup>
@@ -262,6 +266,7 @@ import {
   helpers,
 } from '@vuelidate/validators'
 import { uuid } from '@baserow/modules/core/utils/string'
+import { BASEROW_FORMULA_MODES } from '@baserow/modules/core/formula/constants'
 
 export default {
   name: 'CoreHTTPRequestService',
@@ -296,6 +301,9 @@ export default {
     }
   },
   computed: {
+    BASEROW_FORMULA_MODES() {
+      return BASEROW_FORMULA_MODES
+    },
     methods() {
       return [
         { name: 'GET', value: 'GET' },

--- a/web-frontend/modules/integrations/core/components/services/CoreSMTPEmailServiceForm.vue
+++ b/web-frontend/modules/integrations/core/components/services/CoreSMTPEmailServiceForm.vue
@@ -101,7 +101,11 @@
     >
       <InjectedFormulaInput
         v-model="values.body"
-        :enable-advanced-mode="values.body_type === 'html' ? false : true"
+        :enabled-modes="
+          values.body_type === 'plain'
+            ? BASEROW_FORMULA_MODES
+            : ['raw', 'simple']
+        "
         :placeholder="$t('smtpEmailForm.bodyPlaceholder')"
         textarea
       />
@@ -114,6 +118,7 @@ import form from '@baserow/modules/core/mixins/form'
 import InjectedFormulaInput from '@baserow/modules/core/components/formula/InjectedFormulaInput'
 import IntegrationDropdown from '@baserow/modules/core/components/integrations/IntegrationDropdown'
 import { SMTPIntegrationType } from '@baserow/modules/integrations/core/integrationTypes'
+import { BASEROW_FORMULA_MODES } from '@baserow/modules/core/formula/constants'
 
 export default {
   name: 'CoreSMTPEmailServiceForm',
@@ -161,6 +166,9 @@ export default {
     }
   },
   computed: {
+    BASEROW_FORMULA_MODES() {
+      return BASEROW_FORMULA_MODES
+    },
     integrations() {
       if (!this.application) {
         return []


### PR DESCRIPTION
### What is in this PR
Fixes #4377 
The FormulaComponent crashes in simple mode when mixed contents including HTML, line breaks, and data nodes, are present.
We have also agreed to disable the Formula Input advanced mode when the body type is set to HTML, cause some HTML characters (`<` or `>` for instance) are interpreted as operators in advanced mode. 


### How to test this PR

- Set up a Send email node in an automation. Set the body type to HTML. 
- Confirm the advanced mode cannot be toggled
- Try to type something like in an HTML Body field 

```
<h1>Hello<h1>
[LINEBREAK]
<p>[DATA_NODE]</p>
```
- Click on another automation node and click again on the email one, and confirm the Body field is still displaying as expected. 


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
