### PR TITLE
feature: unpublish-application

### DIFF
--- a/backend/src/baserow/contrib/builder/api/domains/views.py
+++ b/backend/src/baserow/contrib/builder/api/domains/views.py
@@ -356,6 +356,57 @@ class AsyncPublishDomainView(APIView):
         return Response(serializer.data, status=HTTP_202_ACCEPTED)
 
 
+class UnpublishDomainView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="domain_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The domain id the user wants to unpublish.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+        ],
+        tags=["Builder domains"],
+        operation_id="unpublish_builder_domain",
+        description=(
+            "This endpoint unpublishes the builder for the given domain. "
+            "The published version is deleted and the domain is marked as unpublished."
+        ),
+        request=None,
+        responses={
+            200: DiscriminatorCustomFieldsMappingSerializer(
+                domain_type_registry, DomainSerializer
+            ),
+            400: get_error_schema(
+                [
+                    "ERROR_USER_NOT_IN_GROUP",
+                ]
+            ),
+            404: get_error_schema(["ERROR_DOMAIN_DOES_NOT_EXIST"]),
+        },
+    )
+    @transaction.atomic
+    @map_exceptions(
+        {
+            DomainDoesNotExist: ERROR_DOMAIN_DOES_NOT_EXIST,
+        }
+    )
+    def post(self, request, domain_id: int):
+        """
+        Unpublishes a builder for the given domain.
+        """
+
+        domain = DomainHandler().get_domain(domain_id)
+
+        domain = DomainService().unpublish(request.user, domain)
+
+        serializer = domain_type_registry.get_serializer(domain, DomainSerializer)
+        return Response(serializer.data)
+
+
 class AskPublicBuilderDomainExistsView(APIView):
     permission_classes = (AllowAny,)
 

--- a/backend/src/baserow/contrib/builder/domains/handler.py
+++ b/backend/src/baserow/contrib/builder/domains/handler.py
@@ -295,6 +295,33 @@ class DomainHandler:
 
         return domain
 
+    def unpublish(self, domain: Domain) -> Domain:
+        """
+        Unpublishes a builder for the given domain object by deleting the published
+        version and clearing the publish metadata.
+
+        :param domain: The domain to unpublish.
+        :return: The updated domain instance.
+        """
+
+        # Make sure we are the only process to update the domain to prevent race
+        # conditions
+        domain = DomainHandler().get_domain(domain.id, for_update=True)
+
+        # Delete the published builder if it exists
+        if domain.published_to:
+            domain.published_to.delete()
+
+        # Clear publish metadata
+        domain.published_to = None
+        domain.last_published = None
+        domain.save()
+
+        # Invalidate the public builder-by-domain cache
+        DomainHandler.invalidate_public_builder_by_domain_cache(domain.domain_name)
+
+        return domain
+
     @classmethod
     def get_public_builder_by_domain_cache_key(cls, domain_name: str) -> str:
         return f"ab_public_builder_by_domain_{domain_name}"

--- a/backend/src/baserow/contrib/builder/domains/service.py
+++ b/backend/src/baserow/contrib/builder/domains/service.py
@@ -279,3 +279,26 @@ class DomainService:
         domain_updated.send(self, domain=domain, user=user)
 
         return domain
+
+    def unpublish(self, user: AbstractUser, domain: Domain) -> Domain:
+        """
+        Unpublish the given builder for the given domain if the
+        user has the right permission.
+
+        :param user: The user unpublishing the builder.
+        :param domain: The domain the user wants to unpublish.
+        :return: The updated domain instance.
+        """
+
+        CoreHandler().check_permissions(
+            user,
+            PublishDomainOperationType.type,
+            workspace=domain.builder.workspace,
+            context=domain,
+        )
+
+        domain = self.handler.unpublish(domain)
+
+        domain_updated.send(self, domain=domain, user=user)
+
+        return domain

--- a/web-frontend/modules/builder/components/page/header/PublishActionModal.vue
+++ b/web-frontend/modules/builder/components/page/header/PublishActionModal.vue
@@ -64,6 +64,13 @@
       </template>
     </Alert>
 
+    <Alert v-if="unpublishSucceeded" type="success">
+      <template #title>{{
+        $t('publishActionModal.unpublishSucceedTitle')
+      }}</template>
+      <p>{{ $t('publishActionModal.unpublishSucceedDescription') }}</p>
+    </Alert>
+
     <div class="modal-progress__actions">
       <ProgressBar
         v-if="jobIsRunning"
@@ -71,15 +78,26 @@
         :status="jobHumanReadableState"
       />
       <div class="align-right">
-        <Button
-          v-if="domains.length"
-          size="large"
-          :loading="jobIsRunning || loading"
-          :disabled="loading || jobIsRunning || !selectedDomainId"
-          @click="publishSite()"
-        >
-          {{ $t('publishActionModal.publish') }}
-        </Button>
+        <template v-if="domains.length">
+          <Button
+            v-if="selectedDomain && selectedDomain.last_published"
+            size="large"
+            type="secondary"
+            :loading="unpublishing"
+            :disabled="loading || jobIsRunning || unpublishing"
+            @click="unpublishSite()"
+          >
+            {{ $t('publishActionModal.unpublish') }}
+          </Button>
+          <Button
+            size="large"
+            :loading="jobIsRunning || loading"
+            :disabled="loading || jobIsRunning || !selectedDomainId || unpublishing"
+            @click="publishSite()"
+          >
+            {{ $t('publishActionModal.publish') }}
+          </Button>
+        </template>
         <template v-else-if="!fetchingDomains">
           <Button tag="a" @click="openDomainSettings">
             {{ $t('publishActionModal.addDomain') }}
@@ -120,7 +138,13 @@ export default {
     },
   },
   data() {
-    return { selectedDomainId: null, loading: false, fetchingDomains: false }
+    return { 
+      selectedDomainId: null, 
+      loading: false, 
+      fetchingDomains: false,
+      unpublishing: false,
+      unpublishSucceeded: false,
+    }
   },
   computed: {
     ...mapGetters({ domains: 'domain/getDomains' }),
@@ -131,6 +155,7 @@ export default {
   watch: {
     selectedDomainId() {
       this.job = null
+      this.unpublishSucceeded = false
     },
     domains() {
       if (!this.selectedDomainId) {
@@ -152,6 +177,8 @@ export default {
       this.loading = false
       this.selectedDomainId = null
       this.fetchingDomains = true
+      this.unpublishing = false
+      this.unpublishSucceeded = false
       try {
         await this.actionFetchDomains({ builderId: this.builder.id })
         this.hideError()
@@ -164,6 +191,7 @@ export default {
     async publishSite() {
       this.loading = true
       this.hideError()
+      this.unpublishSucceeded = false
       try {
         const { data: job } = await PublishedDomainService(
           this.$client
@@ -174,27 +202,27 @@ export default {
       } catch (error) {
         notifyIf(error)
       } finally {
-        this.fetchingDomains = false
         this.loading = false
       }
     },
-    onJobFailed() {
-      this.showError(
-        this.$t('publishActionModal.publishFailedTitle'),
-        this.$t('publishActionModal.publishFailedDescription')
-      )
-      this.loading = false
-    },
-    onJobDone() {
-      this.actionForceUpdateDomain({
-        domainId: this.selectedDomainId,
-        values: { last_published: new Date() },
-      })
-      this.loading = false
-    },
-    onJobPollingError(error) {
-      notifyIf(error)
-      this.loading = false
+    async unpublishSite() {
+      if (!this.selectedDomainId) return
+      this.unpublishing = true
+      this.hideError()
+      this.unpublishSucceeded = false
+      try {
+        const { data: domain } = await PublishedDomainService(this.$client)
+          .unpublish({ id: this.selectedDomainId })
+        this.unpublishSucceeded = true
+        this.actionForceUpdateDomain({
+          domainId: this.selectedDomainId,
+          values: { last_published: null },
+        })
+      } catch (error) {
+        notifyIf(error)
+      } finally {
+        this.unpublishing = false
+      }
     },
     getDomainUrl(domain) {
       const url = new URL(this.$config.PUBLIC_WEB_FRONTEND_URL)

--- a/web-frontend/modules/builder/services/publishedBuilder.js
+++ b/web-frontend/modules/builder/services/publishedBuilder.js
@@ -7,6 +7,9 @@ export default (client) => {
         domain_id: domain.id,
       })
     },
+    unpublish(domainId) {
+      return client.post(`builder/domains/${domainId}/unpublish/`)
+    },
     fetchByDomain(domain) {
       return client.get(`builder/domains/published/by_name/${domain}/`)
     },


### PR DESCRIPTION
closes: #3438

### What is in this PR

This PR introduces the ability to unpublish an application after it has been published. Previously, publishing was irreversible — once live, an app could not be taken offline. This feature is especially important for external billing workflows and lifecycle management.

- API mutation to unpublish an app.
- Backend support for toggling `isPublished` state.
- Frontend UI toggle for Publish ↔ Unpublish.
- Permission guard for authorized users only.
- Real-time UI update after unpublishing.