### PR TITLE
Gracefully handle missing specific instance of DataSource service

### DIFF
--- a/backend/src/baserow/contrib/builder/data_sources/handler.py
+++ b/backend/src/baserow/contrib/builder/data_sources/handler.py
@@ -1,11 +1,9 @@
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union
 from zipfile import ZipFile
 
 from django.core.files.storage import Storage
 from django.db.models import QuerySet
 from django.db.utils import DatabaseError, IntegrityError
-
-from loguru import logger
 
 from baserow.contrib.builder.data_sources.builder_dispatch_context import (
     BuilderDispatchContext,
@@ -137,43 +135,6 @@ class DataSourceHandler:
             base_queryset=queryset,
         )
 
-    def _get_specific_services(self, service_ids: List[int]) -> Dict[int, Service]:
-        """
-        This method attempts to return all specific services for the
-        provided service IDs with an efficient query.
-
-        If a specific service doesn't exist for some reason (race condition, etc),
-        we individually fetch each specific service, and log the ones that don't
-        exist.
-        """
-
-        try:
-            return {
-                s.id: s
-                for s in ServiceHandler().get_services(
-                    base_queryset=Service.objects.filter(id__in=service_ids)
-                )
-            }
-        except Service.DoesNotExist:
-            pass
-
-        # There is a data integrity error, so fall back to individual fetches
-        specific_services_map = {}
-        for service_id in service_ids:
-            try:
-                service = ServiceHandler().get_service(
-                    service_id, base_queryset=Service.objects.filter(id=service_id)
-                )
-                specific_services_map[service_id] = service
-            except Exception as e:
-                # Handle any DoesNotExist, e.g. LocalBaserowGetRow.DoesNotExist, etc.
-                if "DoesNotExist" in str(type(e)):
-                    logger.error(f"Specific service {service_id} doesn't exist.")
-                    continue
-                raise
-
-        return specific_services_map
-
     def _query_data_sources(
         self, base_queryset: QuerySet, specific=True, with_cache=False
     ):
@@ -200,7 +161,12 @@ class DataSourceHandler:
                 if data_source.service_id is not None
             ]
 
-            specific_services_map = self._get_specific_services(service_ids)
+            specific_services_map = {
+                s.id: s
+                for s in ServiceHandler().get_services(
+                    base_queryset=Service.objects.filter(id__in=service_ids)
+                )
+            }
 
             # Distribute specific services to their data_source
             for data_source in data_sources:

--- a/backend/src/baserow/core/services/handler.py
+++ b/backend/src/baserow/core/services/handler.py
@@ -112,6 +112,7 @@ class ServiceHandler:
                 specific_iterator(
                     queryset,
                     per_content_type_queryset_hook=per_content_type_queryset_hook,
+                    skip_missing_specific_objects=True,
                 )
             )
 

--- a/backend/tests/baserow/contrib/builder/data_sources/test_data_source_handler.py
+++ b/backend/tests/baserow/contrib/builder/data_sources/test_data_source_handler.py
@@ -659,9 +659,10 @@ def test_query_data_sources_excludes_trashed_service(data_fixture):
 
 
 @pytest.mark.django_db
-def test_get_specific_services(data_fixture):
+def test_query_data_sources_with_missing_specific_service(data_fixture):
     """
-    Test that _get_specific_services handles Services with missing specific records.
+    Test that a missing specific instance of a local baserow service
+    doesn't cause an exception.
     """
 
     user = data_fixture.create_user()
@@ -673,18 +674,17 @@ def test_get_specific_services(data_fixture):
     service_1 = data_fixture.create_local_baserow_get_row_service(
         integration=integration
     )
-    data_source_1 = data_fixture.create_builder_local_baserow_get_row_data_source(
+    data_source = data_fixture.create_builder_local_baserow_get_row_data_source(
         page=page, service=service_1
     )
     service_2 = data_fixture.create_local_baserow_get_row_service(
         integration=integration
     )
-    data_source_2 = data_fixture.create_builder_local_baserow_get_row_data_source(
+    data_fixture.create_builder_local_baserow_get_row_data_source(
         page=page, service=service_2
     )
 
     missing_service_id = service_2.id
-    service_ids = [service_1.id, missing_service_id]
 
     # Simulate a data integrity issue
     specific_table_name = LocalBaserowGetRow._meta.db_table
@@ -696,13 +696,12 @@ def test_get_specific_services(data_fixture):
             [missing_service_id],
         )
 
-    with mock.patch(
-        "baserow.contrib.builder.data_sources.handler.logger"
-    ) as mock_logger:
-        specific_services_map = DataSourceHandler()._get_specific_services(service_ids)
+    with mock.patch("baserow.core.db.logger") as mock_logger:
+        data_sources = DataSourceHandler()._query_data_sources(
+            DataSource.objects.filter(page=page), specific=True
+        )
 
     mock_logger.error.assert_called_once_with(
-        f"Specific service {missing_service_id} doesn't exist."
+        f"The specific object with id {missing_service_id} does not exist."
     )
-    assert len(specific_services_map) == 1
-    assert service_1.id in specific_services_map
+    assert data_sources == [data_source]


### PR DESCRIPTION
### What is in this PR
This PR is an attempt to more gracefully handle the occasional cases where the base Service exists, but the specific service doesn't. We currently hard-fail causing a crash and have a long-running Sentry issue (6063571996) that keeps re-triggering.

The PR doesn't fix the root cause; I'm not 100% sure what the root cause is. Could be a race condition or something else. But this PR will ensure we stop crashing hard in the rare cases, and at least return some/most of the data source services that don't have the problem.

### How to test this PR
In Builder, create two Data Sources and use them in two different elements. E.g. I created two Get Row data sources: "Foo Get" and "Bar Get". I then created two Heading elements that used one each.

In your DB shell (or DBeaver etc), look at the `builder_datasource` table to find the `service_id` of the 2nd data source. Then in the `integrations_localbaserowgetrow` table, delete the row that uses this service ID (`service_ptr_id` field)`.

Back in Builder, reload the page. You should see the frontend shows a "Page not found" error, whilst the backend crashes with:
```
  File "/baserow/backend/src/baserow/contrib/builder/data_sources/handler.py", line 166, in _query_data_sources
    for s in ServiceHandler().get_services(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/baserow/backend/src/baserow/core/services/handler.py", line 112, in get_services
    specific_iterator(
  File "/baserow/backend/src/baserow/core/db.py", line 186, in specific_iterator
    raise base_model.DoesNotExist(
baserow.core.services.models.Service.DoesNotExist: The specific object with id 766 does not exist.
```

In this PR, the backend shouldn't crash. The frontend will show the first data source, where as the 2nd data source isn't shown. The 2nd element using the 2nd data source will now show an error in the formula field.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
