### PR TITLE
Ensure element visibility works with form data.

### DIFF
--- a/web-frontend/modules/builder/components/elements/ElementPreview.vue
+++ b/web-frontend/modules/builder/components/elements/ElementPreview.vue
@@ -111,6 +111,13 @@ export default {
       getClosestSiblingElement: 'element/getClosestSiblingElement',
       loggedUser: 'userSourceUser/getUser',
     }),
+    applicationContext() {
+      return {
+        ...this.injectedApplicationContext,
+        ...this.applicationContextAdditions,
+        element: this.element,
+      }
+    },
     pageTop() {
       return this.pageTopData.value
     },

--- a/web-frontend/modules/builder/components/page/PageElement.vue
+++ b/web-frontend/modules/builder/components/page/PageElement.vue
@@ -64,6 +64,13 @@ export default {
     BACKGROUND_TYPES: () => BACKGROUND_TYPES,
     CHILD_WIDTH_TYPES: () => CHILD_WIDTH_TYPES,
     WIDTH_TYPES: () => WIDTH_TYPES,
+    applicationContext() {
+      return {
+        ...this.injectedApplicationContext,
+        ...this.applicationContextAdditions,
+        element: this.element,
+      }
+    },
     themeConfigBlocks() {
       return this.$registry.getOrderedList('themeConfigBlock')
     },

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -310,10 +310,7 @@ export class ElementType extends Registerable {
     if (
       element.visibility_condition?.formula &&
       !ensureBoolean(
-        this.resolveFormula(element.visibility_condition, {
-          element,
-          ...applicationContext,
-        }),
+        this.resolveFormula(element.visibility_condition, applicationContext),
         { useStrict: false }
       )
     ) {


### PR DESCRIPTION
### What is in this PR

For element visibility to work with form data, the `applicationContext` must contain the `element`. At the moment it's missing, so when we resolve the formula, it's always `null`.

### How to test this PR

- In `develop`: add a heading element and data input. Set the heading's `element_visibility` to `{formData} = "foo"` in advanced mode.
- Preview the page, and set the data input value to "foo". You'll see that the heading doesn't appear.
- In this branch: try again, and it'll appear.

It's because under the hood, when we resolve the formula, `FormDataProviderType.getDataContent` calls `formElementsInNamespacePath`, which needs a `targetElement` from the application context. When the element's visibility is checked with `elementType.isVisible`, the context doesn't have an element, so we need to make sure it's added during formula resolution.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
