### PR TITLE
Added default number formatting options for rating fields.

### DIFF
--- a/changelog/entries/unreleased/feature/4394_rating_fields_default_number_formatting_options.json
+++ b/changelog/entries/unreleased/feature/4394_rating_fields_default_number_formatting_options.json
@@ -1,0 +1,8 @@
+{
+    "type": "feature",
+    "message": "Add some default number formatting options for rating fields #4394",
+    "domain": "database",
+    "issue_number": 4394  ,
+    "bullet_points": [],
+    "created_at": "2025-12-04"
+}

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1995,6 +1995,10 @@ export class RatingFieldType extends FieldType {
     }
   }
 
+  toHumanReadableString(field, value) {
+    return formatDecimalNumber(field, value)
+  }
+
   /**
    * First checks if the value is numeric, if that is the case, the number is going
    * to be formatted.


### PR DESCRIPTION
### What is in this PR
- Added default number formatting options for rating fields.

### How to test this PR
- Follow this screenshot:
<img width="357" height="495" alt="baserow-rating-average-after" src="https://github.com/user-attachments/assets/1dd6e93a-c234-487a-a5bf-aa13b47d8c68" />


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
