### PR TITLE
Fix indentation for TLS configuration in ingress.yaml

### DIFF
--- a/deploy/helm/baserow/templates/ingress.yaml
+++ b/deploy/helm/baserow/templates/ingress.yaml
@@ -73,8 +73,8 @@ spec:
                 name: {{ include "baserow.global.fullname" . }}-baserow-frontend
                 port:
                   number: 80
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{ tpl (toYaml .Values.ingress.tls | indent 4) . }}
+    {{- toYaml . | nindent 4 }}
   {{- end -}}
 {{ end }}


### PR DESCRIPTION
### What is in this PR
Fix helm template rendering when ingress.tls key is present in helm values.
https://github.com/baserow/baserow/issues/4404

### How to test this PR
helm template . -f my-values.yaml, where my-values.yaml contains an ingress.tls key.
https://github.com/baserow/baserow/issues/4404

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
