### PR TITLE
feature: positioned-container-element

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -38,6 +38,7 @@ from baserow.contrib.builder.elements.mixins import (
     ContainerElementTypeMixin,
     FormElementTypeMixin,
     MultiPageElementTypeMixin,
+    PositionedContainerElementTypeMixin,
 )
 from baserow.contrib.builder.elements.models import (
     INPUT_TEXT_TYPES,
@@ -2513,3 +2514,17 @@ class MenuElementType(ElementType):
                 if new_formula is not None:
                     setattr(item, formula_field, new_formula)
                     yield item
+
+class PositionedContainerElementType(
+    PositionedContainerElementTypeMixin, ElementType
+):
+    type = "positioned_container"
+    model_class = PositionedContainerElement
+    allowed_fields = ["alignment", "behaviour"]
+    serializer_field_names = ["alignment", "behaviour"]
+    
+
+    class SerializedDict(PositionedContainerElementTypeMixin.SerializedDict):
+        alignment: str
+        behaviour: str
+x

--- a/backend/src/baserow/contrib/builder/elements/mixins.py
+++ b/backend/src/baserow/contrib/builder/elements/mixins.py
@@ -84,7 +84,7 @@ class ContainerElementTypeMixin:
     ) -> List[str]:
         """
         This method defines what elements in the container have been removed preceding
-        an update of hte container element.
+        an update of the container element.
 
         :param values: The new values that are being set
         :param instance: The current state of the element
@@ -130,6 +130,24 @@ class ContainerElementTypeMixin:
         """
 
         return True
+
+
+class PositionedContainerElementTypeMixin(ContainerElementTypeMixin):
+    """
+    Mixin for positioned container element types with alignment and behaviour.
+    """
+
+    @property
+    def allowed_fields(self):
+        return super().allowed_fields + ["alignment", "behaviour"]
+
+    @property
+    def serializer_field_names(self):
+        return super().serializer_field_names + ["alignment", "behaviour"]
+
+    class SerializedDict(ContainerElementTypeMixin.SerializedDict):
+        alignment: str
+        behaviour: str
 
 
 class CollectionElementTypeMixin:

--- a/backend/src/baserow/contrib/builder/elements/models.py
+++ b/backend/src/baserow/contrib/builder/elements/models.py
@@ -1120,3 +1120,30 @@ class SimpleContainerElement(ContainerElement):
     """
     A simple container to group elements
     """
+
+class PositionedContainerElement(ContainerElement):
+    """
+    A container element that can be positioned at the top or bottom of the page
+    with fixed or sticky behavior.
+    """
+
+    class ALIGNMENTS(models.TextChoices):
+        TOP = "top"
+        BOTTOM = "bottom"
+
+    class BEHAVIOURS(models.TextChoices):
+        FIXED = "fixed"
+
+    alignment = models.CharField(
+        choices=ALIGNMENTS.choices,
+        max_length=10,
+        default=ALIGNMENTS.TOP,
+        help_text="The alignment of the container on the page.",
+    )
+
+    behaviour = models.CharField(
+        choices=BEHAVIOURS.choices,
+        max_length=10,
+        default=BEHAVIOURS.FIXED,
+        help_text="How the container behaves during page scroll.",
+    )

--- a/web-frontend/modules/builder/components/elements/components/PositionedContainerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/PositionedContainerElement.vue
@@ -1,0 +1,102 @@
+<template>
+  <div :class="positionClasses">
+    <template
+      v-if="
+        mode === 'editing' &&
+        children.length === 0 &&
+        $hasPermission('builder.page.create_element', currentPage, workspace.id)
+      "
+    >
+      <AddElementZone @add-element="showAddElementModal" />
+      <AddElementModal ref="addElementModal" :page="elementPage" />
+    </template>
+
+    <template v-else>
+      <template v-for="child in children">
+        <ElementPreview
+          v-if="mode === 'editing'"
+          :key="child.id"
+          :element="child"
+          @move="$emit('move', $event)"
+        />
+        <PageElement
+          v-else
+          :key="`${child.id}else`"
+          :element="child"
+          :mode="mode"
+        />
+      </template>
+    </template>
+  </div>
+</template>
+
+<script>
+import AddElementZone from '@baserow/modules/builder/components/elements/AddElementZone'
+import containerElement from '@baserow/modules/builder/mixins/containerElement'
+import AddElementModal from '@baserow/modules/builder/components/elements/AddElementModal'
+import ElementPreview from '@baserow/modules/builder/components/elements/ElementPreview'
+import PageElement from '@baserow/modules/builder/components/page/PageElement'
+
+export default {
+  name: 'PositionedContainerElement',
+  components: {
+    PageElement,
+    ElementPreview,
+    AddElementModal,
+    AddElementZone,
+  },
+  mixins: [containerElement],
+
+  props: {
+    element: {
+      type: Object,
+      required: true,
+    },
+  },
+
+  computed: {
+    positionClasses() {
+      const alignment = this.element.alignment || 'top'
+      const behaviour = this.element.behaviour || 'fixed'
+
+      return {
+        'positioned-container': true,
+        'position-fixed': behaviour === 'fixed',
+        'position-top': alignment === 'top',
+        'position-bottom': alignment === 'bottom',
+      }
+    },
+  },
+
+  methods: {
+    showAddElementModal() {
+      this.$refs.addElementModal.show({
+        placeInContainer: null,
+        parentElementId: this.element.id,
+      })
+    },
+  },
+}
+</script>
+
+<style scoped>
+.position-fixed {
+  position: fixed;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+}
+
+.position-top {
+  top: 0;
+}
+
+.position-bottom {
+  bottom: 0;
+}
+
+.positioned-container {
+  width: 100%;
+  background: inherit;
+}
+</style>

--- a/web-frontend/modules/builder/components/elements/components/forms/general/PositionedContainerElementForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/forms/general/PositionedContainerElementForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <form @submit.prevent>
+    <FormGroup
+      :label="$t('positionedContainerElementForm.alignment')"
+      small-label
+      required
+      class="margin-bottom-2"
+    >
+      <Dropdown v-model="values.alignment" :show-search="false" small>
+        <DropdownItem
+          v-for="alignment in alignmentOptions"
+          :key="alignment.value"
+          :name="alignment.name"
+          :value="alignment.value"
+        />
+      </Dropdown>
+    </FormGroup>
+
+    <FormGroup
+      :label="$t('positionedContainerElementForm.behaviour')"
+      small-label
+      required
+      class="margin-bottom-2"
+    >
+      <Dropdown v-model="values.behaviour" :show-search="false" small>
+        <DropdownItem
+          v-for="behaviour in behaviourOptions"
+          :key="behaviour.value"
+          :name="behaviour.name"
+          :value="behaviour.value"
+        />
+      </Dropdown>
+    </FormGroup>
+  </form>
+</template>
+
+<script>
+import form from '@baserow/modules/core/mixins/form'
+
+export default {
+  name: 'PositionedContainerElementForm',
+  mixins: [form],
+
+  data() {
+    return {
+      values: {
+        alignment: 'top',
+        behaviour: 'fixed',
+      },
+    }
+  },
+
+  mounted() {
+    // Load existing element values into form
+    this.values.alignment = this.defaultValues.alignment
+    this.values.behaviour = this.defaultValues.behaviour
+  },
+
+  watch: {
+    values: {
+      handler() {
+        this.$emit('input', this.values)
+      },
+      deep: true,
+    },
+  },
+
+  computed: {
+    alignmentOptions() {
+      return [
+        {
+          value: 'top',
+          name: this.$t('positionedContainerElementForm.alignmentTop'),
+        },
+        {
+          value: 'bottom',
+          name: this.$t('positionedContainerElementForm.alignmentBottom'),
+        },
+      ]
+    },
+    behaviourOptions() {
+      return [
+        {
+          value: 'fixed',
+          name: this.$t('positionedContainerElementForm.behaviourFixed'),
+        },
+      ]
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -99,6 +99,7 @@ import elementImageRepeat from '@baserow/modules/builder/assets/icons/element-re
 import elementImageSimpleContainer from '@baserow/modules/builder/assets/icons/element-simple_container.svg'
 import elementImageTable from '@baserow/modules/builder/assets/icons/element-table.svg'
 import elementImageText from '@baserow/modules/builder/assets/icons/element-text.svg'
+import elementImagePositionedContainer from '@baserow/modules/builder/assets/icons/element-positioned_container.svg'
 import moment from '@baserow/modules/core/moment'
 
 import _ from 'lodash'
@@ -1184,6 +1185,87 @@ export class SimpleContainerElementType extends ContainerElementTypeMixin(
 
   getElementPlaces(element) {
     return [null]
+  }
+}
+
+export class PositionedContainerElementType extends ContainerElementTypeMixin(
+  ElementType
+) {
+  static getType() {
+    return 'positioned_container'
+  }
+
+  category() {
+    return 'layoutElement'
+  }
+
+  get name() {
+    return this.app.i18n.t('elementType.positionedContainer')
+  }
+
+  get description() {
+    return this.app.i18n.t('elementType.positionedContainerDescription')
+  }
+
+  get iconClass() {
+    return 'iconoir-position-align'
+  }
+
+  get image() {
+    return elementImagePositionedContainer
+  }
+
+  get component() {
+    return PositionedContainerElement
+  }
+
+  get generalFormComponent() {
+    return PositionedContainerElementForm
+  }
+
+  getDefaultValues(page, values) {
+    const superValues = super.getDefaultValues(page, values)
+    return {
+      ...superValues,
+      style_padding_left: 0,
+      style_padding_right: 0,
+      style_padding_top: 0,
+      style_padding_bottom: 0,
+    }
+  }
+
+  getDefaultChildValues(page, values) {
+    return {}
+  }
+
+  getElementPlaces(element) {
+    return [null]
+  }
+
+  /**
+   * We can't have this element inside another container.
+   */
+  isDisallowedReason({
+    workspace,
+    builder,
+    page,
+    parentElement,
+    beforeElement,
+    placeInContainer,
+    pagePlace,
+  }) {
+    if (parentElement) {
+      return this.app.i18n.t('elementType.notAllowedInsideContainer')
+    }
+    return super.isDisallowedReason({
+      workspace,
+      builder,
+      page,
+      parentElement,
+      beforeElement,
+      placeInContainer,
+      pagePlace,
+    })
   }
 }
 


### PR DESCRIPTION
closes: #3559

### What is in this PR:

This PR introduces a new Positioned Container element for the Builder, allowing users to place a container fixed to the top or bottom of the page.
- Added a new element type: `positioned_container`.
- Prevents nesting inside another container (same as Page-level elements).
- Fully configurable via the element’s general settings form.