### PR TITLE
feature: allow-single-select-deselect

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -661,7 +661,7 @@ class RecordSelectorElementType(
         else:
             record_id = value
 
-            if not record_id:
+            if record_id is None:
                 if element.required:
                     msg = "The value is required"
                     raise ValueError(msg)

--- a/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
@@ -200,7 +200,7 @@ export default {
       if (this.element.multiple) {
         return this.selectedOption.map(({ name }) => name).join(', ')
       } else {
-        return this.selectedOption?.name
+        return this.selectedOption?.name || ''
       }
     },
     elementContent() {

--- a/web-frontend/modules/core/mixins/dropdown.js
+++ b/web-frontend/modules/core/mixins/dropdown.js
@@ -460,8 +460,9 @@ export default {
         this.$emit('input', newValue)
         this.$emit('change', newValue)
       } else {
-        this.$emit('input', value)
-        this.$emit('change', value)
+        const newValue = _.isEqual(this.value, value) ? null : value
+        this.$emit('input', newValue)
+        this.$emit('change', newValue)
         this.hide()
       }
     },

--- a/web-frontend/modules/database/mixins/selectDropdown.js
+++ b/web-frontend/modules/database/mixins/selectDropdown.js
@@ -49,6 +49,7 @@ export default {
             event.key === 'F2')
         ) {
           this.toggleDropdown()
+          event.preventDefault()
         }
       }
       document.body.addEventListener('keydown', this.$el.keydownEvent)


### PR DESCRIPTION
closes: #3719

### What is in this PR:

This PR adds the ability to deselect a selected value in the Record Selector when `allowMultiple = false`.

Previously, once a value was chosen in single-select mode, the user had no way to clear it without reloading the page. This caused issues for fields where `null ` is a valid value (e.g., link row fields).
