### PR TITLE
feature: zapier-multi-row-actions

### DIFF
--- a/backend/src/baserow/contrib/database/api/rows/serializers.py
+++ b/backend/src/baserow/contrib/database/api/rows/serializers.py
@@ -642,3 +642,59 @@ class RowHistorySerializer(serializers.ModelSerializer):
             "after",
             "fields_metadata",
         ]
+
+
+class RowIdSerializer(serializers.Serializer):
+    row_id = serializers.IntegerField(
+        min_value=0,
+        help_text="The ID of the row to update or delete."
+    )
+
+
+class BatchRowIdSerializer(serializers.Serializer):
+    row_ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=0),
+        min_length=1,
+        help_text="An array of row IDs to update or delete."
+    )
+
+
+class FlexibleRowIdField(serializers.Field):
+    """
+    A field that accepts either a single integer or an array of integers for row_id.
+    """
+
+    def to_internal_value(self, data):
+        if isinstance(data, int):
+            return [data]
+        elif isinstance(data, list):
+            if not data:
+                raise serializers.ValidationError("row_id array cannot be empty")
+            for item in data:
+                if not isinstance(item, int) or item < 0:
+                    raise serializers.ValidationError(
+                        "All row_id values must be positive integers"
+                    )
+            return data
+        else:
+            raise serializers.ValidationError(
+                "row_id must be an integer or an array of integers"
+            )
+
+    def to_representation(self, value):
+        return value
+
+
+class UpdateRowQueryParamsSerializer(serializers.Serializer):
+    row_id = FlexibleRowIdField(
+        help_text="The ID of the row(s) to update. Can be a single integer or an array of integers."
+    )
+    user_field_names = serializers.BooleanField(required=False, default=False)
+    send_webhook_events = serializers.BooleanField(required=False, default=True)
+
+
+class DeleteRowQueryParamsSerializer(serializers.Serializer):
+    row_id = FlexibleRowIdField(
+        help_text="The ID of the row(s) to delete. Can be a single integer or an array of integers."
+    )
+    send_webhook_events = serializers.BooleanField(required=False, default=True)

--- a/backend/src/baserow/contrib/database/api/rows/views.py
+++ b/backend/src/baserow/contrib/database/api/rows/views.py
@@ -865,8 +865,8 @@ class RowView(APIView):
             OpenApiParameter(
                 name="row_id",
                 location=OpenApiParameter.PATH,
-                type=OpenApiTypes.INT,
-                description="Updates the row related to the value.",
+                type=OpenApiTypes.ANY,
+                description="Updates the row(s) related to the value. Can be a single integer or comma-separated integers.",
             ),
             OpenApiParameter(
                 name="view",
@@ -903,8 +903,9 @@ class RowView(APIView):
         tags=["Database table rows"],
         operation_id="update_database_table_row",
         description=(
-            "Updates an existing row in the table if the user has access to the "
-            "related table's workspace. The accepted body fields are depending on the "
+            "Updates an existing row or multiple rows in the table if the user has access to the "
+            "related table's workspace. The row_id can be a single integer or a comma-separated "
+            "list of integers to update multiple rows at once. The accepted body fields are depending on the "
             "fields that the table has. For a complete overview of fields use the "
             "**list_database_table_fields** endpoint to list them all. None of the "
             "fields are required, if they are not provided the value is not going to "
@@ -946,17 +947,14 @@ class RowView(APIView):
     )
     @atomic_with_retry_on_deadlock()
     @require_request_data_type(dict)
-    @validate_query_parameters(UpdateRowQueryParamsSerializer)
-    def patch(
-        self, request: Request, table_id: int, row_id: int, query_params
-    ) -> Response:
+    def patch(self, request: Request, table_id: int, row_id: int) -> Response:
         """
-        Updates the row with the given row_id for the table with the given
+        Updates the row(s) with the given row_id(s) for the table with the given
         table_id. Also the post data is validated according to the tables field types.
 
         :param request: The request object
         :param table_id: The id of the table to update the row in
-        :param row_id: The id of the row to update
+        :param row_id: The id(s) of the row(s) to update (can be comma-separated)
         :return: The updated row values serialized as a json object
         """
 
@@ -967,10 +965,6 @@ class RowView(APIView):
 
         user_field_names = extract_user_field_names_from_params(request.GET)
         send_webhook_events = extract_send_webhook_events_from_params(request.GET)
-
-        view_id = query_params.get("view")
-        view = ViewHandler().get_view(view_id) if view_id else None
-
         field_ids, field_names = None, None
 
         if user_field_names:
@@ -986,28 +980,38 @@ class RowView(APIView):
             user_field_names=user_field_names,
         )
         data = validate_data(validation_serializer, request_data, return_validated=True)
+        
         try:
-            data["id"] = int(row_id)
-            row = (
+            rows_data = [{"id": rid, **data} for rid in row_ids]
+            
+            result = (
                 action_type_registry.get_by_type(UpdateRowsActionType)
                 .do(
                     request.user,
                     table,
-                    [data],
+                    rows_data,
                     model=model,
                     view=view,
                     send_webhook_events=send_webhook_events,
                 )
-                .updated_rows[0]
             )
+            
+            if len(row_ids) == 1:
+                row = result.updated_rows[0]
+                serializer_class = get_row_serializer_class(
+                    model, RowSerializer, is_response=True, user_field_names=user_field_names
+                )
+                serializer = serializer_class(row)
+                return Response(serializer.data)
+            else:
+                serializer_class = get_row_serializer_class(
+                    model, RowSerializer, is_response=True, user_field_names=user_field_names
+                )
+                serializer = serializer_class(result.updated_rows, many=True)
+                return Response({"items": serializer.data})
+                
         except ValidationError as exc:
             raise RequestBodyValidationException(detail=exc.message) from exc
-
-        serializer_class = get_row_serializer_class(
-            model, RowSerializer, is_response=True, user_field_names=user_field_names
-        )
-        serializer = serializer_class(row)
-        return Response(serializer.data)
 
     @extend_schema(
         parameters=[
@@ -1027,8 +1031,8 @@ class RowView(APIView):
             OpenApiParameter(
                 name="row_id",
                 location=OpenApiParameter.PATH,
-                type=OpenApiTypes.INT,
-                description="Deletes the row related to the value.",
+                type=OpenApiTypes.ANY,
+                description="Deletes the row(s) related to the value. Can be a single integer or comma-separated integers.",
             ),
             OpenApiParameter(
                 name="send_webhook_events",
@@ -1046,8 +1050,9 @@ class RowView(APIView):
         tags=["Database table rows"],
         operation_id="delete_database_table_row",
         description=(
-            "Deletes an existing row in the table if the user has access to the "
-            "table's workspace."
+            "Deletes an existing row or multiple rows in the table if the user has access to the "
+            "table's workspace. The row_id can be a single integer or a comma-separated "
+            "list of integers to delete multiple rows at once."
         ),
         responses={
             204: None,
@@ -1075,7 +1080,7 @@ class RowView(APIView):
     @validate_query_parameters(DeleteRowQueryParamsSerializer)
     def delete(self, request, table_id, row_id, query_params):
         """
-        Deletes an existing row with the given row_id for table with the given
+        Deletes an existing row or rows with the given row_id(s) for table with the given
         table_id.
         """
 
@@ -1088,11 +1093,7 @@ class RowView(APIView):
         view = ViewHandler().get_view(view_id) if view_id else None
 
         action_type_registry.get_by_type(DeleteRowActionType).do(
-            request.user,
-            table,
-            row_id,
-            view=view,
-            send_webhook_events=send_webhook_events,
+            request.user, table, row_id, send_webhook_events=send_webhook_events
         )
 
         return Response(status=204)

--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -2104,13 +2104,22 @@ class LocalBaserowUpsertRowServiceType(
         model = table.get_model()
 
         if row_id:
+            row_ids_to_update = row_id if isinstance(row_id, list) else [row_id]
+            
             try:
-                (row,) = UpdateRowsActionType.do(
+                rows_values_to_update = [
+                    {**row_values, "id": rid} for rid in row_ids_to_update
+                ]
+                
+                result = UpdateRowsActionType.do(
                     service.integration.authorized_user,
                     table,
-                    rows_values=[{**row_values, "id": row_id}],
+                    rows_values=rows_values_to_update,
                     model=model,
-                ).updated_rows
+                )
+                
+                row = result.updated_rows[0] if len(row_ids_to_update) == 1 else result.updated_rows
+                
             except RowDoesNotExist as exc:
                 raise ServiceImproperlyConfiguredDispatchException(
                     f"The row with id {row_id} does not exist."

--- a/integrations/zapier/src/creates/delete-row.js
+++ b/integrations/zapier/src/creates/delete-row.js
@@ -13,25 +13,46 @@ const deleteRowInputFields = [
   {
     key: 'rowID',
     label: 'Row ID',
-    type: 'integer',
+    type: 'string',
     required: true,
-    helpText: 'Please the row ID that must be deleted.'
+    helpText: 'Please enter the row ID that must be deleted. You can provide a single ID or comma-separated IDs to delete multiple rows at once.'
   },
 ]
 
 const DeleteRow = async (z, bundle) => {
-  const rowDeleteRequest = await z.request({
-    url: `${bundle.authData.apiURL}/api/database/rows/table/${bundle.inputData.tableID}/${bundle.inputData.rowID}/`,
-    method: 'DELETE',
-    headers: {
-        'Accept': 'application/json',
-        'Authorization': `Token ${bundle.authData.apiToken}`,
-    },
-  })
+  const rowIds = bundle.inputData.rowID.includes(',')
+    ? bundle.inputData.rowID.split(',').map(id => parseInt(id.trim()))
+    : [parseInt(bundle.inputData.rowID)]
+  
+  if (rowIds.length === 1) {
+    const rowDeleteRequest = await z.request({
+      url: `${bundle.authData.apiURL}/api/database/rows/table/${bundle.inputData.tableID}/${rowIds[0]}/`,
+      method: 'DELETE',
+      headers: {
+          'Accept': 'application/json',
+          'Authorization': `Token ${bundle.authData.apiToken}`,
+      },
+    })
 
-  return rowDeleteRequest.status === 204
-    ? { message: `Row ${bundle.inputData.rowID} deleted successfully.` }
-    : { message: 'A problem occurred during DELETE operation. The row was not deleted.' }
+    return rowDeleteRequest.status === 204
+      ? { message: `Row ${rowIds[0]} deleted successfully.` }
+      : { message: 'A problem occurred during DELETE operation. The row was not deleted.' }
+  } else {
+    const rowBatchDeleteRequest = await z.request({
+      url: `${bundle.authData.apiURL}/api/database/rows/table/${bundle.inputData.tableID}/${rowIds.join(',')}/`,
+      method: 'DELETE',
+      headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'Authorization': `Token ${bundle.authData.apiToken}`,
+      },
+      body: { items: rowIds },
+    })
+
+    return rowBatchDeleteRequest.status === 204
+      ? { message: `Rows ${rowIds.join(', ')} deleted successfully.` }
+      : { message: 'A problem occurred during batch DELETE operation.' }
+  }
 }
 
 module.exports = {

--- a/integrations/zapier/src/creates/update-row.js
+++ b/integrations/zapier/src/creates/update-row.js
@@ -11,36 +11,45 @@ const updateRowInputFields = [
     type: 'integer',
     required: true,
     altersDynamicFields: true,
-    helpText: 'Please enter the table ID where the row must be updated in. You can ' +
-      'find the ID by clicking on the three dots next to the table. It\'s the ' +
-      'number between brackets.'
+    helpText:
+      'Please enter the table ID where the row must be updated. ' +
+      'You can find the ID by clicking on the three dots next to the table. ' +
+      'It’s the number between brackets.'
   },
   {
     key: 'rowID',
     label: 'Row ID',
-    type: 'integer',
+    type: 'string',
     required: true,
-    helpText: 'Please enter the row ID that must be updated.'
+    helpText:
+      'Enter a single row ID or comma-separated IDs to update multiple rows at once.'
   },
 ]
 
 const updateRow = async (z, bundle) => {
   const rowData = await prepareInputDataForBaserow(z, bundle)
-  const rowPatchRequest = await z.request({
-    url: `${bundle.authData.apiURL}/api/database/rows/table/${bundle.inputData.tableID}/${bundle.inputData.rowID}/`,
+
+  const rowIds = bundle.inputData.rowID.includes(',')
+    ? bundle.inputData.rowID.split(',').map(id => id.trim())
+    : [bundle.inputData.rowID]
+
+  const rowIdPath = rowIds.join(',')
+
+  const response = await z.request({
+    url: `${bundle.authData.apiURL}/api/database/rows/table/${bundle.inputData.tableID}/${rowIdPath}/`,
     method: 'PATCH',
     headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Authorization': `Token ${bundle.authData.apiToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Token ${bundle.authData.apiToken}`,
     },
     params: {
-      'user_field_names': 'true',
+      user_field_names: 'true',
     },
     body: rowData,
   })
 
-  return rowPatchRequest.json
+  return response.json
 }
 
 module.exports = {
@@ -48,7 +57,7 @@ module.exports = {
   noun: 'Row',
   display: {
     label: 'Update Row',
-    description: 'Updates an existing row.'
+    description: 'Updates one or more existing rows.'
   },
   operation: {
     perform: updateRow,


### PR DESCRIPTION
closes: #3874

### What is in this PR:

- This PR enhances the Zapier integration to allow users to pass multiple Row IDs for both Update Row and Delete Row actions.

1. Delete Row (delete-row.js):

- Updated rowID input field to accept comma-separated IDs.
- Added parsing logic to convert `"1, 2, 3"` into `[1, 2, 3]`.
- Implemented:
      Single-row deletion using the standard `DELETE` endpoint.
      Multi-row deletion using the `batch-delete` endpoint.

2. Update Row (update-row.js):

- Updated rowID to accept multiple values (comma-separated).
- Added logic to: Perform a regular PATCH for a single row.

3. InputField Improvements:

- `rowID` changed from integer → string.
- Updated help text to describe support for multiple row IDs clearly.