### PR TITLE
Track data sync type in Posthog

### DIFF
--- a/backend/src/baserow/contrib/database/data_sync/actions.py
+++ b/backend/src/baserow/contrib/database/data_sync/actions.py
@@ -37,6 +37,7 @@ class CreateDataSyncTableActionType(UndoableActionType):
         "database_id",
         "table_id",
         "data_sync_id",
+        "data_sync_type",
     ]
 
     @dataclasses.dataclass


### PR DESCRIPTION
Tiny PR that adds the `data_sync_type` to the analytics params.