### PR TITLE
feature: markdown-support-in-table-text-fields

### DIFF
--- a/backend/src/baserow/contrib/builder/builder_beta_init_application.py
+++ b/backend/src/baserow/contrib/builder/builder_beta_init_application.py
@@ -166,7 +166,10 @@ class BuilderApplicationTypeInitApplication:
                 {
                     "name": "Notes",
                     "type": "text",
-                    "config": {"value": "'Some notes about this user.'"},
+                    "config": {
+                        "value": "'Some notes about this user.'",
+                        "format": "plain",
+                    },
                 },
             ],
         )

--- a/backend/src/baserow/contrib/builder/elements/collection_field_types.py
+++ b/backend/src/baserow/contrib/builder/elements/collection_field_types.py
@@ -75,20 +75,34 @@ class RatingCollectionFieldType(CollectionFieldType):
 
 class TextCollectionFieldType(CollectionFieldType):
     type = "text"
-    allowed_fields = ["value"]
-    serializer_field_names = ["value"]
+    allowed_fields = ["value", "format"]
+    serializer_field_names = ["value", "format"]
     simple_formula_fields = ["value"]
 
     class SerializedDict(TypedDict):
         value: BaserowFormulaObject
+        format: str
 
     @property
     def serializer_field_overrides(self):
+        from baserow.core.formula.serializers import FormulaSerializerField
+
         return {
             "value": FormulaSerializerField(
-                help_text="The formula for the text.",
+                help_text="The value of the field.",
+            ),
+            "format": serializers.ChoiceField(
+                choices=[("plain", "Plain"), ("markdown", "Markdown")],
+                default="plain",
+                help_text="The format of the text: plain or markdown",
                 required=False,
             ),
+        }
+
+    def get_pytest_params(self, pytest_data_fixture):
+        return {
+            "value": "'test'",
+            "format": "plain",
         }
 
 

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -843,7 +843,10 @@
   },
   "textFieldForm": {
     "fieldValueLabel": "Value",
-    "fieldValuePlaceholder": "Enter value..."
+    "fieldValuePlaceholder": "Enter value",
+    "formatLabel": "Format",
+    "formatPlain": "Plain text",
+    "formatMarkdown": "Markdown"
   },
   "linkFieldForm": {
     "fieldValueLabel": "Url",


### PR DESCRIPTION
closes: #4330

### What is in this PR:

This PR introduces the ability to render Markdown inside table element text fields within the Application Builder — bringing the same rich text capabilities already available in the Text Element.

- Updated `TextCollectionFieldType` to include a new `format` property.
- Updated serializer to validate and persist the chosen format.
- Ensures backward compatibility by defaulting to `"plain"`.
