### PR TITLE
feature: formula-click-navigate-node-explorer

### DIFF
--- a/web-frontend/modules/core/assets/scss/components/formula_input_field.scss
+++ b/web-frontend/modules/core/assets/scss/components/formula_input_field.scss
@@ -141,3 +141,12 @@
     padding-right: 2px;
   }
 }
+
+.function-formula-component,
+.operator-formula-component {
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}

--- a/web-frontend/modules/core/components/formula/FormulaInputContext.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputContext.vue
@@ -6,7 +6,7 @@
     overflow-scroll
   >
     <NodeExplorer
-      :node-selected="nodeSelected"
+      :node-selected="selectedPath"
       :mode="mode"
       :nodes-hierarchy="nodesHierarchy"
       :allow-node-selection="allowNodeSelection"
@@ -105,6 +105,11 @@ export default {
       required: false,
       default: false,
     },
+    selectedFunctionOrOperator: {
+      type: Object,
+      required: false,
+      default: null,
+    },
   },
   data() {
     return {
@@ -120,6 +125,15 @@ export default {
   computed: {
     isAdvancedMode() {
       return this.mode === 'advanced'
+    },
+    selectedPath() {
+      if (this.selectedFunctionOrOperator) {
+        return this.findNodePath(
+          this.nodesHierarchy,
+          this.selectedFunctionOrOperator
+        )
+      }
+      return this.nodeSelected
     },
   },
   watch: {
@@ -246,6 +260,25 @@ export default {
     },
     cancelModeChange() {
       this.$refs.advancedModeModal.hide()
+    },
+    findNodePath(nodes, target, currentPath = '') {
+      for (const node of nodes) {
+        const nodePath = currentPath ? `${currentPath}.${node.name}` : node.name
+        
+        if (target.type === 'function' && node.type === 'function' && node.name === target.name) {
+          return nodePath
+        }
+        
+        if (target.type === 'operator' && node.type === 'operator' && node.signature?.operator === target.symbol) {
+          return nodePath
+        }
+        
+        if (node.nodes && node.nodes.length > 0) {
+          const found = this.findNodePath(node.nodes, target, nodePath)
+          if (found) return found
+        }
+      }
+      return null
     },
   },
 }

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -10,6 +10,8 @@
         :class="classes"
         :editor="editor"
         @data-node-clicked="dataNodeClicked"
+        @function-clicked="functionClicked"
+        @operator-clicked="operatorClicked"
       />
     </div>
 
@@ -22,6 +24,7 @@
       :has-value="value.length > 0"
       :allow-node-selection="allowNodeSelection"
       :nodes-hierarchy="nodesHierarchy"
+      :selected-function-or-operator="selectedFunctionOrOperator"
       @node-selected="handleNodeSelected"
       @node-unselected="unSelectNode"
       @mode-changed="handleModeChange"
@@ -161,6 +164,7 @@ export default {
       isHandlingModeChange: false,
       intersectionObserver: null,
       key: 0,
+      selectedFunctionOrOperator: null,
     }
   },
   computed: {
@@ -537,6 +541,31 @@ export default {
     },
     dataNodeClicked(node) {
       this.editor.commands.selectNode(node)
+      this.selectedFunctionOrOperator = null
+    },
+    functionClicked(data) {
+      this.selectedFunctionOrOperator = {
+        name: data.functionName,
+        type: 'function',
+      }
+      this.isFocused = true
+      this.$nextTick(() => {
+        if(this.editor) {
+          this.editor.commands.showContext()
+        }
+      })
+    },
+    operatorClicked(data) {
+      this.selectedFunctionOrOperator = {
+        symbol: data.operatorSymbol,
+        type: 'operator',
+      }
+      this.isFocused = true
+      this.$nextTick(() => {
+        if(this.editor) {
+          this.editor.commands.showContext()
+        }
+      })
     },
     handleEditorClick() {
       if (this.editor && !this.disabled && !this.readOnly) {
@@ -590,6 +619,7 @@ export default {
     },
     unSelectNode() {
       this.editor?.commands.unselectNode()
+      this.selectedFunctionOrOperator = null
     },
   },
 }

--- a/web-frontend/modules/core/components/formula/FunctionFormulaComponent.vue
+++ b/web-frontend/modules/core/components/formula/FunctionFormulaComponent.vue
@@ -3,6 +3,7 @@
     as="span"
     class="function-formula-component"
     :data-no-args="hasNoArgs ? 'true' : undefined"
+    @click.stop="handleClick"
   >
     <span class="function-formula-component__name">{{ functionName }}(</span>
   </NodeViewWrapper>
@@ -24,6 +25,14 @@ export default {
     },
     hasNoArgs() {
       return this.node?.attrs?.hasNoArgs || false
+    },
+  },
+  methods: {
+    handleClick() {
+      this.emitToEditor('function-clicked', {
+        functionName: this.functionName,
+        type: 'function',
+      })
     },
   },
 }

--- a/web-frontend/modules/core/components/formula/OperatorFormulaComponent.vue
+++ b/web-frontend/modules/core/components/formula/OperatorFormulaComponent.vue
@@ -3,6 +3,7 @@
     as="span"
     class="operator-formula-component"
     :contenteditable="false"
+    @click.stop="handleClick"
   >
     <span class="operator-formula-component__symbol">{{ operatorSymbol }}</span>
   </NodeViewWrapper>
@@ -21,6 +22,14 @@ export default {
   computed: {
     operatorSymbol() {
       return this.node?.attrs?.operatorSymbol || ''
+    },
+  },
+  methods: {
+    handleClick() {
+      this.emitToEditor('operator-clicked', {
+        operatorSymbol: this.operatorSymbol,
+        type: 'operator',
+      })
     },
   },
 }


### PR DESCRIPTION
closes: #4216

### What is in this PR:

Now, clicking on any function or operator within the formula input field automatically selects and highlights it in the Node Explorer — similar to how clicking on field references already works.

This enables users to instantly jump between functions and operators, making formula editing significantly faster and more intuitive.

