### PR TITLE
Fix bug causing workflow deletion to crash sometimes

### DIFF
--- a/changelog/entries/unreleased/bug/4293_fixed_a_crash_when_the_workflow_is_uninitialized.json
+++ b/changelog/entries/unreleased/bug/4293_fixed_a_crash_when_the_workflow_is_uninitialized.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a potential crash while deleting a workflow.",
+    "issue_origin": "github",
+    "issue_number": 4293,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2025-12-10"
+}

--- a/web-frontend/modules/automation/store/automationWorkflow.js
+++ b/web-frontend/modules/automation/store/automationWorkflow.js
@@ -108,7 +108,7 @@ const actions = {
     )
   },
   async forceDelete({ commit }, { automation, workflow }) {
-    if (workflow._.selected) {
+    if (workflow._?.selected) {
       // Redirect back to the dashboard because the workflow doesn't exist anymore.
       await this.$router.push({ name: 'dashboard' })
       commit('UNSELECT')


### PR DESCRIPTION
### What is in this PR
This PR fixes the Sentry issue 7036036020.

When a workflow is being deleting, the `workflow._` might be undefined for some reason. This PR adds a defensive check to ensure we don't crash when that happens.

The Sentry error:
```
TypeError: Error Cannot read properties of undefined (reading 'workflows')
```

Closes https://github.com/baserow/baserow/issues/4293

### How to test this PR
Look at the trace in Sentry, it looks like the problem originates from a realtime event that tries to delete the workflow. I'm not sure how we can reproduce this, but the fix is minimal and defensive.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
