### PR TITLE
Improve Local Baserow one-way and two-way data sync support.

### DIFF
--- a/backend/src/baserow/contrib/integrations/api/local_baserow/serializers.py
+++ b/backend/src/baserow/contrib/integrations/api/local_baserow/serializers.py
@@ -16,10 +16,14 @@ class LocalBaserowTableSerializer(serializers.ModelSerializer):
         source="is_data_synced_table",
         help_text="Whether this table is a data synced table or not.",
     )
+    is_two_way_data_sync = serializers.BooleanField(
+        source="is_two_way_data_synced_table",
+        help_text="Whether this table is a two-way data synced table or not.",
+    )
 
     class Meta:
         model = Table
-        fields = ("id", "database_id", "name", "is_data_sync")
+        fields = ("id", "database_id", "name", "is_data_sync", "is_two_way_data_sync")
 
 
 class LocalBaserowDatabaseSerializer(ApplicationSerializer):

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_integration_types.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_integration_types.py
@@ -215,6 +215,7 @@ def test_get_integrations_serializer(
                         "name": table.name,
                         "database_id": table.database_id,
                         "is_data_sync": table.is_data_synced_table,
+                        "is_two_way_data_sync": table.is_two_way_data_synced_table,
                     }
                 ],
                 "views": [

--- a/changelog/entries/unreleased/refactor/improved_oneway_and_twoway_data_sync_support_in_local_basero.json
+++ b/changelog/entries/unreleased/refactor/improved_oneway_and_twoway_data_sync_support_in_local_basero.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Improved one-way and two-way data sync support in Local Baserow actions.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2025-12-09"
+}

--- a/web-frontend/modules/automation/components/workflow/sidePanels/NodeSidePanel.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/NodeSidePanel.vue
@@ -27,6 +27,7 @@
       small
       :loading="nodeLoading"
       :service="node.service"
+      :service-type="nodeType.serviceType"
       :application="automation"
       enable-integration-picker
       :default-values="node.service"

--- a/web-frontend/modules/builder/components/dataSource/DataSourceForm.vue
+++ b/web-frontend/modules/builder/components/dataSource/DataSourceForm.vue
@@ -64,6 +64,7 @@
         ref="subForm"
         :application="builder"
         :service="dataSource"
+        :service-type="serviceType"
         :default-values="defaultValues"
         :context-data="integration.context_data"
         @values-changed="emitChange($event)"

--- a/web-frontend/modules/builder/components/workflowAction/WorkflowActionWithService.vue
+++ b/web-frontend/modules/builder/components/workflowAction/WorkflowActionWithService.vue
@@ -3,6 +3,7 @@
     :is="serviceType.formComponent"
     :application="builder"
     :service="defaultValues.service"
+    :service-type="serviceType"
     :loading="workflowActionLoading"
     :default-values="defaultValues.service"
     @values-changed="values.service = { ...workflowAction.service, ...$event }"

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowAggregateRowsForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowAggregateRowsForm.vue
@@ -4,6 +4,7 @@
       <div class="col col-12">
         <LocalBaserowServiceForm
           :application="application"
+          :service-type="serviceType"
           :default-values="defaultValues"
           :enable-integration-picker="enableIntegrationPicker"
           @values-changed="values = { ...values, ...$event }"

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowGetRowForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowGetRowForm.vue
@@ -5,6 +5,7 @@
         <div class="col col-12">
           <LocalBaserowServiceForm
             :application="application"
+            :service-type="serviceType"
             :default-values="defaultValues"
             :enable-integration-picker="enableIntegrationPicker"
             @values-changed="values = { ...values, ...$event }"

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowListRowsForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowListRowsForm.vue
@@ -4,6 +4,7 @@
       <div class="col col-12">
         <LocalBaserowServiceForm
           :application="application"
+          :service-type="serviceType"
           :default-values="defaultValues"
           :enable-integration-picker="enableIntegrationPicker"
           @values-changed="values = { ...values, ...$event }"

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowServiceForm.vue
@@ -17,10 +17,10 @@
     <LocalBaserowTableSelector
       v-if="selectedIntegration"
       v-model="fakeTableId"
-      :view-id.sync="values.view_id"
       :databases="databases"
+      :service-type="serviceType"
+      :view-id.sync="values.view_id"
       :display-view-dropdown="enableViewPicker"
-      :disallow-data-synced-tables="disallowDataSyncedTables"
     />
     <FormGroup
       v-if="enableRowId && values.integration_id"
@@ -64,6 +64,10 @@ export default {
       type: Object,
       required: true,
     },
+    serviceType: {
+      type: Object,
+      required: true,
+    },
     enableRowId: {
       type: Boolean,
       required: false,
@@ -88,15 +92,6 @@ export default {
       type: Boolean,
       required: false,
       default: true,
-    },
-    /**
-     * Whether to disallow the selection of data synced tables. Data sources
-     * can select them, but a create-row workflow action cannot.
-     */
-    disallowDataSyncedTables: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
   },
   data() {

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowSignalTriggerServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowSignalTriggerServiceForm.vue
@@ -3,6 +3,7 @@
     <LocalBaserowServiceForm
       ref="serviceForm"
       :application="application"
+      :service-type="serviceType"
       :default-values="defaultValues"
       :enable-view-picker="false"
       @values-changed="emitServiceChange($event)"
@@ -23,6 +24,10 @@ export default defineComponent({
       required: true,
     },
     service: {
+      type: Object,
+      required: true,
+    },
+    serviceType: {
       type: Object,
       required: true,
     },

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowTableSelector.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowTableSelector.vue
@@ -36,15 +36,11 @@
         @input="$emit('input', $event)"
       >
         <DropdownItem
-          v-for="table in tables"
+          v-for="table in supportedServiceTables"
           :key="table.id"
           :name="table.name"
           :value="table.id"
-          :description="
-            table.is_data_sync
-              ? $t('localBaserowTableSelector.dataSyncedTableDescription')
-              : null
-          "
+          :description="getTableDescription(table)"
         >
           {{ table.name }}
         </DropdownItem>
@@ -100,6 +96,10 @@ export default {
       type: Array,
       required: true,
     },
+    serviceType: {
+      type: Object,
+      required: true,
+    },
     displayViewDropdown: {
       type: Boolean,
       default: true,
@@ -111,11 +111,6 @@ export default {
         return ['regular', 'large'].includes(value)
       },
       default: 'regular',
-    },
-    disallowDataSyncedTables: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
   },
   data() {
@@ -130,11 +125,10 @@ export default {
       )
     },
     tables() {
-      return (
-        this.databaseSelected?.tables.filter(
-          (table) => !(this.disallowDataSyncedTables && table.is_data_sync)
-        ) || []
-      )
+      return this.databaseSelected?.tables || []
+    },
+    supportedServiceTables() {
+      return this.serviceType.supportedTables(this.tables)
     },
     views() {
       return (
@@ -157,6 +151,20 @@ export default {
         }
       },
       immediate: true,
+    },
+  },
+  methods: {
+    getTableDescription(table) {
+      if (table.is_two_way_data_sync) {
+        return this.$t(
+          'localBaserowTableSelector.twoWayDataSyncedTableDescription'
+        )
+      } else if (table.is_data_sync) {
+        return this.$t(
+          'localBaserowTableSelector.oneWayDataSyncedTableDescription'
+        )
+      }
+      return null
     },
   },
 }

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowUpsertRowServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowUpsertRowServiceForm.vue
@@ -1,11 +1,11 @@
 <template>
   <form @submit.prevent>
     <LocalBaserowServiceForm
+      :service-type="serviceType"
       :enable-row-id="enableRowId"
       :application="application"
       :enable-view-picker="false"
       :default-values="defaultValues"
-      :disallow-data-synced-tables="disallowDataSyncedTables"
       @table-changed="handleTableChange"
       @values-changed="emitServiceChange($event)"
     ></LocalBaserowServiceForm>
@@ -57,23 +57,17 @@ export default {
     service: {
       type: Object,
       required: false,
-      default: null,
+      default: () => ({}),
+    },
+    serviceType: {
+      type: Object,
+      required: false,
+      default: () => ({}),
     },
     enableRowId: {
       type: Boolean,
       required: false,
       default: false,
-    },
-    /**
-     * Whether to disallow selecting data synced tables. It defaults to
-     * true as this is the default behaviour for the create row action
-     * form. The update row action form allows data synced tables, assuming
-     * they have writable fields.
-     */
-    disallowDataSyncedTables: {
-      type: Boolean,
-      required: false,
-      default: true,
     },
   },
   data() {

--- a/web-frontend/modules/integrations/localBaserow/mixins/localBaserowService.js
+++ b/web-frontend/modules/integrations/localBaserow/mixins/localBaserowService.js
@@ -12,6 +12,11 @@ export default {
       required: false,
       default: () => ({}),
     },
+    serviceType: {
+      type: Object,
+      required: false,
+      default: () => ({}),
+    },
     contextData: {
       type: Object,
       required: false,

--- a/web-frontend/modules/integrations/localBaserow/serviceTypes.js
+++ b/web-frontend/modules/integrations/localBaserow/serviceTypes.js
@@ -33,6 +33,17 @@ export class LocalBaserowTableServiceType extends ServiceType {
   }
 
   /**
+   * Given an array of tables, returns the supported tables for this service type.
+   * By default, we return all tables, but specific service types can override this
+   * method to restrict the tables that can be selected.
+   * @param {Array} tables - The array of tables to filter.
+   * @returns {Array} - The supported tables.
+   */
+  supportedTables(tables) {
+    return tables
+  }
+
+  /**
    * Responsible for determining if this service is in error. It will be if the
    * `table_id` is missing.
    * @param service - The service object.
@@ -414,6 +425,18 @@ export class LocalBaserowCreateRowWorkflowServiceType extends WorkflowActionServ
     return 'local_baserow_create_row'
   }
 
+  /**
+   * The Local Baserow create row service will only work on tables which are
+   * not data-synced, or are data-synced but are two-way synced.
+   * @param {Array} tables - The array of tables to filter.
+   * @returns {Array} - The supported tables.
+   */
+  supportedTables(tables) {
+    return tables.filter(
+      (table) => !table.is_data_sync || table.is_two_way_data_sync
+    )
+  }
+
   get icon() {
     return 'iconoir-plus'
   }
@@ -476,6 +499,18 @@ export class LocalBaserowDeleteRowWorkflowServiceType extends WorkflowActionServ
 
   get formComponent() {
     return LocalBaserowDeleteRowServiceForm
+  }
+
+  /**
+   * The Local Baserow delete row service will only work on tables which are
+   * not data-synced, or are data-synced but are two-way synced.
+   * @param {Array} tables - The array of tables to filter.
+   * @returns {Array} - The supported tables.
+   */
+  supportedTables(tables) {
+    return tables.filter(
+      (table) => !table.is_data_sync || table.is_two_way_data_sync
+    )
   }
 }
 

--- a/web-frontend/modules/integrations/locales/en.json
+++ b/web-frontend/modules/integrations/locales/en.json
@@ -229,7 +229,8 @@
     "tableFieldLabel": "Table",
     "chooseNoView": "Not selected",
     "databaseFieldLabel": "Database",
-    "dataSyncedTableDescription": "Data synced table"
+    "oneWayDataSyncedTableDescription": "One-way synced",
+    "twoWayDataSyncedTableDescription": "Two-way synced"
   },
   "smtpIntegrationType": {
     "smtpSummary": "SMTP - {host}:{port}"

--- a/web-frontend/test/unit/integrations/localBaserow/serviceTypes.spec.js
+++ b/web-frontend/test/unit/integrations/localBaserow/serviceTypes.spec.js
@@ -1,6 +1,9 @@
 import {
   LocalBaserowListRowsServiceType,
   LocalBaserowGetRowServiceType,
+  LocalBaserowTableServiceType,
+  LocalBaserowCreateRowWorkflowServiceType,
+  LocalBaserowDeleteRowWorkflowServiceType,
 } from '@baserow/modules/integrations/localBaserow/serviceTypes'
 import { TestApp } from '@baserow/test/helpers/testApp'
 
@@ -148,5 +151,121 @@ describe('Local baserow service types', () => {
     expect(
       dataProvider.getDataChunk(applicationContext, ['1', 'field_42'])
     ).toEqual('Field 42 content')
+  })
+
+  test('LocalBaserowTableServiceType supportedTables returns all tables it is given.', () => {
+    const fakeApp = {}
+    const serviceType = new LocalBaserowTableServiceType(fakeApp)
+
+    const tables = [
+      {
+        id: 1,
+        name: 'Table 1',
+        is_data_sync: false,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 2,
+        name: 'Table 2',
+        is_data_sync: true,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 3,
+        name: 'Table 3',
+        is_data_sync: true,
+        is_two_way_data_sync: true,
+      },
+    ]
+
+    const result = serviceType.supportedTables(tables)
+    expect(result).toEqual(tables)
+    expect(result.length).toBe(3)
+  })
+
+  test('LocalBaserowCreateRowWorkflowServiceType supportedTables returns non data-synced tables or two-way data-synced tables.', () => {
+    const fakeApp = {}
+    const serviceType = new LocalBaserowCreateRowWorkflowServiceType(fakeApp)
+
+    const tables = [
+      {
+        id: 1,
+        name: 'Table 1',
+        is_data_sync: false,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 2,
+        name: 'Table 2',
+        is_data_sync: true,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 3,
+        name: 'Table 3',
+        is_data_sync: true,
+        is_two_way_data_sync: true,
+      },
+    ]
+
+    const result = serviceType.supportedTables(tables)
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: 'Table 1',
+        is_data_sync: false,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 3,
+        name: 'Table 3',
+        is_data_sync: true,
+        is_two_way_data_sync: true,
+      },
+    ])
+    expect(result.length).toBe(2)
+  })
+
+  test('LocalBaserowDeleteRowWorkflowServiceType supportedTables returns non data-synced tables or two-way data-synced tables', () => {
+    const fakeApp = {}
+    const serviceType = new LocalBaserowDeleteRowWorkflowServiceType(fakeApp)
+
+    const tables = [
+      {
+        id: 1,
+        name: 'Table 1',
+        is_data_sync: false,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 2,
+        name: 'Table 2',
+        is_data_sync: true,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 3,
+        name: 'Table 3',
+        is_data_sync: true,
+        is_two_way_data_sync: true,
+      },
+    ]
+
+    const result = serviceType.supportedTables(tables)
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: 'Table 1',
+        is_data_sync: false,
+        is_two_way_data_sync: false,
+      },
+      {
+        id: 3,
+        name: 'Table 3',
+        is_data_sync: true,
+        is_two_way_data_sync: true,
+      },
+    ])
+    expect(result.length).toBe(2)
   })
 })


### PR DESCRIPTION
### What is in this PR

Improving the Local Baserow integration support for our one-way and two-way data synced tables. The goal in this PR is to do away with the hard-coded allow/disallow data-synced tables props, and instead bake into the service types themselves what *kinds* of tables they support. It essentially boils down to: by default, Local Baserow services accept all table types, but create and delete have a specific requirement, they will only accept non-data synced tables OR two-way synced tables.

Reviewer, you will notice that there's some passing around of the node/workflow action/data source service type. This is down to a quirk which I added a long time ago that is now proving difficult to work with.

In the backend, there is a `local_baserow_upsert_row` service type, and this service type *does not exist* in the frontend. Unfortunately, with this service type, which is created when you add a create/update row node/workflow action, you cannot distinguish what kind of parent record you're creating (is it an update, or a create?). This means that within the lower components, such as `LocalBaserowTableSelector`, I can't just pass down the service and get its type from the registry, because `local_baserow_upsert_row` doesn't exist. The only solution I have to work with, if I want to bake the table choices directly into the service types, is to have the parent object (node/workflow action/data source) pass its `serviceType` down, which will give you the 'correct' create/update row service type.

### How to test this PR

1. Ask @picklepete for a workspace export, which will speed up testing.
2. Verify, using the matrix below, that your Local Baserow row-event actions work correctly. Remember that in all three cases, you can only ever write/update to *writable fields*.
3. Confirm that the three service forms still work correctly:
    - AB datasources: you can still create/update/delete data sources.
    - AB workflow actions: you can still create/update/delete them.
    - WA nodes: you can still create/update/delete them. 

|   | Create row | Update row | Delete row |
|--------|--------|--------|--------|
| Normal table | ✅  | ✅ | ✅ |
| One-way synced table | ❌  | ✅  | ❌ |
| Two-way synced table | ✅ | ✅ | ✅ | 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
