### PR TITLE
fix: exclude-personal-views-from-local-baserow-integrations

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
@@ -159,7 +159,7 @@ class LocalBaserowIntegrationType(IntegrationType):
         views = ViewHandler().list_workspace_views(user, workspace, specific=False)
 
         views = list(
-            views.only(
+            views.filter(owned_by__isnull=True).only(
                 "id",
                 "name",
                 "table_id",

--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -443,22 +443,66 @@ class LocalBaserowTableServiceType(LocalBaserowServiceType):
         user: AbstractUser,
         instance: Optional[ServiceSubClass] = None,
     ) -> Dict[str, Any]:
-        """Load the table instance instead of the ID."""
+        """Load the table & view instance instead of the ID."""
 
-        # Check if we already have a table. We may have already
-        # added it in `LocalBaserowViewServiceType.prepare_values`.
-        if "table_id" in values and "table" not in values:
-            table_id = values.pop("table_id")
-            if table_id is not None:
+        values = super().prepare_values(values, user, instance)
+
+        if "table" in values:
+            if (
+                "view_id" not in values
+                and instance
+                and instance.view_id
+                and instance.view.table_id != values["table"].id
+            ):
+                values["view"] = None
+
+        if "view_id" in values:
+            view_id = values.pop("view_id")
+            if view_id is not None:
                 try:
-                    table = TableService().get_table(user, table_id)
-                except TableDoesNotExist:
+                    view = ViewService().get_view(user, view_id)
+                except ViewDoesNotExist as exc:
                     raise DRFValidationError(
-                        f"The table with ID {table_id} does not exist."
+                        detail={
+                            "detail": f"The view with ID {view_id} does not exist.",
+                            "error": "view_does_not_exist",
+                        },
+                        code="view_does_not_exist",
+                    ) from exc
+
+                if view.owned_by_id is not None:
+                    raise DRFValidationError(
+                        detail={
+                            "detail": f"The view with ID {view_id} is a personal view and cannot be used in integrations.",
+                            "error": "personal_view_not_allowed",
+                        },
+                        code="personal_view_not_allowed",
                     )
-                values["table"] = table
+                table_to_validate = values.get(
+                    "table", getattr(instance, "table", None)
+                )
+
+                if not table_to_validate:
+                    raise DRFValidationError(
+                        detail={
+                            "detail": "A table ID is required alongside the view ID.",
+                            "error": "required",
+                        },
+                        code="required",
+                    )
+
+                if view.table_id != table_to_validate.id:
+                    raise DRFValidationError(
+                        detail=f"The view with ID {view_id} is not related to the "
+                        f"given table {table_to_validate.id}.",
+                        code="invalid_view",
+                    )
+                else:
+                    # Add the missing table
+                    values["table"] = view.table
+                values["view"] = view
             else:
-                values["table"] = None
+                values["view"] = None
 
         return super().prepare_values(values, user, instance)
 
@@ -838,6 +882,15 @@ class LocalBaserowViewServiceType(LocalBaserowTableServiceType):
                         },
                         code="view_does_not_exist",
                     ) from exc
+
+                if view.owned_by_id is not None:
+                    raise DRFValidationError(
+                        detail={
+                            "detail": f"The view with ID {view_id} is a personal view and cannot be used in integrations.",
+                            "error": "personal_view_not_allowed",
+                        },
+                        code="personal_view_not_allowed",
+                    )
 
                 # If we're PATCHing with a `table_id` alongside the `view_id`,
                 # validate with that table, otherwise we're PATCHing with just a

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_integration_types.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_integration_types.py
@@ -274,3 +274,31 @@ def test_after_import(data_fixture):
     integration.refresh_from_db()
 
     assert integration.authorized_user == user
+
+
+@pytest.mark.django_db
+def test_get_local_baserow_databases_excludes_personal_views(data_fixture):
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    builder = data_fixture.create_builder_application(workspace=workspace)
+    integration = data_fixture.create_local_baserow_integration(
+        authorized_user=user, application=builder
+    )
+    database = data_fixture.create_database_application(
+        user=user, workspace=workspace, order=1
+    )
+    table = data_fixture.create_database_table(database=database, order=1)
+    
+    regular_view = data_fixture.create_grid_view(table=table, order=1)
+    personal_view = data_fixture.create_grid_view(table=table, order=2, owned_by=user)
+
+    databases = LocalBaserowIntegrationType.get_local_baserow_databases(integration)
+
+    assert len(databases) == 1
+    assert databases[0].id == database.id
+    assert len(databases[0].tables) == 1
+    assert databases[0].tables[0].id == table.id
+    
+    view_ids = [v.id for v in databases[0].views]
+    assert regular_view.id in view_ids
+    assert personal_view.id not in view_ids

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_service_types.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_service_types.py
@@ -1370,6 +1370,28 @@ def test_local_baserow_view_service_type_prepare_values(data_fixture):
     )
 
 
+@pytest.mark.django_db
+def test_local_baserow_view_service_type_prepare_values_rejects_personal_views(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database)
+    personal_view = data_fixture.create_grid_view(table=table, owned_by=user)
+
+    service_type = LocalBaserowViewServiceType
+    service_type.model_class = Mock()
+    instance = data_fixture.create_local_baserow_list_rows_service(table=table)
+
+    with pytest.raises(DRFValidationError) as exc:
+        service_type().prepare_values(
+            {"view_id": personal_view.id}, user, instance
+        )
+    
+    assert exc.value.detail["error"] == "personal_view_not_allowed"
+    assert "personal view" in str(exc.value.detail["detail"]).lower()
+
+
 @pytest.fixture
 def local_baserow_get_context_data_fixture(data_fixture):
     """


### PR DESCRIPTION
closes: #3364

### What is in this PR:

- Excludes personal views from LocalBaserowIntegrationType.get_local_baserow_databases() so they are not included in the integration context.
- Prevents services from accepting personal views by raising a DRFValidationError when a personal view ID is provided in LocalBaserowViewServiceType.prepare_values().
