### PR TITLE
fix(helm): correct ingress TLS template indentation

### DIFF
--- a/changelog/entries/unreleased/bug/4404_fix_helm_ingress_tls_template.json
+++ b/changelog/entries/unreleased/bug/4404_fix_helm_ingress_tls_template.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fix Helm chart ingress TLS template rendering failure.",
+  "issue_origin": "github",
+  "issue_number": 4404,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2025-12-11"
+}

--- a/deploy/helm/baserow/templates/ingress.yaml
+++ b/deploy/helm/baserow/templates/ingress.yaml
@@ -73,8 +73,8 @@ spec:
                 name: {{ include "baserow.global.fullname" . }}-baserow-frontend
                 port:
                   number: 80
-  {{- if .Values.ingress.tls }}
+  {{- with .Values.ingress.tls }}
   tls:
-    {{ tpl (toYaml .Values.ingress.tls | indent 4) . }}
-  {{- end -}}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
## Summary

- Fix Helm chart ingress template YAML parsing failure when TLS configuration is provided
- Replace incorrect `if/indent/tpl` pattern with standard `with/nindent` pattern
- Align TLS section templating with existing annotations section style

## Root Cause

The TLS section in `deploy/helm/baserow/templates/ingress.yaml` used:
```yaml
{{- if .Values.ingress.tls }}
tls:
  {{ tpl (toYaml .Values.ingress.tls | indent 4) . }}
{{- end -}}
```

This caused improper indentation resulting in: `error converting YAML to JSON: yaml: line 72: did not find expected key`

## Solution

Changed to match the annotations block pattern:
```yaml
{{- with .Values.ingress.tls }}
tls:
  {{- toYaml . | nindent 4 }}
{{- end }}
```

## Test Plan

- [x] Verified `helm template` renders correctly with TLS values
- [x] Verified `helm template` renders correctly without TLS values (backwards compatible)
- [x] Verified `helm lint` passes

## Related Issue

Closes #4404
