### PR TITLE
feat(rbac): Improve the Role Assignment Form (#4345)

### DIFF
--- a/enterprise/web-frontend/modules/baserow_enterprise/components/InvitesRoleField.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/InvitesRoleField.vue
@@ -14,6 +14,8 @@
       :roles="roles"
       :workspace="workspace"
       role-value-column="permissions"
+      confirm-no-access
+      :no-access-confirm-message="$t('noAccessConfirmModal.message')"
       @update-role="roleUpdate($event)"
     ></EditRoleContext>
   </div>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/MembersRoleField.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/MembersRoleField.vue
@@ -26,6 +26,8 @@
       :roles="roles"
       :workspace="workspace"
       role-value-column="role_uid"
+      confirm-no-access
+      :no-access-confirm-message="$t('noAccessConfirmModal.message')"
       @update-role="roleUpdate($event)"
     ></EditRoleContext>
     <HelpIcon

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/crudTable/fields/TeamRoleField.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/crudTable/fields/TeamRoleField.vue
@@ -25,6 +25,8 @@
       :roles="roles"
       :workspace="workspace"
       role-value-column="default_role"
+      confirm-no-access
+      :no-access-confirm-message="$t('noAccessConfirmModal.message')"
       @update-role="roleUpdate($event)"
     ></EditRoleContext>
   </div>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/rbac/NoAccessConfirmModal.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/rbac/NoAccessConfirmModal.vue
@@ -1,0 +1,44 @@
+<template>
+  <Modal small>
+    <h2 class="box__title">
+      {{ $t('noAccessConfirmModal.title') }}
+    </h2>
+    <p>
+      {{ $t('noAccessConfirmModal.message') }}
+    </p>
+    <div>
+      <div class="actions">
+        <ul class="action__links">
+          <li>
+            <a @click.prevent="cancel()">{{
+              $t('noAccessConfirmModal.cancel')
+            }}</a>
+          </li>
+        </ul>
+
+        <Button type="danger" @click.prevent="confirm()">
+          {{ $t('noAccessConfirmModal.confirm') }}
+        </Button>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script>
+import modal from '@baserow/modules/core/mixins/modal'
+
+export default {
+  name: 'NoAccessConfirmModal',
+  mixins: [modal],
+  methods: {
+    cancel() {
+      this.$emit('cancel')
+      this.hide()
+    },
+    confirm() {
+      this.$emit('confirm')
+      this.hide()
+    },
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/rbac/SelectSubjectsListFooter.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/rbac/SelectSubjectsListFooter.vue
@@ -18,7 +18,7 @@
       <Button
         type="primary"
         :disabled="!inviteEnabled"
-        @click="inviteEnabled ? $emit('invite', roleSelected) : null"
+        @click="handleInviteClick"
         >{{
           $t('selectSubjectsListFooter.invite', {
             count,
@@ -27,17 +27,22 @@
         }}
       </Button>
     </div>
+    <NoAccessConfirmModal
+      ref="noAccessConfirmModal"
+      @confirm="emitInvite"
+    ></NoAccessConfirmModal>
   </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
 import RoleSelector from '@baserow_enterprise/components/member-roles/RoleSelector'
+import NoAccessConfirmModal from '@baserow_enterprise/components/rbac/NoAccessConfirmModal'
 import { filterRoles } from '@baserow_enterprise/utils/roles'
 
 export default {
   name: 'SelectSubjectsListFooter',
-  components: { RoleSelector },
+  components: { RoleSelector, NoAccessConfirmModal },
   props: {
     showRoleSelector: {
       type: Boolean,
@@ -86,10 +91,29 @@ export default {
     },
   },
   mounted() {
-    // Set a default selected role, the last role is usually the one with the least
-    // access
-    this.roleSelected =
-      this.roles.length > 0 ? this.roles[this.roles.length - 1] : {}
+    // Set a default selected role, preferring VIEWER as a safe default that still
+    // allows access instead of NO_ACCESS which could accidentally lock users out
+    this.roleSelected = this.getDefaultRole()
+  },
+  methods: {
+    getDefaultRole() {
+      if (this.roles.length === 0) return {}
+      // Prefer VIEWER role as safe default, fall back to last role
+      const viewerRole = this.roles.find((role) => role.uid === 'VIEWER')
+      return viewerRole || this.roles[this.roles.length - 1]
+    },
+    handleInviteClick() {
+      if (!this.inviteEnabled) return
+      // Show confirmation modal when NO_ACCESS role is selected
+      if (this.roleSelected?.uid === 'NO_ACCESS') {
+        this.$refs.noAccessConfirmModal.show()
+      } else {
+        this.emitInvite()
+      }
+    },
+    emitInvite() {
+      this.$emit('invite', this.roleSelected)
+    },
   },
 }
 </script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -270,6 +270,12 @@
     },
     "helpTooltip": "Member role assignments override team role assignments."
   },
+  "noAccessConfirmModal": {
+    "title": "Confirm No Access",
+    "message": "Are you sure you want to assign the 'No access' role? This will completely revoke access to this resource and the affected user(s) will no longer be able to view or interact with it.",
+    "confirm": "Yes, assign No Access",
+    "cancel": "Cancel"
+  },
   "membersRoleField": {
     "noAccessHelpText": "This user requires explicit access to resources.",
     "adminHelpText": "Admins can restrict other admins roles."

--- a/web-frontend/modules/core/components/settings/members/EditRoleContext.vue
+++ b/web-frontend/modules/core/components/settings/members/EditRoleContext.vue
@@ -124,6 +124,14 @@ export default {
       type: Boolean,
       default: false,
     },
+    confirmNoAccess: {
+      type: Boolean,
+      default: false,
+    },
+    noAccessConfirmMessage: {
+      type: String,
+      default: '',
+    },
   },
   computed: {
     visibleRoles() {
@@ -137,6 +145,16 @@ export default {
     roleUpdate(roleNew, subject) {
       if (subject[this.roleValueColumn] === roleNew) {
         return
+      }
+
+      // Show confirmation when assigning NO_ACCESS role if confirmNoAccess is enabled
+      if (this.confirmNoAccess && roleNew === 'NO_ACCESS') {
+        const message =
+          this.noAccessConfirmMessage ||
+          "Are you sure you want to assign the 'No access' role? This will completely revoke access to this resource."
+        if (!window.confirm(message)) {
+          return
+        }
       }
 
       this.$emit('update-role', { uid: roleNew, subject })

--- a/web-frontend/modules/core/components/workspace/WorkspaceInviteForm.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceInviteForm.vue
@@ -136,7 +136,11 @@ export default {
     },
     defaultRole() {
       const activeRoles = this.roles.filter((role) => !role.isDeactivated)
-      return activeRoles.length > 0 ? activeRoles[activeRoles.length - 1] : null
+      if (activeRoles.length === 0) return null
+      // Prefer VIEWER role as safe default to prevent accidentally assigning
+      // NO_ACCESS which could lock users out
+      const viewerRole = activeRoles.find((role) => role.uid === 'VIEWER')
+      return viewerRole || activeRoles[activeRoles.length - 1]
     },
     atLeastOneBillableRole() {
       return this.roles.some((role) => role.isBillable)


### PR DESCRIPTION
## Summary

This PR addresses issue #4345 by improving the RBAC role assignment form to prevent users from accidentally locking themselves out of access-controlled records.

### Changes

1. **Change default role from NO_ACCESS to VIEWER**
   - `SelectSubjectsListFooter.vue`: Updated to prefer VIEWER as default role
   - `WorkspaceInviteForm.vue`: Updated to prefer VIEWER as default role
   - This provides a safer default that still allows access to resources

2. **Add confirmation prompt for NO_ACCESS selection**
   - `EditRoleContext.vue`: Added `confirmNoAccess` and `noAccessConfirmMessage` props
   - `NoAccessConfirmModal.vue`: New modal component for invite flow confirmation
   - `SelectSubjectsListFooter.vue`: Integrated confirmation modal for invites
   - `MembersRoleField.vue`, `InvitesRoleField.vue`, `TeamRoleField.vue`: Enabled confirmation
   - Added translations for the confirmation dialog

## Test Plan

- [x] Open role assignment modal for database/table/view
- [x] Verify VIEWER is pre-selected as default instead of NO_ACCESS
- [x] Select NO_ACCESS role and verify confirmation dialog appears
- [x] Confirm the dialog and verify role is assigned
- [x] Cancel the dialog and verify role is not changed
- [x] Test workspace member invite flow with NO_ACCESS role
- [x] Test team role assignment with NO_ACCESS role

## Files Changed

| File | Purpose |
|------|---------|
| `SelectSubjectsListFooter.vue` | Default role logic + confirmation modal integration |
| `WorkspaceInviteForm.vue` | Default role logic for workspace invites |
| `EditRoleContext.vue` | Confirmation props for role context menu |
| `NoAccessConfirmModal.vue` | New confirmation modal component |
| `MembersRoleField.vue` | Enable confirmation for member role changes |
| `InvitesRoleField.vue` | Enable confirmation for invite role changes |
| `TeamRoleField.vue` | Enable confirmation for team role changes |
| `en.json` | Translations for confirmation modal |

Fixes #4345