### PR TITLE
Workaround for ArrayValueSerializer can fail hard with ConversionSyntax exception

### DIFF
--- a/backend/src/baserow/contrib/database/api/fields/serializers.py
+++ b/backend/src/baserow/contrib/database/api/fields/serializers.py
@@ -8,6 +8,7 @@ from django.utils.functional import lazy
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
+from loguru import logger
 from rest_framework import serializers
 from rest_framework.serializers import SkipField, empty
 
@@ -227,7 +228,14 @@ class ArrayValueSerializer(serializers.Serializer):
         self.fields["value"] = child
 
     def to_representation(self, instance):
-        return super().to_representation(instance)
+        # Note this is workaround for https://github.com/baserow/baserow/issues/4424
+        # Once we have a proper way to handle this, we can remove this
+        # and return the super().to_representation(instance) directly.
+        try:
+            return super().to_representation(instance)
+        except Exception:
+            logger.exception("Mismatch between field type and value type")
+        return []
 
 
 class LinkRowValueSerializer(serializers.Serializer):

--- a/changelog/entries/unreleased/bug/4424_do_not_fail_hard_when_arrayvalueserializer_throws_conversion.json
+++ b/changelog/entries/unreleased/bug/4424_do_not_fail_hard_when_arrayvalueserializer_throws_conversion.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Do not fail hard when ArrayValueSerializer throws ConversionSyntax exception",
+    "issue_origin": "github",
+    "issue_number": 4424,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2025-12-11"
+}


### PR DESCRIPTION
### What is in this PR

Workaround for the issue so users can access their table.

### How to test this PR
- Follow steps from issue description and observe that it does not fail hard

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
