### PR TITLE
fix: domain-name-not-unique-error-handling

### DIFF
--- a/backend/src/baserow/contrib/builder/api/domains/views.py
+++ b/backend/src/baserow/contrib/builder/api/domains/views.py
@@ -80,6 +80,7 @@ class DomainsView(APIView):
                 [
                     "ERROR_USER_NOT_IN_GROUP",
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_DOMAIN_NAME_NOT_UNIQUE",
                 ]
             ),
             404: get_error_schema(["ERROR_APPLICATION_DOES_NOT_EXIST"]),
@@ -89,6 +90,7 @@ class DomainsView(APIView):
     @map_exceptions(
         {
             ApplicationDoesNotExist: ERROR_APPLICATION_DOES_NOT_EXIST,
+            DomainNameNotUniqueError: ERROR_DOMAIN_NAME_NOT_UNIQUE,
             SubDomainHasInvalidDomainName: ERROR_SUB_DOMAIN_HAS_INVALID_DOMAIN_NAME,
         }
     )

--- a/backend/tests/baserow/contrib/builder/api/domains/test_domain_views.py
+++ b/backend/tests/baserow/contrib/builder/api/domains/test_domain_views.py
@@ -130,7 +130,7 @@ def test_create_domain_domain_already_exists(api_client, data_fixture):
     )
 
     assert response.status_code == HTTP_400_BAD_REQUEST
-    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response.json()["error"] == "ERROR_DOMAIN_NAME_NOT_UNIQUE"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
closes: #3338

### What is in this PR:

This PR ensures that the API consistently returns `ERROR_DOMAIN_NAME_NOT_UNIQUE` with a 400 Bad Request status when a domain name conflict occurs.
