### PR TITLE
fix: Prefix row-related workflow action types with LocalBaserow and update frontend registry

### DIFF
--- a/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/workflow_action_types.py
@@ -440,8 +440,8 @@ class LocalBaserowWorkflowActionType(BuilderWorkflowServiceActionType):
     pass
 
 
-class UpsertRowWorkflowActionType(LocalBaserowWorkflowActionType):
-    type = "upsert_row"
+class LocalBaserowUpsertRowWorkflowActionType(LocalBaserowWorkflowActionType):
+    type = "local_baserow_upsert_row"
     service_type = LocalBaserowUpsertRowServiceType.type
 
     def get_pytest_params(self, pytest_data_fixture) -> Dict[str, int]:
@@ -449,18 +449,18 @@ class UpsertRowWorkflowActionType(LocalBaserowWorkflowActionType):
         return {"service": service}
 
 
-class CreateRowWorkflowActionType(UpsertRowWorkflowActionType):
-    type = "create_row"
+class LocalBaserowCreateRowWorkflowActionType(LocalBaserowUpsertRowWorkflowActionType):
+    type = "local_baserow_create_row"
     model_class = LocalBaserowCreateRowWorkflowAction
 
 
-class UpdateRowWorkflowActionType(UpsertRowWorkflowActionType):
-    type = "update_row"
+class LocalBaserowUpdateRowWorkflowActionType(LocalBaserowUpsertRowWorkflowActionType):
+    type = "local_baserow_update_row"
     model_class = LocalBaserowUpdateRowWorkflowAction
 
 
-class DeleteRowWorkflowActionType(LocalBaserowWorkflowActionType):
-    type = "delete_row"
+class LocalBaserowDeleteRowWorkflowActionType(LocalBaserowWorkflowActionType):
+    type = "local_baserow_delete_row"
     model_class = LocalBaserowDeleteRowWorkflowAction
     service_type = LocalBaserowDeleteRowServiceType.type
 

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -351,9 +351,9 @@ export class CoreSMTPEmailWorkflowActionType extends WorkflowActionServiceType {
   }
 }
 
-export class CreateRowWorkflowActionType extends WorkflowActionServiceType {
+export class LocalBaserowCreateRowWorkflowActionType extends WorkflowActionServiceType {
   static getType() {
-    return 'create_row'
+    return 'local_baserow_create_row'
   }
 
   get serviceType() {
@@ -364,9 +364,9 @@ export class CreateRowWorkflowActionType extends WorkflowActionServiceType {
   }
 }
 
-export class UpdateRowWorkflowActionType extends WorkflowActionServiceType {
+export class LocalBaserowUpdateRowWorkflowActionType extends WorkflowActionServiceType {
   static getType() {
-    return 'update_row'
+    return 'local_baserow_update_row'
   }
 
   get serviceType() {
@@ -377,15 +377,28 @@ export class UpdateRowWorkflowActionType extends WorkflowActionServiceType {
   }
 }
 
-export class DeleteRowWorkflowActionType extends WorkflowActionServiceType {
+export class LocalBaserowDeleteRowWorkflowActionType extends WorkflowActionServiceType {
   static getType() {
-    return 'delete_row'
+    return 'local_baserow_delete_row'
   }
 
   get serviceType() {
     return this.app.$registry.get(
       'service',
       LocalBaserowDeleteRowWorkflowServiceType.getType()
+    )
+  }
+}
+
+export class LocalBaserowUpsertRowWorkflowActionType extends WorkflowActionServiceType {
+  static getType() {
+    return 'local_baserow_upsert_row'
+  }
+
+  get serviceType() {
+    return this.app.$registry.get(
+      'service',
+      LocalBaserowUpsertRowWorkflowServiceType.getType()
     )
   }
 }


### PR DESCRIPTION
closes: #3737

### What is in this PR:

This PR renames and scopes all row-related `WorkflowActionType` classes to explicitly tie them to the Local Baserow integration. The goal is to avoid generic naming and prepare for future non-Baserow row workflow actions.

**Backend Changes:**

- Updated their type to String.

`UpsertRowWorkflowActionType → LocalBaserowUpsertRowWorkflowActionType`
`CreateRowWorkflowActionType → LocalBaserowCreateRowWorkflowActionType`
`UpdateRowWorkflowActionType → LocalBaserowUpdateRowWorkflowActionType`
`DeleteRowWorkflowActionType → LocalBaserowDeleteRowWorkflowActionType`

**FrontEnd Changes:**

- Updated:

`LocalBaserowUpdateRowWorkflowActionType`
`LocalBaserowDeleteRowWorkflowActionType`
`LocalBaserowUpsertRowWorkflowActionType`

