### PR TITLE
feat: automation-node-celery-dispatch

### DIFF
--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -182,6 +182,12 @@ CELERY_TASK_ROUTES = {
     "baserow.core.usage.tasks": {"queue": BASEROW_GROUP_STORAGE_USAGE_QUEUE},
     "baserow.contrib.database.table.tasks.run_row_count_job": {"queue": "export"},
     "baserow.core.jobs.tasks.clean_up_jobs": {"queue": "export"},
+    "baserow.contrib.automation.workflows.tasks.start_workflow_celery_task": {
+        "queue": "automation_workflow"
+    },
+    "baserow.contrib.automation.workflows.tasks.dispatch_node_celery_task": {
+        "queue": "automation_workflow"
+    },
 }
 CELERY_SOFT_TIME_LIMIT = 60 * 5  # 5 minutes
 CELERY_TIME_LIMIT = CELERY_SOFT_TIME_LIMIT + 60  # 60 seconds

--- a/backend/src/baserow/contrib/automation/automation_dispatch_context.py
+++ b/backend/src/baserow/contrib/automation/automation_dispatch_context.py
@@ -125,3 +125,36 @@ class AutomationDispatchContext(DispatchContext):
         self, fields: List[str], refinement: ServiceAdhocRefinements
     ):
         ...
+
+    def to_dict(self) -> Dict:
+        """Serialize the dispatch context for passing to Celery tasks."""
+        return {
+            "event_payload": self.event_payload,
+            "simulate_until_node_id": self.simulate_until_node.id if self.simulate_until_node else None,
+            "iteration_context": self.iteration_context,
+            "dispatched_nodes": [(node.id, output_uid) for node, output_uid in self.dispatched_nodes],
+        }
+
+    @classmethod
+    def from_dict(cls, workflow: "AutomationWorkflow", data: Dict) -> "AutomationDispatchContext":
+        """Reconstruct dispatch context from serialized data."""
+        from baserow.contrib.automation.nodes.handler import AutomationNodeHandler
+
+        simulate_until_node = None
+        if data.get("simulate_until_node_id"):
+            simulate_until_node = AutomationNodeHandler().get_node(
+                data["simulate_until_node_id"]
+            )
+
+        context = cls(
+            workflow,
+            data.get("event_payload"),
+            simulate_until_node=simulate_until_node,
+        )
+        context.iteration_context = data.get("iteration_context", {})
+
+        for node_id, output_uid in data.get("dispatched_nodes", []):
+            node = AutomationNodeHandler().get_node(node_id)
+            context.dispatched_nodes.append((node, output_uid))
+
+        return context

--- a/backend/src/baserow/contrib/automation/nodes/handler.py
+++ b/backend/src/baserow/contrib/automation/nodes/handler.py
@@ -412,3 +412,32 @@ class AutomationNodeHandler(metaclass=baserow_trace_methods(tracer)):
             raise AutomationNodeMisconfiguredService(
                 f"The node {node.id} is misconfigured and cannot be dispatched. {str(e)}"
             ) from e
+
+    def dispatch_node_async(
+    self,
+    node: "AutomationNode",
+    dispatch_context: AutomationDispatchContext,
+    allowed_nodes=None,
+):
+     """
+     Schedule one node asynchronously using Celery. Node execution happens inside
+    `dispatch_node_celery_task`.
+     """
+     from baserow.contrib.automation.workflows.tasks import dispatch_node_celery_task
+
+     if dispatch_context.simulate_until_node and allowed_nodes is None:
+        allowed_nodes = {
+            *dispatch_context.simulate_until_node.get_previous_nodes(),
+            dispatch_context.simulate_until_node,
+        }
+
+     if allowed_nodes is not None and node not in allowed_nodes:
+        return
+
+     allowed_node_ids = [n.id for n in allowed_nodes] if allowed_nodes else None
+     dispatch_node_celery_task.delay(
+        node.workflow.id,
+        node.id,
+        dispatch_context.to_dict(),
+        allowed_node_ids,
+    )

--- a/backend/src/baserow/contrib/automation/workflows/handler.py
+++ b/backend/src/baserow/contrib/automation/workflows/handler.py
@@ -52,6 +52,7 @@ from baserow.core.services.exceptions import DispatchException
 from baserow.core.storage import ExportZipFile, get_default_storage
 from baserow.core.telemetry.utils import baserow_trace_methods
 from baserow.core.trash.handler import TrashHandler
+from baserow.contrib.automation.workflows.tasks import dispatch_node_celery_task
 from baserow.core.utils import (
     ChildProgressBuilder,
     MirrorDict,
@@ -897,7 +898,7 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
         event_payload: Optional[Union[Dict, List[Dict]]],
         simulate_until_node: Optional[int] = None,
     ) -> None:
-        """Runs the workflow."""
+        """Runs the workflow using async node execution."""
 
         from baserow.contrib.automation.nodes.handler import AutomationNodeHandler
 
@@ -929,8 +930,11 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
 
         try:
             self.before_run(original_workflow)
-            AutomationNodeHandler().dispatch_node(
-                workflow.get_trigger(), dispatch_context
+            dispatch_node_celery_task.delay(
+                workflow.id,
+                workflow.get_trigger().id,
+                dispatch_context.to_dict(),
+                allowed_node_ids=None,
             )
         except AutomationWorkflowTooManyErrors as e:
             history_message = str(e)

--- a/backend/src/baserow/contrib/automation/workflows/tasks.py
+++ b/backend/src/baserow/contrib/automation/workflows/tasks.py
@@ -28,3 +28,51 @@ def start_workflow_celery_task(
         event_payload,
         simulate_until_node=simulate_until_node,
     )
+
+@app.task(bind=True, queue="automation_workflow")
+@atomic_with_retry_on_deadlock()
+def dispatch_node_celery_task(self, workflow_id, node_id, dispatch_context_data, allowed_node_ids=None):
+    from baserow.contrib.automation.automation_dispatch_context import AutomationDispatchContext
+    from baserow.contrib.automation.nodes.handler import AutomationNodeHandler
+    from baserow.contrib.automation.workflows.handler import AutomationWorkflowHandler
+
+    workflow = AutomationWorkflowHandler().get_workflow(workflow_id)
+    node = AutomationNodeHandler().get_node(node_id)
+
+    dispatch_context = AutomationDispatchContext.from_dict(workflow, dispatch_context_data)
+
+    allowed_nodes = None
+    if allowed_node_ids is not None:
+        allowed_nodes = {AutomationNodeHandler().get_node(nid) for nid in allowed_node_ids}
+
+    node_type = node.get_type()
+    dispatch_result = node_type.dispatch(node, dispatch_context)
+    dispatch_context.after_dispatch(node, dispatch_result)
+
+    if children := node.get_children():
+        node_data = dispatch_result.data["results"]
+        iterations = [0] if dispatch_context.simulate_until_node else range(len(node_data))
+
+        for index in iterations:
+            sub_dispatch_context = dispatch_context.clone()
+            sub_dispatch_context.set_current_iteration(node, index)
+
+            for child in children:
+                allowed_node_ids_list = [n.id for n in allowed_nodes] if allowed_nodes else None
+                dispatch_node_celery_task.delay(
+                    workflow_id,
+                    child.id,
+                    sub_dispatch_context.to_dict(),
+                    allowed_node_ids_list,
+                )
+
+    next_nodes = node.get_next_nodes(dispatch_result.output_uid)
+    for next_node in next_nodes:
+        allowed_node_ids_list = [n.id for n in allowed_nodes] if allowed_nodes else None
+        dispatch_node_celery_task.delay(
+            workflow_id,
+            next_node.id,
+            dispatch_context.to_dict(),
+            allowed_node_ids_list,
+        )
+


### PR DESCRIPTION
closes: #3838

### What is in this PR:
Refactor AutomationNodeHandler to dispatch nodes asynchronously via Celery tasks. 
- dispatch_node_async now queues Celery tasks instead of executing nodes inline.
- dispatch_node kept for synchronous simulation/testing.
- Ensures each node and its children are executed in separate Celery tasks.
- Improves parallel execution and scalability of automation workflows.
