### PR TITLE
date dependencies/timeline/kanban nuxt 3 updates

### DIFF
--- a/enterprise/web-frontend/modules/baserow_enterprise/components/dateDependency/DateDependencyFieldPicker.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/dateDependency/DateDependencyFieldPicker.vue
@@ -7,13 +7,13 @@
     :error="hasError"
   >
     <Dropdown
-      :value="value"
+      :value="modelValue"
       :show-search="true"
       :fixed-items="true"
       :disabled="disabled"
       :error="hasError"
       size="regular"
-      @change="$emit('input', $event)"
+      @update:model-value="$emit('update:modelValue', $event)"
     >
       <DropdownItem
         v-for="r in fields"
@@ -31,6 +31,7 @@ import _ from 'lodash'
 
 export default {
   name: 'DateDependencyFieldPicker',
+  emits: ['update:modelValue'],
   props: {
     required: {
       type: Boolean,
@@ -44,6 +45,11 @@ export default {
     fields: {
       type: Array,
       required: true,
+    },
+    modelValue: {
+      type: [Number, String],
+      required: false,
+      default: null,
     },
     value: {
       type: [Number, String],

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanView.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanView.vue
@@ -263,10 +263,18 @@ export default {
     },
     existingSelectOption() {
       return this.singleSelectField.select_options.filter((option) => {
-        return this.$store.getters[
-          this.$options.propsData.storePrefix + 'view/kanban/stackExists'
-        ](option.id)
+        return this.$store.getters[`${this.storePrefix}view/kanban/stackExists`](option.id)
       })
+    },
+    singleSelectFieldId() {
+      return this.$store.getters[`${this.storePrefix}view/kanban/getSingleSelectFieldId`]
+    },
+    allRows(){return this.$store.getters[`${this.storePrefix}view/kanban/getAllRows`]},
+    draggingRow() {return this.$store.getters[`${this.storePrefix}view/kanban/getDraggingRow`]},
+      fieldOptions() {
+      return this.$store.getters[
+        `${this.storePrefix}view/kanban/getAllFieldOptions`
+      ]
     },
   },
   watch: {
@@ -288,19 +296,6 @@ export default {
         }
       },
     },
-  },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        singleSelectFieldId:
-          this.$options.propsData.storePrefix +
-          'view/kanban/getSingleSelectFieldId',
-        allRows: this.$options.propsData.storePrefix + 'view/kanban/getAllRows',
-        draggingRow:
-          this.$options.propsData.storePrefix + 'view/kanban/getDraggingRow',
-      }),
-    }
   },
   mounted() {
     if (this.row !== null) {

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
@@ -130,16 +130,6 @@ export default {
       tableLoading: (state) => state.table.loading,
     }),
   },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        singleSelectFieldId:
-          this.$options.propsData.storePrefix +
-          'view/kanban/getSingleSelectFieldId',
-      }),
-    }
-  },
   methods: {
     async updateAllFieldOptions({ newFieldOptions, oldFieldOptions }) {
       try {

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewStack.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewStack.vue
@@ -257,9 +257,6 @@ export default {
       const fieldId = this.view.card_cover_image_field
       return this.fields.find((field) => field.id === fieldId) || null
     },
-    singleSelectField() {
-      return this.fields.find((field) => field.id === this.singleSelectFieldId)
-    },
   },
   watch: {
     cardHeight() {
@@ -289,21 +286,6 @@ export default {
   beforeDestroy() {
     window.removeEventListener('resize', this.$el.resizeEvent)
     this.$refs.scroll.$el.removeEventListener('scroll', this.$el.scrollEvent)
-  },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        draggingRow:
-          this.$options.propsData.storePrefix + 'view/kanban/getDraggingRow',
-        draggingOriginalStackId:
-          this.$options.propsData.storePrefix +
-          'view/kanban/getDraggingOriginalStackId',
-        singleSelectFieldId:
-          this.$options.propsData.storePrefix +
-          'view/kanban/getSingleSelectFieldId',
-      }),
-    }
   },
   methods: {
     /**

--- a/premium/web-frontend/modules/baserow_premium/components/views/timeline/TimelineContainer.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/timeline/TimelineContainer.vue
@@ -303,6 +303,7 @@ export default {
       showHiddenFieldsInRowModal: false,
       enableAutoScroll: false,
       refreshingRow: false,
+      onUnmountCallback: null,
     }
   },
   computed: {
@@ -443,9 +444,6 @@ export default {
 
     const el = this.scrollAreaElement
     el.addEventListener('scroll', onScroll)
-    this.$once('hook:beforeDestroy', () => {
-      el.removeEventListener('scroll', onScroll)
-    })
 
     // Setup the resize observer to update the grid when the size of the container changes.
     const setupGridDebounced = debounce(() => {
@@ -455,13 +453,24 @@ export default {
       setupGridDebounced()
     })
     resizeObserver.observe(this.$el)
-    this.$once('hook:beforeDestroy', () => {
-      resizeObserver.disconnect()
-    })
+
 
     // Open the row edit modal if the row is set.
     if (this.row !== null) {
       this.populateAndEditRow(this.row)
+    }
+
+    this.onUnmountCallback = ()=> {
+
+      el.removeEventListener('scroll', onScroll)
+      resizeObserver.disconnect()
+    }
+  },
+  beforeUnmount() {
+    if (this.onUnmountCallback) {
+
+      this.onUnmountCallback()
+      this.onUnmountCallback = null
     }
   },
   methods: {

--- a/premium/web-frontend/modules/baserow_premium/components/views/timeline/TimelineViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/timeline/TimelineViewHeader.vue
@@ -89,19 +89,13 @@ export default {
     isDev() {
       return process.env.NODE_ENV === 'development'
     },
+    fieldOptions(){
+      return this.$store.getters[`${this.storePrefix}view/timeline/getAllFieldOptions`]
+      },
     ...mapState({
       tableLoading: (state) => state.table.loading,
     }),
-  },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        fieldOptions:
-          this.$options.propsData.storePrefix +
-          'view/timeline/getAllFieldOptions',
-      }),
-    }
+
   },
   methods: {
     showChooseDatesFieldContext() {

--- a/premium/web-frontend/modules/baserow_premium/mixins/kanbanViewHelper.js
+++ b/premium/web-frontend/modules/baserow_premium/mixins/kanbanViewHelper.js
@@ -8,6 +8,21 @@ export default {
       required: true,
     },
   },
+  computed: {
+    fieldOptions() {
+      return this.$store.getters[
+        `${this.storePrefix}view/kanban/getAllFieldOptions`
+      ]
+    },
+     singleSelectFieldId() {
+      return this.$store.getters[`${this.storePrefix}view/kanban/getSingleSelectFieldId`]
+    },
+    allRows(){return this.$store.getters[`${this.storePrefix}view/kanban/getAllRows`]},
+    draggingRow() {return this.$store.getters[`${this.storePrefix}view/kanban/getDraggingRow`]},
+    draggingOriginalStackId() {
+      return this.$store.getters[`${this.storePrefix}view/kanban/getDraggingOriginalStackId`]
+    }
+  },
   methods: {
     async updateKanban(values) {
       const view = this.view
@@ -24,15 +39,5 @@ export default {
 
       this.$store.dispatch('view/setItemLoading', { view, value: false })
     },
-  },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        fieldOptions:
-          this.$options.propsData.storePrefix +
-          'view/kanban/getAllFieldOptions',
-      }),
-    }
   },
 }

--- a/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
@@ -322,13 +322,14 @@ export const actions = {
     { commit, getters, rootGetters },
     { dateTime, fields, includeFieldOptions = false }
   ) {
+    const { $client, $config, $registry } = useNuxtApp()
     const calendarId = getters.getLastCalendarId
     commit('SET_SELECTED_DATE', dateTime)
 
     const df = getters.getDateField(fields)
     if (
       !df ||
-      this.$registry.get('field', df.type).canRepresentDate(df) === false
+      $registry.get('field', df.type).canRepresentDate(df) === false
     ) {
       commit('RESET')
       return
@@ -340,7 +341,7 @@ export const actions = {
     const filters = getFilters(view, getters.getAdhocFiltering)
 
     try {
-      const { data } = await CalendarService(this.$client).fetchRows({
+      const { data } = await CalendarService($client).fetchRows({
         calendarId: getters.getLastCalendarId,
         limit: getters.getBufferRequestSize,
         offset: 0,
@@ -349,7 +350,7 @@ export const actions = {
         toTimestamp,
         userTimeZone: getUserTimeZone(),
         search: getters.getServerSearchTerm,
-        searchMode: getDefaultSearchModeFromEnv(this.$config),
+        searchMode: getDefaultSearchModeFromEnv($config),
         filters,
         publicUrl: rootGetters['page/view/public/getIsPublic'],
         publicAuthToken: rootGetters['page/view/public/getAuthToken'],
@@ -393,6 +394,7 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { date, fields }
   ) {
+    const { $client, $config} = useNuxtApp()
     const calendarId = getters.getLastCalendarId
     const stack = getters.getDateStack(date)
     const rows = stack.results
@@ -401,7 +403,7 @@ export const actions = {
     const toTimestamp = moment.tz(fromTimestamp, timezone).add(1, 'day')
     const view = rootGetters['view/get'](calendarId)
     const filters = getFilters(view, getters.getAdhocFiltering)
-    const { data } = await CalendarService(this.$client).fetchRows({
+    const { data } = await CalendarService($client).fetchRows({
       calendarId,
       limit: getters.getBufferRequestSize,
       offset: rows.length,
@@ -410,7 +412,7 @@ export const actions = {
       toTimestamp,
       userTimeZone: getUserTimeZone(),
       search: getters.getServerSearchTerm,
-      searchMode: getDefaultSearchModeFromEnv(this.$config),
+      searchMode: getDefaultSearchModeFromEnv($config),
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       filters,
@@ -449,13 +451,13 @@ export const actions = {
     { newFieldOptions, oldFieldOptions, readOnly = false }
   ) {
     dispatch('forceUpdateAllFieldOptions', newFieldOptions)
-
+    const {$client} = useNuxtApp()
     const calendarId = getters.getLastCalendarId
     if (!readOnly) {
       const updateValues = { field_options: newFieldOptions }
 
       try {
-        await ViewService(this.$client).updateFieldOptions({
+        await ViewService($client).updateFieldOptions({
           viewId: calendarId,
           values: updateValues,
         })
@@ -525,13 +527,14 @@ export const actions = {
     })
 
     if (!readOnly) {
+      const {$client, } = useNuxtApp()
       const calendarId = getters.getLastCalendarId
       const oldValues = clone(getters.getAllFieldOptions[field.id])
       const updateValues = { field_options: {} }
       updateValues.field_options[field.id] = values
 
       try {
-        await ViewService(this.$client).updateFieldOptions({
+        await ViewService($client).updateFieldOptions({
           viewId: calendarId,
           values: updateValues,
           undoRedoActionGroupId,
@@ -552,10 +555,11 @@ export const actions = {
     { dispatch, commit, getters },
     { view, table, fields, values }
   ) {
-    const preparedRow = prepareRowForRequest(values, fields, this.$registry)
+    const {$client, $registry} = useNuxtApp()
+    const preparedRow = prepareRowForRequest(values, fields, $registry)
 
     commit('SET_CREATING', true)
-    const { data } = await RowService(this.$client).create(
+    const { data } = await RowService($client).create(
       table.id,
       preparedRow
     )
@@ -581,6 +585,7 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { view, values, fields }
   ) {
+    const { $registry} = useNuxtApp()
     const row = clone(values)
     populateRow(row)
     const matchesFilters = await dispatch('rowMatchesFilters', {
@@ -612,7 +617,7 @@ export const actions = {
     ]
     const sortedRows = clone(stack.results)
     sortedRows.push(row)
-    sortedRows.sort(getRowSortFunction(this.$registry, sortings, fields))
+    sortedRows.sort(getRowSortFunction($registry, sortings, fields))
     const index = sortedRows.findIndex((r) => r.id === row.id)
     const isLast = index === sortedRows.length - 1
 
@@ -632,14 +637,14 @@ export const actions = {
    */
   async deleteRow({ commit, dispatch, getters }, { table, view, row, fields }) {
     commit('SET_ROW_LOADING', { row, value: true })
-
+    const {$client} = useNuxtApp()
     try {
       await dispatch('deletedExistingRow', {
         view,
         fields,
         row,
       })
-      await RowService(this.$client).delete(table.id, row.id)
+      await RowService($client).delete(table.id, row.id)
     } catch (error) {
       await dispatch('createdNewRow', {
         view,
@@ -703,6 +708,8 @@ export const actions = {
     { dispatch, getters, commit },
     { view, row, values, fields }
   ) {
+    const {$registry} = useNuxtApp()
+
     const dateFieldId = getters.getDateFieldIdIfNotTrashed(fields)
     const fieldName = `field_${dateFieldId}`
 
@@ -762,7 +769,7 @@ export const actions = {
           type: DEFAULT_SORT_TYPE_KEY,
         },
       ]
-      newStackResults.sort(getRowSortFunction(this.$registry, sortings, fields))
+      newStackResults.sort(getRowSortFunction($registry, sortings, fields))
       newIndex = newStackResults.findIndex((r) => r.id === newRow.id)
       const newIsLast = newIndex === newStackResults.length - 1
       newExists =
@@ -819,6 +826,8 @@ export const actions = {
     { commit, dispatch, getters, state },
     { view, table, row, field, fields, value, oldValue }
   ) {
+
+    const {$registry, $client} = useNuxtApp()
     const { newRowValues, oldRowValues, updateRequestValues } =
       prepareNewOldAndUpdateRequestValues(
         row,
@@ -826,7 +835,7 @@ export const actions = {
         field,
         value,
         oldValue,
-        this.$registry
+        $registry
       )
 
     dispatch('updateSearchMatchesForRow', { row, fields })
@@ -854,7 +863,7 @@ export const actions = {
         const updateRowsData = [
           Object.assign({ id: row.id }, updateRequestValues),
         ]
-        const { data } = await RowService(this.$client).batchUpdate(
+        const { data } = await RowService($client).batchUpdate(
           table.id,
           updateRowsData
         )
@@ -864,7 +873,7 @@ export const actions = {
           data.items[0],
           fields,
           updatedFieldIds,
-          this.$registry
+          $registry
         )
 
         // One of fields updated is our date field, so the row should be checked if
@@ -906,12 +915,13 @@ export const actions = {
     { commit, getters, rootGetters },
     { table, row }
   ) {
+    const {$client} = useNuxtApp()
     const gridId = getters.getLastCalendarId
     const publicUrl = rootGetters['page/view/public/getIsPublic']
     const publicAuthToken = rootGetters['page/view/public/getAuthToken']
     commit('SET_ROW_FETCHING', { row, value: true })
     try {
-      const { data } = await ViewService(this.$client).fetchRow(
+      const { data } = await ViewService($client).fetchRow(
         table.id,
         row.id,
         gridId,
@@ -989,6 +999,7 @@ export const actions = {
     { commit, getters, rootGetters },
     { row, fields = null, overrides, forced = false }
   ) {
+    const { $config, $registry} = useNuxtApp()
     // Avoid computing search on table loading
     if (getters.getActiveSearchTerm || forced) {
       const rowSearchMatches = calculateSingleRowSearchMatches(
@@ -996,8 +1007,8 @@ export const actions = {
         getters.getActiveSearchTerm,
         getters.isHidingRowsNotMatchingSearch,
         fields,
-        this.$registry,
-        getDefaultSearchModeFromEnv(this.$config),
+        $registry,
+        getDefaultSearchModeFromEnv($config),
         overrides
       )
       commit('SET_ROW_SEARCH_MATCHES', rowSearchMatches)

--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -229,8 +229,9 @@ export const actions = {
   ) {
     commit('SET_ADHOC_FILTERING', adhocFiltering)
     commit('SET_LAST_KANBAN_ID', kanbanId)
+    const {$client} = useNuxtApp()
     const view = rootGetters['view/get'](kanbanId)
-    const { data } = await KanbanService(this.$client).fetchRows({
+    const { data } = await KanbanService($client).fetchRows({
       kanbanId,
       limit: getters.getBufferRequestSize,
       offset: 0,
@@ -264,10 +265,11 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { selectOptionId }
   ) {
+    const {$client} = useNuxtApp()
     const kanbanId = getters.getLastKanbanId
     const stack = getters.getStack(selectOptionId)
     const view = rootGetters['view/get'](kanbanId)
-    const { data } = await KanbanService(this.$client).fetchRows({
+    const { data } = await KanbanService($client).fetchRows({
       kanbanId,
       limit: getters.getBufferRequestSize,
       offset: 0,
@@ -320,9 +322,9 @@ export const actions = {
     const kanbanId = getters.getLastKanbanId
     if (!readOnly) {
       const updateValues = { field_options: newFieldOptions }
-
+      const { $client } = useNuxtApp()
       try {
-        await ViewService(this.$client).updateFieldOptions({
+        await ViewService($client).updateFieldOptions({
           viewId: kanbanId,
           values: updateValues,
         })
@@ -392,13 +394,14 @@ export const actions = {
     })
 
     if (!readOnly) {
+      const {$client} = useNuxtApp()
       const kanbanId = getters.getLastKanbanId
       const oldValues = clone(getters.getAllFieldOptions[field.id])
       const updateValues = { field_options: {} }
       updateValues.field_options[field.id] = values
 
       try {
-        await ViewService(this.$client).updateFieldOptions({
+        await ViewService($client).updateFieldOptions({
           viewId: kanbanId,
           values: updateValues,
           undoRedoActionGroupId,
@@ -419,10 +422,11 @@ export const actions = {
     { dispatch, commit, getters },
     { view, table, fields, values }
   ) {
-    const preparedRow = prepareRowForRequest(values, fields, this.$registry)
+    const {$registry, $client} = useNuxtApp()
+    const preparedRow = prepareRowForRequest(values, fields, $registry)
 
     commit('SET_CREATING', true)
-    const { data } = await RowService(this.$client).create(
+    const { data } = await RowService($client).create(
       table.id,
       preparedRow
     )
@@ -448,6 +452,8 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { view, values, fields }
   ) {
+
+    const { $registry} = useNuxtApp()
     const row = clone(values)
     populateRow(row)
 
@@ -467,7 +473,7 @@ export const actions = {
 
     const sortedRows = clone(stack.results)
     sortedRows.push(row)
-    sortedRows.sort(getRowSortFunction(this.$registry, [], fields))
+    sortedRows.sort(getRowSortFunction($registry, [], fields))
     const index = sortedRows.findIndex((r) => r.id === row.id)
     const isLast = index === sortedRows.length - 1
 
@@ -491,14 +497,14 @@ export const actions = {
     { table, view, row, fields }
   ) {
     commit('SET_ROW_LOADING', { row, value: true })
-
+    const {$client} = useNuxtApp()
     try {
       await dispatch('deletedExistingRow', {
         view,
         fields,
         row,
       })
-      await RowService(this.$client).delete(table.id, row.id)
+      await RowService($client).delete(table.id, row.id)
     } catch (error) {
       await dispatch('createdNewRow', {
         view,
@@ -576,6 +582,7 @@ export const actions = {
     { dispatch, getters, commit },
     { view, row, values, fields }
   ) {
+    const { $registry} = useNuxtApp()
     const singleSelectFieldId = getters.getSingleSelectFieldId
     const fieldName = `field_${singleSelectFieldId}`
 
@@ -615,7 +622,7 @@ export const actions = {
     }
     newStackResults.push(newRow)
     newStackCount++
-    newStackResults.sort(getRowSortFunction(this.$registry, [], fields))
+    newStackResults.sort(getRowSortFunction($registry, [], fields))
     const newIndex = newStackResults.findIndex((r) => r.id === newRow.id)
     const newIsLast = newIndex === newStackResults.length - 1
     const newExists =
@@ -653,12 +660,13 @@ export const actions = {
     { commit, getters, rootGetters },
     { table, row }
   ) {
+    const {$client} = useNuxtApp()
     const gridId = getters.getLastKanbanId
     const publicUrl = rootGetters['page/view/public/getIsPublic']
     const publicAuthToken = rootGetters['page/view/public/getAuthToken']
     commit('SET_ROW_FETCHING', { row, value: true })
     try {
-      const { data } = await ViewService(this.$client).fetchRow(
+      const { data } = await ViewService($client).fetchRow(
         table.id,
         row.id,
         gridId,
@@ -704,6 +712,7 @@ export const actions = {
     if (row === null) {
       return
     }
+    const {$client, $registry} = useNuxtApp()
 
     // First we need to figure out what the current position of the row is and how
     // that should be communicated to the backend later. The backend expects another
@@ -722,7 +731,7 @@ export const actions = {
     const singleSelectField = fields.find(
       (field) => field.id === getters.getSingleSelectFieldId
     )
-    const singleSelectFieldType = this.$registry.get(
+    const singleSelectFieldType = $registry.get(
       'field',
       SingleSelectFieldType.getType()
     )
@@ -759,7 +768,7 @@ export const actions = {
     // If the stack has changed, the value needs to be updated with the backend.
     if (originalStackId !== currentStackId) {
       try {
-        const { data } = await RowService(this.$client).update(
+        const { data } = await RowService($client).update(
           table.id,
           row.id,
           newValuesForUpdate
@@ -781,7 +790,7 @@ export const actions = {
       originalStackId !== currentStackId
     ) {
       try {
-        const { data } = await RowService(this.$client).move(
+        const { data } = await RowService($client).move(
           table.id,
           row.id,
           before !== null ? before.id : null
@@ -808,7 +817,8 @@ export const actions = {
         // Only add the row to the temporary copy if it doesn't live the current stack.
         sortedRows.push(row)
       }
-      sortedRows.sort(getRowSortFunction(this.$registry, [], [], null))
+      const {$registry} = useNuxtApp()
+      sortedRows.sort(getRowSortFunction($registry, [], [], null))
       const targetIndex = sortedRows.findIndex((r) => r.id === row.id)
 
       dispatch('forceMoveRowTo', {
@@ -871,6 +881,8 @@ export const actions = {
     { commit, dispatch },
     { view, table, row, field, fields, value, oldValue }
   ) {
+
+    const {$client, $registry} = useNuxtApp()
     const { newRowValues, oldRowValues, updateRequestValues } =
       prepareNewOldAndUpdateRequestValues(
         row,
@@ -878,7 +890,7 @@ export const actions = {
         field,
         value,
         oldValue,
-        this.$registry
+        $registry
       )
 
     await dispatch('updatedExistingRow', {
@@ -904,7 +916,7 @@ export const actions = {
         const updateRowsData = [
           Object.assign({ id: row.id }, updateRequestValues),
         ]
-        const { data } = await RowService(this.$client).batchUpdate(
+        const { data } = await RowService($client).batchUpdate(
           table.id,
           updateRowsData
         )
@@ -914,7 +926,7 @@ export const actions = {
           data.items[0],
           fields,
           updatedFieldIds,
-          this.$registry
+          $registry
         )
         commit('UPDATE_ROW', { row, values: readOnlyData })
       }, row.id)
@@ -940,7 +952,7 @@ export const actions = {
     const field = fields.find(
       (field) => field.id === getters.getSingleSelectFieldId
     )
-
+  const {$client} = useNuxtApp()
     const updateValues = {
       type: field.type,
       select_options: clone(field.select_options),
@@ -950,7 +962,7 @@ export const actions = {
     // Instead of using the field store, we manually update the existing field
     // because we need to extract the newly created select option id from the
     // response before the field is updated in the store.
-    const { data } = await FieldService(this.$client).update(
+    const { data } = await FieldService($client).update(
       field.id,
       updateValues
     )
@@ -987,6 +999,7 @@ export const actions = {
     { getters, commit, dispatch },
     { fields, optionId, values }
   ) {
+    const {$client} = useNuxtApp()
     const field = fields.find(
       (field) => field.id === getters.getSingleSelectFieldId
     )
@@ -999,7 +1012,7 @@ export const actions = {
       type: field.type,
       select_options: options,
     }
-    const { data } = await FieldService(this.$client).update(
+    const { data } = await FieldService($client).update(
       field.id,
       updateValues
     )
@@ -1030,6 +1043,7 @@ export const actions = {
     { getters, commit, dispatch },
     { singleSelectField, optionId, deferredFieldUpdate = false }
   ) {
+    const {$client} = useNuxtApp()
     const options = clone(singleSelectField.select_options)
     const index = options.findIndex((o) => o.id === optionId)
     options.splice(index, 1)
@@ -1038,7 +1052,7 @@ export const actions = {
       type: singleSelectField.type,
       select_options: options,
     }
-    const { data } = await FieldService(this.$client).update(
+    const { data } = await FieldService($client).update(
       singleSelectField.id,
       updateValues
     )

--- a/web-frontend/modules/database/mixins/formViewHelpers.js
+++ b/web-frontend/modules/database/mixins/formViewHelpers.js
@@ -9,6 +9,11 @@ export default {
       required: true,
     },
   },
+  computed: {
+    fieldOptions() {
+          return this.$store.getters[`${this.storePrefix}view/form/getAllFieldOptions`]
+      },
+  },
   methods: {
     async updateForm(values) {
       const view = this.view
@@ -75,14 +80,5 @@ export default {
         notifyIf(error, 'view')
       }
     },
-  },
-  beforeCreate() {
-    this.$options.computed = {
-      ...(this.$options.computed || {}),
-      ...mapGetters({
-        fieldOptions:
-          this.$options.propsData.storePrefix + 'view/form/getAllFieldOptions',
-      }),
-    }
   },
 }

--- a/web-frontend/modules/database/store/view/bufferedRows.js
+++ b/web-frontend/modules/database/store/view/bufferedRows.js
@@ -318,7 +318,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
       context,
       { viewId, fields, adhocFiltering, adhocSorting, initialRowArguments = {} }
     ) {
-      const { $client } = useNuxtApp()
+      const { $client, $config } = useNuxtApp()
       const { commit, getters, rootGetters } = context
       commit('SET_VIEW_ID', viewId)
       commit('SET_SEARCH', {
@@ -332,7 +332,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
         offset: 0,
         limit: getters.getRequestSize,
         search: getters.getServerSearchTerm,
-        searchMode: getDefaultSearchModeFromEnv(this.$config),
+        searchMode: getDefaultSearchModeFromEnv($config),
         publicUrl: rootGetters['page/view/public/getIsPublic'],
         publicAuthToken: rootGetters['page/view/public/getAuthToken'],
         orderBy: getOrderBy(view, adhocSorting),
@@ -363,7 +363,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
       { dispatch, getters, commit, rootGetters },
       parameters
     ) {
-      const { $client } = useNuxtApp()
+      const { $client, $config } = useNuxtApp()
       const viewId = getters.getViewId
       const { startIndex, endIndex } = parameters
 
@@ -417,7 +417,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
           limit: rangeToFetch.limit,
           signal: lastRequestController.signal,
           search: getters.getServerSearchTerm,
-          searchMode: getDefaultSearchModeFromEnv(this.$config),
+          searchMode: getDefaultSearchModeFromEnv($config),
           publicUrl: rootGetters['page/view/public/getIsPublic'],
           publicAuthToken: rootGetters['page/view/public/getAuthToken'],
           orderBy: getOrderBy(view, getters.getAdhocSorting),
@@ -461,7 +461,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
       { dispatch, commit, getters, rootGetters },
       { fields, adhocFiltering, adhocSorting, includeFieldOptions = false }
     ) {
-      const { $client } = useNuxtApp()
+      const { $client, $config } = useNuxtApp()
       const viewId = getters.getViewId
       commit('SET_ADHOC_FILTERING', adhocFiltering)
       commit('SET_ADHOC_SORTING', adhocSorting)
@@ -485,7 +485,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
           viewId,
           signal: lastRequestController.signal,
           search: getters.getServerSearchTerm,
-          searchMode: getDefaultSearchModeFromEnv(this.$config),
+          searchMode: getDefaultSearchModeFromEnv($config),
           publicUrl: rootGetters['page/view/public/getIsPublic'],
           publicAuthToken: rootGetters['page/view/public/getAuthToken'],
           filters: getFilters(view, adhocFiltering),
@@ -527,7 +527,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
             includeFieldOptions,
             signal: lastRequestController.signal,
             search: getters.getServerSearchTerm,
-            searchMode: getDefaultSearchModeFromEnv(this.$config),
+            searchMode: getDefaultSearchModeFromEnv($config),
             publicUrl: rootGetters['page/view/public/getIsPublic'],
             publicAuthToken: rootGetters['page/view/public/getAuthToken'],
             orderBy: getOrderBy(view, adhocSorting),
@@ -1216,7 +1216,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
       { commit, getters, rootGetters },
       { row, fields, overrides, forced = false }
     ) {
-      const { $registry } = useNuxtApp()
+      const { $registry, $config } = useNuxtApp()
       // Avoid computing search on table loading
       if (getters.getActiveSearchTerm || forced) {
         const rowSearchMatches = calculateSingleRowSearchMatches(
@@ -1225,7 +1225,7 @@ export default ({ service, customPopulateRow, fieldOptions }) => {
           getters.isHidingRowsNotMatchingSearch,
           fields,
           $registry,
-          getDefaultSearchModeFromEnv(this.$config),
+          getDefaultSearchModeFromEnv($config),
           overrides
         )
 


### PR DESCRIPTION
### What is in this PR

nuxt 3 fixes in:
- date dependencies modal
- views selection/timeline
- kanban view
that allow to open a view, scroll, partially create items

Things missing:
* creating a card in kanban view doesn't produce correct results yet.
* if a row modal is opened, it's not possible to close it

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
