### PR TITLE
Fix the Local Baserow user source form.

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_user_sources_from_being_creat.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_user_sources_from_being_creat.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented user sources from being created or updated with a user source table.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2025-12-17"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/integrations/localBaserow/components/userSources/LocalBaserowUserSourceForm.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/integrations/localBaserow/components/userSources/LocalBaserowUserSourceForm.vue
@@ -2,8 +2,8 @@
   <form>
     <LocalBaserowTableSelector
       v-model="computedTableId"
-      disallow-data-synced-tables
       class="local-baserow-user-source-form__table-selector"
+      :service-type="userSourceType"
       :databases="integration.context_data.databases"
       :display-view-dropdown="false"
       dropdown-size="large"

--- a/enterprise/web-frontend/modules/baserow_enterprise/integrations/userSourceTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/integrations/userSourceTypes.js
@@ -67,6 +67,15 @@ export class LocalBaserowUserSourceType extends UserSourceType {
   }
 
   /**
+   * The Local Baserow user source will only work on tables which are not data-synced.
+   * @param {Array} tables - The array of tables to filter.
+   * @returns {Array} - The supported tables.
+   */
+  supportedTables(tables) {
+    return tables.filter((table) => !table.is_data_sync)
+  }
+
+  /**
    * Returns the allowed field type list for the role field.
    * It's defined here so that it can be changed by a plugin.
    *

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowDeleteRowServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowDeleteRowServiceForm.vue
@@ -4,7 +4,6 @@
     enable-row-id
     v-bind="$attrs"
     :enable-view-picker="false"
-    disallow-data-synced-tables
     v-on="$listeners"
   />
 </template>

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowUpdateRowServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowUpdateRowServiceForm.vue
@@ -1,7 +1,6 @@
 <template>
   <UpsertRowWorkflowActionForm
     enable-row-id
-    :disallow-data-synced-tables="false"
     v-bind="$attrs"
     v-on="$listeners"
   />


### PR DESCRIPTION
### What is in this PR

At the moment if you visit the Local Baserow user source form, after creating the record, you can't then select a table. This is due to my recent `LocalBaserowTableSelector` changes, I missed `LocalBaserowUserSourceForm`.

### How to test this PR

- Try in develop, you'll notice it doesn't work.
- Try and create/update a Local Baserow user source in this branch, it'll work.
- Confirm you still can't choose a data-synced table in the form.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
