### PR TITLE
Update install on Cloudron doc - the cloudron cli is not needed for t…

### DIFF
--- a/docs/installation/install-on-cloudron.md
+++ b/docs/installation/install-on-cloudron.md
@@ -11,92 +11,26 @@ you follow the installation guide to the end and log into the cloudron app store
 you have Cloudron installed and running on your service you can follow the steps below
 to install the Baserow app.
 
-> Basic experience with the Cloudron CLI is required.
+## Install 
 
-## Install Cloudron CLI
+When Cloudron is installed and running, you can install Baserow by following these steps:
+1. Open the Cloudron app store by navigating to your Cloudron URL in a web browser
+2. Search for "Baserow" in the app store
+3. Click on the Baserow app and then click on the "Install" button
+4. Follow the prompts to configure the Baserow app domain
+5. Once the installation is complete, you can access Baserow by navigating to the
+   domain you specified during the installation process or just click on the Baserow app in
+   the Cloudron dashboard
 
-The Cloudron CLI runs on your local machine and not the server. It can be installed on
-Linux/Mac using the following command. More information about installing can be found on
-their website at
-[https://docs.cloudron.io/custom-apps/cli/](https://docs.cloudron.io/custom-apps/cli/).
+## Updates
 
-```
-$ # Do not attempt to install on your server, but instead on your local machine.
-$ sudo npm install -g cloudron
-```
+Cloudron automatically handles updates for all installed apps, including Baserow. When
+a new version of Baserow is released, Cloudron will automatically update the app to the latest
+version without any manual intervention required.
 
-## Installing Baserow
+## Noteworthy extra settings
 
-If you have not already been logged into your Cloudron platform you can do so by
-executing the following command.
-
-```
-$ cloudron login my.{YOUR_DOMAIN}
-```
-
-When you have successfully logged in, you need to clone the latest Baserow repository to
-your machine. This contains the Cloudron manifest file that you need when installing the
-app.
-
-```
-$ git clone --branch master https://github.com/baserow/baserow.git
-$ cd baserow/deploy/cloudron
-```
-
-After that you can install the Baserow Cloudron app by executing the following commands.
-
-```
-$ cloudron install -l baserow.{YOUR_DOMAIN} --image baserow/cloudron:2.0.5
-App is being installed.
-...
-App is installed.
-```
-
-> All the available versions can be found here:
-> [https://hub.docker.com/r/baserow/cloudron](https://hub.docker.com/r/baserow/cloudron)
-
-> If you get Failed to install app: 402 message: Missing token errors make sure you
-> have fully completed the installation of the cloudron server linked at the start.
-> Specifically you need to login to your cloudron account on your server's cloudron
-> webpage.
-
-When the installation has finished you can visit your domain and create a new account
-from there.
-
-## Updating
-
-When a new Baserow version becomes available you can easily update to that version.
-First you need to figure out what your app id is. You can do so by executing the
-`cloudron list` command. After determining your app id, if you do not have a local
-copy of the Baserow repository then run the following command to get one:
-
-```
-git clone --branch master https://github.com/baserow/baserow.git
-cd baserow/deploy/cloudron
-```
-
-If you do have an existing copy of the Baserow repo then run the following commands
-from the root of the repository to update the repository to the latest version:
-
-```
-cd baserow # change to where-ever your local baserow repo is found
-git pull
-cd deploy/cloudron
-```
-
-Once you have an up-to date local copy of the Baserow repo, and you have changed into 
-the `baserow/deploy/cloudron` folder, you can upgrade your cloudron baserow server to 
-the latest version by running the following command:
-
-```
-cloudron update --app {YOUR_APP_ID} --image baserow/cloudron:2.0.5
-```
-
-> Note that you must replace the image with the most recent image of Baserow. The
-> latest version can be found here:
-> [https://gitlab.com/baserow/baserow/container_registry/1692077](https://gitlab.com/baserow/baserow/container_registry/1692077)
-
-## Application builder domains
+### Application builder domains
 
 Baserow has an application builder that allows to deploy an application to a specific
 domain. Because Cloudron has a reverse proxy that routes a domain to the right Cloudron

--- a/docs/installation/install-on-cloudron.md
+++ b/docs/installation/install-on-cloudron.md
@@ -28,7 +28,7 @@ Cloudron automatically handles updates for all installed apps, including Baserow
 a new version of Baserow is released, Cloudron will automatically update the app to the latest
 version without any manual intervention required.
 
-## Noteworthy extra settings
+## Extra settings
 
 ### Application builder domains
 


### PR DESCRIPTION
### What is in this PR
Updating the documentation for installation on/with Cloudron.
The current documentation is the manual / custom app guide, which is not needed since Baserow is available in the app store:
https://www.cloudron.io/store/io.baserow.cloudronapp.html

### How to test this PR
If you'd like to confirm this doc change.
Visit https://my.demo.cloudron.io/ login with username `cloudron` and password `cloudron` go to the app store and install baserow.

