### PR TITLE
Prevent creating a new constraint when the enter key of the default value is pressed

### DIFF
--- a/changelog/entries/unreleased/bug/present_constraint_create_on_form_submit_event.json
+++ b/changelog/entries/unreleased/bug/present_constraint_create_on_form_submit_event.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Prevent creating a new constraint when the enter key of the default value is pressed.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2025-12-22"
+}

--- a/web-frontend/modules/database/components/field/FieldConstraintsSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldConstraintsSubForm.vue
@@ -12,6 +12,7 @@
             !disabled && hasAvailableConstraints && !hasConflictingConstraints
           "
           :disabled="allConstraintsAdded || hasDisabledFieldConstraints"
+          tag="a"
           icon="iconoir-plus"
           @click.prevent="addConstraint"
         >


### PR DESCRIPTION
### What is in this PR

Prevent adding new constraint when enter key is pressed on default input.

Before:

https://github.com/user-attachments/assets/8f1dc7ad-1fd2-417a-b5ee-f58bd8cab42d


### How to test this PR

- Open a the grid view of a table.
- Add a new text field.
- Focus on the default value and press the enter key.
- Observe that no constraint is added.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
