### PR TITLE
Ensure button fields are styled correctly.

### DIFF
--- a/changelog/entries/unreleased/bug/4494_resolve_an_issue_with_styling_button_fields_in_table_element.json
+++ b/changelog/entries/unreleased/bug/4494_resolve_an_issue_with_styling_button_fields_in_table_element.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolve an issue with styling button fields in table elements.",
+    "issue_origin": "github",
+    "issue_number": 4494,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2025-12-22"
+}

--- a/web-frontend/modules/builder/components/elements/components/collectionField/form/ButtonFieldForm.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/form/ButtonFieldForm.vue
@@ -17,6 +17,7 @@
           style-key="cell"
           :config-block-types="['table', 'button']"
           :theme="baseTheme"
+          :on-styles-changed="onFieldStylesChanged"
           :extra-args="{ onlyCell: true, noAlignment: true }"
           variant="normal"
         />


### PR DESCRIPTION
### What is in this PR

In #4427 I forgot to change `ButtonField`, so the style change isn't working for collection field types of `button`.

### How to test this PR

- Add a table element
- Change a column's type to `button`
- Style its override
- In `develop` it won't work, in this branch it will.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
