### PR TITLE
Token auth endpoint response labels.

### DIFF
--- a/backend/src/baserow/api/user/schemas.py
+++ b/backend/src/baserow/api/user/schemas.py
@@ -79,8 +79,14 @@ success_create_user_response_schema = build_object_type(
 
 authenticated_user_response_schema = {
     "oneOf": [
-        success_create_user_response_schema,
-        two_factor_required_response_schema,
+        {
+            "title": "Without two-factor authentication",
+            **success_create_user_response_schema,
+        },
+        {
+            "title": "With two-factor authentication",
+            **two_factor_required_response_schema,
+        },
     ],
 }
 

--- a/changelog/entries/unreleased/bug/improved_the_token_auth_endpoints_response_labels_so_that_de.json
+++ b/changelog/entries/unreleased/bug/improved_the_token_auth_endpoints_response_labels_so_that_de.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Improved the `token_auth` endpoint's response labels so that developers can differentiate between 2fa enabled and 2fa disabled responses.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2025-12-30"
+}


### PR DESCRIPTION
### What is in this PR

Add a title to the two schemas so that developers can differentiate between the two.

### How to test this PR

Check [the API redoc](http://localhost:8000/api/redoc/#tag/User/operation/token_auth).

| Before | After |
|--------|--------|
| <img width="501" height="396" alt="Screenshot 2025-12-30 at 09 56 07" src="https://github.com/user-attachments/assets/40a7c8bb-f3c3-46f0-b40b-18f6422c38b6" /> | <img width="496" height="388" alt="Screenshot 2025-12-30 at 09 55 37" src="https://github.com/user-attachments/assets/a4024cb2-fb9d-4486-8130-aba7fbe2607a" />

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
