### PR TITLE
Fix field mapping when importing CSV

### DIFF
--- a/changelog/entries/unreleased/bug/primary_key_change_import.json
+++ b/changelog/entries/unreleased/bug/primary_key_change_import.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix field mapping when importing CSV",
+    "issue_origin": "github",
+    "issue_number": 3259,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-01-07"
+}

--- a/web-frontend/modules/database/components/table/ImportFileModal.vue
+++ b/web-frontend/modules/database/components/table/ImportFileModal.vue
@@ -98,7 +98,7 @@
           <SimpleGrid
             class="import-modal__preview"
             :rows="previewImportData"
-            :fields="fields"
+            :fields="sortedFields"
           />
         </Tab>
         <Tab :title="$t('importFileModal.filePreview')">
@@ -245,6 +245,18 @@ export default {
     }
   },
   computed: {
+    sortedFields() {
+      // The sort needs to follow the same sort logic as
+      // RowHandler.import_rows(...) in the backend
+      return [...this.fields].sort((a, b) => {
+        const aPrimary = !!a.primary
+        const bPrimary = !!b.primary
+        if (aPrimary !== bPrimary) return aPrimary ? -1 : 1
+        const orderDiff = (a.order ?? 0) - (b.order ?? 0)
+        if (orderDiff !== 0) return orderDiff
+        return a.id - b.id
+      })
+    },
     isTableCreated() {
       if (!this.job?.table_id) {
         return false
@@ -281,7 +293,7 @@ export default {
      * All writable fields.
      */
     writableFields() {
-      return this.fields.filter((field) =>
+      return this.sortedFields.filter((field) =>
         this.fieldTypes[field.type].canWriteFieldValues(field)
       )
     },
@@ -353,7 +365,7 @@ export default {
     },
     availableUpsertFields() {
       const selected = Object.values(this.mapping)
-      return this.fields.filter((field) => {
+      return this.sortedFields.filter((field) => {
         return (
           selected.includes(field.id) && this.fieldTypes[field.type].canUpsert()
         )

--- a/web-frontend/modules/database/store/field.js
+++ b/web-frontend/modules/database/store/field.js
@@ -265,7 +265,6 @@ export const actions = {
     data = populateField(data, $registry)
 
     commit('UPDATE_ITEM', { id: field.id, values: data })
-    commit('UPDATE_ITEM', { id: field.id, values: data })
 
     // The view might need to do some cleanup regarding the filters and sortings if the
     // type has changed.


### PR DESCRIPTION
### What is in this PR

The fix sorts field items in the `field` store after primary field change so that the import functionality correctly maps data to columns in order. It also makes fields on `table.vue` page to be reactive, so that such change is propagated into a view, e.g. that a grid view is correctly rendered after the fields are sorted.

### How to test this PR
- Follow the steps to reproduce from the bug report, the problem should be fixed.

### Checklist

- [X] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
