### PR TITLE
Resolve realtime event glitches.

### DIFF
--- a/changelog/entries/unreleased/bug/4520_resolved_a_bug_where_unsubscribing_from_a_baserow_pages_real.json
+++ b/changelog/entries/unreleased/bug/4520_resolved_a_bug_where_unsubscribing_from_a_baserow_pages_real.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug where unsubscribing from a Baserow page's realtime events wouldn't work correctly.",
+    "issue_origin": "github",
+    "issue_number": 4520,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-01-09"
+}

--- a/web-frontend/modules/core/plugins/realTimeHandler.js
+++ b/web-frontend/modules/core/plugins/realTimeHandler.js
@@ -166,12 +166,14 @@ export class RealTimeHandler {
     this.pages = this.pages.filter(
       (item) => JSON.stringify(item) !== JSON.stringify({ page, parameters })
     )
-    this.socket?.send(
-      JSON.stringify({
-        remove_page: page,
-        ...parameters,
-      })
-    )
+    if (this.connected) {
+      this.socket.send(
+        JSON.stringify({
+          remove_page: page,
+          ...parameters,
+        })
+      )
+    }
   }
 
   /*


### PR DESCRIPTION
### What is in this PR

Resolving two issues:

1. In our `realTimeHandler`, don't `unsubscribe` the client if the state isn't `CONNECTED`, if they're re-connecting then it'll throw an error when `socket.send` is called.
2. For defensive programming purposes, in the `table` page's `beforeDestroy`, ensure we have a `realtimePage` before trying to `unsubscribe` from it. If we attempt to destroy before `mounted` happens, then `realtimePage` is still null.

See Sentry issue 7087880696 for a real example of (1) happening. Case (2) isn't happening yet, but it could.

### How to test this PR

Roughly the error you'll see in the console (could be CONNECTING, though, like in Sentry):

<img width="2421" height="641" alt="Screenshot 2026-01-09 at 10 49 20" src="https://github.com/user-attachments/assets/3bccb61a-aa25-4282-8e77-5139ca8b29d5" />

- In `develop`:
    - Visit a database table
    - Force a disconnection with `$nuxt.$realtime.disconnect()`
    - Navigate to another table
    - You'll get a JS error in the console (see above)
 - In this branch:
    - When you navigate, you won't get an error.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
