### PR TITLE
Fix page title

### DIFF
--- a/web-frontend/modules/core/components/FormInput.vue
+++ b/web-frontend/modules/core/components/FormInput.vue
@@ -126,7 +126,7 @@ function updateValue(raw) {
 }
 
 function onInput(e) {
-  const raw = input.value?.value
+  const raw = input.value.value
 
   if (!raw && props.defaultValueWhenEmpty !== null) return
 
@@ -134,9 +134,9 @@ function onInput(e) {
 }
 
 function onBlur(e) {
-  const raw = input.value?.value
+  const raw = input.value.value
 
-  if (!raw && props.defaultValueWhenEmpty !== null && input.value) {
+  if (!raw && props.defaultValueWhenEmpty !== null) {
     input.value.value = props.defaultValueWhenEmpty
     updateValue(props.defaultValueWhenEmpty)
   }


### PR DESCRIPTION
This PR fixes the page title for published apps.

When you publish a Builder app, although the browser tab showed the correct page name, the `<title>` in the HTML source showed stale/cached data. To clear the cache, I had to either reload the page or re-publish the app.

I couldn't narrow down exactly where the caching/stale data was coming from. I tried disabling caching via the `getCachedData()` option in the `useAsyncData()` composable. I also tried setting a unique key as the first argument to `useAsyncData()` (this was needed because we now use a composable, and in the previous version we used a plain component).

Ultimately, I found that forcing the cache-control headers fixed the issue. This should be fine, since we didn't do any caching in the frontend in the previous version anyway, as we controlled caching at the API level.