### PR TITLE
Fix missing front-end job types are not handled properly

### DIFF
--- a/changelog/entries/unreleased/bug/missing_job_registry.json
+++ b/changelog/entries/unreleased/bug/missing_job_registry.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix missing front-end job types are not handled properly",
+    "issue_origin": "github",
+    "issue_number": 4544,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-01-15"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/jobTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/jobTypes.js
@@ -1,0 +1,11 @@
+import { JobType } from '@baserow/modules/core/jobTypes'
+
+export class AuditLogExportJobType extends JobType {
+  static getType() {
+    return 'audit_log_export'
+  }
+
+  getName() {
+    return 'audit_log_export'
+  }
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugin.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugin.js
@@ -1,3 +1,4 @@
+import { AuditLogExportJobType } from '@baserow_enterprise/jobTypes'
 import { registerRealtimeEvents } from '@baserow_enterprise/realtime'
 import {
   RolePermissionManagerType,
@@ -152,6 +153,8 @@ export default defineNuxtPlugin({
       'workspaceSettingsPage',
       new TeamsWorkspaceSettingsPageType(context)
     )
+
+    $registry.register('job', new AuditLogExportJobType(context))
 
     $registry.register('license', new AdvancedLicenseType(context))
     $registry.register(

--- a/web-frontend/modules/database/jobTypes.js
+++ b/web-frontend/modules/database/jobTypes.js
@@ -80,3 +80,23 @@ export class FileImportJobType extends JobType {
     return 'fileImport'
   }
 }
+
+export class DuplicateFieldJobType extends JobType {
+  static getType() {
+    return 'duplicate_field'
+  }
+
+  getName() {
+    return 'duplicate_field'
+  }
+}
+
+export class AirtableJobType extends JobType {
+  static getType() {
+    return 'airtable'
+  }
+
+  getName() {
+    return 'airtable'
+  }
+}

--- a/web-frontend/modules/database/plugin.js
+++ b/web-frontend/modules/database/plugin.js
@@ -4,6 +4,8 @@ import {
   DuplicateTableJobType,
   SyncDataSyncTableJobType,
   FileImportJobType,
+  DuplicateFieldJobType,
+  AirtableJobType,
 } from '@baserow/modules/database/jobTypes'
 import {
   GridViewType,
@@ -386,6 +388,8 @@ export default defineNuxtPlugin({
     $registry.register('job', new DuplicateTableJobType(context))
     $registry.register('job', new SyncDataSyncTableJobType(context))
     $registry.register('job', new FileImportJobType(context))
+    $registry.register('job', new DuplicateFieldJobType(context))
+    $registry.register('job', new AirtableJobType(context))
 
     $registry.register('view', new GridViewType(context))
     $registry.register('view', new GalleryViewType(context))


### PR DESCRIPTION
Fix for missing items in the job registry:
- Added missing job types
- Handled error when a new job type is added on the backend without its front-end counterpart

### Checklist

- [X] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
