### PR TITLE
Allow form input with row ID to set link row field

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/utils.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/utils.py
@@ -195,6 +195,25 @@ def prepare_files_for_db(value: Any, user: AbstractUser) -> List[dict]:
     return result
 
 
+def ensure_link_row_value(value: Any) -> Any:
+    """
+    Convert string values that look like integers to actual integers.
+    This is used for link row fields where IDs may be passed as strings
+    (e.g. from form data).
+
+    :param value: The value to process.
+    :return: The value possibly converted to an integer.
+    """
+
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return value
+
+    return value
+
+
 def guess_cast_function_from_response_serializer_field(
     serializer_field: Union[Field, Serializer], service: LocalBaserowUpsertRow
 ) -> Optional[Callable]:
@@ -207,6 +226,7 @@ def guess_cast_function_from_response_serializer_field(
 
     from baserow.contrib.database.api.fields.serializers import (
         FileFieldRequestSerializer,
+        LinkRowRequestSerializer,
     )
 
     if isinstance(serializer_field, FileFieldRequestSerializer):
@@ -216,6 +236,12 @@ def guess_cast_function_from_response_serializer_field(
         return lambda value: prepare_files_for_db(
             value, service.integration.authorized_user
         )
+
+    if isinstance(serializer_field, LinkRowRequestSerializer):
+        # Special case for the link row field serializer. The resolved value may
+        # be a string or an integer. When it is a string, it may be a numeric
+        # row ID that needs to be converted to an integer.
+        return ensure_link_row_value
 
     json_type = guess_json_type_from_response_serializer_field(serializer_field)
 

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_upsert_row_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_upsert_row_service_type.py
@@ -833,3 +833,57 @@ def test_extract_properties_returns_expected_list(path, expected):
     result = service_type.extract_properties(path)
 
     assert result == expected
+
+
+@pytest.mark.django_db
+def test_local_baserow_upsert_row_service_dispatch_data_link_row_with_string_id(
+    data_fixture,
+):
+    """
+    Test that when using a link row field mapping, the resolved value is converted
+    to an integer if it is a row ID that is a string (e.g. form data)
+    """
+
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    integration = data_fixture.create_local_baserow_integration(
+        application=page.builder, user=user
+    )
+    database = data_fixture.create_database_application(
+        workspace=page.builder.workspace
+    )
+
+    related_table = TableHandler().create_table_and_fields(
+        user=user,
+        database=database,
+        name=data_fixture.fake.name(),
+        fields=[("Name", "text", {})],
+    )
+    related_row = RowHandler().create_row(user=user, table=related_table, values={})
+
+    table = TableHandler().create_table_and_fields(
+        user=user,
+        database=database,
+        name=data_fixture.fake.name(),
+        fields=[
+            ("linked", "link_row", {"link_row_table": related_table}),
+        ],
+    )
+
+    service = data_fixture.create_local_baserow_upsert_row_service(
+        table=table,
+        integration=integration,
+    )
+    service_type = service.get_type()
+    link_field = table.field_set.get(name="linked")
+    service.field_mappings.create(field=link_field, value='get("form_data.999")')
+
+    # Simulate form data where the row ID is provided as a string
+    formula_context = {"form_data": {"999": str(related_row.id)}}
+    dispatch_context = FakeDispatchContext(context=formula_context)
+
+    dispatch_values = service_type.resolve_service_formulas(service, dispatch_context)
+    dispatch_data = service_type.dispatch_data(
+        service, dispatch_values, dispatch_context
+    )
+    assert getattr(dispatch_data["data"], link_field.db_column).count() == 1

--- a/changelog/entries/unreleased/bug/3887_fixed_a_bug_where_form_data_couldnt_be_used_to_set_a_link_ro.json
+++ b/changelog/entries/unreleased/bug/3887_fixed_a_bug_where_form_data_couldnt_be_used_to_set_a_link_ro.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where form data with string IDs couldn't be used to set a link row field.",
+    "issue_origin": "github",
+    "issue_number": 3887,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-01-19"
+}


### PR DESCRIPTION
# What is in this PR
This PR fixes a bug when using a Form to set a Link row field.

Previously, if you had a Form that uses a data input to set a Link row field, you'd get this error upon submitting the form:
```
Invalid form
The "Create a row" action failed: One or more fields contain invalid values.
Value3 error for field "linked games": The provided text value '1' doesn't match any row in the linked table.
```

This is because the frontend sends a string version of the ID during dispatch (e.g. `"1"`). In the backend, this fails because it's not an integer, so we default to searching the primary field for a matching value.

We now cast the value to an int. The downside is that if the primary field contains string numbers, we won't be able to match on that (since we're now looking for an int). If we want to be able to support both cases, we could perform a query to check if a row exists where the primary field has that string value. But that would be an extra query for every request, so I'm not sure if we want to do that.

# How to test this PR
In DB:
- Create a Table "A" that has a Link to table field
- Create another Table "B" that has some rows

In AB:
- Create a Form element containing a Data Input element.
- Configure the Data Input element by setting its Value to a specific ID of a specific row in "Table B".
- In the Form, add a "Create a row" event that updates the Link to table field using the Form data -> Data input.

When you preview this app and submit the form, you'll get the error described above.

In this branch,  you should be able to submit the form without any errors.

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
