### PR TITLE
fix: migration tests broken after pgvector 

### DIFF
--- a/backend/src/baserow/contrib/database/migrations/0170_update_password_tsv_fields.py
+++ b/backend/src/baserow/contrib/database/migrations/0170_update_password_tsv_fields.py
@@ -32,4 +32,4 @@ class Migration(migrations.Migration):
         ("database", "0169_alter_galleryview_card_cover_image_field"),
     ]
 
-    operations = [migrations.RunSQL(update_password_tsv_index)]
+    operations = [migrations.RunSQL(update_password_tsv_index, migrations.RunSQL.noop)]

--- a/backend/src/baserow/test_utils/pytest_conftest.py
+++ b/backend/src/baserow/test_utils/pytest_conftest.py
@@ -828,6 +828,14 @@ def second_separate_database_for_migrations(
     _set_suffix_to_test_databases(suffix)
 
     with django_db_blocker.unblock():
+        # Clear ContentType cache before setting up the second database.
+        # The cache may contain IDs from the first test database, which would
+        # cause foreign key violations when post_migrate signals try to create
+        # records referencing ContentTypes in the new database.
+        from django.contrib.contenttypes.models import ContentType
+
+        ContentType.objects.clear_cache()
+
         db_cfg = setup_databases(
             verbosity=request.config.option.verbose,
             interactive=False,

--- a/enterprise/backend/src/baserow_enterprise/migrations/0044_migrate_app_labels.py
+++ b/enterprise/backend/src/baserow_enterprise/migrations/0044_migrate_app_labels.py
@@ -29,5 +29,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(migrate_app_labels),
+        migrations.RunPython(migrate_app_labels, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
### What is in this PR
- A fix for migration test

### How to test this PR
Verify that
```
BASEROW_TESTS_SETUP_DB_FIXTURE=off just b t -k test_0082_remove_duplicate_workspace_invitation_forwards --run-once-per-day-in-ci
```
now works

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
