### PR TITLE
Optimize the resetting of Workflow temporary states

### DIFF
--- a/backend/src/baserow/contrib/automation/workflows/handler.py
+++ b/backend/src/baserow/contrib/automation/workflows/handler.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core.files.storage import Storage
 from django.db import IntegrityError
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from loguru import logger
@@ -847,17 +847,26 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
         This should be executed after an event for this workflow is received.
         """
 
-        fields_to_save = []
-        if workflow.allow_test_run_until:
-            workflow.allow_test_run_until = None
-            fields_to_save.append("allow_test_run_until")
+        # Conditionally update the temporary states only when needed to avoid
+        # unnecessary writes.
+        updated = (
+            AutomationWorkflow.objects.filter(id=workflow.id)
+            .filter(
+                Q(allow_test_run_until__isnull=False)
+                | Q(simulate_until_node__isnull=False)
+            )
+            .update(
+                allow_test_run_until=None,
+                simulate_until_node=None,
+            )
+        )
 
-        if workflow.simulate_until_node:
-            workflow.simulate_until_node = None
-            fields_to_save.append("simulate_until_node")
+        # Update any potential stale states in memory, e.g. a concurrent
+        # worker running the same workflow.
+        workflow.allow_test_run_until = None
+        workflow.simulate_until_node = None
 
-        if fields_to_save:
-            workflow.save(update_fields=fields_to_save)
+        if updated:
             automation_workflow_updated.send(self, user=None, workflow=workflow)
 
     def async_start_workflow(

--- a/backend/tests/baserow/contrib/automation/workflows/test_workflow_handler.py
+++ b/backend/tests/baserow/contrib/automation/workflows/test_workflow_handler.py
@@ -870,3 +870,35 @@ def test_toggle_simulate_mode_on_immediate(
 
     mock_automation_workflow_updated.send.assert_called_once()
     mock_async_start_workflow.assert_called_once()
+
+
+@patch(f"{WORKFLOWS_MODULE}.handler.automation_workflow_updated")
+@pytest.mark.django_db
+def test_reset_workflow_temporary_states_doesnt_write_when_already_null(
+    mock_automation_workflow_updated, data_fixture
+):
+    """
+    When both of the workflow temporary states are already null, we shouldn't write
+    to the database to avoid unnecessary row locking.
+    """
+
+    workflow = data_fixture.create_automation_workflow(
+        trigger_type=LocalBaserowRowsCreatedNodeTriggerType.type
+    )
+
+    # This simulates a scenario where we have multiple workers running the
+    # same workflow. The first workflow run would have caused the temporary
+    # states to be reset.
+    #
+    # A subsequent workflow run (this one) would still have the stale states
+    # in memory, but it shouldn't cause a database write since the reset logic
+    # does a conditional update.
+    workflow.simulate_until_node_id = 123
+    workflow.allow_test_run_until = datetime.datetime.now()
+
+    AutomationWorkflowHandler().reset_workflow_temporary_states(workflow)
+
+    assert workflow.simulate_until_node_id is None
+    assert workflow.allow_test_run_until is None
+
+    mock_automation_workflow_updated.send.assert_not_called()

--- a/changelog/entries/unreleased/refactor/optimize_how_workflow_temporary_states_are_updated_to_reduce.json
+++ b/changelog/entries/unreleased/refactor/optimize_how_workflow_temporary_states_are_updated_to_reduce.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Optimized how workflow temporary states are updated to reduce lock contention.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-02-02"
+}


### PR DESCRIPTION
# What is in this PR
This PR optimizes how the temporary workflow states are reset.

In the currently implementation, when there are multiple Celery workers running the same workflow, the following could happen:
- Workflow run 1 acquires a lock to reset the temporary states.
- Workflow run 2 might have not-null values in memory because it fetched the states before run 1 was committed.
- Workflow run 2 waits for the lock to be released, and then performs an unnecessary update (the temp states were already set by run 1).

The current implementation checks `if workflow.allow_test_run_until` and ` if workflow.simulate_until_node`, which is checking the object value. This means that even if the database was already updated by run 1, it will still perform an update (acquiring a new lock).

This PR refactors the reset logic to conditionally update the temporary states only when needed. This should minimize lock contention and unnecessary writes. 

# How to test this PR
This is hard to test, since the underlying scenario is a race condition via concurrent workers running the same workflow. But the test case should cover this well.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
