### PR TITLE
Skip nonexisting jobs in run_export_job task

### DIFF
--- a/backend/src/baserow/contrib/database/export/tasks.py
+++ b/backend/src/baserow/contrib/database/export/tasks.py
@@ -2,6 +2,8 @@ from datetime import timedelta
 
 from django.conf import settings
 
+from celery.exceptions import Ignore
+
 from baserow.config.celery import app
 
 EXPORT_SOFT_TIME_LIMIT = 60 * 60
@@ -23,8 +25,11 @@ def run_export_job(self, job_id):
     from baserow.contrib.database.export.handler import ExportHandler
     from baserow.contrib.database.export.models import ExportJob
 
-    job = ExportJob.objects.get(id=job_id)
-    ExportHandler.run_export_job(job)
+    try:
+        job = ExportJob.objects.get(id=job_id)
+        ExportHandler.run_export_job(job)
+    except ExportJob.DoesNotExist:
+        raise Ignore("Task obsolete")
 
 
 # noinspection PyUnusedLocal

--- a/backend/tests/baserow/contrib/database/export/test_export_tasks.py
+++ b/backend/tests/baserow/contrib/database/export/test_export_tasks.py
@@ -1,0 +1,11 @@
+import pytest
+from celery.exceptions import Ignore
+
+from baserow.contrib.database.export.tasks import run_export_job
+
+
+@pytest.mark.django_db
+def test_run_export_job_skips_nonexisting_jobs():
+    non_existing_job_id = 999
+    with pytest.raises(Ignore):
+        run_export_job(non_existing_job_id)


### PR DESCRIPTION
From Sentry: https://baserow.sentry.io/issues/6723081204/events/fc3244935b374dc6b34b423316292cd3/