### PR TITLE
chore: fix failing test_single_select_field_type_rows

### DIFF
--- a/backend/src/baserow/contrib/database/fields/handler.py
+++ b/backend/src/baserow/contrib/database/fields/handler.py
@@ -793,7 +793,9 @@ class FieldHandler(metaclass=baserow_trace_methods(tracer)):
             from_field_type.can_have_select_options
             and not to_field_type.can_have_select_options
         ):
-            SelectOption.objects.filter(field_id=field.id).delete()
+            SelectOption.objects.filter(field_id=field.id)._raw_delete(
+                using=DEFAULT_DB_ALIAS
+            )
 
         to_field_type.after_update(
             old_field,


### PR DESCRIPTION
### What is in this PR

Fix this error recently appeared on an old test:

```
sql = 'UPDATE "database_table_1" SET "field_2" = NULL WHERE "database_table_1"."field_2" IN (%s, %s)'
params = (4, 5)
ignored_wrapper_args = (False, {'connection': <DatabaseWrapper vendor='postgresql' alias='default'>, 'cursor': <django.db.backends.utils.CursorWrapper object at 0x115659290>})

    def _execute(self, sql, params, *ignored_wrapper_args):
        # Raise a warning during app initialization (stored_app_configs is only
        # ever set during testing).
        if not apps.ready and not apps.stored_app_configs:
            warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E               psycopg2.errors.UndefinedFunction: operator does not exist: text = integer
E               LINE 1: ...field_2" = NULL WHERE "database_table_1"."field_2" IN (4, 5)
E                                                                             ^
E               HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.

.venv/lib/python3.11/site-packages/django/db/backends/utils.py:105: UndefinedFunction

The above exception was the direct cause of the following exception:

data_fixture = <baserow.test_utils.fixtures.Fixtures object at 0x1152146d0>
django_assert_num_queries = functools.partial(<function _assert_num_queries at 0x108bb8d60>, <_pytest.config.Config object at 0x106977b90>)

    @pytest.mark.django_db
    def test_single_select_field_type_rows(data_fixture, django_assert_num_queries):
        user = data_fixture.create_user()
        database = data_fixture.create_database_application(user=user, name="Placeholder")
        table = data_fixture.create_database_table(name="Example", database=database)
        other_select_option = data_fixture.create_select_option()
    
        field_handler = FieldHandler()
        row_handler = RowHandler()
    
        field = field_handler.create_field(
            user=user,
            table=table,
            name="name",
            type_name="single_select",
            select_options=[
                {"value": "Option 1", "color": "red"},
                {"value": "Option 2", "color": "blue"},
            ],
        )
    
        with pytest.raises(ValidationError):
            row_handler.create_row(
                user=user, table=table, values={f"field_{field.id}": 999999}
            )
    
        with pytest.raises(ValidationError):
            row_handler.create_row(
                user=user, table=table, values={f"field_{field.id}": other_select_option.id}
            )
    
        with pytest.raises(ValidationError):
            row_handler.create_row(
                user=user, table=table, values={f"field_{field.id}": "Missing option value"}
            )
    
        select_options = field.select_options.all()
        row = row_handler.create_row(
            user=user, table=table, values={f"field_{field.id}": select_options[0].id}
        )
    
        assert getattr(row, f"field_{field.id}").id == select_options[0].id
        assert getattr(row, f"field_{field.id}").value == select_options[0].value
        assert getattr(row, f"field_{field.id}").color == select_options[0].color
        assert getattr(row, f"field_{field.id}_id") == select_options[0].id
    
        field = field_handler.update_field(
            user=user,
            field=field,
            select_options=[
                {"value": "Option 3", "color": "orange"},
                {"value": "Option 4", "color": "purple"},
            ],
        )
    
        select_options = field.select_options.all()
        row_2 = row_handler.create_row(
            user=user, table=table, values={f"field_{field.id}": select_options[0].value}
        )
        assert getattr(row_2, f"field_{field.id}").id == select_options[0].id
        assert getattr(row_2, f"field_{field.id}").value == select_options[0].value
        assert getattr(row_2, f"field_{field.id}").color == select_options[0].color
        assert getattr(row_2, f"field_{field.id}_id") == select_options[0].id
    
        row_3 = row_handler.create_row(
            user=user, table=table, values={f"field_{field.id}": select_options[1].id}
        )
        assert getattr(row_3, f"field_{field.id}").id == select_options[1].id
        assert getattr(row_3, f"field_{field.id}_id") == select_options[1].id
    
        row_4 = row_handler.create_row(
            user=user, table=table, values={f"field_{field.id}": select_options[0].id}
        )
        assert getattr(row_4, f"field_{field.id}").id == select_options[0].id
        assert getattr(row_4, f"field_{field.id}_id") == select_options[0].id
    
        model = table.get_model()
        row_0, row_1, row_2, row_3 = model.objects.all()
    
        with django_assert_num_queries(2):
            rows = list(model.objects.all().enhance_by_fields())
    
        assert getattr(row_0, f"field_{field.id}") is None
        assert getattr(row_1, f"field_{field.id}").id == select_options[0].id
        assert getattr(row_2, f"field_{field.id}").id == select_options[1].id
        assert getattr(row_3, f"field_{field.id}").id == select_options[0].id
    
        row.refresh_from_db()
        assert getattr(row, f"field_{field.id}") is None
        assert getattr(row, f"field_{field.id}_id") is None
    
>       field = field_handler.update_field(user=user, field=field, new_type_name="text")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

backend/tests/baserow/contrib/database/field/test_single_select_field_type.py:256: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
backend/src/baserow/core/telemetry/utils.py:120: in _sync_wrapper
    return wrapped_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend/src/baserow/contrib/database/fields/handler.py:796: in update_field
    SelectOption.objects.filter(field_id=field.id).delete()
.venv/lib/python3.11/site-packages/django/db/models/query.py:1201: in delete
    num_deleted, num_deleted_per_model = collector.delete()
                                         ^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/django/db/models/deletion.py:485: in delete
    combined_updates.update(**{field.name: value})
.venv/lib/python3.11/site-packages/django/db/models/query.py:1263: in update
    rows = query.get_compiler(self.db).execute_sql(ROW_COUNT)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:2060: in execute_sql
    row_count = super().execute_sql(result_type)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1623: in execute_sql
    cursor.execute(sql, params)
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:79: in execute
    return self._execute_with_wrappers(
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:92: in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:100: in _execute
    with self.db.wrap_database_errors:
.venv/lib/python3.11/site-packages/django/db/utils.py:91: in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
```

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
