### PR TITLE
Fix multiple refresh token api calls

### DIFF
--- a/web-frontend/modules/core/middleware/authentication.js
+++ b/web-frontend/modules/core/middleware/authentication.js
@@ -32,37 +32,8 @@ export default defineNuxtRouteMiddleware(async (to) => {
       await store.dispatch('auth/refresh', refreshToken)
     } catch (error) {
       if (error.response?.status === 401) {
-        return navigateTo({ name: 'login' }, { external: true })
+        return navigateTo({ name: 'login' }, { external: true }) // force browser 302 redirect to get rid of the jwt cookie in the request headers
       }
     }
   }
 })
-
-/*
-Previous Nuxt 2 middleware:
-export default function ({ store, req, app, route, redirect }) {
-  // If nuxt generate or already authenticated, pass this middleware
-  if ((import.meta.server && !req) || store.getters['auth/isAuthenticated']) return
-
-  const userSession = route.query.user_session
-  if (userSession) {
-    setUserSessionCookie(app, userSession)
-  }
-
-  // token can be in the query string (SSO) or in the cookies (previous session)
-  let refreshToken = route.query.token
-  if (refreshToken) {
-    setToken(app, refreshToken)
-  } else {
-    refreshToken = getTokenIfEnoughTimeLeft(app)
-  }
-
-  if (refreshToken) {
-    return store.dispatch('auth/refresh', refreshToken).catch((error) => {
-      if (error.response?.status === 401) {
-        return redirect({ name: 'login' })
-      }
-    })
-  }
-}
-*/


### PR DESCRIPTION
### What is in this PR
This MR is addressing the multiple refresh token api calls 

### How to test this PR
- Login into baserow. Open dev tools and amend the jwt cookie appending `xxx`. 
- Refresh the page and observe you are redirected to the login page, and there is no multiple api calls to the `/api/auth/refresh-token` endpoint`  in the server logs

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
