### PR TITLE
Changed license detail page descriptions

### DIFF
--- a/enterprise/web-frontend/modules/baserow_enterprise/licenseTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/licenseTypes.js
@@ -88,6 +88,13 @@ export class AdvancedLicenseType extends LicenseType {
     const { $i18n } = this.app
     return $i18n.t('enterprise.overflowWarning')
   }
+
+  getLicenseSeatOverflowButton(license) {
+    return {
+      href: 'https://baserow.io/subscriptions',
+      text: this.app.$i18n.t('advanced.openSubscriptions'),
+    }
+  }
 }
 
 export class EnterpriseWithoutSupportLicenseType extends AdvancedLicenseType {
@@ -120,6 +127,13 @@ export class EnterpriseWithoutSupportLicenseType extends AdvancedLicenseType {
 
   getLicenseBadgeColor() {
     return 'neutral'
+  }
+
+  getLicenseSeatOverflowButton(license) {
+    return {
+      href: 'https://baserow.io/contact-sales',
+      text: this.app.$i18n.t('license.contactSalesMoreSeats'),
+    }
   }
 }
 

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -4,7 +4,8 @@
     "cannotDisableAllAuthProvidersDescription": "It is not possible to disable or delete last enabled provider."
   },
   "advanced": {
-    "license": "Advanced"
+    "license": "Advanced",
+    "openSubscriptions": "Open subscriptions for more seats"
   },
   "enterprise": {
     "license": "Enterprise",

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -12,8 +12,8 @@
     "sidebarTooltip": "Your account has access to the enterprise features globally",
     "rbac": "RBAC",
     "sso": "SSO",
-    "licenseDescription": "Viewers are free with Baserow Enterprise. If a user has any other role, in any workspace then they will use a paid seat automatically.",
-    "overflowWarning": "You have too many non-viewer users and have used up all of your paid seats. Change users to become viewers on each workspaces members page.",
+    "licenseDescription": "Viewers and commenters free in this plan. If a user has any other role, in any workspace then they will use a paid seat automatically.",
+    "overflowWarning": "You have too many non-viewer/commenter users and have used up all of your paid seats. Change users to become viewers on each workspaces members page.",
     "deactivated": "Available in the advanced/enterprise version"
   },
   "trashType": {

--- a/premium/web-frontend/modules/baserow_premium/components/license/AutomaticLicenseSeats.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/license/AutomaticLicenseSeats.vue
@@ -31,6 +31,7 @@
         tag="a"
         :href="moreSeatsButton.href"
         target="_blank"
+        rel="noopener noreferrer"
       >
         {{ moreSeatsButton.text }}
       </Button>

--- a/premium/web-frontend/modules/baserow_premium/components/license/AutomaticLicenseSeats.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/license/AutomaticLicenseSeats.vue
@@ -26,12 +26,13 @@
         {{ licenseType.getLicenseSeatOverflowWarning(license) }}
       </p>
       <Button
+        v-if="moreSeatsButton"
         type="secondary"
         tag="a"
-        href="https://baserow.io/contact-sales"
+        :href="moreSeatsButton.href"
         target="_blank"
       >
-        {{ $t('license.contactSalesMoreSeats') }}
+        {{ moreSeatsButton.text }}
       </Button>
     </div>
   </div>
@@ -64,6 +65,9 @@ export default {
     },
     licenseType() {
       return this.$registry.get('license', this.license.product_code)
+    },
+    moreSeatsButton() {
+      return this.licenseType.getLicenseSeatOverflowButton(this.license)
     },
   },
 }

--- a/premium/web-frontend/modules/baserow_premium/components/license/DisconnectLicenseModal.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/license/DisconnectLicenseModal.vue
@@ -5,7 +5,12 @@
     </h2>
     <Error :error="error"></Error>
     <div>
-      <i18n-t keypath="disconnectLicenseModal.disconnectDescription" tag="p">
+      <i18n-t keypath="license.disconnectDescription" tag="p">
+        <template #subscriptions>
+          <a href="https://baserow.io/subscriptions" target="_blank"
+            >baserow.io/subscriptions</a
+          >
+        </template>
         <template #contact>
           <a href="https://baserow.io/contact" target="_blank"
             >baserow.io/contact</a

--- a/premium/web-frontend/modules/baserow_premium/licenseTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/licenseTypes.js
@@ -117,4 +117,11 @@ export class PremiumLicenseType extends LicenseType {
   getLicenseSeatOverflowWarning(license) {
     return ''
   }
+
+  /**
+   * Can optionally return an object like `{"href": "https://", "text": "Click here"}`.
+   */
+  getLicenseSeatOverflowButton(license) {
+    return null
+  }
 }

--- a/premium/web-frontend/modules/baserow_premium/licenseTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/licenseTypes.js
@@ -54,6 +54,13 @@ export class LicenseType extends Registerable {
   getLicenseSeatOverflowWarning(license) {
     throw new Error('Must be set by the implementing sub class.')
   }
+
+  /**
+   * Can optionally return an object like `{"href": "https://", "text": "Click here"}`.
+   */
+  getLicenseSeatOverflowButton(license) {
+    return null
+  }
 }
 
 export class PremiumLicenseType extends LicenseType {
@@ -116,12 +123,5 @@ export class PremiumLicenseType extends LicenseType {
 
   getLicenseSeatOverflowWarning(license) {
     return ''
-  }
-
-  /**
-   * Can optionally return an object like `{"href": "https://", "text": "Click here"}`.
-   */
-  getLicenseSeatOverflowButton(license) {
-    return null
   }
 }

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -239,7 +239,7 @@
     "rowUsage": "Row usage",
     "storeUsage": "Storage usage",
     "disconnectLicense": "Disconnect license",
-    "disconnectDescription": "Are you sure that you want to disconnect this license? If you disconnect this license while it's active, the related users won’t have access to the plan anymore. It will effectively remove the license form this instance. You can change the instance ID of your subscription via the subscriptions page on {subscriptions} or by contacting our support team at {contact} if you're on enterprise.",
+    "disconnectDescription": "Are you sure that you want to disconnect this license? If you disconnect this license while it's active, the related users won’t have access to the plan anymore. It will effectively remove the license from this instance. You can change the instance ID of your subscription via the subscriptions page on {subscriptions} or by contacting our support team at {contact} if you're on enterprise.",
     "moreSeatsNeededTitle": "More Seats Needed",
     "contactSalesMoreSeats": "Contact Sales for more seats",
     "automaticSeatsProgressBarStatus": "{seats_taken} / {seats} paid seats and {free_users_count} free seats in use",

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -76,8 +76,7 @@
     }
   },
   "disconnectLicenseModal": {
-    "disconnectLicense": "Disconnect license",
-    "disconnectDescription": "Are you sure that you want to disconnect this license? If you disconnect this license while it's active, the related users won’t have access to the plan anymore. It will effectively remove the license. Please contact our support team at {contact} if you want to use this license in another self hosted instance."
+    "disconnectLicense": "Disconnect license"
   },
   "registerLicenseForm": {
     "licenseKey": "License key"
@@ -240,7 +239,7 @@
     "rowUsage": "Row usage",
     "storeUsage": "Storage usage",
     "disconnectLicense": "Disconnect license",
-    "disconnectDescription": "If you disconnect this license while it's active, the related users won’t have access to the plan anymore. It will effectively remove the license. Please contact our support team at {contact} if you want to use this license in another self hosted instance.",
+    "disconnectDescription": "Are you sure that you want to disconnect this license? If you disconnect this license while it's active, the related users won’t have access to the plan anymore. It will effectively remove the license form this instance. You can change the instance ID of your subscription via the subscriptions page on {subscriptions} or by contacting our support team at {contact} if you're on enterprise.",
     "moreSeatsNeededTitle": "More Seats Needed",
     "contactSalesMoreSeats": "Contact Sales for more seats",
     "automaticSeatsProgressBarStatus": "{seats_taken} / {seats} paid seats and {free_users_count} free seats in use",

--- a/premium/web-frontend/modules/baserow_premium/pages/admin/license.vue
+++ b/premium/web-frontend/modules/baserow_premium/pages/admin/license.vue
@@ -178,12 +178,18 @@
             </div>
             <i18n-t keypath="license.disconnectDescription" tag="p">
               <template #subscriptions>
-                <a href="https://baserow.io/subscriptions" target="_blank"
+                <a
+                  href="https://baserow.io/subscriptions"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >baserow.io/subscriptions</a
                 >
               </template>
               <template #contact>
-                <a href="https://baserow.io/contact" target="_blank"
+                <a
+                  href="https://baserow.io/contact"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   >baserow.io/contact</a
                 >
               </template>
@@ -218,7 +224,7 @@ definePageMeta({
 
 const route = useRoute()
 const router = useRouter()
-const { $client, $registry } = useNuxtApp()
+const { $client, $registry, $i18n } = useNuxtApp()
 
 // Fetch license data
 const { data, error } = await useAsyncData(
@@ -263,6 +269,10 @@ const disconnectModal = ref(null)
 const licenseType = computed(() => {
   if (!license.value) return null
   return $registry.get('license', license.value.product_code)
+})
+
+useHead({
+  title: $i18n.t('license.title', { name: licenseType.value?.getName() || '' }),
 })
 
 const licenseFeatureDescription = computed(() => {

--- a/premium/web-frontend/modules/baserow_premium/pages/admin/license.vue
+++ b/premium/web-frontend/modules/baserow_premium/pages/admin/license.vue
@@ -177,6 +177,11 @@
               {{ $t('license.disconnectLicense') }}
             </div>
             <i18n-t keypath="license.disconnectDescription" tag="p">
+              <template #subscriptions>
+                <a href="https://baserow.io/subscriptions" target="_blank"
+                  >baserow.io/subscriptions</a
+                >
+              </template>
               <template #contact>
                 <a href="https://baserow.io/contact" target="_blank"
                   >baserow.io/contact</a

--- a/premium/web-frontend/modules/baserow_premium/pages/admin/licenses.vue
+++ b/premium/web-frontend/modules/baserow_premium/pages/admin/licenses.vue
@@ -34,7 +34,11 @@
         >
           {{ $t('licenses.registerLicense') }}
         </Button>
-        <RedirectToBaserowModal :href="getLicenseURL" target="_blank">
+        <RedirectToBaserowModal
+          :href="getLicenseURL"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {{ $t('licenses.getLicense') }}
         </RedirectToBaserowModal>
       </div>


### PR DESCRIPTION
### What is in this PR

- Now shows "Open subscriptions for more seats" when looking at an over limit advanced license.
- Changed the "disconnect license" text to also be correct for premium and enterprise.
- Removed duplicate translation.

<img width="1361" height="821" alt="image" src="https://github.com/user-attachments/assets/b8ca5506-b0bd-4147-8244-9381d4a1f9d3" />


### How to test this PR

- Create an 1 seats premium, advanced and enterprise license and register them all in one instance.
- Make sure there are more than 1 paid seats in the instance.
- Confirm that the "More seats needed" warning and "Disconnect license" have the correct text. It should match how the user bought the license.
