### PR TITLE
Nuxt3 fix automation after big merge

### DIFF
--- a/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
+++ b/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="tree__sub" :class="{ active: workflow?._?.selected }">
+  <li class="tree__sub" :class="{ active: workflow?._.selected }">
     <a
       class="tree__sub-link"
       :title="workflow.name"
@@ -152,6 +152,9 @@ export default {
       })
     },
     async selectWorkflow(automation, workflow) {
+      if (workflow?._.selected) {
+        return
+      }
       this.setLoading(automation, true)
       try {
         await this.$nuxt.$router.push({

--- a/web-frontend/modules/automation/pages/automationWorkflow.vue
+++ b/web-frontend/modules/automation/pages/automationWorkflow.vue
@@ -317,11 +317,15 @@ onBeforeRouteUpdate((to, from) => {
   onRouteChange(from)
 })
 
+const leavingRoute = ref(false)
 onBeforeRouteLeave((to, from) => {
   onRouteChange(from)
+  leavingRoute.value = true
 })
 
 onUnmounted(() => {
-  $store.dispatch('automationWorkflow/unselect')
+  if (leavingRoute.value) {
+    $store.dispatch('automationWorkflow/unselect')
+  }
 })
 </script>

--- a/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
+++ b/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
@@ -146,6 +146,9 @@ export default {
       })
     },
     async selectPage(builder, page) {
+      if (page._.selected) {
+        return
+      }
       this.setLoading(builder, true)
       try {
         await this.$nuxt.$router.push({


### PR DESCRIPTION
### What is in this PR

This PR fixes the following bugs:
- When you leave an automation page to visit something else, the automation appears briefly empty and the create trigger modal appears (the stores are probably cleared too early)
- The spinner doesn’t stop in the sidebar if you click again on the same workflow in the sidebar (also fixed it for the builder)

### How to test this PR

Let me know if you nede more info on how to test something.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
