### PR TITLE
chore: fix frontend env vars

### DIFF
--- a/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantSidebarItem.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/assistant/AssistantSidebarItem.vue
@@ -41,7 +41,7 @@ export default {
       )
     },
     isConfigured() {
-      return !!this.$config.public.baserowEnterpriseAssistantLLMModel
+      return !!this.$config.public.baserowEnterpriseAssistantLlmModel
     },
   },
   mounted() {

--- a/enterprise/web-frontend/modules/baserow_enterprise/databaseOnboardingStepTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/databaseOnboardingStepTypes.js
@@ -34,7 +34,7 @@ export class AIDatabaseOnboardingStepType extends DatabaseOnboardingStepType {
   isVisible() {
     // Only show if the AI-assistant is configured because it will use the
     // AI-assistant to create the database.
-    return !!this.app.$config.public.baserowEnterpriseAssistantLLMModel
+    return !!this.app.$config.public.baserowEnterpriseAssistantLlmModel
   }
 
   isValid(data, vuelidate, refs) {

--- a/enterprise/web-frontend/modules/baserow_enterprise/module.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/module.js
@@ -7,6 +7,7 @@ import {
 } from 'nuxt/kit'
 import { routes, rootChildRoutes } from './routes'
 import { locales } from '../../../../web-frontend/config/locales.js'
+import _ from 'lodash'
 
 export default defineNuxtModule({
   meta: {
@@ -77,9 +78,12 @@ export default defineNuxtModule({
 
     // Runtime config defaults - values can be overridden at runtime via NUXT_ prefixed env vars
     // See env-remap.mjs for the env var remapping that enables backwards compatibility
-    Object.assign(nuxt.options.runtimeConfig.public, {
-      baserowEnterpriseAssistantLLMModel: null,
-    })
+    nuxt.options.runtimeConfig.public = _.defaultsDeep(
+      nuxt.options.runtimeConfig.public,
+      {
+        baserowEnterpriseAssistantLlmModel: '',
+      }
+    )
 
     // Override Baserow's existing default.scss in favor of our own because that one
     // imports the original. We do this so that we can use the existing variables,

--- a/premium/web-frontend/modules/baserow_premium/components/PaidFeaturesModal.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/PaidFeaturesModal.vue
@@ -51,7 +51,7 @@
         <Button
           type="primary"
           size="large"
-          :href="getPricingURL"
+          :href="pricingURL"
           target="_blank"
           tag="a"
           >{{ $t('paidFeaturesModal.viewPricing') }}</Button
@@ -97,7 +97,7 @@ export default {
     }
   },
   computed: {
-    getPricingURL() {
+    pricingURL() {
       const runtimeConfig = useRuntimeConfig()
       return (
         runtimeConfig.public.baserowPricingUrl || getPricingURL(this.instanceId)

--- a/premium/web-frontend/modules/baserow_premium/module.js
+++ b/premium/web-frontend/modules/baserow_premium/module.js
@@ -6,6 +6,7 @@ import {
 } from 'nuxt/kit'
 import { routes } from './routes'
 import { locales } from '../../../../web-frontend/config/locales.js'
+import _ from 'lodash'
 
 export default defineNuxtModule({
   meta: {
@@ -49,9 +50,12 @@ export default defineNuxtModule({
 
     // Runtime config defaults - values can be overridden at runtime via NUXT_ prefixed env vars
     // See env-remap.mjs for the env var remapping that enables backwards compatibility
-    Object.assign(nuxt.options.runtimeConfig.public, {
-      baserowPremiumGroupedAggregateServiceMaxSeries: 3,
-      baserowPricingUrl: null,
-    })
+    nuxt.options.runtimeConfig.public = _.defaultsDeep(
+      nuxt.options.runtimeConfig.public,
+      {
+        baserowPremiumGroupedAggregateServiceMaxSeries: 3,
+        baserowPricingUrl: '',
+      }
+    )
   },
 })

--- a/web-frontend/modules/core/module.js
+++ b/web-frontend/modules/core/module.js
@@ -13,7 +13,6 @@ import {
 } from '@nuxt/kit'
 import { routes } from './routes'
 import _ from 'lodash'
-import defu from 'defu'
 import pathe from 'pathe'
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
@@ -97,7 +96,7 @@ export default defineNuxtModule({
     // See env-remap.mjs for the env var remapping that enables backwards compatibility
     nuxt.options.runtimeConfig.privateBackendUrl = 'http://backend:8000'
 
-    nuxt.options.runtimeConfig.public = defu(
+    nuxt.options.runtimeConfig.public = _.defaultsDeep(
       nuxt.options.runtimeConfig.public,
       {
         buildDate: new Date().toISOString(),


### PR DESCRIPTION
…roperly

### What is in this PR
- A fix for the AI assistant env var.
- Replaces `defu` with `_.defaultsDeep` to handle null and undefined default values

### How to test this PR
- Verify you can now set the assistant model in saas and it works as expected. Please note that it must be explicitly added to the `docker-compose.yml` file for now, as all core env vars are not exported (A fix for that will come later)

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
