### PR TITLE
Switching track workspace usage no longer disable email verification

### DIFF
--- a/backend/src/baserow/api/settings/serializers.py
+++ b/backend/src/baserow/api/settings/serializers.py
@@ -40,7 +40,10 @@ class SettingsSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         representation = super().to_representation(instance)
         # TODO Remove in a future release once email_verification is null=False
-        if representation["email_verification"] is None:
+        if (
+            "email_verification" in representation
+            and representation["email_verification"] is None
+        ):
             representation["email_verification"] = (
                 Settings.EmailVerificationOptions.NO_VERIFICATION
             )

--- a/backend/src/baserow/api/settings/views.py
+++ b/backend/src/baserow/api/settings/views.py
@@ -66,7 +66,7 @@ class UpdateSettingsView(APIView):
             200: SettingsSerializer,
         },
     )
-    @validate_body(SettingsSerializer, partial=True)
+    @validate_body(SettingsSerializer, partial=True, return_validated=True)
     @transaction.atomic
     def patch(self, request, data):
         """


### PR DESCRIPTION
### What is in this PR

Fixes issue when enabling "Track workspace usage" was silently disabling "Email verification" (without refreshing UI)

### How to test this PR
- Go to Admin -> Settings
- Set "Email Verification" to Recommended
- Enable "Track workspace usage"
- Refresh page (switching between pages is not enough) and note that "Email verification" was not reset

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
