### PR TITLE
Fix table sync modal loading state

### DIFF
--- a/web-frontend/modules/database/components/dataSync/SyncTableModal.vue
+++ b/web-frontend/modules/database/components/dataSync/SyncTableModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <Modal ref="modal" :can-close="!jobIsRunning" @hidden="hidden">
+  <Modal
+    ref="modal"
+    :can-close="!syncLoading && !jobIsRunning"
+    @hidden="hidden"
+  >
     <template #content>
       <div class="import-modal__header">
         <h2 class="import-modal__title">
@@ -12,8 +16,8 @@
       <Error :error="error"></Error>
       <div class="modal-progress__actions margin-top-2">
         <ProgressBar
-          v-if="jobIsRunning || jobHasSucceeded"
-          :value="job.progress_percentage"
+          v-if="syncLoading || jobIsRunning || jobHasSucceeded"
+          :value="job?.progress_percentage || 0"
           :status="jobHumanReadableState"
         />
         <div class="align-right">
@@ -21,8 +25,8 @@
             v-if="!jobHasSucceeded"
             type="primary"
             size="large"
-            :disabled="jobIsRunning"
-            :loading="jobIsRunning"
+            :disabled="syncLoading || jobIsRunning"
+            :loading="syncLoading || jobIsRunning"
             @click="syncTable(table)"
           >
             {{ $t('syncTableModal.sync') }}
@@ -48,11 +52,6 @@ export default {
       type: Object,
       required: true,
     },
-  },
-  data() {
-    return {
-      creatingJob: false,
-    }
   },
   methods: {
     show() {

--- a/web-frontend/modules/database/mixins/dataSync.js
+++ b/web-frontend/modules/database/mixins/dataSync.js
@@ -12,6 +12,7 @@ export default {
       properties: null,
       syncedProperties: [],
       updateLoading: false,
+      syncLoading: false,
     }
   },
   beforeUnmount() {
@@ -106,6 +107,7 @@ export default {
 
       this.hideError()
       this.job = null
+      this.syncLoading = true
 
       try {
         const { data: job } = await DataSyncService(this.$client).syncTable(
@@ -114,6 +116,8 @@ export default {
         this.startJobPoller(job)
       } catch (error) {
         this.handleError(error)
+      } finally {
+        this.syncLoading = false
       }
     },
     async update(table, values, syncTable = true) {


### PR DESCRIPTION
### What is in this PR
Fix the following behavior :

If I create a new data synced table, click on the three dots of the table, then on “Sync table”, and then in the modal on “Sync table”, the loading animation is not immediately shown. 

### How to test this PR
- Replay the above scenario and observe the loading animation triggers immediately. 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
