### PR TITLE
Fix download link

### DIFF
--- a/web-frontend/modules/core/components/DownloadLink.vue
+++ b/web-frontend/modules/core/components/DownloadLink.vue
@@ -41,7 +41,7 @@ export default {
   },
   computed: {
     downloadXHR() {
-      return this.$config.public.downloadFileViaXhr === '1'
+      return `${this.$config.public.downloadFileViaXhr}` === '1'
     },
     href() {
       // Add the filename to the query string


### PR DESCRIPTION
### What is in this PR

Fix the download link everywhere it's used.

### How to test this PR

Set the env var `NUXT_PUBLIC_DOWNLOAD_FILE_VIA_XHR=1` and start the frontend with that. 
Then try to download an image or an exported file  and it should trigger the downlod of the file, not displaying it. To check the right thing is happening, you should not have the `dl=filename` in the link url.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
