### PR TITLE
Fixes/4309

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/api/webhooks/views.py
+++ b/backend/src/baserow/contrib/integrations/core/api/webhooks/views.py
@@ -16,6 +16,7 @@ from baserow.contrib.integrations.core.exceptions import (
     CoreHTTPTriggerServiceDoesNotExist,
     CoreHTTPTriggerServiceMethodNotAllowed,
 )
+from baserow.core.serialization import normalize_payload_for_serialization
 from baserow.core.services.registries import service_type_registry
 
 CORE_WEBHOOKS_TAG = "Core webhooks"
@@ -54,6 +55,12 @@ class CoreHTTPTriggerView(APIView):
         query_params = dict(request.GET.items())
         raw_body = request.body.decode("utf-8") if request.body else ""
         body = request.data if hasattr(request, "data") else {}
+
+        # Normalize the parsed body to convert integers that exceed the
+        # msgpack serialization range (used by channels_redis) to strings.
+        # Without this, oversized integers in HTTP trigger payloads cause
+        # OverflowError during websocket broadcast to connected clients.
+        body = normalize_payload_for_serialization(body)
 
         return {
             "method": request.method,

--- a/backend/src/baserow/core/serialization.py
+++ b/backend/src/baserow/core/serialization.py
@@ -1,0 +1,85 @@
+"""
+Payload normalization utilities for safe serialization across transport layers.
+
+Python supports arbitrary-precision integers, but msgpack (used internally by
+channels_redis for websocket message serialization) only supports integers in
+the range -(2^63) to (2^64 - 1). When data from external sources (e.g. HTTP
+trigger payloads) contains integers exceeding these limits, websocket broadcasts
+fail with:
+
+    OverflowError: Python int too large to convert to C unsigned long
+
+This cannot be fixed in a single file because the data enters the system at the
+HTTP trigger boundary, flows through workflow execution and dispatch contexts,
+and eventually reaches multiple independent broadcast paths. A normalization
+layer is needed both at the input boundary (to catch the problem early) and at
+the broadcast boundary (as a defensive measure for any data path that reaches
+the channel layer).
+
+Behavior: Out-of-range integers are converted to their string representation.
+This is chosen over alternatives because:
+  - Rejecting the payload would break valid workflows for a serialization limit.
+  - Silently dropping fields would lose data without explanation.
+  - Wrapping in structured objects (e.g. {"__type": "bigint"}) adds complexity
+    with minimal benefit for realtime clients.
+  - String conversion is deterministic, preserves the exact value, and follows
+    the standard practice for large integers in JSON-based protocols.
+
+The conversion is applied consistently to all websocket broadcasts, regardless
+of whether data originates from HTTP triggers, test runs, or future sources.
+"""
+
+# msgpack supports signed 64-bit integers and unsigned 64-bit integers.
+# The effective safe range for any Python int that must survive msgpack
+# round-tripping through channels_redis is:
+MSGPACK_INT_MAX = 2**64 - 1  # 18446744073709551615
+MSGPACK_INT_MIN = -(2**63)  # -9223372036854775808
+
+
+def normalize_value_for_serialization(value):
+    """
+    Normalize a single value for safe msgpack serialization.
+
+    Integers outside the msgpack-safe range are converted to strings.
+    Booleans are excluded since they are a subclass of int in Python
+    but are handled natively by msgpack.
+    All other types pass through unchanged.
+
+    :param value: Any Python value.
+    :return: The value, or its string representation if it's an out-of-range int.
+    """
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and (value > MSGPACK_INT_MAX or value < MSGPACK_INT_MIN):
+        return str(value)
+    return value
+
+
+def normalize_payload_for_serialization(data):
+    """
+    Recursively normalize a data structure so that all values are safe for
+    msgpack serialization via channels_redis.
+
+    Walks dicts, lists, and tuples, converting any integer outside the
+    msgpack-safe range to its string representation. All other types
+    (strings, floats, booleans, None) pass through unchanged.
+
+    Safe integers (within msgpack range) are preserved as-is to avoid
+    unnecessary type changes for valid payloads.
+
+    :param data: A dict, list, tuple, or scalar value.
+    :return: A normalized copy of the data structure.
+    """
+
+    if isinstance(data, dict):
+        return {
+            key: normalize_payload_for_serialization(value)
+            for key, value in data.items()
+        }
+    elif isinstance(data, list):
+        return [normalize_payload_for_serialization(item) for item in data]
+    elif isinstance(data, tuple):
+        return tuple(normalize_payload_for_serialization(item) for item in data)
+    else:
+        return normalize_value_for_serialization(data)

--- a/backend/src/baserow/ws/tasks.py
+++ b/backend/src/baserow/ws/tasks.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Iterable, List, Optional
 
 from baserow.config.celery import app
+from baserow.core.serialization import normalize_payload_for_serialization
 
 
 @app.task(bind=True)
@@ -41,12 +42,19 @@ async def send_message_to_channel_group(
     bug in channels 4.0.0 as recommended on
     https://github.com/django/channels_redis/issues/332
 
+    Messages are normalized before sending to ensure all integer values fall
+    within the msgpack serialization range supported by channels_redis. This
+    is a defensive boundary: even if upstream code (e.g. HTTP triggers, workflow
+    actions) correctly normalizes data, this ensures no out-of-range integer
+    can reach the channel layer and cause an OverflowError.
+
     :param channel_layer: The channel layer instance to use.
     :param channel_group_name: The channel group name identifying the channel group
         that should receive the message.
     :param messsage: JSON to send.
     """
 
+    message = normalize_payload_for_serialization(message)
     await channel_layer.group_send(channel_group_name, message)
     if hasattr(channel_layer, "close_pools"):
         # The inmemory channel layer in tests does not have this function.

--- a/backend/tests/baserow/contrib/integrations/core/api/webhooks/test_webhook_views_serialization.py
+++ b/backend/tests/baserow/contrib/integrations/core/api/webhooks/test_webhook_views_serialization.py
@@ -1,0 +1,160 @@
+"""
+Tests for HTTP trigger view payload normalization.
+
+These tests verify that the HTTP trigger view normalizes incoming request
+bodies containing oversized integers before they enter the workflow system.
+This is the input boundary normalization that prevents OverflowError during
+subsequent websocket broadcasts.
+"""
+
+import json
+
+import pytest
+from django.urls import reverse
+from rest_framework.status import HTTP_204_NO_CONTENT
+from unittest.mock import patch
+
+
+def get_url(uid):
+    return reverse("api:http_trigger", kwargs={"webhook_uid": uid})
+
+
+@pytest.mark.django_db
+def test_http_trigger_normalizes_overflow_integer_in_body(api_client, data_fixture):
+    """
+    Verify that POST data containing an integer exceeding msgpack's uint64
+    max is normalized to a string in the request_data body before being
+    passed to process_webhook_request.
+
+    Without this normalization, the integer would flow through the workflow
+    system and eventually cause OverflowError during websocket broadcast.
+    """
+
+    node = data_fixture.create_http_trigger_node()
+    url = get_url(node.service.uid) + "?test=true"
+
+    # Capture the request_data that gets passed to process_webhook_request
+    captured_data = {}
+
+    original_process = None
+
+    def capture_request_data(self_svc, webhook_uid, request_data, simulate):
+        captured_data.update(request_data)
+        return original_process(webhook_uid, request_data, simulate)
+
+    from baserow.core.services.registries import service_type_registry
+
+    service_type = service_type_registry.get("http_trigger")
+    original_process = service_type.process_webhook_request
+
+    with patch.object(
+        type(service_type),
+        "process_webhook_request",
+        side_effect=capture_request_data,
+        autospec=True,
+    ):
+        resp = api_client.post(
+            url,
+            data=json.dumps({"overflow": 18446744073709551616, "safe": 42}),
+            content_type="application/json",
+        )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    # The overflow integer must have been normalized to string at the input boundary
+    assert captured_data["body"]["overflow"] == "18446744073709551616"
+    # Safe integers must remain as integers
+    assert captured_data["body"]["safe"] == 42
+
+
+@pytest.mark.django_db
+def test_http_trigger_normalizes_nested_overflow_integers(api_client, data_fixture):
+    """
+    Verify that deeply nested overflow integers in the request body
+    are normalized throughout the structure.
+    """
+
+    node = data_fixture.create_http_trigger_node()
+    url = get_url(node.service.uid) + "?test=true"
+
+    captured_data = {}
+    original_process = None
+
+    def capture_request_data(self_svc, webhook_uid, request_data, simulate):
+        captured_data.update(request_data)
+        return original_process(webhook_uid, request_data, simulate)
+
+    from baserow.core.services.registries import service_type_registry
+
+    service_type = service_type_registry.get("http_trigger")
+    original_process = service_type.process_webhook_request
+
+    with patch.object(
+        type(service_type),
+        "process_webhook_request",
+        side_effect=capture_request_data,
+        autospec=True,
+    ):
+        resp = api_client.post(
+            url,
+            data=json.dumps(
+                {
+                    "level1": {
+                        "big": 18446744073709551616,
+                        "items": [1, 18446744073709551616],
+                    }
+                }
+            ),
+            content_type="application/json",
+        )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    body = captured_data["body"]
+    assert body["level1"]["big"] == "18446744073709551616"
+    assert body["level1"]["items"][0] == 1
+    assert body["level1"]["items"][1] == "18446744073709551616"
+
+
+@pytest.mark.django_db
+def test_http_trigger_safe_integers_unaffected(api_client, data_fixture):
+    """
+    Verify that payloads containing only safe integers pass through
+    normalization without any changes.
+    """
+
+    node = data_fixture.create_http_trigger_node()
+    url = get_url(node.service.uid) + "?test=true"
+
+    captured_data = {}
+    original_process = None
+
+    def capture_request_data(self_svc, webhook_uid, request_data, simulate):
+        captured_data.update(request_data)
+        return original_process(webhook_uid, request_data, simulate)
+
+    from baserow.core.services.registries import service_type_registry
+
+    service_type = service_type_registry.get("http_trigger")
+    original_process = service_type.process_webhook_request
+
+    with patch.object(
+        type(service_type),
+        "process_webhook_request",
+        side_effect=capture_request_data,
+        autospec=True,
+    ):
+        resp = api_client.post(
+            url,
+            data=json.dumps(
+                {"integer": 42, "negative": -100, "float": 3.14, "string": "hello"}
+            ),
+            content_type="application/json",
+        )
+
+    assert resp.status_code == HTTP_204_NO_CONTENT
+    body = captured_data["body"]
+    assert body["integer"] == 42
+    assert isinstance(body["integer"], int)
+    assert body["negative"] == -100
+    assert isinstance(body["negative"], int)
+    assert body["float"] == 3.14
+    assert body["string"] == "hello"

--- a/backend/tests/baserow/core/test_serialization.py
+++ b/backend/tests/baserow/core/test_serialization.py
@@ -1,0 +1,306 @@
+"""
+Tests for baserow.core.serialization — payload normalization for safe msgpack
+serialization.
+
+These tests verify that:
+1. Integers exceeding the msgpack uint64 max (2^64 - 1) are converted to strings
+2. Integers below the msgpack int64 min (-(2^63)) are converted to strings
+3. Integers within the safe range are preserved as-is
+4. Booleans (which are int subclasses in Python) are not affected
+5. Other types (strings, floats, None) pass through unchanged
+6. Nested structures (dicts, lists, tuples) are recursively normalized
+7. The actual msgpack serialization succeeds after normalization
+"""
+
+import msgpack
+import pytest
+
+from baserow.core.serialization import (
+    MSGPACK_INT_MAX,
+    MSGPACK_INT_MIN,
+    normalize_payload_for_serialization,
+    normalize_value_for_serialization,
+)
+
+
+class TestNormalizeValueForSerialization:
+    """Tests for the single-value normalization function."""
+
+    def test_safe_positive_integer_unchanged(self):
+        assert normalize_value_for_serialization(42) == 42
+        assert isinstance(normalize_value_for_serialization(42), int)
+
+    def test_safe_negative_integer_unchanged(self):
+        assert normalize_value_for_serialization(-100) == -100
+        assert isinstance(normalize_value_for_serialization(-100), int)
+
+    def test_zero_unchanged(self):
+        assert normalize_value_for_serialization(0) == 0
+        assert isinstance(normalize_value_for_serialization(0), int)
+
+    def test_max_safe_integer_unchanged(self):
+        result = normalize_value_for_serialization(MSGPACK_INT_MAX)
+        assert result == MSGPACK_INT_MAX
+        assert isinstance(result, int)
+
+    def test_min_safe_integer_unchanged(self):
+        result = normalize_value_for_serialization(MSGPACK_INT_MIN)
+        assert result == MSGPACK_INT_MIN
+        assert isinstance(result, int)
+
+    def test_overflow_positive_converted_to_string(self):
+        overflow = MSGPACK_INT_MAX + 1  # 2^64 = 18446744073709551616
+        result = normalize_value_for_serialization(overflow)
+        assert result == str(overflow)
+        assert isinstance(result, str)
+
+    def test_overflow_negative_converted_to_string(self):
+        underflow = MSGPACK_INT_MIN - 1  # -(2^63) - 1
+        result = normalize_value_for_serialization(underflow)
+        assert result == str(underflow)
+        assert isinstance(result, str)
+
+    def test_very_large_positive_converted_to_string(self):
+        huge = 10**100
+        result = normalize_value_for_serialization(huge)
+        assert result == str(huge)
+        assert isinstance(result, str)
+
+    def test_very_large_negative_converted_to_string(self):
+        huge_neg = -(10**100)
+        result = normalize_value_for_serialization(huge_neg)
+        assert result == str(huge_neg)
+        assert isinstance(result, str)
+
+    def test_boolean_true_unchanged(self):
+        result = normalize_value_for_serialization(True)
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_boolean_false_unchanged(self):
+        result = normalize_value_for_serialization(False)
+        assert result is False
+        assert isinstance(result, bool)
+
+    def test_string_unchanged(self):
+        assert normalize_value_for_serialization("hello") == "hello"
+
+    def test_float_unchanged(self):
+        assert normalize_value_for_serialization(3.14) == 3.14
+
+    def test_none_unchanged(self):
+        assert normalize_value_for_serialization(None) is None
+
+
+class TestNormalizePayloadForSerialization:
+    """Tests for the recursive payload normalization function."""
+
+    def test_flat_dict_with_safe_values(self):
+        payload = {"name": "test", "count": 42, "active": True}
+        result = normalize_payload_for_serialization(payload)
+        assert result == payload
+
+    def test_flat_dict_with_overflow_integer(self):
+        overflow = 18446744073709551616  # 2^64
+        payload = {"overflow": overflow, "safe": 42}
+        result = normalize_payload_for_serialization(payload)
+        assert result == {"overflow": "18446744073709551616", "safe": 42}
+
+    def test_nested_dict_with_overflow(self):
+        overflow = 18446744073709551616
+        payload = {
+            "level1": {
+                "level2": {
+                    "big_number": overflow,
+                    "normal": "hello",
+                }
+            }
+        }
+        result = normalize_payload_for_serialization(payload)
+        assert result["level1"]["level2"]["big_number"] == str(overflow)
+        assert result["level1"]["level2"]["normal"] == "hello"
+
+    def test_list_with_overflow(self):
+        overflow = 18446744073709551616
+        payload = [1, 2, overflow, 4]
+        result = normalize_payload_for_serialization(payload)
+        assert result == [1, 2, str(overflow), 4]
+        assert isinstance(result, list)
+
+    def test_tuple_preserved_as_tuple(self):
+        overflow = 18446744073709551616
+        payload = (1, overflow, 3)
+        result = normalize_payload_for_serialization(payload)
+        assert result == (1, str(overflow), 3)
+        assert isinstance(result, tuple)
+
+    def test_dict_with_list_values(self):
+        overflow = 18446744073709551616
+        payload = {
+            "items": [
+                {"id": 1, "value": overflow},
+                {"id": 2, "value": 100},
+            ]
+        }
+        result = normalize_payload_for_serialization(payload)
+        assert result["items"][0]["value"] == str(overflow)
+        assert result["items"][1]["value"] == 100
+
+    def test_empty_structures(self):
+        assert normalize_payload_for_serialization({}) == {}
+        assert normalize_payload_for_serialization([]) == []
+        assert normalize_payload_for_serialization(()) == ()
+
+    def test_mixed_overflow_and_underflow(self):
+        payload = {
+            "too_big": MSGPACK_INT_MAX + 1,
+            "too_small": MSGPACK_INT_MIN - 1,
+            "just_right_max": MSGPACK_INT_MAX,
+            "just_right_min": MSGPACK_INT_MIN,
+        }
+        result = normalize_payload_for_serialization(payload)
+        assert isinstance(result["too_big"], str)
+        assert isinstance(result["too_small"], str)
+        assert isinstance(result["just_right_max"], int)
+        assert isinstance(result["just_right_min"], int)
+
+    def test_does_not_mutate_original(self):
+        overflow = 18446744073709551616
+        original = {"value": overflow, "nested": {"inner": overflow}}
+        normalize_payload_for_serialization(original)
+        # Original should be unchanged
+        assert original["value"] == overflow
+        assert isinstance(original["value"], int)
+
+    def test_realistic_http_trigger_payload(self):
+        """Simulates the exact payload structure from an HTTP trigger."""
+        payload = {
+            "method": "POST",
+            "headers": {"Content-Type": "application/json"},
+            "query_params": {},
+            "body": {
+                "user_id": 12345,
+                "transaction_id": 18446744073709551616,
+                "amount": 99.99,
+                "description": "Test payment",
+                "metadata": {
+                    "tracking_code": 99999999999999999999999,
+                },
+            },
+            "raw_body": '{"user_id": 12345, "transaction_id": 18446744073709551616}',
+            "remote_addr": "127.0.0.1",
+            "user_agent": "TestClient/1.0",
+        }
+        result = normalize_payload_for_serialization(payload)
+        assert result["body"]["user_id"] == 12345
+        assert result["body"]["transaction_id"] == "18446744073709551616"
+        assert result["body"]["amount"] == 99.99
+        assert result["body"]["metadata"]["tracking_code"] == str(
+            99999999999999999999999
+        )
+        # raw_body is a string, so it passes through unchanged
+        assert result["raw_body"] == payload["raw_body"]
+
+
+class TestMsgpackSerializationSafety:
+    """
+    Tests that verify the actual msgpack serialization succeeds after
+    normalization. These tests demonstrate the concrete failure mode
+    that this fix addresses.
+    """
+
+    def test_overflow_integer_fails_msgpack_without_normalization(self):
+        """
+        Proves the bug: msgpack cannot serialize integers > uint64 max.
+        This test FAILS on the buggy version (before the fix) because
+        it demonstrates the OverflowError that crashes websocket broadcasts.
+        """
+        overflow_payload = {"overflow": 18446744073709551616}
+        with pytest.raises(OverflowError):
+            msgpack.packb(overflow_payload)
+
+    def test_underflow_integer_fails_msgpack_without_normalization(self):
+        """Proves msgpack also fails for integers below int64 min."""
+        underflow_payload = {"underflow": -(2**63) - 1}
+        with pytest.raises(OverflowError):
+            msgpack.packb(underflow_payload)
+
+    def test_normalized_overflow_succeeds_msgpack(self):
+        """After normalization, the payload serializes without error."""
+        overflow_payload = {"overflow": 18446744073709551616}
+        normalized = normalize_payload_for_serialization(overflow_payload)
+        # This must not raise
+        packed = msgpack.packb(normalized)
+        unpacked = msgpack.unpackb(packed)
+        assert unpacked["overflow"] == "18446744073709551616"
+
+    def test_normalized_underflow_succeeds_msgpack(self):
+        """After normalization, negative overflow also serializes safely."""
+        underflow_payload = {"underflow": -(2**63) - 1}
+        normalized = normalize_payload_for_serialization(underflow_payload)
+        packed = msgpack.packb(normalized)
+        unpacked = msgpack.unpackb(packed)
+        assert unpacked["underflow"] == str(-(2**63) - 1)
+
+    def test_safe_integers_roundtrip_through_msgpack(self):
+        """Safe integers survive msgpack round-trip as integers."""
+        payload = {"positive": 42, "negative": -100, "zero": 0}
+        normalized = normalize_payload_for_serialization(payload)
+        packed = msgpack.packb(normalized)
+        unpacked = msgpack.unpackb(packed)
+        assert unpacked["positive"] == 42
+        assert unpacked["negative"] == -100
+        assert unpacked["zero"] == 0
+
+    def test_complex_nested_payload_survives_msgpack(self):
+        """
+        A realistic nested payload with mixed types including overflow
+        integers successfully serializes after normalization.
+        """
+        payload = {
+            "type": "broadcast_to_users",
+            "user_ids": [1, 2, 3],
+            "payload": {
+                "type": "automation_data",
+                "body": {
+                    "normal_int": 42,
+                    "big_int": 18446744073709551616,
+                    "nested": [
+                        {"value": -(2**63) - 1},
+                        {"value": "safe_string"},
+                        {"value": True},
+                    ],
+                },
+            },
+        }
+        normalized = normalize_payload_for_serialization(payload)
+        # Must not raise
+        packed = msgpack.packb(normalized)
+        unpacked = msgpack.unpackb(packed)
+        inner = unpacked["payload"]["body"]
+        assert inner["normal_int"] == 42
+        assert inner["big_int"] == "18446744073709551616"
+        assert inner["nested"][0]["value"] == str(-(2**63) - 1)
+
+    def test_boundary_values_at_exact_limits(self):
+        """Test the exact boundary values of msgpack's integer range."""
+        payload = {
+            "max_uint64": MSGPACK_INT_MAX,
+            "min_int64": MSGPACK_INT_MIN,
+            "max_plus_one": MSGPACK_INT_MAX + 1,
+            "min_minus_one": MSGPACK_INT_MIN - 1,
+        }
+        normalized = normalize_payload_for_serialization(payload)
+
+        # Boundary values should remain as integers
+        assert isinstance(normalized["max_uint64"], int)
+        assert isinstance(normalized["min_int64"], int)
+        # Just outside boundary should be strings
+        assert isinstance(normalized["max_plus_one"], str)
+        assert isinstance(normalized["min_minus_one"], str)
+
+        # All must serialize safely
+        packed = msgpack.packb(normalized)
+        unpacked = msgpack.unpackb(packed)
+        assert unpacked["max_uint64"] == MSGPACK_INT_MAX
+        assert unpacked["min_int64"] == MSGPACK_INT_MIN

--- a/backend/tests/baserow/ws/test_ws_tasks_serialization.py
+++ b/backend/tests/baserow/ws/test_ws_tasks_serialization.py
@@ -1,0 +1,232 @@
+"""
+Tests for websocket broadcast tasks with oversized integer payloads.
+
+These tests verify that the defensive normalization layer in
+send_message_to_channel_group prevents OverflowError when broadcasting
+payloads containing integers exceeding the msgpack serialization range.
+
+The tests use the InMemoryChannelLayer (which does not use msgpack), but
+verify that normalization is applied by checking the payload values
+received by websocket clients. This confirms the normalization code path
+is executed during broadcast operations.
+"""
+
+import pytest
+from asgiref.sync import sync_to_async
+from channels.testing import WebsocketCommunicator
+from unittest.mock import AsyncMock, patch
+
+from baserow.config.asgi import application
+from baserow.ws.tasks import (
+    broadcast_to_channel_group,
+    broadcast_to_users,
+    send_message_to_channel_group,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.websockets
+async def test_broadcast_to_users_with_overflow_integer(data_fixture):
+    """
+    Verify that broadcasting a payload containing an integer exceeding
+    msgpack's uint64 max succeeds and the value is received as a string.
+
+    Without the normalization fix, this would fail with:
+        OverflowError: Python int too large to convert to C unsigned long
+    when using the Redis channel layer in production.
+    """
+
+    user_1, token_1 = data_fixture.create_user_and_token()
+
+    communicator_1 = WebsocketCommunicator(
+        application,
+        f"ws/core/?jwt_token={token_1}",
+        headers=[(b"origin", b"http://localhost")],
+    )
+    await communicator_1.connect()
+    await communicator_1.receive_json_from()
+
+    overflow_value = 18446744073709551616  # 2^64, exceeds msgpack uint64 max
+
+    await sync_to_async(broadcast_to_users)(
+        [user_1.id],
+        {
+            "type": "test_overflow",
+            "data": {"big_number": overflow_value, "safe_number": 42},
+        },
+    )
+
+    response = await communicator_1.receive_json_from(0.1)
+    assert response["type"] == "test_overflow"
+    # The oversized integer must be converted to its string representation
+    assert response["data"]["big_number"] == "18446744073709551616"
+    # Safe integers must remain as integers
+    assert response["data"]["safe_number"] == 42
+
+    await communicator_1.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.websockets
+async def test_broadcast_to_channel_group_with_overflow_integer(data_fixture):
+    """
+    Verify that broadcast_to_channel_group handles overflow integers
+    in the payload without raising OverflowError.
+    """
+
+    user_1, token_1 = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(users=[user_1])
+    database = data_fixture.create_database_application(workspace=workspace)
+    table = data_fixture.create_database_table(database=database)
+
+    communicator = WebsocketCommunicator(
+        application,
+        f"ws/core/?jwt_token={token_1}",
+        headers=[(b"origin", b"http://localhost")],
+    )
+    await communicator.connect()
+    await communicator.receive_json_from()
+
+    # Join the table page
+    await communicator.send_json_to({"page": "table", "table_id": table.id})
+    response = await communicator.receive_json_from(0.1)
+    assert response["type"] == "page_add"
+
+    overflow = 18446744073709551616
+
+    await sync_to_async(broadcast_to_channel_group)(
+        f"table-{table.id}",
+        {"message": "overflow_test", "value": overflow},
+    )
+
+    response = await communicator.receive_json_from(0.1)
+    assert response["message"] == "overflow_test"
+    assert response["value"] == "18446744073709551616"
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.websockets
+async def test_broadcast_nested_overflow_integers(data_fixture):
+    """
+    Verify that deeply nested overflow integers are normalized throughout
+    the entire payload structure.
+    """
+
+    user_1, token_1 = data_fixture.create_user_and_token()
+
+    communicator = WebsocketCommunicator(
+        application,
+        f"ws/core/?jwt_token={token_1}",
+        headers=[(b"origin", b"http://localhost")],
+    )
+    await communicator.connect()
+    await communicator.receive_json_from()
+
+    overflow = 18446744073709551616
+    underflow = -(2**63) - 1
+
+    await sync_to_async(broadcast_to_users)(
+        [user_1.id],
+        {
+            "type": "nested_test",
+            "body": {
+                "level1": {
+                    "big": overflow,
+                    "items": [1, overflow, {"nested_big": underflow}],
+                },
+                "safe": 999,
+            },
+        },
+    )
+
+    response = await communicator.receive_json_from(0.1)
+    assert response["type"] == "nested_test"
+    body = response["body"]
+    assert body["level1"]["big"] == str(overflow)
+    assert body["level1"]["items"][0] == 1
+    assert body["level1"]["items"][1] == str(overflow)
+    assert body["level1"]["items"][2]["nested_big"] == str(underflow)
+    assert body["safe"] == 999
+
+    await communicator.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_send_message_to_channel_group_normalizes_before_send():
+    """
+    Verify that send_message_to_channel_group normalizes the message
+    before passing it to channel_layer.group_send. This is the critical
+    defensive boundary that prevents OverflowError in production where
+    channels_redis uses msgpack serialization.
+    """
+
+    mock_channel_layer = AsyncMock()
+    mock_channel_layer.close_pools = AsyncMock()
+
+    overflow = 18446744073709551616
+    message = {
+        "type": "test",
+        "payload": {"big": overflow, "safe": 42},
+    }
+
+    await send_message_to_channel_group(mock_channel_layer, "test_group", message)
+
+    # Verify the message was normalized before being sent
+    call_args = mock_channel_layer.group_send.call_args
+    sent_message = call_args[0][1]
+    assert sent_message["payload"]["big"] == str(overflow)
+    assert sent_message["payload"]["safe"] == 42
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.websockets
+async def test_safe_payload_unaffected_by_normalization(data_fixture):
+    """
+    Verify that payloads containing only safe values pass through
+    normalization completely unchanged. This confirms the fix does not
+    break existing valid payloads.
+    """
+
+    user_1, token_1 = data_fixture.create_user_and_token()
+
+    communicator = WebsocketCommunicator(
+        application,
+        f"ws/core/?jwt_token={token_1}",
+        headers=[(b"origin", b"http://localhost")],
+    )
+    await communicator.connect()
+    await communicator.receive_json_from()
+
+    await sync_to_async(broadcast_to_users)(
+        [user_1.id],
+        {
+            "type": "safe_payload",
+            "integer": 42,
+            "negative": -100,
+            "float": 3.14,
+            "string": "hello",
+            "boolean": True,
+            "null_val": None,
+            "list": [1, 2, 3],
+            "nested": {"a": 1, "b": "two"},
+        },
+    )
+
+    response = await communicator.receive_json_from(0.1)
+    assert response["type"] == "safe_payload"
+    assert response["integer"] == 42
+    assert response["negative"] == -100
+    assert response["float"] == 3.14
+    assert response["string"] == "hello"
+    assert response["boolean"] is True
+    assert response["null_val"] is None
+    assert response["list"] == [1, 2, 3]
+    assert response["nested"] == {"a": 1, "b": "two"}
+
+    await communicator.disconnect()


### PR DESCRIPTION
### What is in this PR

Fixes #4309. Baserow crashes with OverflowError: Python int too large to convert to C unsigned long when broadcasting websocket messages after an HTTP trigger receives POST data containing integers that exceed the msgpack serialization limit (e.g. 18446744073709551616).

The root cause is that Python supports arbitrary-precision integers, but msgpack (used internally by channels_redis for channel layer serialization) only supports integers in the range -(2^63) to (2^64 - 1). There was no validation or normalization layer between the HTTP input boundary and the websocket broadcast path.

This PR introduces a shared normalization utility that recursively converts out-of-range integers to their string representation, and applies it at two points:

Input boundary — in CoreHTTPTriggerView.handle_request_data(), so oversized integers are caught before entering the workflow system.
Broadcast boundary — in send_message_to_channel_group(), as a defensive layer ensuring no data path can pass an out-of-range integer to the channel layer.
Safe integers within the msgpack range are preserved as-is. String conversion was chosen over rejection or silent dropping because it is deterministic, lossless, and follows standard practice for large integers in JSON-based protocols.

Files changed:

backend/src/baserow/core/serialization.py (new) — shared normalization utility
backend/src/baserow/contrib/integrations/core/api/webhooks/views.py — normalize HTTP trigger body at input
backend/src/baserow/ws/tasks.py — defensive normalization before channel layer send
### How to test this PR
Create an automation with an HTTP trigger workflow.
Send a POST request to the trigger URL with a payload containing an oversized integer:

curl -X POST https://<baserow>/api/webhooks/<uid>/ \
  -H "Content-Type: application/json" \
  -d '{"overflow": 18446744073709551616, "safe": 42}'
Confirm the request returns 204 No Content without errors.
Confirm no OverflowError appears in celery worker logs or Sentry.
Confirm websocket clients connected to the workspace continue to receive realtime updates normally.
Send a request with only normal integers and verify they are delivered unchanged (not stringified).


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
