### PR TITLE
Fix Missing context ref when deleting a grid view field

### DIFF
--- a/web-frontend/modules/database/components/field/FieldContext.vue
+++ b/web-frontend/modules/database/components/field/FieldContext.vue
@@ -187,6 +187,8 @@ export default {
       try {
         const { data } = await this.$store.dispatch('field/deleteCall', field)
         this.$emit('delete')
+        this.hide()
+        this.deleteLoading = false
         await this.$store.dispatch('field/forceDelete', field)
         await this.$store.dispatch('field/forceUpdateFields', {
           fields: data.related_fields,
@@ -198,13 +200,14 @@ export default {
       } catch (error) {
         if (error.response && error.response.status === 404) {
           this.$emit('delete')
+          this.hide()
+          this.deleteLoading = false
           await this.$store.dispatch('field/forceDelete', field)
         } else {
           notifyIf(error, 'field')
+          this.deleteLoading = false
         }
       }
-      this.hide()
-      this.deleteLoading = false
     },
   },
 }


### PR DESCRIPTION
### What is in this PR
Fix the following warning in the console: 
```When I delete a field in the grid view, it works as expected, but I noticed Missing context ref in this component error in the console.```

There was an issue in the operations order when deleting a field:

forceDelete → (component destroyed) →  hide() →  missing ref


### How to test this PR
- Replay the scenario above and observe there is no longer warning in the console

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
