### PR TITLE
Fix loading state issue after workspace search

### DIFF
--- a/web-frontend/modules/core/components/RouterViewPlaceholder.vue
+++ b/web-frontend/modules/core/components/RouterViewPlaceholder.vue
@@ -1,0 +1,15 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+/**
+ * This component is used as a placeholder for routes that do not have a component
+ * but need one to satisfy the router. It renders nothing, allowing the parent route
+ * or router-view to handle the structure. This is particularly useful for nested
+ * routes where a segment is logical but has no specific UI representation itself.
+ */
+export default {
+  name: 'RouterViewPlaceholder',
+}
+</script>

--- a/web-frontend/modules/database/routes.js
+++ b/web-frontend/modules/database/routes.js
@@ -14,6 +14,10 @@ export const routes = [
       {
         path: 'row/:rowId',
         name: 'database-table-row',
+        file: path.resolve(
+          __dirname,
+          '../core/components/RouterViewPlaceholder.vue'
+        ),
       },
       {
         path: 'webhooks',


### PR DESCRIPTION
### What is in this PR
Fixing the following behavior:

```If I’m on the workspace homepage, use the workspace level search to find a row, click on the row, then it shows the right row enlarged, but Nuxt remains in a page loading state until the modal is closed or navigated to another row.```

The issue is that the router was expecting a component file for the route, which was missing.  We have to use a placeholder component for that purpose. I gave him a generic name so we can reuse it if we face the same use case in the future. 

### How to test this PR
- Replay the scenario above; the loading state should not remain.



### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
