### PR TITLE
Fix field options on select related row modal

### DIFF
--- a/web-frontend/modules/database/components/row/SelectRowContent.vue
+++ b/web-frontend/modules/database/components/row/SelectRowContent.vue
@@ -233,20 +233,24 @@ export default {
         return
       }
 
-      // Remove the not existing keys because the related fields might have been
-      // deleted in the meantime, and so we're keeping the local storage clean.
+      // Remove entries for fields that no longer exist in the table, keeping
+      // IndexedDB clean. Uses allFields (the actual table fields) instead of
+      // fieldOptions (grid view API response) which may be empty or incomplete.
+      const existingFieldIds = new Set(
+        this.allFields.map((field) => field.id.toString())
+      )
       value = Object.fromEntries(
-        Object.entries(value).filter((key) => {
-          return Object.prototype.hasOwnProperty.call(this.fieldOptions, key[0])
-        })
+        Object.entries(value).filter(([key]) => existingFieldIds.has(key))
       )
 
       try {
+        // clone() strips Vue 3 Proxy wrappers so the value can be stored via
+        // IndexedDB's structured clone algorithm.
         await setData(
           databaseName,
           storeName,
           this.persistentFieldOptionsKey,
-          value
+          clone(value)
         )
       } catch (error) {
         /* empty */
@@ -266,6 +270,17 @@ export default {
     }
 
     await this.orderFieldsByFirstGridViewFieldOptions(this.tableId)
+
+    if (this.persistentFieldOptionsKey) {
+      try {
+        const override = await getData(
+          databaseName,
+          storeName,
+          this.persistentFieldOptionsKey
+        )
+        this.fieldOptionsOverride = override || {}
+      } catch (error) {}
+    }
 
     // Because the page data depends on having some initial metadata we mark the state
     // as loaded after that. Only a loading animation is shown if there isn't any
@@ -338,15 +353,6 @@ export default {
           data: { field_options: fieldOptions },
         } = await ViewService(this.$client).fetchFieldOptions(views[0].id)
         this.fieldOptions = fieldOptions
-
-        if (this.persistentFieldOptionsKey) {
-          const override = await getData(
-            databaseName,
-            storeName,
-            this.persistentFieldOptionsKey
-          )
-          this.fieldOptionsOverride = override || {}
-        }
       } catch (error) {
         notifyIf(error, 'view')
       }


### PR DESCRIPTION
### What is in this PR
Fixes issue on link row selection modal with persistent:
- adjusting columns width
- hide/show fields
- field order  

### How to test this PR
- have two tables i.e. `Table1` and `Table2`
- add link row field in `Table1` to `Table2`
- try to add records and check that you can show/hide fields, change it widths and reorder (through show/hide option)
- refresh page and note it's persistent   

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
