### PR TITLE
Remove local media file mount

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,9 +20,6 @@ services:
   caddy:
     volumes:
       - $PWD/Caddyfile.dev:/etc/caddy/Caddyfile
-      # For local development, mount the local backend/media folder so Caddy can
-      # serve files uploaded by the native backend process.
-      - $PWD/backend/media:/baserow/media
 
   backend:
     image: baserow_backend:dev


### PR DESCRIPTION
### What is in this PR

Undoes a change that breaks the file serving for the Docker dev env. Because this change was added last, I'm removing it here. We would probably need to come up with a different docker compose file for the local dev environment.

### How to test this PR

- Checkout this branch.
- Start the `just dc-dev up` dev env.
- Confirm that files can be uploaded and that they're visible in Baserow.
