### PR TITLE
Fix browser history for navigation between tables

### DIFF
--- a/web-frontend/modules/database/pages/table.vue
+++ b/web-frontend/modules/database/pages/table.vue
@@ -179,8 +179,10 @@ if (error.value) {
 }
 
 if (data.value?.redirect) {
-  // We have a redirect, we can apply it now
-  await navigateTo(data.value.redirect.href)
+  // We have a redirect, we can apply it now. Using `replace` so the intermediate
+  // URL (without viewId) doesn't stay in the browser history — otherwise the back
+  // button would land on it and immediately redirect forward again.
+  await navigateTo(data.value.redirect.href, { replace: true })
 }
 
 /**


### PR DESCRIPTION
### What is in this PR

When switching between tables using the sidebar, pressing the browser back button doesn't return to the previous table. Instead, it lands on an intermediate URL (without a view ID) that immediately redirects forward to the default view — effectively trapping the user on the same page.

This happens because each table navigation creates two history entries: one for the table URL without a view, and a second when the page redirects to the default view. The back button hits the first entry, which triggers the redirect again.

### How to test this PR
- Have few tables
- Open table A
- Go to table B
- Go to table C
- Play with back/forward buttons in browser and observer that using them navigate properly between tables

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
