### PR TITLE
Fix timing problem when switching tables

### DIFF
--- a/web-frontend/modules/database/pages/table.vue
+++ b/web-frontend/modules/database/pages/table.vue
@@ -139,7 +139,6 @@ const { data, error, pending, status, refresh } = await useAsyncData(
 
         if (type.isDeactivated(currentDatabase.workspace.id)) {
           result.error = { statusCode: 400, message: type.getDeactivatedText() }
-          $store.dispatch('table/setLoading', false)
           return result
         }
 
@@ -154,7 +153,6 @@ const { data, error, pending, status, refresh } = await useAsyncData(
         if (e.response === undefined && !(e instanceof StoreItemLookupError))
           throw e
         result.error = normalizeError(e)
-        $store.dispatch('table/setLoading', false)
         return result
       }
     }
@@ -166,8 +164,6 @@ const { data, error, pending, status, refresh } = await useAsyncData(
         rowId: currentParams.rowId,
       })
     }
-
-    $store.dispatch('table/setLoading', false)
 
     return result
   }
@@ -190,7 +186,7 @@ if (data.value?.redirect) {
  */
 const database = computed(() => data.value?.database)
 const table = computed(() => data.value?.table)
-const view = computed(() => data.value?.view || {})
+const view = computed(() => data.value?.view)
 const fields = computed(() => data.value?.fields)
 const dataError = computed(() => data.value?.error)
 
@@ -210,6 +206,7 @@ onMounted(() => {
   if (table.value) {
     $realtime.subscribe('table', { table_id: table.value.id })
   }
+  $store.dispatch('table/setLoading', false)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
### What is in this PR

Fixes this bug: 

```
I don’t have a clear way of reproducing this, but when I’m having some difficulties navigating to this table [https://staging.aws.baserow.io/database/2517/table/56425/20665](https://staging.aws.baserow.io/database/2517/table/56425/20665). It results in a toString not found error. Relates to this Sentry error on staging [https://baserow-eu.sentry.io/issues/96867269/?project=4510873275793488&query=is%3Aunresolved&referrer=issue-stream](https://baserow-eu.sentry.io/issues/96867269/?project=4510873275793488&query=is%3Aunresolved&referrer=issue-stream).
```

It was caused by a timing problem when switching tables. The table loading state was set to false before the view object was actually replaced. If a view has row coloring in with an `equal` filter on a formula text field, then this specific problem happened. Other filters might have been affected as well. It was mainly related to receiving an `undefined` cell value because the row coloring filter field does not exist at that point.

The solution was simply moving the setLoading = false to the `onMounted` hook. Before, with Nuxt 2, this call was in the created lifecycle hook. This one has been replaced with the mounted one in Nuxt 3.

### How to test this PR

- Install the "Campaign Management" template.
- Open the "Campaigns" table.
- Switch to the "Objectives" table
- Observe that no error message occurs.
