### PR TITLE
fix: dashboard sidebar selection

### DIFF
--- a/web-frontend/modules/dashboard/middleware/dashboardLoading.js
+++ b/web-frontend/modules/dashboard/middleware/dashboardLoading.js
@@ -1,3 +1,5 @@
+import { StoreItemLookupError } from '@baserow/modules/core/errors'
+
 /**
  * Middleware that changes the dashboard loading state to true before the route
  * changes.
@@ -5,6 +7,7 @@
 export default defineNuxtRouteMiddleware(async (to, from) => {
   const nuxtApp = useNuxtApp()
   const store = nuxtApp.$store
+  const { $i18n } = nuxtApp
 
   function parseIntOrNull(x) {
     return x != null ? parseInt(x) : null
@@ -13,6 +16,26 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const toDashboardId = parseIntOrNull(to?.params?.dashboardId)
   const fromDashboardId = parseIntOrNull(from?.params?.dashboardId)
   const differentDashboardId = fromDashboardId !== toDashboardId
+
+  if (toDashboardId) {
+    try {
+      const dashboard = await store.dispatch(
+        'application/selectById',
+        toDashboardId
+      )
+      await store.dispatch('workspace/selectById', dashboard.workspace.id)
+    } catch (e) {
+      if (e.response === undefined && !(e instanceof StoreItemLookupError)) {
+        throw e
+      }
+
+      throw createError({
+        statusCode: 404,
+        message: 'Dashboard not found.',
+        fatal: false,
+      })
+    }
+  }
 
   // If it's the first page or the server side rendered page, then always put the
   // dashboard in the loading state for the correct animation.

--- a/web-frontend/modules/dashboard/pages/dashboard.vue
+++ b/web-frontend/modules/dashboard/pages/dashboard.vue
@@ -35,24 +35,11 @@ const {
 } = await useAsyncData(
   `dashboard-data-${route.params.dashboardId}`,
   async () => {
-    const dashboardId = parseInt(route.params.dashboardId)
-
-    try {
-      const dashboard = await store.dispatch(
-        'application/selectById',
-        dashboardId
-      )
-      const workspace = await store.dispatch(
-        'workspace/selectById',
-        dashboard.workspace.id
-      )
-
-      return {
-        workspace,
-        dashboard,
-      }
-    } catch (e) {
-      throw createError({ statusCode: 404, message: 'Dashboard not found.' })
+    const dashboard = store.getters['application/getSelected']
+    const workspace = store.getters['workspace/getSelected']
+    return {
+      workspace,
+      dashboard,
     }
   }
 )


### PR DESCRIPTION
### What is in this PR
Fix the following behavior:

```The dashboard is not highlighted in the left sidebar after SSR load. It does work when click on the dashboard item.```

### How to test this PR
- Browse to a dashboard page and hard refresh it. Observe the dashboard is selected in the left sidebar. 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
