### PR TITLE
Fix title for dashboards

### DIFF
--- a/web-frontend/modules/dashboard/pages/dashboard.vue
+++ b/web-frontend/modules/dashboard/pages/dashboard.vue
@@ -9,7 +9,7 @@
 import { computed, onMounted, onBeforeUnmount } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
-import { useNuxtApp, useAsyncData, createError } from '#app'
+import { useNuxtApp, useAsyncData, createError, useHead } from '#app'
 
 import DashboardHeader from '@baserow/modules/dashboard/components/DashboardHeader'
 import DashboardContent from '@baserow/modules/dashboard/components/DashboardContent'
@@ -50,6 +50,10 @@ if (fetchError.value) {
 
 const dashboard = computed(() => data.value?.dashboard)
 const workspace = computed(() => data.value?.workspace)
+
+useHead(() => ({
+  title: dashboard.value?.name || '',
+}))
 
 // Mounted logic
 onMounted(() => {


### PR DESCRIPTION
### What is in this PR
Brings back dashboard name in page title

### How to test this PR
Create dashboard and note title is properly set

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
