### PR TITLE
Fix undo/redo keyboard shortcut loading state

### DIFF
--- a/web-frontend/modules/core/layouts/app.vue
+++ b/web-frontend/modules/core/layouts/app.vue
@@ -142,7 +142,7 @@ function keyDown(event) {
 
     if (!avoid) {
       const actionName = event.shiftKey ? 'undoRedo/redo' : 'undoRedo/undo'
-      store.dispatch(actionName, { showLoadingToast: false }).catch(notifyIf)
+      store.dispatch(actionName, { showLoadingToast: true }).catch(notifyIf)
       event.preventDefault()
     }
   }


### PR DESCRIPTION
### What is in this PR
- E.g. a short explanation of what this pull request does.

### How to test this PR

- Make a change in a table.
- Press the ctrl/cmd + z button and observe that a toast in loading state is visible in the bottom right corner.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
