### PR TITLE
Fix select workspace SSR

### DIFF
--- a/web-frontend/modules/core/pages/workspace.vue
+++ b/web-frontend/modules/core/pages/workspace.vue
@@ -243,7 +243,6 @@ definePageMeta({
     'impersonate',
     'workspacesAndApplications',
   ],
-  useRouteWorkspaceParam: 'test',
 })
 
 defineOptions({

--- a/web-frontend/modules/core/utils/workspace.js
+++ b/web-frontend/modules/core/utils/workspace.js
@@ -5,14 +5,7 @@ import { useCookie } from '#app'
 const cookieWorkspaceName = 'baserow_group_id'
 
 export const setWorkspaceCookie = (workspaceId, { $config }) => {
-  if (import.meta.server) return
   const secure = isSecureURL($config.public.publicWebFrontendUrl)
-  /*$cookies.set(cookieWorkspaceName, workspaceId, {
-    path: '/',
-    maxAge: 60 * 60 * 24 * 7,
-    sameSite: $config.BASEROW_FRONTEND_SAME_SITE_COOKIE,
-    secure,
-  })*/
   const cookie = useCookie(cookieWorkspaceName, {
     path: '/',
     maxAge: 60 * 60 * 24 * 7,
@@ -23,16 +16,10 @@ export const setWorkspaceCookie = (workspaceId, { $config }) => {
 }
 
 export const unsetWorkspaceCookie = () => {
-  if (import.meta.server) return
   const cookie = useCookie(cookieWorkspaceName)
   cookie.value = null
-  //deleteCookie(cookieWorkspaceName)
-  //$cookies.remove(cookieWorkspaceName)
 }
 
 export const getWorkspaceCookie = () => {
-  if (import.meta.server) return
   return useCookie(cookieWorkspaceName).value
-  //return getCookie(cookieWorkspaceName)
-  //return $cookies.get(cookieWorkspaceName)
 }


### PR DESCRIPTION
### What is in this PR

Fixes a problem where the correct workspace was not selected during server side rendering by:
- Allows extracting the workspace ID from the cookie on the server side.
- Remove left over `test value.`

### How to test this PR

- Create two workspaces.
- Open the members page of workspace A and copy the URL.
- Open the members page of workspace B (so that the cookie is updated).
- Refresh the members page of workspace B. Confirm that the server side rendered sidebar matches the client side.
- Open a new tab and visit the members page of workspace A by pasting the URL. Confirm that the server side rendered sidebar matches the client side.
- Repeat the same for the workspace homepage.