### PR TITLE
Fix routing with hash inside a parameter value

### DIFF
--- a/web-frontend/modules/builder/utils/routing.js
+++ b/web-frontend/modules/builder/utils/routing.js
@@ -4,12 +4,10 @@ export const resolveApplicationRoute = (pages, fullPath) => {
   if (fullPath === undefined || fullPath === null) {
     return undefined
   }
-  // Nuxt route.fullPath usually includes query/hash; path-to-regexp matches pathnames.
-  const pathname = fullPath.split('?')[0].split('#')[0]
 
   for (const page of pages) {
     const matcher = match(page.path.slice(1))
-    const matched = matcher(pathname)
+    const matched = matcher(fullPath)
 
     if (matched) {
       // matched = { path, params, index? }


### PR DESCRIPTION
### What is in this PR

Fix the regression mentionned here: https://community.baserow.io/t/search-parameter-with-a-hashtag-doesnt-work-anymore/

### How to test this PR

- Create an application with a page using a page text parameter.
- Create a link to that page frow another page that set this parameter to a string with a hash `#` as first character.
- Try to navigate to that page on preview or publish application. It should work with this branch but not with develop
- Also check you can still use a hash and query parameters as usual
- Check that the menu element still works 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
