### PR TITLE
Show 404 error instead of throwing it for public pages

### DIFF
--- a/web-frontend/modules/builder/pages/publicPage.vue
+++ b/web-frontend/modules/builder/pages/publicPage.vue
@@ -303,7 +303,11 @@ const { data: asyncDataResult, error } = await useAsyncData(
 
 if (error.value) {
   // If we have an error we want to display it.
-  throw error.value
+  if (error.value.statusCode === 404) {
+    showError(error.value)
+  } else {
+    throw error.value
+  }
 }
 
 const workspace = computed(() => asyncDataResult.value.workspace)


### PR DESCRIPTION
### What is in this PR

This PR helps to prevent to many issues in sentry regarding page not found for public website: https://baserow-eu.sentry.io/issues/97209122/?environment=production&project=4510873275793488&query=is%3Aunresolved%20age%3A-24h&referrer=issue-stream&sort=freq

### How to test this PR

- Publish a website and check that an invalid URL still displays the 404 page but it's using showError in the code now.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
