### PR TITLE
Fix FormInput error on blur

### DIFF
--- a/web-frontend/modules/core/components/FormInput.vue
+++ b/web-frontend/modules/core/components/FormInput.vue
@@ -134,6 +134,12 @@ function onInput(e) {
 }
 
 function onBlur(e) {
+  if (!input.value) {
+    // The FormInput element was unmounted in the meantime. It happens in the login
+    // form for instance if you hit enter after filling the form.
+    return
+  }
+
   const raw = input.value.value
 
   if (!raw && props.defaultValueWhenEmpty !== null) {


### PR DESCRIPTION
### What is in this PR

Fix the sentry error https://baserow-eu.sentry.io/issues/97214153/?environment=production&project=4510873275793488&query=is%3Aunresolved%20age%3A-24h&referrer=issue-stream&sort=freq

On some browser (Chrome/edge) When the FormiInput element is unmounted, the `input.value` DOM ref is null but the blur event was still triggered so we end up accessing a property of a null value.

### How to test this PR

- Use chrome browser, Login without clicking on the button but hit enter instead. It should show the error on develp and nothing on this branch.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
