### PR TITLE
Handle client side locale switch with english fallback

### DIFF
--- a/web-frontend/modules/core/plugins/i18n.js
+++ b/web-frontend/modules/core/plugins/i18n.js
@@ -7,17 +7,23 @@ export default defineNuxtPlugin({
 
     moment.locale($i18n.locale.value)
 
-    $i18n.onLanguageSwitched = (oldLocale, newLocale) => {
-      moment.locale(newLocale)
-    }
-
-    if ($i18n.locale.value !== 'en') {
-      try {
-        $i18n.fallbackLocale.value = 'en'
-        await $i18n.loadLocaleMessages('en')
-      } catch (error) {
-        console.warn('Failed to load fallback locale messages:', error)
+    const loadFallbackIfNeeded = async (locale) => {
+      if (locale !== 'en') {
+        try {
+          $i18n.fallbackLocale.value = 'en'
+          await $i18n.loadLocaleMessages('en')
+        } catch (error) {
+          console.warn('Failed to load fallback locale messages:', error)
+        }
       }
     }
+
+    // Use watch to react to client side locale switch
+    watch($i18n.locale, async (newLocale, oldLocale) => {
+      moment.locale(newLocale)
+      await loadFallbackIfNeeded(newLocale)
+    })
+
+    await loadFallbackIfNeeded($i18n.locale.value)
   },
 })


### PR DESCRIPTION
### What is in this PR
- When switching the locale client side, fallback english translations were not displayed.  

### How to test this PR
- Change the language interface and observe its fallback to english if the current language translation is missing


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
