### PR TITLE
Fix context closing error when panning

### DIFF
--- a/web-frontend/modules/automation/components/workflow/WorkflowNodeContent.vue
+++ b/web-frontend/modules/automation/components/workflow/WorkflowNodeContent.vue
@@ -166,9 +166,10 @@ onMove(() => {
 
 const editNodeContext = ref(null)
 const editNodeContextToggle = ref(null)
+
 const openEditContext = () => {
   if (editNodeContext.value && editNodeContextToggle.value) {
-    activeNodeContext.value = editNodeContext
+    activeNodeContext.value = editNodeContext.value
     editNodeContext.value.toggle(
       editNodeContextToggle.value,
       'bottom',
@@ -179,12 +180,13 @@ const openEditContext = () => {
 }
 
 const replaceNodeContext = ref(null)
+
 const openReplaceContext = async () => {
   editNodeContext.value.hide()
   // As the target isn't the element that triggered the show of the context it is not
   // ignored by the click outside handler and it immediately closes the context
   await flushPromises()
-  activeNodeContext.value = replaceNodeContext
+  activeNodeContext.value = replaceNodeContext.value
   replaceNodeContext.value.toggle(
     editNodeContextToggle.value,
     'bottom',


### PR DESCRIPTION
### What is in this PR

Fix https://baserow-eu.sentry.io/issues/97276254/replays/?project=4510873275793488

### How to test this PR

- Create an automation with at least a node
- Open the node context menu (three dots on the node)
- And without closing it, pan the graph -> On develop it shou raise an exception, not with this branch.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
