### PR TITLE
Fix pending state when quickly switching from one page to another

### DIFF
--- a/web-frontend/modules/builder/components/PageEditorContent.vue
+++ b/web-frontend/modules/builder/components/PageEditorContent.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="page-editor">
+    <PageHeader />
+    <div class="layout__col-2-2 page-editor__content">
+      <div :style="{ width: `calc(100% - ${panelWidth}px)` }">
+        <PagePreview />
+      </div>
+      <div
+        class="page-editor__side-panel"
+        :style="{ width: `${panelWidth}px` }"
+      >
+        <PageSidePanels />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, provide } from 'vue'
+import PageHeader from '@baserow/modules/builder/components/page/header/PageHeader'
+import PagePreview from '@baserow/modules/builder/components/page/PagePreview'
+import PageSidePanels from '@baserow/modules/builder/components/page/PageSidePanels'
+import { DataProviderType } from '@baserow/modules/core/dataProviderTypes'
+import ApplicationBuilderFormulaInput from '@baserow/modules/builder/components/ApplicationBuilderFormulaInput'
+import _ from 'lodash'
+
+const props = defineProps({
+  workspace: {
+    type: Object,
+    required: true,
+  },
+  builder: {
+    type: Object,
+    required: true,
+  },
+  page: {
+    type: Object,
+    required: true,
+  },
+})
+
+const mode = 'editing'
+const { $store, $registry } = useNuxtApp()
+
+const panelWidth = ref(360)
+
+const applicationContext = computed(() => ({
+  workspace: props.workspace,
+  builder: props.builder,
+  mode,
+}))
+
+const sharedPage = computed(() =>
+  $store.getters['page/getSharedPage'](props.builder)
+)
+
+const dataSources = computed(() => {
+  return $store.getters['dataSource/getPageDataSources'](props.page)
+})
+
+const sharedDataSources = computed(() => {
+  return $store.getters['dataSource/getPageDataSources'](sharedPage.value)
+})
+
+const dispatchContext = computed(() => {
+  return DataProviderType.getAllDataSourceDispatchContext(
+    $registry.getAll('builderDataProvider'),
+    { ...applicationContext.value, page: props.page }
+  )
+})
+
+const applicationDispatchContext = computed(() => {
+  return DataProviderType.getAllDataSourceDispatchContext(
+    $registry.getAll('builderDataProvider'),
+    { builder: props.builder, mode }
+  )
+})
+
+provide('workspace', props.workspace)
+provide('builder', props.builder)
+provide('currentPage', props.page)
+provide('mode', mode)
+provide('formulaComponent', ApplicationBuilderFormulaInput)
+provide('applicationContext', applicationContext)
+
+// Watchers
+watch(
+  dataSources,
+  () => {
+    $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+      page: props.page,
+      data: dispatchContext.value,
+      mode,
+    })
+  },
+  { deep: true }
+)
+
+watch(
+  sharedDataSources,
+  () => {
+    $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+      page: sharedPage.value,
+      data: dispatchContext.value,
+    })
+  },
+  { deep: true }
+)
+
+watch(
+  dispatchContext,
+  (newDispatchContext, oldDispatchContext) => {
+    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
+      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+        page: props.page,
+        data: newDispatchContext,
+        mode,
+      })
+    }
+  },
+  { deep: true }
+)
+
+watch(
+  applicationDispatchContext,
+  (newDispatchContext, oldDispatchContext) => {
+    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
+      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+        page: sharedPage.value,
+        data: newDispatchContext,
+      })
+    }
+  },
+  { deep: true }
+)
+</script>

--- a/web-frontend/modules/builder/pages/pageEditor.vue
+++ b/web-frontend/modules/builder/pages/pageEditor.vue
@@ -1,33 +1,21 @@
 <template>
-  <!-- TODO MIG add a skeleton loader while the page is loading. -->
-  <div v-if="builder && currentPage && sharedPage" class="page-editor">
-    <PageHeader />
-    <div class="layout__col-2-2 page-editor__content">
-      <div :style="{ width: `calc(100% - ${panelWidth}px)` }">
-        <PagePreview />
-      </div>
-      <div
-        class="page-editor__side-panel"
-        :style="{ width: `${panelWidth}px` }"
-      >
-        <PageSidePanels />
-      </div>
-    </div>
-  </div>
+  <PageEditorContent
+    v-if="!pending"
+    :workspace="workspace"
+    :builder="builder"
+    :page="currentPage"
+  />
 </template>
 
 <script setup>
 import { useHead, useAsyncData } from '#imports'
-import { ref, computed, watch, provide } from 'vue'
+import { computed } from 'vue'
 import { onBeforeRouteUpdate, onBeforeRouteLeave } from 'vue-router'
 import { StoreItemLookupError } from '@baserow/modules/core/errors'
-import PageHeader from '@baserow/modules/builder/components/page/header/PageHeader'
-import PagePreview from '@baserow/modules/builder/components/page/PagePreview'
-import PageSidePanels from '@baserow/modules/builder/components/page/PageSidePanels'
 import { DataProviderType } from '@baserow/modules/core/dataProviderTypes'
 import { BuilderApplicationType } from '@baserow/modules/builder/applicationTypes'
-import ApplicationBuilderFormulaInput from '@baserow/modules/builder/components/ApplicationBuilderFormulaInput'
 import _ from 'lodash'
+import PageEditorContent from '@baserow/modules/builder/components/PageEditorContent.vue'
 
 definePageMeta({
   layout: 'app',
@@ -45,21 +33,16 @@ const route = useRoute()
 const { t } = useI18n()
 const { $store, $registry, $i18n } = useNuxtApp()
 
-const panelWidth = ref(360)
-
-// Provide values for child components
-const applicationContext = computed(() => ({
-  workspace: workspace.value,
-  builder: builder.value,
-  mode,
-}))
-
 useHead(() => ({
   title: t('pageEditor.title'),
 }))
 
 // Load page data
-const { data: pageData, error: pageError } = await useAsyncData(
+const {
+  data: pageData,
+  error: pageError,
+  pending,
+} = await useAsyncData(
   () => `page-editor-${route.params.builderId}-${route.params.pageId}`,
   async () => {
     // The objects are selected by the middleware
@@ -122,98 +105,16 @@ const { data: pageData, error: pageError } = await useAsyncData(
 
 if (pageError.value) {
   // If we have an error we want to display it.
-  throw pageError.value
+  if (pageError.value.statusCode === 404) {
+    showError(pageError.value)
+  } else {
+    throw pageError.value
+  }
 }
 
-const workspace = computed(() => pageData.value?.workspace ?? null)
-const builder = computed(() => pageData.value?.builder ?? null)
-const currentPage = computed(() => pageData.value?.page ?? null)
-const sharedPage = computed(() => pageData.value?.sharedPage ?? null)
-
-// Computed properties
-const dataSources = computed(() => {
-  if (!currentPage.value) return []
-  return $store.getters['dataSource/getPageDataSources'](currentPage.value)
-})
-
-const sharedDataSources = computed(() => {
-  if (!sharedPage.value) return []
-  return $store.getters['dataSource/getPageDataSources'](sharedPage.value)
-})
-
-const dispatchContext = computed(() => {
-  if (!currentPage.value || !applicationContext.value) return {}
-  return DataProviderType.getAllDataSourceDispatchContext(
-    $registry.getAll('builderDataProvider'),
-    { ...applicationContext.value, page: currentPage.value }
-  )
-})
-
-const applicationDispatchContext = computed(() => {
-  if (!builder.value) return {}
-  return DataProviderType.getAllDataSourceDispatchContext(
-    $registry.getAll('builderDataProvider'),
-    { builder: builder.value, mode }
-  )
-})
-
-provide('workspace', workspace)
-provide('builder', builder)
-provide('currentPage', currentPage)
-provide('mode', mode)
-provide('formulaComponent', ApplicationBuilderFormulaInput)
-provide('applicationContext', applicationContext)
-
-// Watchers
-watch(
-  dataSources,
-  () => {
-    $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-      page: currentPage.value,
-      data: dispatchContext.value,
-      mode,
-    })
-  },
-  { deep: true }
-)
-
-watch(
-  sharedDataSources,
-  () => {
-    $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-      page: sharedPage.value,
-      data: dispatchContext.value,
-    })
-  },
-  { deep: true }
-)
-
-watch(
-  dispatchContext,
-  (newDispatchContext, oldDispatchContext) => {
-    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
-      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-        page: currentPage.value,
-        data: newDispatchContext,
-        mode,
-      })
-    }
-  },
-  { deep: true }
-)
-
-watch(
-  applicationDispatchContext,
-  (newDispatchContext, oldDispatchContext) => {
-    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
-      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-        page: sharedPage.value,
-        data: newDispatchContext,
-      })
-    }
-  },
-  { deep: true }
-)
+const workspace = computed(() => pageData.value.workspace)
+const builder = computed(() => pageData.value.builder)
+const currentPage = computed(() => pageData.value.page)
 
 // Navigation guards
 onBeforeRouteUpdate((to, from) => {


### PR DESCRIPTION
### What is in this PR

Fixes https://baserow-eu.sentry.io/issues/97025403/events/28b3b79fdd9f40c8b37f2d5935a371a1/

If you quickly navigate between two builder pages or two pages of two different builder you end up triggering the error above because the useAsyncData can be in pending state if the previous useAsyncData is not resolved.

In this PR the asyncData logic and the page content logic is separated (and I believe it's a good pattern for other pages as well) so while it's pending we can easily prevent computation of all computeds and watchers. This solve a lot if `if(something)` the right way.

### How to test this PR

Create a builder with two pages and quiclky navigate between these two pages. On develpo, at some point you should have the error if you are quick enough. It should be impossible to reproduce it with this branch.


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
