### PR TITLE
Fix blur event triggered on unmounted element

### DIFF
--- a/web-frontend/modules/database/mixins/dateField.js
+++ b/web-frontend/modules/database/mixins/dateField.js
@@ -208,7 +208,9 @@ export default {
      * hidden.
      */
     blur(context, event) {
-      context.hide()
+      // The ?. prevents an exception when the context was removed from the DOM then
+      // the blur event is triggered
+      context?.hide()
     },
   },
 }


### PR DESCRIPTION
### What is in this PR

Fix https://baserow-eu.sentry.io/issues/97243391

Similar bug as in https://github.com/baserow/baserow/pull/4797 for similar reasons: it's a race condition between the blur event and the component unmounting.

### How to test this PR

With a chrome browser: create a table with a date field and try to set a date but don't use the mouse to validate the value once choosen, but press enter to save the value. On develop you should have an error log in the console (it breaks on prod) and nothing with this branch.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
