### PR TITLE
Fix view not found being an issue in sentry

### DIFF
--- a/web-frontend/modules/database/pages/form.vue
+++ b/web-frontend/modules/database/pages/form.vue
@@ -184,7 +184,11 @@ const { data, error } = await useAsyncData(
 )
 
 if (error.value) {
-  throw error.value
+  if (error.value.statusCode === 404) {
+    showError(error.value)
+  } else {
+    throw error.value
+  }
 }
 
 if (data.value?.redirect) {

--- a/web-frontend/modules/database/pages/publicView.vue
+++ b/web-frontend/modules/database/pages/publicView.vue
@@ -139,7 +139,11 @@ const { data, error } = await useAsyncData(
 )
 
 if (error.value) {
-  throw error.value
+  if (error.value.statusCode === 404) {
+    showError(error.value)
+  } else {
+    throw error.value
+  }
 }
 
 if (data.value?.redirect) {


### PR DESCRIPTION
### What is in this PR

In lot of places we throw all errors from the useAsyncData composable but actually when it's a 404 error we don't want it to be an issue tracked by sentry. That's why in this case we use showError instead of throwing the error.

### How to test this PR

- Just check that visiting this URL still work properly http://localhost:3000/public/grid/notavalidviewid

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
