### PR TITLE
chore: automatically update lock files on saas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1374,6 +1374,41 @@ jobs:
           git add baserow
           echo "✅ Submodule updated."
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Cache uv Python installation
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/uv/python
+          key: trigger-saas-uv-python-3.14
+
+      - name: Cache yarn packages and node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            .yarn-cache
+            saas/node_modules
+          key: trigger-saas-yarn-${{ hashFiles('saas/yarn.lock') }}
+          restore-keys: trigger-saas-yarn-
+
+      - name: Install just and yarn
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+          npm install -g yarn@1.22.22
+
+      - name: Sync dependencies from updated submodule
+        working-directory: saas
+        run: |
+          uv python install 3.14
+          UV_NO_SYNC=true just sync-deps
+          yarn install --ignore-scripts --no-bin-links --cache-folder ${{ github.workspace }}/.yarn-cache
+
       - name: Commit and push changes to GitLab
         working-directory: saas
         run: |
@@ -1381,6 +1416,8 @@ jobs:
 
           git config user.name "${GIT_USER_NAME}"
           git config user.email "${GIT_USER_EMAIL}"
+
+          git add baserow pyproject.toml uv.lock package.json yarn.lock
 
           if git diff-index --quiet HEAD --; then
             echo "No changes detected — skipping commit."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1394,7 +1394,7 @@ jobs:
           path: |
             .yarn-cache
             saas/node_modules
-          key: trigger-saas-yarn-${{ hashFiles('saas/yarn.lock') }}
+          key: trigger-saas-yarn-${{ github.sha }}-${{ hashFiles('saas/yarn.lock') }}
           restore-keys: trigger-saas-yarn-
 
       - name: Install just and yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1378,36 +1378,28 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
+          cache: "yarn"
+          cache-dependency-path: saas/yarn.lock
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-
-      - name: Cache uv Python installation
-        uses: actions/cache@v4
         with:
-          path: ~/.local/share/uv/python
-          key: trigger-saas-uv-python-3.14
-
-      - name: Cache yarn packages and node_modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            .yarn-cache
-            saas/node_modules
-          key: trigger-saas-yarn-${{ github.sha }}-${{ hashFiles('saas/yarn.lock') }}
-          restore-keys: trigger-saas-yarn-
+          # Keep in sync with the uv pin in baserow-saas backend Dockerfiles,
+          # which consume the uv.lock this job generates with `uv sync --frozen`.
+          version: "0.9.26"
+          python-version: "3.14"
+          cache-python: true
 
       - name: Install just and yarn
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+          curl --proto '=https' --tlsv1.2 -sSf --retry 3 https://just.systems/install.sh | bash -s -- --to /usr/local/bin --tag 1.55.1
           npm install -g yarn@1.22.22
 
       - name: Sync dependencies from updated submodule
         working-directory: saas
         run: |
-          uv python install 3.14
           UV_NO_SYNC=true just sync-deps
-          yarn install --ignore-scripts --no-bin-links --cache-folder ${{ github.workspace }}/.yarn-cache
+          yarn install --ignore-scripts --no-bin-links
 
       - name: Commit and push changes to GitLab
         working-directory: saas


### PR DESCRIPTION
### What is in this PR
Some changes for ci.yml to automatically update pyproject.toml, uv.lock, package.json and yarn.lock on saas on every submodule update to keep them in sync with core

### How to test this PR
- Merge and 🤞

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered


### Notes / follow-ups

- The saas `.gitlab-ci.yml` still contains an `update-baserow-submodule` job duplicating this sync-deps + lock-file logic. That job is dead (its trigger path via the GitLab core mirror no longer fires), which is why its 2026-02 sync-deps addition never took effect. It should be removed in a paired saas MR to avoid drift or a push race if the mirror pipeline is ever reactivated.
- The pushed lockfiles are validated only by the post-push saas pipeline (accepted risk): the blast radius is dev-dependency scope, staging keeps its last good deploy, and a bad lock shows up as a red saas develop pipeline to revert.
- The uv version is pinned to `0.9.26` to match the saas backend Dockerfiles (`ghcr.io/astral-sh/uv:0.9.26`, which consume the generated `uv.lock` with `uv sync --frozen`). Bump both pins together; optionally enforce later via `[tool.uv] required-version` in the saas `pyproject.toml`.
