### PR TITLE
Fix input.blur()

### DIFF
--- a/web-frontend/modules/database/components/row/RowEditFieldDuration.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldDuration.vue
@@ -9,7 +9,7 @@
       :disabled="readOnly"
       class="field-duration"
       @keypress="onKeyPress(field, $event)"
-      @keyup.enter="$refs.input.blur()"
+      @keyup.enter="$refs.input?.$el?.blur()"
       @keyup="updateCopy(field, $event.target.value)"
       @focus="select()"
       @blur="unselect()"

--- a/web-frontend/modules/database/components/row/RowEditFieldEmail.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldEmail.vue
@@ -6,7 +6,7 @@
       size="large"
       :error="touched && !valid"
       :disabled="readOnly"
-      @keyup.enter="$refs.input.blur()"
+      @keyup.enter="$refs.input?.$el?.blur()"
       @focus="select()"
       @blur="unselect()"
     ></FormInput>

--- a/web-frontend/modules/database/components/row/RowEditFieldNumber.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldNumber.vue
@@ -7,7 +7,7 @@
       :error="touched && !valid"
       :disabled="readOnly"
       @keypress="onKeyPress"
-      @keyup.enter="(onBlur(), $refs.input.blur())"
+      @keyup.enter="(onBlur(), $refs.input?.$el?.blur())"
       @focus="(onFocus(), select())"
       @blur="(onBlur(), unselect())"
       @input="handleInput"

--- a/web-frontend/modules/database/components/row/RowEditFieldPhoneNumber.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldPhoneNumber.vue
@@ -7,7 +7,7 @@
       type="tel"
       :error="touched && !valid"
       :disabled="readOnly"
-      @keyup.enter="$refs.input.blur()"
+      @keyup.enter="$refs.input?.$el?.blur()"
       @focus="select()"
       @blur="unselect()"
     >

--- a/web-frontend/modules/database/components/row/RowEditFieldText.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldText.vue
@@ -6,7 +6,7 @@
       size="large"
       :error="touched && !valid"
       :disabled="readOnly"
-      @keyup.enter="$refs.input.blur()"
+      @keyup.enter="$refs.input?.$el?.blur()"
       @focus="select()"
       @blur="unselect()"
     />

--- a/web-frontend/modules/database/components/row/RowEditFieldURL.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldURL.vue
@@ -8,7 +8,7 @@
         :error="touched && !valid"
         :disabled="readOnly"
         :text-invisible="!editing"
-        @keyup.enter="$refs.input.blur()"
+        @keyup.enter="$refs.input?.$el?.blur()"
         @focus="select()"
         @blur="unselect()"
       />


### PR DESCRIPTION
Fixing input.blur() problem that could be observed when pressing Enter while editing fields in row edit modal & forms
