### PR TITLE
Fix crash while refreshing a view

### DIFF
--- a/web-frontend/modules/database/components/table/Table.vue
+++ b/web-frontend/modules/database/components/table/Table.vue
@@ -614,11 +614,7 @@ export default {
           notifyIf(error)
         }
       }
-      if (
-        Object.prototype.hasOwnProperty.call(this.$refs, 'view') &&
-        // TODO crash here can't convert undefined to object
-        Object.prototype.hasOwnProperty.call(this.$refs.view, 'refresh')
-      ) {
+      if (typeof this.$refs.view?.refresh === 'function') {
         await this.$refs.view.refresh()
       }
       // Before the callback is called, mark the table as not refreshing anymore, so


### PR DESCRIPTION
### What is in this PR

Fixes https://baserow-eu.sentry.io/issues/97304380 

### How to test this PR

Honestly I wus able to find a way to reproduce it but I suspect a bug with `.hasOwnProperty`  known as not playing well with proxy object of vuejs so it's more an attempt than a sure fix. So you should just check that refreshing a Table view just work as before by setting a filter for instance.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
