### PR TITLE
Fix workspace delete ref not found

### DIFF
--- a/web-frontend/modules/core/components/workspace/WorkspaceContext.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceContext.vue
@@ -209,7 +209,6 @@ export default {
           await pageFinished()
           await nextTick()
         }
-        this.hide()
       } catch (error) {
         notifyIf(error, 'application')
       }


### PR DESCRIPTION
### What is in this PR

Fixes an error related to hiding the workspace context menu after deleting it. There is no need to hide the context because the workspace context is only shown on the workspace homepage. The `WorkspaceContext` component is destroyed because the workspace is deleted, which makes it hide anyway.

### How to test this PR

- Go to the workspace dashboard.
- Click on the workspace name at the top and then delete on "Delete workspace".
- Observe that no error is shown.

