### PR TITLE
Add public blur function to FormInput

### DIFF
--- a/web-frontend/modules/core/components/FormInput.vue
+++ b/web-frontend/modules/core/components/FormInput.vue
@@ -154,8 +154,12 @@ function focus() {
   input.value?.focus()
 }
 
+function blur() {
+  input.value?.blur()
+}
+
 const slots = useSlots()
 const hasSuffixSlot = computed(() => !!slots.suffix)
 
-defineExpose({ focus })
+defineExpose({ focus, blur })
 </script>


### PR DESCRIPTION
### What is in this PR

Fixes: https://baserow-eu.sentry.io/issues/97325163/?project=4510873275793488&query=is%3Aunresolved%20blur&referrer=issue-stream

Before the `FormInput` had a publicly accessible function called `blur` that could be called. This was not the case anymore since the Nuxt 3 upgrade. This pull request adds that.

### How to test this PR

- Open the row edit modal of any row with a text field.
- Focus on the text field input and press the enter key.
- Observe that the input is unfoccussed and no error is shown.
