### PR TITLE
Submit form view on enter instead of clicking on buttons in fields

### DIFF
--- a/web-frontend/modules/database/components/row/RowEditFieldFile.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldFile.vue
@@ -36,6 +36,7 @@
     <ButtonText
       v-if="!readOnly"
       icon="iconoir-plus"
+      tag="a"
       @click.prevent="showModal()"
     >
       {{ $t('rowEditFieldFile.addFile') }}

--- a/web-frontend/modules/database/components/row/RowEditFieldMultipleCollaborators.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldMultipleCollaborators.vue
@@ -28,7 +28,7 @@
       </li>
     </ul>
     <span v-if="!readOnly" ref="dropdownLink">
-      <ButtonText icon="iconoir-plus" @click.prevent="toggleDropdown()">
+      <ButtonText icon="iconoir-plus" tag="a" @click.prevent="toggleDropdown()">
         {{ $t('rowEditFieldMultipleCollaborators.addCollaborator') }}
       </ButtonText></span
     >

--- a/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
@@ -20,7 +20,7 @@
       </li>
     </ul>
     <span v-if="!readOnly" ref="dropdownLink">
-      <ButtonText icon="iconoir-plus" @click.prevent="toggleDropdown()">
+      <ButtonText icon="iconoir-plus" tag="a" @click.prevent="toggleDropdown()">
         {{ $t('rowEditFieldMultipleSelect.addOption') }}
       </ButtonText></span
     >


### PR DESCRIPTION
### What is in this PR

This pull request prevents opening a file upload modal, single select dropdown, and multiple select dropdown when the enter key is pressed in the form. This was originally the case because these buttons were added as `<button>` element, which is clicked on the form submit event, which can be triggered by pressing enter in a field.

Example of the problem:

https://github.com/user-attachments/assets/123f137b-2ed5-4701-9dc1-9cfa5eeb8c13


### How to test this PR

- Install the "All fields" template.
- Create a form view and add a fields.
- In the first text field press the enterprise key. You'll probably notice an error which is fixed in (https://github.com/baserow/baserow/pull/4811).
- You'll also see that all the fields become invalid. Fill them all out.
- Press enter again in the first text field.
- On develop it opens the upload file modal, single select dropdown, or multiple select dropdown. That should not be the case on this branch anymore.
