### PR TITLE
Fix unobserve element error by replacing with disconnect

### DIFF
--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -58,7 +58,7 @@ export default {
     if (!this.resizeObserver) {
       return
     }
-    this.resizeObserver.unobserve(parent)
+    this.resizeObserver.disconnect()
     this.clearScrollEvents()
   },
   methods: {

--- a/web-frontend/modules/core/components/crudTable/ExpandOnOverflowList.vue
+++ b/web-frontend/modules/core/components/crudTable/ExpandOnOverflowList.vue
@@ -88,7 +88,7 @@ export default {
     this.$el.resizeObserver.observe(this.$el)
   },
   beforeUnmount() {
-    this.$el.resizeObserver.unobserve(this.$el)
+    this.$el.resizeObserver.disconnect()
   },
   created() {
     this.recalculateHiddenRecords()

--- a/web-frontend/modules/core/directives/autoOverflowScroll.js
+++ b/web-frontend/modules/core/directives/autoOverflowScroll.js
@@ -51,7 +51,7 @@ export default {
     el.autoOverflowScrollHeightObserverBinded = true
   },
   removeListeners(el) {
-    el.autoOverflowScrollHeightObserver?.unobserve(el)
+    el.autoOverflowScrollHeightObserver?.disconnect()
     el.autoOverflowScrollHeightObserverBinded = false
   },
 }

--- a/web-frontend/modules/database/components/view/gallery/GalleryView.vue
+++ b/web-frontend/modules/database/components/view/gallery/GalleryView.vue
@@ -374,7 +374,7 @@ export default {
   },
   beforeUnmount() {
     if (this.resizeObserver !== null) {
-      this.resizeObserver.unobserve(this.$el)
+      this.resizeObserver.disconnect()
     }
     if (this.$refs.scroll) {
       this.$refs.scroll.removeEventListener('scroll', this.scrollEvent)

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -671,7 +671,7 @@ export default {
   },
   beforeUnmount() {
     if (this.resizeObserver !== null) {
-      this.resizeObserver.unobserve(this.$el)
+      this.resizeObserver.disconnect()
     }
     window.removeEventListener('keydown', this.keyDownEvent)
     window.removeEventListener('copy', this.copySelection)

--- a/web-frontend/modules/database/components/view/grid/GridViewSection.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewSection.vue
@@ -594,7 +594,7 @@ export default {
   beforeUnmount() {
     const sectionElement = this.$refs.section
     if (this.resizeObserver !== null) {
-      this.resizeObserver.unobserve(sectionElement)
+      this.resizeObserver.disconnect()
     }
     if (this.horizontalScrollEvent !== null) {
       sectionElement.removeEventListener('scroll', this.horizontalScrollEvent)


### PR DESCRIPTION
### What is in this PR

Related to: https://baserow-eu.sentry.io/issues/97210565/?project=4510873275793488&query=is%3Aunresolved%20lastSeen%3A-1h&referrer=issue-stream

It seems that this problem is somehow happening on mobile devices only based on the Sentry logs. It's difficult to reproduce. This fix is definitely not fixing the root cause because I've not been able to reproduce the scenario where `this.$el` is empty. Howerver, it replaces `.unobserve(el)` with `.disconnect()`. The difference is that disconnect removes all observers without needing the element. This will have the same result as before, but without the error.

### How to test this PR

- I've thoroughly tested all the resizeobservers and confirm that they're actually cleared on unmount. This can be repeated by adding a console.log to the `new ResizeObserver(() => {  ...here... })`.
