### PR TITLE
Ensure that the router node label can be updated.

### DIFF
--- a/backend/src/baserow/contrib/automation/nodes/node_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/node_types.py
@@ -277,12 +277,12 @@ class CoreRouterActionNodeType(AutomationNodeActionNodeType):
         :return: The prepared values for the router node.
         """
 
-        if instance:
-            service = instance.service.specific
-
+        service_values = values.get("service", {})
+        if instance and "edges" in service_values:
             prepared_uids = [
-                str(edge["uid"]) for edge in values["service"].get("edges", [])
+                str(edge["uid"]) for edge in service_values.get("edges", [])
             ]
+            service = instance.service.specific
             persisted_uids = [str(edge.uid) for edge in service.edges.only("uid")]
             removed_uids = list(set(persisted_uids) - set(prepared_uids))
 

--- a/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
+++ b/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
@@ -677,6 +677,44 @@ def test_updating_router_node_with_edge_removals_when_they_have_output_nodes_dis
 
 
 @pytest.mark.django_db
+def test_updating_router_node_without_service_allowed(
+    api_client,
+    data_fixture,
+):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user)
+    service = data_fixture.create_core_router_service(default_edge_label="Default")
+    router = data_fixture.create_core_router_action_node(
+        workflow=workflow, service=service, label="Original"
+    )
+    edge = data_fixture.create_core_router_service_edge(
+        service=service, label="Do this", condition="'true'"
+    )
+
+    assert (
+        workflow.get_graph().get_node_at_position(router, "south", str(edge.uid))
+        is not None
+    )
+
+    response = api_client.patch(
+        reverse(API_URL_ITEM, kwargs={"node_id": router.id}),
+        {"label": "Modified"},
+        **get_api_kwargs(token),
+    )
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json["label"] == "Modified"
+    assert response_json["service"]["edges"] == [
+        {
+            "uid": str(edge.uid),
+            "label": edge.label,
+            "order": AnyStr(),
+            "condition": edge.condition,
+        }
+    ]
+
+
+@pytest.mark.django_db
 def test_deleting_router_node_with_output_nodes_disallowed(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     workflow = data_fixture.create_automation_workflow(user)

--- a/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_router_nodes_from_being_re.json
+++ b/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_router_nodes_from_being_re.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved an issue which prevented router nodes from being renamed once they had branches.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-02-19"
+}


### PR DESCRIPTION
### What is in this PR

I was playing around with the router node, and I noticed that the API started returning 400s on a `label` change. This used to work, so maybe at some point we had a regression...

This PR ensures that `CoreRouterActionNodeType.prepare_values` checks if the request payload contains the `service` object and `edges` array before doing any further checks.

### How to test this PR

- In `develop`: add a router node with a branch (not just the default branch). Then add an output node on your branch. Try to rename the node's label, and you'll get a 400.
- In this branch, it'll work.

It just boils down to these permutations:

> PATCH /api/automation/node/{nodeId}

```json
{
    "label": "My new label"
}
```
&
```json
{
    "label": "My new label",
    "service": {
        "type": "router"
    }
}
```

Will now work.

```json
{
    "label": "My new label",
    "service": {
        "type": "router",
        "edges": []
    }
}
```

Will still throw a 400; you can't clear the edges when one or more edges have an output node.

```json
{
    "label": "My new label",
    "service": {
        "type": "router",
        "edges": [
            {
                "uid": "582999db-ab3e-4b37-82f6-510d4f479881",
                "label": "Renaming my branch to something else",
                "order": "1.00000000000000000000",
                "condition": {
                    "mode": "simple",
                    "version": "0.1",
                    "formula": ""
                }
            }
        ]
    }
}
```

Is still permitted, so users can rename their existing branch name.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
