### PR TITLE
Fix context ref reference when deleting widgets

### DIFF
--- a/web-frontend/modules/dashboard/components/widget/WidgetContext.vue
+++ b/web-frontend/modules/dashboard/components/widget/WidgetContext.vue
@@ -58,7 +58,9 @@ export default {
         notifyIf(error, 'dashboard')
       }
       this.isDeleteInProgress = false
-      this.hide()
+      if (this.$refs.context) {
+        this.hide()
+      }
     },
   },
 }


### PR DESCRIPTION
Fixes Sentry issue https://baserow-eu.sentry.io/issues/97260032/events/2cf71b00bd7e4c99a8c174ae38764370/

When deleting dashboard widgets, you will see a console error on develop branch. On this branch, you should not see it anymore.