### PR TITLE
Ensure workspaces with AI integration ai_settings can be imported and exported correctly.

### DIFF
--- a/backend/src/baserow/contrib/integrations/ai/integration_types.py
+++ b/backend/src/baserow/contrib/integrations/ai/integration_types.py
@@ -9,6 +9,7 @@ from baserow.api.workspaces.serializers import get_generative_ai_settings_serial
 from baserow.contrib.integrations.ai.models import AIIntegration
 from baserow.core.integrations.registries import IntegrationType
 from baserow.core.integrations.types import IntegrationDict
+from baserow.core.models import Application
 
 
 class AIIntegrationType(IntegrationType):
@@ -97,6 +98,30 @@ class AIIntegrationType(IntegrationType):
         """
 
         return provider_type in integration.ai_settings
+
+    def import_serialized(
+        self,
+        application: Application,
+        serialized_values: Dict[str, Any],
+        id_mapping: Dict,
+        files_zip=None,
+        storage=None,
+        cache=None,
+    ) -> AIIntegration:
+        if cache is None:
+            cache = {}
+
+        # AI settings are sensitive data, the serialized data will set it `None`.
+        serialized_values["ai_settings"] = serialized_values["ai_settings"] or {}
+
+        return super().import_serialized(
+            application,
+            serialized_values,
+            id_mapping,
+            files_zip=files_zip,
+            storage=storage,
+            cache=cache,
+        )
 
     def export_serialized(
         self,

--- a/changelog/entries/unreleased/bug/resolved_a_bug_in_the_ai_integration_which_prevented_workspa.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_in_the_ai_integration_which_prevented_workspa.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug in the AI integration which prevented workspaces from being exported and then imported correctly.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-02-19"
+}


### PR DESCRIPTION
### What is in this PR

When `ai_settings` are exported, as they're sensitive data, they will be serialized to `None`. When we import the serialized data, we need to convert `None` to a blank dict or the import will fail.

### How to test this PR

See the steps in #4534

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
