### PR TITLE
Fix hydration issue on publicView pages

### DIFF
--- a/web-frontend/modules/database/pages/publicView.vue
+++ b/web-frontend/modules/database/pages/publicView.vue
@@ -42,6 +42,7 @@ const detectedLocale = useState('public-view-detected-locale', () => {
   return $i18n.getBrowserLocale() || $i18n.defaultLocale
 })
 $i18n.locale.value = detectedLocale.value
+await $i18n.loadLocaleMessages(detectedLocale.value)
 
 const { data, error } = await useAsyncData(
   `database-public-view-${route.params.slug}`,

--- a/web-frontend/modules/database/pages/publicViewLogin.vue
+++ b/web-frontend/modules/database/pages/publicViewLogin.vue
@@ -66,6 +66,7 @@ const detectedLocale = useState('public-view-login-detected-locale', () => {
   return $i18n.getBrowserLocale() || $i18n.defaultLocale
 })
 $i18n.locale.value = detectedLocale.value
+await $i18n.loadLocaleMessages(detectedLocale.value)
 
 // Page title
 useHead({


### PR DESCRIPTION
### What is in this PR
This PR fixes hydration issue on publicView pages by detecting language on server side and sharing this value with client, so client does not have to determine it on it's own (which can cause hydration mismatch)

The way it works:
* Server: initializer runs `getBrowserLocale()` and  detects from `Accept-Language` header then  value serialized into Nuxt payload
* Client hydration: `useState` reads the serialized value from payload and initializer does not re-run.  `$i18n.locale` is set to the exact same value the server used


### How to test this PR
- Share grid view with/without password and open shared view in separate browser (i.e. private mode).
- Observe there are no hydration mismatch errors

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
