### PR TITLE
Fixed prevent moving forward in scratch onboarding step validation bug

### DIFF
--- a/changelog/entries/unreleased/bug/fix_onboarding_scratch_step_validation.json
+++ b/changelog/entries/unreleased/bug/fix_onboarding_scratch_step_validation.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixed prevent moving forward in scratch onboarding step validation bug.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2026-02-20"
+}

--- a/web-frontend/modules/database/components/onboarding/DatabaseScratchTrackStep.vue
+++ b/web-frontend/modules/database/components/onboarding/DatabaseScratchTrackStep.vue
@@ -43,23 +43,17 @@
       v-show="what !== ''"
       :key="index"
       class="margin-bottom-2"
-      :error="v$['row' + index]?.$error"
       small-label
     >
       <template v-if="index === 0" #label>
         {{ $t('databaseScratchTrackStep.thisIncludes') }}</template
       >
       <FormInput
-        v-model="v$['row' + index].$model"
+        v-model="$data['row' + index]"
         :placeholder="$t('databaseScratchTrackStep.rowName') + '...'"
         size="large"
-        :error="v$['row' + index]?.$error"
         @input="updateValue"
-        @blur="v$['row' + index].$touch"
       />
-      <template #error>
-        {{ v$['row' + index].$errors[0].$message }}
-      </template>
     </FormGroup>
   </div>
 </template>
@@ -126,14 +120,17 @@ export default {
         this.what !== value &&
         Object.prototype.hasOwnProperty.call(this.whatItems, value)
       ) {
-        this.v$.row0.$model = this.whatItems[value][0]
-        this.v$.row1.$model = this.whatItems[value][1]
-        this.v$.row2.$model = this.whatItems[value][2]
+        this.row0 = this.whatItems[value][0]
+        this.row1 = this.whatItems[value][1]
+        this.row2 = this.whatItems[value][2]
       }
 
-      // this.v$.row0?.$touch()
       this.what = value
-      this.updateValue()
+
+      this.$nextTick(() => {
+        this.v$.$touch()
+        this.updateValue()
+      })
     },
     updateValue() {
       this.$nextTick(() => {
@@ -145,16 +142,6 @@ export default {
   },
   validations() {
     const rules = {}
-
-    rules.row0 = {
-      required: helpers.withMessage(this.$t('error.requiredField'), required),
-    }
-    rules.row1 = {
-      required: helpers.withMessage(this.$t('error.requiredField'), required),
-    }
-    rules.row2 = {
-      required: helpers.withMessage(this.$t('error.requiredField'), required),
-    }
 
     if (this.what === 'own') {
       rules.tableName = {


### PR DESCRIPTION
### What is in this PR

Before:

https://github.com/user-attachments/assets/6341ff6d-67c4-44a7-9bfd-4109e4a945b0

After:

https://github.com/user-attachments/assets/f38aad67-a305-49d6-9dd4-cf31830951ae


### How to test this PR

- Create a new account and start the onboarding.
- Click on "Scratch" en on continue, then on "Add your own button".
- Before you had to focus on the table name input before the button would work.
- After checking out this branch that is not needed anymore, and the validation on the rows should be removed. No need to fill those out.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
