### PR TITLE
Fix Local Baserow service filtering with a formula value.

### DIFF
--- a/changelog/entries/unreleased/bug/4860_resolved_a_bug_which_prevented_builder_data_source_and_workf.json
+++ b/changelog/entries/unreleased/bug/4860_resolved_a_bug_which_prevented_builder_data_source_and_workf.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented builder data source and workflow action filtering with formula values from working correctly.",
+    "issue_origin": "github",
+    "issue_number": 4860,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-02-24"
+}

--- a/web-frontend/modules/builder/components/dataSource/DataSourceCreateEditModal.vue
+++ b/web-frontend/modules/builder/components/dataSource/DataSourceCreateEditModal.vue
@@ -88,7 +88,7 @@ export default {
   computed: {
     submitIsDisabled() {
       return (
-        this.loading || !this.changed || this.$refs.dataSourceForm.v$.$anyError
+        this.loading || !this.changed || this.$refs.dataSourceForm?.v$.$anyError
       )
     },
     dataSources() {

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
@@ -111,6 +111,9 @@ export default {
     },
   },
   emits: ['update:modelValue'],
+  setup() {
+    return useDatePickerLanguage()
+  },
   data() {
     return {
       dateInputValue: '',
@@ -137,9 +140,6 @@ export default {
       },
       immediate: true,
     },
-  },
-  setup() {
-    return useDatePickerLanguage()
   },
   methods: {
     refreshDate(value) {

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowTableServiceConditionalForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowTableServiceConditionalForm.vue
@@ -32,7 +32,7 @@
       >
         <InjectedFormulaInput
           v-if="filter.value_is_formula && propFilterType.hasEditableValue"
-          :value="getFormulaObject(filter)"
+          :model-value="getFormulaObject(filter)"
           class="filters__value--formula-input"
           :placeholder="
             $t(


### PR DESCRIPTION
### What is in this PR

Fix a nuxt3 upgrade bug which prevents our Local Baserow filtering with a formula value from working correctly. The `InjectedFormulaInput` doesn't take a `value` prop anymore.

### How to test this PR

See #4860.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
