### PR TITLE
Resolve data input validation and cached used property name bugs.

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -1519,13 +1519,13 @@ class InputTextElementType(InputElementType):
         :return: Whether the value is valid or not for this element.
         """
 
-        if value == "":
+        if value == "" or value is None:
             if element.required:
                 raise ValueError("The value is required")
 
         elif element.validation_type == "integer":
             try:
-                return ensure_numeric(value)
+                return ensure_numeric(value, True)
             except (InvalidOperation, ValidationError) as exc:
                 raise TypeError(f"{value} is not a valid number") from exc
 

--- a/backend/src/baserow/contrib/builder/handler.py
+++ b/backend/src/baserow/contrib/builder/handler.py
@@ -1,6 +1,7 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db.models.query import QuerySet
 
 from baserow.contrib.builder.formula_property_extractor import (
@@ -24,6 +25,8 @@ BUILDER_PUBLIC_RECORDS_CACHE_TTL_SECONDS = 60 * 60
 BUILDER_PREVIEW_USED_PROPERTIES_CACHE_TTL_SECONDS = 60 * 10
 
 SENTINEL = "__no_results__"
+
+User = get_user_model()
 
 
 class BuilderHandler:
@@ -56,14 +59,14 @@ class BuilderHandler:
         return f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_version_{builder.id}"
 
     def get_builder_used_properties_cache_key(
-        self, user: UserSourceUser, builder: Builder
+        self, user: Union[User, UserSourceUser], builder: Builder
     ) -> str:
         """
         Returns a cache key that can be used to key the results of making the
         expensive function call to get_builder_used_property_names().
         """
 
-        if user.is_anonymous or not user.role:
+        if user.is_anonymous or not hasattr(user, "role"):
             # When the user is anonymous, only use the prefix + page ID.
             role = ""
         else:

--- a/backend/src/baserow/contrib/database/rows/data_providers.py
+++ b/backend/src/baserow/contrib/database/rows/data_providers.py
@@ -1,14 +1,14 @@
 from typing import List, Union
 
-from baserow.contrib.builder.data_sources.builder_dispatch_context import (
-    BuilderDispatchContext,
+from baserow.contrib.database.rows.runtime_formula_contexts import (
+    HumanReadableRowContext,
 )
 from baserow.core.formula.registries import DataProviderType
 
 
 class HumanReadableFieldsDataProviderType(DataProviderType):
     """
-    This data provider type is used to read the human readable values for the row
+    This data provider type is used to read the human-readable values for the row
     fields. This is used for example in the AI field to be able to reference other
     fields in the same row to generate a different prompt for each row based on the
     values of the other fields.
@@ -17,8 +17,8 @@ class HumanReadableFieldsDataProviderType(DataProviderType):
     type = "fields"
 
     def get_data_chunk(
-        self, dispatch_context: BuilderDispatchContext, path: List[str]
-    ) -> Union[int, str]:
+        self, dispatch_context: HumanReadableRowContext, path: List[str]
+    ) -> Union[int, str] | None:
         """
         When a page parameter is read, returns the value previously saved from the
         request object.

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -524,6 +524,7 @@ def test_choice_element_import_export_formula(data_fixture):
         (True, "integer", "42", 42),
         (True, "integer", "horse", TypeError),
         (False, "integer", "", ""),
+        (False, "integer", None, None),
         (True, "email", "", ValueError),
         (True, "email", "foo@bar.com", "foo@bar.com"),
         (True, "email", "foobar.com", ValueError),

--- a/backend/tests/baserow/contrib/builder/test_builder_handler.py
+++ b/backend/tests/baserow/contrib/builder/test_builder_handler.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 from django.contrib.auth import get_user_model
 
 import pytest
+from faker import Faker
 
 from baserow.contrib.builder.handler import (
     USED_PROPERTIES_CACHE_KEY_PREFIX,
@@ -11,7 +12,16 @@ from baserow.contrib.builder.handler import (
 from baserow.core.exceptions import ApplicationDoesNotExist
 from baserow.core.user_sources.user_source_user import UserSourceUser
 
+fake = Faker()
 User = get_user_model()
+
+
+def fake_user_source_user(role: str = "") -> UserSourceUser:
+    user_source = MagicMock()
+    original_user = MagicMock()
+    return UserSourceUser(
+        user_source, original_user, 123, fake.name(), fake.email(), role=role
+    )
 
 
 @pytest.mark.django_db
@@ -44,48 +54,37 @@ def test_get_builder_select_related_theme_config(
 
 
 @pytest.mark.parametrize(
-    "is_anonymous,user_role,expected_cache_key",
+    "user,expected_cache_key",
     [
+        # An anonymous User.
         (
-            True,
-            "",
+            MagicMock(is_anonymous=True, spec=["is_anonymous"]),
             f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_100",
         ),
+        # An authenticated User
         (
-            True,
-            "foo_role",
+            MagicMock(is_anonymous=False, spec=["is_anonymous"]),
             f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_100",
         ),
+        # A UserSourceUser, with no role.
         (
-            False,
-            "foo_role",
-            f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_100_foo_role",
+            fake_user_source_user(role=""),
+            f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_100_",
+        ),
+        # A UserSourceUser, with a role.
+        (
+            fake_user_source_user(role="admin"),
+            f"{USED_PROPERTIES_CACHE_KEY_PREFIX}_100_admin",
         ),
     ],
 )
 def test_get_builder_used_properties_cache_key_returned_expected_cache_key(
-    is_anonymous, user_role, expected_cache_key
+    user, expected_cache_key
 ):
-    """
-    Test the BuilderHandler::get_builder_used_properties_cache_key() method.
-
-    Ensure the expected cache key is returned.
-    """
-
-    user_source_user = MagicMock()
-    user_source_user.is_anonymous = is_anonymous
-    user_source_user.role = user_role
-
-    mock_builder = MagicMock()
-    mock_builder.id = 100
-
-    handler = BuilderHandler()
-
-    cache_key = handler.get_builder_used_properties_cache_key(
-        user_source_user, mock_builder
+    assert (
+        BuilderHandler().get_builder_used_properties_cache_key(user, MagicMock(id=100))
+        == expected_cache_key
     )
-
-    assert cache_key == expected_cache_key
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/resolved_a_caching_issue_when_applications_users_had_no_role.json
+++ b/changelog/entries/unreleased/bug/resolved_a_caching_issue_when_applications_users_had_no_role.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a caching issue when applications users had no role set.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-02-25"
+}

--- a/changelog/entries/unreleased/bug/resolved_a_data_input_bug_which_prevented_optional_numeric_i.json
+++ b/changelog/entries/unreleased/bug/resolved_a_data_input_bug_which_prevented_optional_numeric_i.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a data input bug which prevented optional numeric inputs from being accepted.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-02-25"
+}


### PR DESCRIPTION
### What is in this PR

1. Continuing a fix in `a4ddf3ba5e951a73f4b88be4a7cd403abf5639dc`, the `InputTextElementType.is_valid` method needs to check for a blank string OR `None` (I didn't account for the latter). If we receive `None` and `validation_type=number`, then we need to ensure `ensure_numeric` accepts `None`.
2. Fixing a bug in `get_builder_used_properties_cache_key` which caused authenticated `UserSourceUser` with no `role` (a blank string) to share the same cache as anonymous users.

### How to test this PR

1. Add a form container with a data input within it. Add any old event to the container. In the data input, set the validation type to number, and leave required off. You'll get a backend error on submission as we're trying to ensure that `None` is a number.
2. This one is a bit more time-consuming; it's probably easiest for me to share an export, rather than set everything up from scratch.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
