### PR TITLE
Resolve a bug in collection element useAsyncData.

### DIFF
--- a/changelog/entries/unreleased/bug/4862_resolved_a_bug_which_caused_table_and_repeat_element_load_mo.json
+++ b/changelog/entries/unreleased/bug/4862_resolved_a_bug_which_caused_table_and_repeat_element_load_mo.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which caused table and repeat element load more buttons to only load more after a second click.",
+    "issue_origin": "github",
+    "issue_number": 4862,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-02-25"
+}

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -83,7 +83,7 @@ export default {
      * @property {Object} fields - The fields of the data source.
      * @property {int} items_per_page - The number of items per page.
      * @property {string} button_color - The color of the button.
-     * @property {string} orientation - The orientation for eaceh device.
+     * @property {string} orientation - The orientation for each device.
      */
     element: {
       type: Object,

--- a/web-frontend/modules/builder/composables/useCollectionElement.js
+++ b/web-frontend/modules/builder/composables/useCollectionElement.js
@@ -28,7 +28,7 @@ export function useCollectionElement(props) {
   const adhocFilters = ref()
   const adhocSortings = ref()
   const adhocSearch = ref()
-  const currentOffset = ref(0)
+  const currentOffset = useState(`element-offset-${unref(element).id}`, () => 0)
   const errorNotified = ref(false)
   const resetTimeout = ref(null)
   const contentFetchEnabled = ref(true)


### PR DESCRIPTION
### What is in this PR

In the nuxt3 upgrade we swapped from using `mounted` to `useAsyncData` in our collection element when fetching the initial content. This isn't working correctly, as `useAsyncData` wasn't being awaited, so we ended up in a state where the load more's range assumed we had all the available content on the first load-more click. I'm reverting us to `onMounted`, which fixes the problem.

Closes https://github.com/baserow/baserow/issues/4862

### How to test this PR

Follow the steps in the [issue](https://github.com/baserow/baserow/issues/4862), in this branch, load more works again.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
