### PR TITLE
Fix builder error page

### DIFF
--- a/changelog/entries/unreleased/bug/use_error_page_in_preview.json
+++ b/changelog/entries/unreleased/bug/use_error_page_in_preview.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Use error page in preview",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-02-25"
+}

--- a/web-frontend/modules/builder/components/PublicSiteErrorPage.vue
+++ b/web-frontend/modules/builder/components/PublicSiteErrorPage.vue
@@ -3,8 +3,8 @@
     <div class="placeholder__logo">
       <nuxt-link
         :to="{
-          name: 'application-builder-page',
-          params: { pathMatch: '/' },
+          name: routeName,
+          params: { pathMatch: '' },
         }"
         custom
       >
@@ -52,22 +52,28 @@ export default {
     content() {
       return this.error.content || this.$t('errorLayout.error')
     },
+    routeName() {
+      return this.$route.name
+    },
   },
   methods: {
     onHome() {
       if (
-        this.$route.name === 'application-builder-page' &&
-        this.$route.params.pathMatch === '/'
+        ['application-builder-page', 'application-builder-preview'].includes(
+          this.routeName
+        )
       ) {
-        // Reload the current page
-        this.$router.go(0)
-      } else {
-        // Navigate to the home route
-        this.$router.push({
-          name: 'application-builder-page',
-          params: { pathMatch: '/' },
-          query: null, // Remove query parameters
-        })
+        if (this.$route.params.pathMatch === '/') {
+          // Reload the current page
+          this.$router.go(0)
+        } else {
+          // Navigate to the home route
+          this.$router.push({
+            name: this.routeName,
+            params: { pathMatch: '' },
+            query: null, // Remove query parameters
+          })
+        }
       }
     },
   },

--- a/web-frontend/modules/builder/errorPageTypes.js
+++ b/web-frontend/modules/builder/errorPageTypes.js
@@ -8,7 +8,8 @@ export class PublicSiteErrorPageType extends ErrorPageType {
 
   isApplicable() {
     return (
-      this.app.$router.currentRoute.value.name === 'application-builder-page'
+      this.app.$router.currentRoute.value.name === 'application-builder-page' ||
+      this.app.$router.currentRoute.value.name === 'application-builder-preview'
     )
   }
 


### PR DESCRIPTION
### What is in this PR

The builder error page was broken:
- When you click `back to home page` a `%2f` was appended to the new route
- The error page wasn't applied to preview

This PR fixes these two things.


### How to test this PR

- On develop create an application with a page that contains a link with a custom url to `/notexist`.
- Preview it and click on that link -> it should show the baserow common error page and not the builder page
- Publish it and click on that link again -> it should should show the right error page but when you navigate to home you end up with strange charater to your URL.

With this branch the two issues should be gone.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
