### PR TITLE
Fix our changelog markdown string links.

### DIFF
--- a/changelog/src/changelog_entry.py
+++ b/changelog/src/changelog_entry.py
@@ -44,8 +44,10 @@ class ChangelogEntry(abc.ABC):
         string = f"* {message}"
 
         if issue_number is not None:
-            url_prefix = GITLAB_URL if issue_origin == "gitlab" else GITHUB_URL
-            string += f" [#{issue_number}]({url_prefix}/-/issues/{issue_number})"
+            if issue_origin == "github":
+                string += f" [#{issue_number}]({GITHUB_URL}/issues/{issue_number})"
+            elif issue_origin == "gitlab":
+                string += f" [#{issue_number}]({GITLAB_URL}/-/issues/{issue_number})"
 
         return string
 


### PR DESCRIPTION
### What is in this PR

Resolves an oversight in `ChangelogEntry.get_markdown_string`. If the `issue_origin` is Github, at the moment we use the same URI strucutre as Gitlab, which is wrong. This PR ensures we cater to both, and link to the correct issue pages.

### How to test this PR

- Source your changelog venv
- Look at your current `changelog.md`:
    - Find a Github link, you'll see it 404s.
    - Find a Gitlab link, you'll see it works.
- `./changelog.py generate`
- Re-open your `changelog.md`:
    - Find a Github link, you'll see it works.
    - Find a Gitlab link, you'll see it works.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
