### PR TITLE
chore (deps): upgrade redis server

### DIFF
--- a/changelog/entries/unreleased/refactor/upgrade_redisserver_in_allinone_image_to_resolve_cves.json
+++ b/changelog/entries/unreleased/refactor/upgrade_redisserver_in_allinone_image_to_resolve_cves.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Upgrade redis-server in all-in-one image to resolve CVEs",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-02-27"
+}

--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -118,11 +118,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Install postgres + redis (PGDG repo already added in base stage)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://packages.redis.io/gpg | gpg --batch --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb trixie main" > /etc/apt/sources.list.d/redis.list && \
     apt-get update && \
     apt-get install --no-install-recommends -y \
     "postgresql-${POSTGRES_VERSION}" \
     "postgresql-${POSTGRES_VERSION}-pgvector" \
-    redis-server && \
+    redis && \
     # Setup redis
     usermod -a -G tty redis && \
     sed -i 's/daemonize yes/daemonize no/g' /etc/redis/redis.conf && \


### PR DESCRIPTION
### What is in this PR
- Upgrade the redis server in the all-in-one image to resolve 2 CVEs

### How to test this PR
- build the image on develop with `just build all-in-one latest --no-cache` and run `docker scout cves local://baserow/baserow:latest`. Notice 2 High CVEs related to redis
- do the same on this branch and notice the CVEs for redis are now gone

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
