### PR TITLE
bug: install tzdata-legacy for timezones removed after the upgrade to trixie

### DIFF
--- a/changelog/entries/unreleased/bug/install_tzdatalegacy_in_allinone_image_for_timezones_removed.json
+++ b/changelog/entries/unreleased/bug/install_tzdatalegacy_in_allinone_image_for_timezones_removed.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Install tzdata-legacy in all-in-one image for timezones removed after the upgrade to trixie.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-02-27"
+}

--- a/deploy/all-in-one/Dockerfile
+++ b/deploy/all-in-one/Dockerfile
@@ -43,6 +43,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     xmlsec1 \
     gettext \
     tini \
+    tzdata-legacy \
     && \
     # Setup user and group with fixed UID/GID for volume permission consistency
     getent group "$GID" || groupadd --system --gid "$GID" "${DOCKER_USER}" && \


### PR DESCRIPTION
### What is in this PR
Fix a problem introduced with the upgrade of our base image from bookworm to trixie, as some timezones that pytz consider valid are now in the tzdata-legacy package, which wasn't installed before this PR.

### How to test this PR

On develop:
- build the all-in-one image with `just build all-in-one`
- Run the container with: 
```
docker run \
  --name baserow --rm -it --entrypoint bash \
  -e BASEROW_PUBLIC_URL=http://localhost \
  -v baserow_data:/baserow/data \
  -p 80:80 \
  -p 443:443 \
  baserow/baserow:latest
```
- Start the db with `./baserow.sh start-only-db &`
- Open a django shell with `./baserow.sh shell`
- Run the following code and verify it fails with this error
```
>>> from django.db import connection
>>> with connection.cursor() as cursor:
...     cursor.execute("SELECT '2026-01-01 12:00:00 UTC'::timestamptz AT TIME ZONE 'US/Eastern';")
...     print(cursor.fetchone())
...
 [POSTGRES][2026-02-27 10:42:47] 2026-02-27 10:40:37.509 UTC [518] LOG:  database system is ready to accept connections
 [POSTGRES][2026-02-27 10:42:47] 2026-02-27 10:42:47.062 UTC [816] baserow@baserow ERROR:  time zone "US/Eastern" not recognized
Traceback (most recent call last):
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 103, in _execute
    return self.cursor.execute(sql)
           ~~~~~~~~~~~~~~~~~~~^^^^^
psycopg2.errors.InvalidParameterValue: time zone "US/Eastern" not recognized


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<console>", line 2, in <module>
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 79, in execute
    return self._execute_with_wrappers(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        sql, params, many=False, executor=self._execute
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 100, in _execute
    with self.db.wrap_database_errors:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/baserow/venv/lib/python3.14/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/baserow/venv/lib/python3.14/site-packages/django/db/backends/utils.py", line 103, in _execute
    return self.cursor.execute(sql)
           ~~~~~~~~~~~~~~~~~~~^^^^^
django.db.utils.DataError: time zone "US/Eastern" not recognized
```

Now do it again on this branch, and verify it works

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
