### PR TITLE
Remove domain::core from labels

### DIFF
--- a/.github/workflows/database-projects-issues-workflow.yml
+++ b/.github/workflows/database-projects-issues-workflow.yml
@@ -2,7 +2,7 @@ name: Update Database Team Project Fields
 
 env:
   PROJECT_NUMBER: '3'
-  DOMAIN_LABELS: '["domain::database", "domain::core"]'
+  DOMAIN_LABELS: '["domain::database"]'
   STATUS_FIELD_NAME: 'Status'
   STATUS_TODO: 'Todo'
 

--- a/.github/workflows/database-projects-pr-workflow.yml
+++ b/.github/workflows/database-projects-pr-workflow.yml
@@ -2,7 +2,7 @@ name: Database Team PR Automation
 
 env:
   PROJECT_NUMBER: '3'
-  DOMAIN_LABELS: '["domain::database", "domain::core"]'
+  DOMAIN_LABELS: '["domain::database"]'
   STATUS_FIELD_NAME: 'Status'
   REVIEW_STATUS_FIELD_NAME: 'Review Status'
   STATUS_IN_PROGRESS: 'In Progress'


### PR DESCRIPTION
### What is in this PR

The database workflow automatically adds all `domain::core` issues and PRs to the database project, but this has proven too broad and includes a bunch of WAB PRs and issues.
This PR removes domain::core from the labels for now, so only issues and PRs with domain::database will be handled by the CI workflow.


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
