### PR TITLE
Migrate jira sync table endpoint

### DIFF
--- a/changelog/entries/unreleased/bug/4888_migrate_jira_sync_table_endpoint.json
+++ b/changelog/entries/unreleased/bug/4888_migrate_jira_sync_table_endpoint.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Migrate jira sync table endpoint",
+    "issue_origin": "github",
+    "issue_number": 4888,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-03-02"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/jira_issues_data_sync.py
@@ -221,8 +221,26 @@ class JiraIssuesDataSyncType(DataSyncType):
         except ValueError:
             raise SyncError(f"The date {value} could not be parsed.")
 
+    def _get_issue_count(self, instance, jql, headers, kwargs):
+        """Get approximate issue count for progress tracking."""
+
+        url = f"{instance.jira_url}/rest/api/2/search/approximate-count"
+        try:
+            response = advocate.post(
+                url,
+                headers={**headers, "Content-Type": "application/json"},
+                json={"jql": jql},
+                timeout=10,
+                **kwargs,
+            )
+            if response.ok:
+                return response.json().get("count", 0)
+        except (RequestException, UnacceptableAddressException, ConnectionError):
+            pass
+        return 0
+
     def _fetch_issues(self, instance, progress_builder: ChildProgressBuilder):
-        headers = {"Content-Type": "application/json"}
+        headers = {"Accept": "application/json"}
         kwargs = {}
 
         if instance.jira_authentication == JIRA_ISSUES_DATA_SYNC_PERSONAL_ACCESS_TOKEN:
@@ -234,21 +252,35 @@ class JiraIssuesDataSyncType(DataSyncType):
             )
 
         issues = []
-        start_at = 0
         max_results = 50
-        progress = None
+        next_page_token = None
+
+        if instance.jira_project_key:
+            jql = f"project={instance.jira_project_key} ORDER BY created DESC"
+        else:
+            jql = "created IS NOT EMPTY ORDER BY created DESC"
+
+        issue_count = self._get_issue_count(instance, jql, headers, kwargs)
+        page_count = math.ceil(issue_count / max_results) if issue_count > 0 else 0
+        progress = ChildProgressBuilder.build(
+            progress_builder, child_total=page_count + 1
+        )
+        progress.increment(by=1)
+
         try:
             while True:
-                url = (
-                    f"{instance.jira_url}"
-                    + f"/rest/api/2/search"
-                    + f"?startAt={start_at}"
-                    + f"&maxResults={max_results}"
-                )
-                if instance.jira_project_key:
-                    url += f"&jql=project={instance.jira_project_key}"
+                url = f"{instance.jira_url}/rest/api/2/search/jql"
+                params = {
+                    "jql": jql,
+                    "maxResults": max_results,
+                    "fields": "*all",
+                }
+                if next_page_token:
+                    params["nextPageToken"] = next_page_token
 
-                response = advocate.get(url, headers=headers, timeout=10, **kwargs)
+                response = advocate.get(
+                    url, headers=headers, params=params, timeout=10, **kwargs
+                )
                 if not response.ok:
                     try:
                         json = response.json()
@@ -262,25 +294,18 @@ class JiraIssuesDataSyncType(DataSyncType):
 
                 data = response.json()
 
-                # The response of any request gives us the total, allowing us to
-                # properly construct a progress bar.
-                if data["total"] and progress is None:
-                    progress = ChildProgressBuilder.build(
-                        progress_builder,
-                        child_total=math.ceil(data["total"] / max_results),
-                    )
-                if progress:
-                    progress.increment(by=1)
+                progress.increment(by=1)
 
-                if len(data["issues"]) == 0 and start_at == 0:
+                if len(data["issues"]) == 0 and next_page_token is None:
                     raise SyncError(
                         "No issues found. This is usually because the authentication "
                         "details are wrong."
                     )
 
                 issues.extend(data["issues"])
-                start_at += max_results
-                if data["total"] <= start_at:
+
+                next_page_token = data.get("nextPageToken")
+                if not next_page_token:
                     break
         except (RequestException, UnacceptableAddressException, ConnectionError) as e:
             raise SyncError(f"Error connecting to Jira: {str(e)}")

--- a/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_jira_issues_data_sync.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_jira_issues_data_sync.py
@@ -7,8 +7,7 @@ from django.urls import reverse
 
 import pytest
 import responses
-from requests.auth import HTTPBasicAuth
-from responses.matchers import header_matcher
+from responses.matchers import header_matcher, query_param_matcher
 from rest_framework.status import HTTP_200_OK, HTTP_402_PAYMENT_REQUIRED
 
 from baserow.contrib.database.data_sync.handler import DataSyncHandler
@@ -339,39 +338,20 @@ EMPTY_ISSUE = {
 }
 
 SINGLE_ISSUE_RESPONSE = {
-    "expand": "schema,names",
-    "startAt": 0,
-    "maxResults": 50,
-    "total": 1,
     "issues": [SINGLE_ISSUE],
 }
 
 SINGLE_ISSUE_RESPONSE_PAGE_1 = {
-    "expand": "schema,names",
-    "startAt": 0,
-    "maxResults": 50,
-    "total": 51,
     "issues": [SINGLE_ISSUE],
+    "nextPageToken": "page2token",
 }
 SINGLE_ISSUE_RESPONSE_PAGE_2 = {
-    "expand": "schema,names",
-    "startAt": 50,
-    "maxResults": 50,
-    "total": 51,
     "issues": [SECOND_ISSUE],
 }
 NO_ISSUES_RESPONSE = {
-    "expand": "schema,names",
-    "startAt": 0,
-    "maxResults": 50,
-    "total": 0,
     "issues": [],
 }
 EMPTY_ISSUE_RESPONSE = {
-    "expand": "schema,names",
-    "startAt": 0,
-    "maxResults": 50,
-    "total": 1,
     "issues": [EMPTY_ISSUE],
 }
 
@@ -441,11 +421,26 @@ def test_sync_data_sync_table(enterprise_data_fixture):
     auth_header_value = f"Basic {encoded_credentials}"
 
     responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
+    responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=SINGLE_ISSUE_RESPONSE,
-        match=[header_matcher({"Authorization": auth_header_value})],
+        match=[
+            header_matcher({"Authorization": auth_header_value}),
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -603,11 +598,26 @@ def test_sync_data_sync_table_empty_issue(enterprise_data_fixture):
     auth_header_value = f"Basic {encoded_credentials}"
 
     responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
+    responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=EMPTY_ISSUE_RESPONSE,
-        match=[header_matcher({"Authorization": auth_header_value})],
+        match=[
+            header_matcher({"Authorization": auth_header_value}),
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -685,11 +695,26 @@ def test_sync_data_sync_table_empty_issue(enterprise_data_fixture):
 @responses.activate
 def test_sync_data_sync_table_personal_access_token(enterprise_data_fixture):
     responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
+    responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=EMPTY_ISSUE_RESPONSE,
-        match=[header_matcher({"Authorization": "Bearer FAKE_PAT"})],
+        match=[
+            header_matcher({"Authorization": "Bearer FAKE_PAT"}),
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -728,20 +753,42 @@ def test_sync_data_sync_table_personal_access_token(enterprise_data_fixture):
 @override_settings(DEBUG=True)
 @responses.activate
 def test_create_data_sync_table_pagination(enterprise_data_fixture):
-    basic_auth_header = HTTPBasicAuth("test@test.nl", "test_token")
     responses.add(
-        responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
         status=200,
-        json=SINGLE_ISSUE_RESPONSE_PAGE_1,
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        json={"count": 2},
     )
     responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=50&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
+        status=200,
+        json=SINGLE_ISSUE_RESPONSE_PAGE_1,
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
+    )
+    responses.add(
+        responses.GET,
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=SINGLE_ISSUE_RESPONSE_PAGE_2,
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                    "nextPageToken": "page2token",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -785,13 +832,26 @@ def test_create_data_sync_table_pagination(enterprise_data_fixture):
 @override_settings(DEBUG=True)
 @responses.activate
 def test_create_data_sync_table_invalid_auth(enterprise_data_fixture):
-    basic_auth_header = HTTPBasicAuth("test@test.nl", "test_token")
+    responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 0},
+    )
     responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=NO_ISSUES_RESPONSE,
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -823,13 +883,26 @@ def test_create_data_sync_table_invalid_auth(enterprise_data_fixture):
 @override_settings(DEBUG=True)
 @responses.activate
 def test_create_data_sync_table_jira_error_message(enterprise_data_fixture):
-    basic_auth_header = HTTPBasicAuth("test@test.nl", "test_token")
+    responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
     responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=400,
         json={"errorMessages": ["test error"]},
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -859,13 +932,26 @@ def test_create_data_sync_table_jira_error_message(enterprise_data_fixture):
 @override_settings(DEBUG=True)
 @responses.activate
 def test_create_data_sync_table_with_project_key(enterprise_data_fixture):
-    basic_auth_header = HTTPBasicAuth("test@test.nl", "test_token")
+    responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
     responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50&jql=project=TEST",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=SINGLE_ISSUE_RESPONSE,
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "project=TEST ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()
@@ -895,13 +981,26 @@ def test_create_data_sync_table_with_project_key(enterprise_data_fixture):
 @override_settings(DEBUG=True)
 @responses.activate
 def test_create_data_sync_table_jira_not_updated_twice(enterprise_data_fixture):
-    basic_auth_header = HTTPBasicAuth("test@test.nl", "test_token")
+    responses.add(
+        responses.POST,
+        "https://test.atlassian.net/rest/api/2/search/approximate-count",
+        status=200,
+        json={"count": 1},
+    )
     responses.add(
         responses.GET,
-        "https://test.atlassian.net/rest/api/2/search?startAt=0&maxResults=50",
+        "https://test.atlassian.net/rest/api/2/search/jql",
         status=200,
         json=SINGLE_ISSUE_RESPONSE,
-        headers={"Authorization": f"Basic {basic_auth_header}"},
+        match=[
+            query_param_matcher(
+                {
+                    "jql": "created IS NOT EMPTY ORDER BY created DESC",
+                    "maxResults": "50",
+                    "fields": "*all",
+                }
+            ),
+        ],
     )
 
     enterprise_data_fixture.enable_enterprise()


### PR DESCRIPTION
### What is in this PR

Address issue #4888 

* changed endpoint: `GET /rest/api/2/search`  to  `/rest/api/2/search/jql` - the new endpoint requires an explicit `jql` query string parameter and `fields=*all` to return full issue data
* replaced  offset-based pagination (`startAt / total)` with cursor-based pagination using `nextPageToken`.
* use `/rest/api/2/search/approximate-count` endpoint to know how many records are to be imported as `/rest/api/2/search/jq` does not provide that information
* use v2 over v3 API for fetching data as the v3 endpoint returns issue descriptions as _Atlassian Document Format_ (ADF) JSON, while v2 returns wiki markup that can be converted to Markdown via `jira2markdown`  

### How to test this PR
Follow steps from the issue description and observe that sync work

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
