### PR TITLE
Fix the collection field BooleanField component

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_the_application_builder_ta.json
+++ b/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_the_application_builder_ta.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved an issue which prevented the application builder table element's boolean fields from being checked correctly.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-02"
+}

--- a/web-frontend/modules/builder/components/elements/components/collectionField/BooleanField.vue
+++ b/web-frontend/modules/builder/components/elements/components/collectionField/BooleanField.vue
@@ -1,5 +1,5 @@
 <template>
-  <ABCheckbox :value="value" :read-only="true" />
+  <ABCheckbox :model-value="value" :read-only="true" />
 </template>
 
 <script>

--- a/web-frontend/modules/builder/components/theme/InputThemeConfigBlock.vue
+++ b/web-frontend/modules/builder/components/theme/InputThemeConfigBlock.vue
@@ -283,7 +283,7 @@
               v-for="(option, index) in options"
               :key="option.value"
               :name="option.name"
-              :value="index === 1"
+              :model-value="index === 1"
             >
               {{ option.name }}
             </ABCheckbox>


### PR DESCRIPTION
### What is in this PR

A fix for the `BooleanField` collection field. `ABCheckbox` now takes a `model-value` after the nuxt3 upgrade, not a `value`. This is currently preventing it from working correctly in tables.

### How to test this PR

- Add a table element, with a data source pointing to a table with one or more boolean fields (some checked, some not).
- In `develop`: none of the checkboxes will be checked.
- In this branch: the checked ones in the database table will be checked in the builder table

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
