### PR TITLE
Fix number formatting for row history entries

### DIFF
--- a/changelog/entries/unreleased/bug/4898_fix_number_formatting_for_row_history_entries.json
+++ b/changelog/entries/unreleased/bug/4898_fix_number_formatting_for_row_history_entries.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix number formatting for row history entries",
+    "issue_origin": "github",
+    "issue_number": 4898,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-03-03"
+}

--- a/web-frontend/modules/database/components/row/RowHistoryFieldNumber.vue
+++ b/web-frontend/modules/database/components/row/RowHistoryFieldNumber.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { NumberFieldType } from '@baserow/modules/database/fieldTypes'
+import { formatDecimalNumber } from '@baserow/modules/database/utils/number'
 
 export default {
   name: 'RowHistoryFieldNumber',
@@ -36,7 +36,7 @@ export default {
   methods: {
     formattedNumber(value) {
       const metadata = this.entry.fields_metadata[this.fieldIdentifier]
-      return NumberFieldType.formatNumber(metadata, value)
+      return formatDecimalNumber(metadata, value)
     },
   },
 }


### PR DESCRIPTION
### What is in this PR
Closes #4898 

### How to test this PR
- Create table with number field 
- Add value like `1234567.89` and check each formatting option that is properly displayed in history entry for that row

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
