### PR TITLE
fix: data source create modal not being reset after creation

### DIFF
--- a/changelog/entries/unreleased/bug/data_source_context_was_not_reset_after_a_data_source_creati.json
+++ b/changelog/entries/unreleased/bug/data_source_context_was_not_reset_after_a_data_source_creati.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Data source context was not reset after a data source creation",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-04"
+}

--- a/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModePreviewSurvey.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModePreviewSurvey.vue
@@ -55,8 +55,9 @@
                   type="primary"
                   size="large"
                   @click="next()"
-                  >Next</Button
                 >
+                  {{ $t('action.next') }}
+                </Button>
                 <template v-else-if="index >= fields.length - 1">
                   <Editable
                     ref="submitText"

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -58,7 +58,8 @@
     "download": "Download",
     "copyToClipboard": "Copy to clipboard",
     "reset": "Reset",
-    "hide": "Hide"
+    "hide": "Hide",
+    "next": "Next"
   },
   "adminType": {
     "settings": "Settings",

--- a/web-frontend/modules/builder/components/dataSource/DataSourceCreateEditModal.vue
+++ b/web-frontend/modules/builder/components/dataSource/DataSourceCreateEditModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal ref="modal" wide v-on="$attrs">
+  <Modal ref="modal" wide v-on="$attrs" @show="onShow">
     <h2 class="box__title">
       {{
         create
@@ -19,7 +19,7 @@
         :data-source="dataSource"
         :builder="builder"
         :page="dataSourcePage"
-        :default-values="dataSource"
+        :default-values="currentDefaultValues"
         :integrations="integrations"
         :create="create"
         :application-context-additions="{
@@ -77,18 +77,18 @@ export default {
   props: {
     dataSourceId: { type: Number, required: false, default: null },
   },
-  emits: ['updated'],
+  emits: ['updated', 'data-source-created'],
   data() {
     return {
       loading: false,
-      actualDataSourceId: this.dataSourceId,
       changed: false,
+      currentDefaultValues: {},
     }
   },
   computed: {
     submitIsDisabled() {
       return (
-        this.loading || !this.changed || this.$refs.dataSourceForm?.v$.$anyError
+        this.loading || !this.changed || this.$refs.dataSourceForm.v$.$anyError
       )
     },
     dataSources() {
@@ -108,7 +108,7 @@ export default {
       return [...this.dataSources, ...this.sharedDataSources]
     },
     create() {
-      return !this.actualDataSourceId
+      return !this.dataSourceId
     },
     isShared() {
       return !this.create && this.dataSource?.page_id === this.sharedPage.id
@@ -117,9 +117,7 @@ export default {
       if (this.create) {
         return undefined
       }
-      return this.allDataSources.find(
-        ({ id }) => id === this.actualDataSourceId
-      )
+      return this.allDataSources.find(({ id }) => id === this.dataSourceId)
     },
     integrations() {
       return this.$store.getters['integration/getIntegrations'](this.builder)
@@ -143,14 +141,22 @@ export default {
       ]
     },
   },
+  watch: {
+    dataSource(newValue) {
+      this.currentDefaultValues = { ...this.dataSource }
+    },
+  },
   methods: {
     ...mapActions({
       actionFetchIntegrations: 'integration/fetch',
       actionCreateDataSource: 'dataSource/create',
       actionUpdateDataSource: 'dataSource/update',
     }),
+    onShow() {
+      this.currentDefaultValues = { ...this.dataSource }
+    },
     onValuesChanged(values) {
-      if (!this.actualDataSourceId) {
+      if (!this.dataSourceId) {
         this.changed = true
         return
       }
@@ -159,6 +165,10 @@ export default {
       )
 
       if (differences.length) {
+        this.currentDefaultValues = {
+          ...this.currentDefaultValues,
+          ...Object.fromEntries(differences),
+        }
         this.changed = true
       }
     },
@@ -172,7 +182,7 @@ export default {
             page: this.currentPage,
             values,
           })
-          this.actualDataSourceId = createdDataSource.id
+          this.$emit('data-source-created', createdDataSource)
         } else {
           const differences = Object.fromEntries(
             Object.entries(values).filter(

--- a/web-frontend/modules/builder/components/page/header/DataSourceContext.vue
+++ b/web-frontend/modules/builder/components/page/header/DataSourceContext.vue
@@ -112,9 +112,9 @@
       </div>
     </template>
     <DataSourceCreateEditModal
-      :key="currentDataSourceId"
       ref="dataSourceCreateEditModal"
       :data-source-id="currentDataSourceId"
+      @data-source-created="currentDataSourceId = $event.id"
       @hidden="onHide"
     />
   </Context>

--- a/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowServiceForm.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/services/LocalBaserowServiceForm.vue
@@ -146,7 +146,7 @@ export default {
       )
     },
     databases() {
-      return this.selectedIntegration?.context_data.databases || []
+      return this.selectedIntegration?.context_data?.databases || []
     },
   },
   watch: {


### PR DESCRIPTION
### What is in this PR

The data source context is not correctly reset when you've just created a data source.

### How to test this PR

- On develop try to create two data sources in a row. You should find the data of the first data source when you try to create the second one.
- With this branch it should be fixed.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
