### PR TITLE
Use sender domain for generated Message-ID headers

### DIFF
--- a/backend/src/baserow/core/emails.py
+++ b/backend/src/baserow/core/emails.py
@@ -1,4 +1,5 @@
 import re
+from email.utils import make_msgid, parseaddr
 from typing import List
 
 from django.conf import settings
@@ -46,8 +47,20 @@ class BaseEmailMessage(EmailMultiAlternatives):
 
         text_content = self._get_plain_text_from_html(html_content)
 
+        _, from_email_address = parseaddr(from_email)
+        message_id_domain = (
+            from_email_address.rsplit("@", 1)[-1]
+            if "@" in from_email_address
+            else None
+        )
+        message_id = make_msgid(domain=message_id_domain)
+
         super().__init__(
-            subject=subject, body=text_content, from_email=from_email, to=to
+            subject=subject,
+            body=text_content,
+            from_email=from_email,
+            to=to,
+            headers={"Message-ID": message_id},
         )
         self.attach_alternative(html_content, "text/html")
 


### PR DESCRIPTION
### What is in this PR
- set an explicit `Message-ID` header in `BaseEmailMessage` using `email.utils.make_msgid`
- derive the Message-ID domain from the configured sender address (`from_email`) instead of default host FQDN
- prevents leaking infra hostnames (e.g., celery worker pod names) in outbound email headers

### How to test this PR
- run `python3 -m compileall backend/src/baserow/core/emails.py`
- create/send any `BaseEmailMessage`-derived email (verification/invitation/notification) and inspect `Message-ID` in headers
- verify the domain part matches the sender domain (for example `@baserow.io`)

### Checklist
- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered

Closes #4567