### PR TITLE
Fix the periodic service form's hour/minute values being reset.

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_hour_and_minute_values_fro.json
+++ b/changelog/entries/unreleased/bug/resolved_an_issue_which_prevented_hour_and_minute_values_fro.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved an issue which prevented hour and minute values from persisting in the periodic trigger form.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-03-09"
+}

--- a/web-frontend/modules/integrations/core/components/services/CorePeriodicServiceForm.vue
+++ b/web-frontend/modules/integrations/core/components/services/CorePeriodicServiceForm.vue
@@ -311,6 +311,12 @@ export default {
       }
     },
     syncValuesFromUser() {
+      if (!this.syncedFromValues) {
+        // This function could have been called before the initial sync from `values`
+        // to `user` in mounted() has completed. In that case, we don't want to run
+        // this logic yet since `user` won't have the correct values yet.
+        return
+      }
       this.v$.$touch()
       if (this.v$.values.interval.$invalid) return
       if (this.showMinuteFrequencyField && this.v$.user.minute.$invalid) return


### PR DESCRIPTION
### What is in this PR

A fix for the `hour` and `minute` values.

### How to test this PR

- Try setting the `hour` and `minute` for each interval.
- You'll find in `develop` that only `interval=minute && minute` work when you set it up -> click another node -> return to the trigger, every other permutation doesn't work as of the nuxt3 migration.
- In this branch, each permutation works.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
