### PR TITLE
fix: Ensure running workflow histories aren't deleted

### DIFF
--- a/backend/src/baserow/contrib/automation/workflows/handler.py
+++ b/backend/src/baserow/contrib/automation/workflows/handler.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core.files.storage import Storage
 from django.db import IntegrityError
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from celery.canvas import chain
@@ -698,17 +698,23 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
         keep the most recent MAX_HISTORY_ENTRIES entries.
         """
 
+        is_finished = ~Q(status=HistoryStatusChoices.STARTED)
+
         oldest_history_date = timezone.now() - timedelta(
             days=settings.AUTOMATION_WORKFLOW_HISTORY_MAX_DAYS
         )
-        workflow.workflow_histories.filter(started_on__lt=oldest_history_date).delete()
+        workflow.workflow_histories.filter(
+            is_finished, started_on__lt=oldest_history_date
+        ).delete()
 
         history_ids_to_keep = list(
             workflow.workflow_histories.order_by("-started_on").values_list(
                 "id", flat=True
             )[: settings.AUTOMATION_WORKFLOW_HISTORY_MAX_ENTRIES]
         )
-        workflow.workflow_histories.exclude(id__in=history_ids_to_keep).delete()
+        workflow.workflow_histories.filter(is_finished).exclude(
+            id__in=history_ids_to_keep
+        ).delete()
 
     def _get_rate_limit_cache_key(self, workflow_id: int) -> str:
         return WORKFLOW_RATE_LIMIT_CACHE_PREFIX.format(workflow_id)

--- a/backend/tests/baserow/contrib/automation/workflows/test_workflow_handler.py
+++ b/backend/tests/baserow/contrib/automation/workflows/test_workflow_handler.py
@@ -880,11 +880,15 @@ def test_clear_old_history_deletes_history_older_than_max_days(data_fixture):
     workflow = data_fixture.create_automation_workflow()
 
     with freeze_time("2025-02-01 12:00:00"):
-        old_history = data_fixture.create_automation_workflow_history(workflow=workflow)
+        old_history = data_fixture.create_automation_workflow_history(
+            workflow=workflow,
+            status=HistoryStatusChoices.SUCCESS,
+        )
 
     with freeze_time("2025-02-02 12:00:00"):
         recent_history = data_fixture.create_automation_workflow_history(
-            workflow=workflow
+            workflow=workflow,
+            status=HistoryStatusChoices.SUCCESS,
         )
 
     # This is 8 days after old_history was created, so it should be deleted.
@@ -906,7 +910,10 @@ def test_clear_old_history_keeps_only_max_entries(data_fixture):
         day += i
         with freeze_time(f"2025-02-{day} 12:00:00"):
             histories.append(
-                data_fixture.create_automation_workflow_history(workflow=workflow)
+                data_fixture.create_automation_workflow_history(
+                    workflow=workflow,
+                    status=HistoryStatusChoices.SUCCESS,
+                )
             )
 
     with freeze_time(f"2025-02-16 12:00:00"):
@@ -1019,3 +1026,57 @@ def test_start_workflow_before_run_error(
 
     assert original_workflow.state == WorkflowState.DRAFT
     assert published_workflow.state == WorkflowState.LIVE
+
+
+@override_settings(AUTOMATION_WORKFLOW_HISTORY_MAX_ENTRIES=2)
+@pytest.mark.django_db
+def test_clear_old_history_excludes_started_workflows_max_entries(data_fixture):
+    workflow = data_fixture.create_automation_workflow()
+
+    # Create three history entries
+    with freeze_time("2026-03-10 12:00:00"):
+        started_history = data_fixture.create_automation_workflow_history(
+            workflow=workflow, status=HistoryStatusChoices.STARTED
+        )
+
+    with freeze_time("2026-03-10 13:00:00"):
+        data_fixture.create_automation_workflow_history(
+            workflow=workflow, status=HistoryStatusChoices.SUCCESS
+        )
+
+    with freeze_time("2026-03-10 14:00:00"):
+        data_fixture.create_automation_workflow_history(
+            workflow=workflow, status=HistoryStatusChoices.SUCCESS
+        )
+
+    # Although max entries is 2 and the oldest history should be deleted,
+    # the oldest one is still kept because its status is STARTED.
+    with freeze_time("2026-03-10 15:00:00"):
+        AutomationWorkflowHandler()._clear_old_history(workflow)
+
+    assert workflow.workflow_histories.filter(id=started_history.id).exists() is True
+    assert workflow.workflow_histories.count() == 3
+
+
+@override_settings(AUTOMATION_WORKFLOW_HISTORY_MAX_DAYS=1)
+@pytest.mark.django_db
+def test_clear_old_history_excludes_started_workflows_max_days(data_fixture):
+    workflow = data_fixture.create_automation_workflow()
+
+    with freeze_time("2026-03-10 12:00:00"):
+        history_1 = data_fixture.create_automation_workflow_history(
+            workflow=workflow, status=HistoryStatusChoices.STARTED
+        )
+
+    with freeze_time("2026-03-11 12:00:00"):
+        history_2 = data_fixture.create_automation_workflow_history(
+            workflow=workflow, status=HistoryStatusChoices.SUCCESS
+        )
+
+    # After 2 days, both history entries are older than MAX_DAYS, but since
+    # history_1 hasn't finished yet it shouldn't be deleted.
+    with freeze_time("2026-03-13 12:00:00"):
+        AutomationWorkflowHandler()._clear_old_history(workflow)
+
+    assert workflow.workflow_histories.filter(id=history_1.id).exists() is True
+    assert workflow.workflow_histories.filter(id=history_2.id).exists() is False

--- a/changelog/entries/unreleased/bug/fixed_a_bug_where_automation_workflow_history_entries_where_.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_where_automation_workflow_history_entries_where_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where automation workflow history entries were being deleted for running workflows.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-03-10"
+}


### PR DESCRIPTION
# What is in this PR
We recently moved workflow node execution from [sync to async](https://github.com/baserow/baserow/pull/4645).

When a workflow runs, the `before_run()` hook calls `_clear_old_history()`, which deletes any related history entries > `AUTOMATION_WORKFLOW_HISTORY_MAX_DAYS` or `AUTOMATION_WORKFLOW_HISTORY_MAX_ENTRIES`.

When the max entries is reached (e.g. 50), we begin deleting older history for a workflow. The bug happens when the same workflow is triggered multiple times quickly (in test or published modes).

When the second workflow runs before the first run completes, the second run can delete an older history related to the first run. When the first run then tries to create a node history related to the now deleted workflow history, we get an error:
```
django.db.utils.IntegrityError: insert or update on table "automation_automationnodehistory" violates foreign key constraint "automation_automatio_workflow_history_id_238f30d1_fk_automatio"
DETAIL:  Key (workflow_history_id)=(44) is not present in table "automation_automationworkflowhistory".
```

The fix is to exclude history entries that aren't finished from being deleted.

# How to test this PR
In production, this seems to happen when the user's workflow has 50 history entries, thus causing the next workflow runs to run into this problem. The easiest way to test this is to override this in `settings/base.py`:
```
AUTOMATION_WORKFLOW_HISTORY_MAX_ENTRIES = 1
```

In the latest `develop`, create a workflow that takes a while to run:
- Create a Periodic trigger
- Create a List rows (in my case, I populated 200 rows in my table)
- Create an Iterator node that loops over those rows
- Create a Create Row iterator child node

Test the workflow once, then quickly test it again (maybe wait 1-2 seconds between tests). You should see the error mentioned earlier in the Celery worker container.

What you're trying to do here is get the 2nd run to delete the first run's history since it exceeds the max entries=1.

In this branch, the workflow runs shouldn't crash.

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
