### PR TITLE
fix: element formulas are imported once all elements exist

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/mixins.py
+++ b/backend/src/baserow/contrib/builder/elements/mixins.py
@@ -46,7 +46,7 @@ from baserow.core.utils import merge_dicts_no_duplicates
 
 class ContainerElementTypeMixin:
     # Container element types are imported first.
-    import_element_priority = 2
+    import_element_priority = 1
 
     class SerializedDict(ElementDict):
         pass
@@ -801,9 +801,6 @@ class CollectionElementWithFieldsTypeMixin(CollectionElementTypeMixin):
 
 
 class FormElementTypeMixin:
-    # Form element types are imported second, after containers.
-    import_element_priority = 1
-
     def is_valid(
         self,
         element: Type[FormElement],

--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -20,7 +20,6 @@ from django.db import models
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from baserow.contrib.builder.formula_importer import import_formula
 from baserow.contrib.builder.mixins import BuilderInstanceWithFormulaMixin
 from baserow.contrib.builder.pages.models import Page
 from baserow.core.formula.types import BaserowFormulaObject
@@ -202,8 +201,6 @@ class ElementType(
         cache: Dict[str, Any] | None = None,
         **kwargs,
     ) -> ElementSubClass:
-        from baserow.contrib.builder.elements.handler import ElementHandler
-
         # Add mapping for builder element event uids (for collection field or other
         # elements that are using dynamic events.
         if "builder_element_event_uids" not in id_mapping:
@@ -211,20 +208,6 @@ class ElementType(
 
         if cache is None:
             cache = {}
-
-        import_context = {}
-
-        parent_element_id = serialized_values["parent_element_id"]
-
-        # If we have a parent element then we want to add used its import context
-        if parent_element_id:
-            imported_parent_element_id = id_mapping["builder_page_elements"][
-                parent_element_id
-            ]
-            import_context = ElementHandler().get_import_context_addition(
-                imported_parent_element_id,
-                element_map=cache.get("imported_element_map", None),
-            )
 
         existing_roles = cache.get("existing_roles", {}).get(page.builder.id)
         if not existing_roles:
@@ -246,15 +229,8 @@ class ElementType(
             files_zip,
             storage,
             cache,
-            **(kwargs | import_context),
+            **kwargs,
         )
-
-        # Update formulas of the current element
-        updated_models = self.import_formulas(
-            created_instance, id_mapping, import_formula, **(kwargs | import_context)
-        )
-
-        [m.save() for m in updated_models]
 
         # Add created instance to an element cache
         cache.setdefault("imported_element_map", {})[created_instance.id] = (

--- a/backend/src/baserow/contrib/builder/pages/handler.py
+++ b/backend/src/baserow/contrib/builder/pages/handler.py
@@ -11,6 +11,7 @@ from baserow.contrib.builder.data_sources.handler import DataSourceHandler
 from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.types import ElementDictSubClass
+from baserow.contrib.builder.formula_importer import import_formula
 from baserow.contrib.builder.models import Builder
 from baserow.contrib.builder.pages.constants import (
     ILLEGAL_PATH_SAMPLE_CHARACTER,
@@ -808,7 +809,6 @@ class PageHandler:
 
         # Sort the serialized elements so that we import:
         # Containers first
-        # Form elements second
         # Everything else after that.
         def element_priority_sort(element_to_sort):
             return element_type_registry.get(
@@ -848,6 +848,30 @@ class PageHandler:
                     was_imported = True
                     if progress:
                         progress.increment(state=IMPORT_SERIALIZED_IMPORTING)
+
+        # Now that all elements have been imported, loop back over them
+        # and start import their formulas. We do this because formulas can
+        # reference one another, so we need the full set of elements to be
+        # imported before we can safely import the formulas without running
+        # into issues of missing referenced elements in `id_mapping`.
+        updated_models = set()
+        for elt in imported_elements:
+            import_context = {}
+            if elt.parent_element_id:
+                import_context = ElementHandler().get_import_context_addition(
+                    elt.parent_element_id,
+                    element_map=cache.get("imported_element_map", None)
+                    if cache
+                    else None,
+                )
+            updated_models = updated_models | elt.get_type().import_formulas(
+                elt,
+                id_mapping,
+                import_formula,
+                **import_context,
+            )
+
+        [m.save() for m in updated_models]
 
         return imported_elements
 

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -38,7 +38,6 @@ from baserow.contrib.builder.elements.exceptions import ElementImproperlyConfigu
 from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.mixins import (
     ContainerElementTypeMixin,
-    FormElementTypeMixin,
 )
 from baserow.contrib.builder.elements.models import (
     ButtonElement,
@@ -64,6 +63,7 @@ from baserow.contrib.builder.elements.registries import (
     element_type_registry,
 )
 from baserow.contrib.builder.elements.service import ElementService
+from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.contrib.builder.pages.service import PageService
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.core.handler import CoreHandler
@@ -269,7 +269,7 @@ def test_link_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     expected_query_formula = f"get('data_source.{data_source_2.id}.field_2')"
@@ -300,7 +300,7 @@ def test_form_container_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.submit_button_label["formula"] == expected_formula
@@ -339,7 +339,7 @@ def test_text_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.value["formula"] == expected_formula
@@ -363,7 +363,7 @@ def test_input_text_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.label["formula"] == expected_formula
@@ -388,7 +388,7 @@ def test_image_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.image_url["formula"] == expected_formula
@@ -411,7 +411,7 @@ def test_button_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.value["formula"] == expected_formula
@@ -500,7 +500,7 @@ def test_choice_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.label["formula"] == expected_formula
@@ -793,18 +793,12 @@ def test_element_type_import_element_priority():
         for element_type in element_types
         if isinstance(element_type, ContainerElementTypeMixin)
     ]
-    form_element_types = [
-        element_type
-        for element_type in element_types
-        if isinstance(element_type, FormElementTypeMixin)
-    ]
     other_element_types = [
         element_type
         for element_type in element_types
         if not isinstance(element_type, ContainerElementTypeMixin)
-        and not isinstance(element_type, FormElementTypeMixin)
     ]
-    manual_ordering = container_element_types + form_element_types + other_element_types
+    manual_ordering = container_element_types + other_element_types
     expected_ordering = sorted(
         element_types,
         key=lambda element_type: element_type.import_element_priority,
@@ -812,7 +806,7 @@ def test_element_type_import_element_priority():
     )
     assert manual_ordering == expected_ordering, (
         "The element types ordering are expected to be: "
-        "containers first, then form elements, then everything else."
+        "containers first, then everything else."
     )
 
 
@@ -852,7 +846,7 @@ def test_checkbox_element_import_export_formula(data_fixture):
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.label["formula"] == expected_formula
@@ -909,8 +903,9 @@ def test_iframe_element_import_export_formula(data_fixture):
 
     # After applying the ID mapping the imported formula should have updated
     # the data source IDs
+    # rather than in element_type.import_serialized.
     id_mapping = {"builder_data_sources": {data_source_1.id: data_source_2.id}}
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.url["formula"] == expected_formula
@@ -961,8 +956,8 @@ def test_image_element_import_export(data_fixture, fake, storage):
     image_file.delete()
 
     with ZipFile(zip_buffer, "r", ZIP_DEFLATED, False) as files_zip:
-        imported_element = element_type.import_serialized(
-            page, serialized, id_mapping, files_zip=files_zip, storage=storage
+        [imported_element] = PageHandler().import_elements(
+            page, [serialized], id_mapping, files_zip=files_zip, storage=storage
         )
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
@@ -995,7 +990,7 @@ def test_choice_element_import_export(data_fixture):
     # the data source IDs
     id_mapping = {"builder_data_sources": {42: data_source_2.id}}
 
-    imported_element = element_type.import_serialized(page, serialized, id_mapping)
+    [imported_element] = PageHandler().import_elements(page, [serialized], id_mapping)
 
     expected_formula = f"get('data_source.{data_source_2.id}.field_1')"
     assert imported_element.label["formula"] == expected_formula

--- a/backend/tests/baserow/contrib/builder/test_element_formula_mixin.py
+++ b/backend/tests/baserow/contrib/builder/test_element_formula_mixin.py
@@ -27,6 +27,7 @@ from baserow.contrib.builder.elements.models import (
     LinkElement,
     TextElement,
 )
+from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.core.formula import BaserowFormulaObject
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
@@ -96,9 +97,9 @@ def test_element_formula_generator_mixin(
     )
     serialized_element = element_type().export_serialized(exported_element)
 
-    imported_element = element_type().import_serialized(
+    [imported_element] = PageHandler().import_elements(
         formula_generator_fixture["page"],
-        serialized_element,
+        [serialized_element],
         formula_generator_fixture["id_mapping"],
     )
 
@@ -143,9 +144,9 @@ def test_link_element_formula_generator(data_fixture, formula_generator_fixture)
     )
     serialized_element = LinkElementType().export_serialized(exported_element)
 
-    imported_element = LinkElementType().import_serialized(
+    [imported_element] = PageHandler().import_elements(
         formula_generator_fixture["page"],
-        serialized_element,
+        [serialized_element],
         formula_generator_fixture["id_mapping"],
     )
 
@@ -248,9 +249,9 @@ def test_menu_element_formula_generator(data_fixture, formula_generator_fixture)
 
     serialized_element = MenuElementType().export_serialized(menu_element)
 
-    imported_element = MenuElementType().import_serialized(
+    [imported_element] = PageHandler().import_elements(
         formula_generator_fixture["page"],
-        serialized_element,
+        [serialized_element],
         formula_generator_fixture["id_mapping"],
     )
 

--- a/changelog/entries/unreleased/bug/resolved_a_bug_where_a_containertype_element_with_a_visibili.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_where_a_containertype_element_with_a_visibili.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug where a container-type element with a visibility condition would be unable to use form data in its formula.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-11"
+}


### PR DESCRIPTION
### What is in this PR

This scenario does not work in `develop`:

- Add a container element
- Add a form element
- In the container, set its `visibility_condition` to use the form element's data.
- In preview, your application will work
- In public, it won't work, as the import process will run into a snag.

A while back we introduced the concept of an `import_element_priority`. Containers should be imported first (for hierarchical import reasons), then form elements, then everything else. Given the steps above however, when we try and `import_path` on the `visibility_condition` formula, the `id_mapping` won't contain the necessary data, as the form element hasn't been imported yet.

To fix this, we'll now import *all* elements in `PageHandler.import_elements`, and then handle the formula imports. This guarantees that our `id_mapping` has the correct values.

I've removed the `import_element_priority` in this PR for form elements, because it isn't necessary anymore, but we do need to keep the container priority.

### How to test this PR

Do the steps above, in `develop` your published application won't work correctly, but the previewed one will. In this branch, both will work.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
