### PR TITLE
fix: custom code endpoint to handle invalid Builder ID

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_crash_when_querying_custom_code_endpoint_with_an_inv.json
+++ b/changelog/entries/unreleased/bug/fixed_a_crash_when_querying_custom_code_endpoint_with_an_inv.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a crash when fetching custom code for a non-existent builder ID.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-12"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/builder/custom_code/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/builder/custom_code/views.py
@@ -5,11 +5,11 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.permissions import AllowAny
 from rest_framework.views import APIView
 
+from baserow.api.applications.errors import ERROR_APPLICATION_DOES_NOT_EXIST
 from baserow.api.decorators import map_exceptions
 from baserow.api.schemas import get_error_schema
-from baserow.contrib.builder.errors import ERROR_BUILDER_DOES_NOT_EXIST
-from baserow.contrib.builder.exceptions import BuilderDoesNotExist
 from baserow.contrib.builder.service import BuilderService
+from baserow.core.exceptions import ApplicationDoesNotExist
 from baserow_enterprise.api.authentication import (
     AuthenticateFromUserSessionAuthentication,
 )
@@ -46,12 +46,16 @@ class PublicCustomCodeView(APIView):
         description=("Returns the css/js for the given builder."),
         responses={
             200: str,
-            404: get_error_schema(["ERROR_BUILDER_DOES_NOT_EXIST"]),
+            404: get_error_schema(
+                [
+                    "ERROR_APPLICATION_DOES_NOT_EXIST",
+                ]
+            ),
         },
     )
     @map_exceptions(
         {
-            BuilderDoesNotExist: ERROR_BUILDER_DOES_NOT_EXIST,
+            ApplicationDoesNotExist: ERROR_APPLICATION_DOES_NOT_EXIST,
         }
     )
     def get(self, request, builder_id, code_type):

--- a/enterprise/backend/tests/baserow_enterprise_tests/builder/custom_code/test_enterprise_application_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/builder/custom_code/test_enterprise_application_views.py
@@ -263,3 +263,17 @@ def test_get_enterprise_builder_custom_code_public_no_licence(api_client, data_f
         url,
     )
     assert response.status_code == HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_get_enterprise_builder_custom_code_public_application_not_found(
+    enable_enterprise, api_client, data_fixture
+):
+    url = reverse(
+        "api:enterprise:custom_code:public_js",
+        kwargs={"builder_id": 123456},
+    )
+
+    response = api_client.get(url)
+
+    assert response.status_code == HTTP_404_NOT_FOUND


### PR DESCRIPTION
# What is in this PR
This PR fixes a hard-crash when querying the Custom Code endpoint with a non-existent Builder ID.

The custom code API has an error mapping for `BuilderDoesNotExist`, but we never actually raise this class. Instead, we raise `ApplicationDoesNotExist`.

# How to test this PR
In a Builder application, add some custom CSS, e.g.:
```
.tsering-style {
  background-color: red;
}
```

Then style one of your elements to use this custom css, and then publish your application.

In `develop`, if you make a GET request to `http://localhost:8000/api/custom_code/203/css/public/` (replace with your published builder ID), you'll see the endpoint crashes hard:
```
ApplicationDoesNotExist at /api/custom_code/203/css/public/
The application with id 203 does not exist.
```

In this branch, you'll see a soft 404 error instead.

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
