### PR TITLE
Fix bug in Periodic trigger service to handle shorter months

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/utils.py
+++ b/backend/src/baserow/contrib/integrations/core/utils.py
@@ -76,8 +76,13 @@ def calculate_next_periodic_run(
         next_run = next_run.replace(hour=hour, minute=minute)
 
     elif interval == PERIODIC_INTERVAL_MONTH:
-        # Run at the specified day_of_month at hour:minute each month
-        next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        try:
+            # Run at the specified day_of_month at hour:minute each month
+            next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        except ValueError:
+            # If the day doesn't exist, use the last day of the month
+            next_run = from_time.replace(day=1) + relativedelta(months=1, days=-1)
+            next_run = next_run.replace(hour=hour, minute=minute)
 
         # If we've already passed this time this month, move to next month
         if next_run <= from_time:

--- a/backend/tests/baserow/contrib/integrations/core/cases/core_periodic_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/cases/core_periodic_service_type.py
@@ -507,6 +507,16 @@ PERIODIC_SERVICE_CALCULATE_NEXT_RUN_CASES = [
         datetime(2025, 2, 15, 10, 0, 0, tzinfo=timezone.utc),
         datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
     ),
+    (
+        PERIODIC_INTERVAL_MONTH,
+        0,
+        0,
+        0,
+        30,  # day 30 which isn't valid for February
+        datetime(2026, 2, 1, 0, 0, 0, tzinfo=timezone.utc),
+        # Should default to the last day of the month
+        datetime(2026, 2, 28, 0, 0, 0, tzinfo=timezone.utc),
+    ),
 ]
 
 PERIODIC_SERVICE_NEXT_RUN_SET_CASES = [

--- a/changelog/entries/unreleased/bug/fix_a_bug_in_the_periodic_trigger_that_could_cause_an_invali.json
+++ b/changelog/entries/unreleased/bug/fix_a_bug_in_the_periodic_trigger_that_could_cause_an_invali.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug in the Periodic Trigger that could cause an invalid day of month to be calculated for shorter months.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-03-13"
+}


### PR DESCRIPTION
### What is in this PR
This fixes a Sentry issue: https://baserow-eu.sentry.io/issues/102785636/

We need to handle the case where Periodic trigger uses a monthly interval, and the day is invalid, e.g. 30th Feb.

### How to test this PR
I couldn't test it manually in the UI (changing system clock to Feb didn't help), but the fix is pretty straight forward 🤞 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
