### PR TITLE
Prevent the reuse of the event payload

### DIFF
--- a/backend/src/baserow/contrib/automation/nodes/node_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/node_types.py
@@ -369,13 +369,16 @@ class AutomationNodeTriggerType(AutomationNodeType):
         for trigger in triggers:
             # If we've received a callable payload, call it with the specific service,
             # this can give us a payload that is specific to the trigger's service.
-            if callable(event_payload):
-                event_payload = event_payload(service_map[trigger.service_id])
+            service_payload = (
+                event_payload(service_map[trigger.service_id])
+                if callable(event_payload)
+                else event_payload
+            )
 
             workflow = trigger.workflow
             AutomationWorkflowHandler().async_start_workflow(
                 workflow,
-                event_payload,
+                service_payload,
             )
 
             # We don't want subsequent events to trigger a new test run

--- a/backend/src/baserow/contrib/integrations/core/utils.py
+++ b/backend/src/baserow/contrib/integrations/core/utils.py
@@ -76,22 +76,26 @@ def calculate_next_periodic_run(
         next_run = next_run.replace(hour=hour, minute=minute)
 
     elif interval == PERIODIC_INTERVAL_MONTH:
-        # Run at the specified day_of_month at hour:minute each month
-        next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        # Run at the specified day_of_month at hour:minute each month.
+        # Handle case where day_of_month doesn't exist in the current month
+        # (e.g., day 30 in February) by using the last day of the month.
+        try:
+            next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        except ValueError:
+            # Use last day of the current month
+            next_run = from_time.replace(day=1) + relativedelta(months=1, days=-1)
+            next_run = next_run.replace(hour=hour, minute=minute)
 
         # If we've already passed this time this month, move to next month
         if next_run <= from_time:
-            # Move to next month
             next_run += relativedelta(months=1)
-
-        # Handle case where day_of_month doesn't exist in the target month
-        # (e.g., day 31 in February)
-        try:
-            next_run = next_run.replace(day=day_of_month)
-        except ValueError:
-            # If the day doesn't exist, use the last day of the month
-            next_run = next_run.replace(day=1) + relativedelta(months=1, days=-1)
-            next_run = next_run.replace(hour=hour, minute=minute)
+            # Handle case where day_of_month doesn't exist in the target month
+            try:
+                next_run = next_run.replace(day=day_of_month)
+            except ValueError:
+                # Use last day of the target month
+                next_run = next_run.replace(day=1) + relativedelta(months=1, days=-1)
+                next_run = next_run.replace(hour=hour, minute=minute)
 
     else:
         # Unknown interval type, default to 1 hour from now

--- a/backend/src/baserow/contrib/integrations/migrations/0026_backfill_coreperiodicservice_next_run_at.py
+++ b/backend/src/baserow/contrib/integrations/migrations/0026_backfill_coreperiodicservice_next_run_at.py
@@ -50,22 +50,26 @@ def _calculate_next_run(interval, minute, hour, day_of_week, day_of_month, from_
         next_run = next_run.replace(hour=hour, minute=minute)
 
     elif interval == "MONTH":
-        # Run at the specified day_of_month at hour:minute each month
-        next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        # Run at the specified day_of_month at hour:minute each month.
+        # Handle case where day_of_month doesn't exist in the current month
+        # (e.g., day 30 in February) by using the last day of the month.
+        try:
+            next_run = from_time.replace(day=day_of_month, hour=hour, minute=minute)
+        except ValueError:
+            # Use last day of the current month
+            next_run = from_time.replace(day=1) + relativedelta(months=1, days=-1)
+            next_run = next_run.replace(hour=hour, minute=minute)
 
         # If we've already passed this time this month, move to next month
         if next_run <= from_time:
-            # Move to next month
             next_run += relativedelta(months=1)
-
-        # Handle case where day_of_month doesn't exist in the target month
-        # (e.g., day 31 in February)
-        try:
-            next_run = next_run.replace(day=day_of_month)
-        except ValueError:
-            # If the day doesn't exist, use the last day of the month
-            next_run = next_run.replace(day=1) + relativedelta(months=1, days=-1)
-            next_run = next_run.replace(hour=hour, minute=minute)
+            # Handle case where day_of_month doesn't exist in the target month
+            try:
+                next_run = next_run.replace(day=day_of_month)
+            except ValueError:
+                # Use last day of the target month
+                next_run = next_run.replace(day=1) + relativedelta(months=1, days=-1)
+                next_run = next_run.replace(hour=hour, minute=minute)
 
     else:
         # Unknown interval type, default to 1 hour from now

--- a/backend/tests/baserow/contrib/integrations/core/cases/core_periodic_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/cases/core_periodic_service_type.py
@@ -507,6 +507,36 @@ PERIODIC_SERVICE_CALCULATE_NEXT_RUN_CASES = [
         datetime(2025, 2, 15, 10, 0, 0, tzinfo=timezone.utc),
         datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc),
     ),
+    # Day doesn't exist in current month (e.g., Feb 30th)
+    (
+        PERIODIC_INTERVAL_MONTH,
+        30,
+        14,
+        0,
+        30,  # Day 30 doesn't exist in February
+        datetime(2025, 2, 10, 10, 0, 0, tzinfo=timezone.utc),  # Currently Feb 10th
+        datetime(2025, 2, 28, 14, 30, 0, tzinfo=timezone.utc),  # Falls back to Feb 28th
+    ),
+    # Day doesn't exist in current month and time has passed (move to next month)
+    (
+        PERIODIC_INTERVAL_MONTH,
+        30,
+        14,
+        0,
+        30,  # Day 30 doesn't exist in February
+        datetime(2025, 2, 28, 15, 0, 0, tzinfo=timezone.utc),  # After 14:30 on Feb 28th
+        datetime(2025, 3, 30, 14, 30, 0, tzinfo=timezone.utc),  # March 30th exists
+    ),
+    # Day doesn't exist in current or next month (Feb -> Mar with day 31)
+    (
+        PERIODIC_INTERVAL_MONTH,
+        30,
+        14,
+        0,
+        31,  # Day 31
+        datetime(2025, 2, 10, 10, 0, 0, tzinfo=timezone.utc),  # Currently Feb 10th
+        datetime(2025, 2, 28, 14, 30, 0, tzinfo=timezone.utc),  # Falls back to Feb 28th
+    ),
 ]
 
 PERIODIC_SERVICE_NEXT_RUN_SET_CASES = [

--- a/changelog/entries/unreleased/bug/resolved_a_bug_in_the_periodic_trigger_which_prevented_it_fr.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_in_the_periodic_trigger_which_prevented_it_fr.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug in the periodic trigger which prevented it from being scheduled correctly.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-03-13"
+}


### PR DESCRIPTION
### What is in this PR

Periodic services are misbehaving in production. The cause, spotted by @paljort, is that in `AutomationNodeTriggerType.on_event`, when we loop over the triggers-with-services-that-are-due, the first iteration will modify the `event_payload` for the next iterations if it's callable:

Trigger 1: `event_payload` is a callable (which it alway should be for periodic services), we make the service type aware that the `next_run_at` should be updated.
Trigger 2...n: `event_payload` is now a dict (from trigger 1's service), and it reuses it. The `next_run_at` isn't updated.

### How to test this PR

It takes time to replicate, but the gist of it is:

- You need multiple published workflows, each with a periodic trigger
- Have them write to separate table, so it's clearer to inspect
- Whichever workflow runs first will run on schedule correctly (it'll be the first one in that loop, so `next_run_at` is updated correctly)
- The next one will have a strange/haphazard schedule.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
