### PR TITLE
fix: Ensure opening the Automation's settings modal doesn't replace automation values

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_bug_that_caused_a_crash_when_trying_to_view_an_autom.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_that_caused_a_crash_when_trying_to_view_an_autom.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug that caused a crash when trying to view an Automation's settings in development mode.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-03-16"
+}

--- a/web-frontend/modules/automation/components/settings/GeneralSettings.vue
+++ b/web-frontend/modules/automation/components/settings/GeneralSettings.vue
@@ -59,6 +59,7 @@ export default {
         name: '',
         notification: false,
       },
+      allowedValues: ['name', 'notification'],
     }
   },
   validations() {


### PR DESCRIPTION
### What is in this PR
This fixes a bug when trying to view the Automation settings via the left side bar.

### How to test this PR
In `develop`:
- Create two Automation applications
- For one of the automations in the left side bar, click Settings

You'll notice that the Automation icon disappears:
> <img width="245" height="195" alt="image" src="https://github.com/user-attachments/assets/d7d8e0b5-01ec-4b4a-9f41-446505203bf8" />

If you then try to click on the Automation, you'll get an error:
```
Cannot set properties of undefined (setting 'selected')
```

In this branch the bug should be fixed.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
