### PR TITLE
fix: moment date localization not working

### DIFF
--- a/changelog/entries/unreleased/bug/fix_date_localization_not_working_with_non_english_languages.json
+++ b/changelog/entries/unreleased/bug/fix_date_localization_not_working_with_non_english_languages.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix date localization not working with non english languages",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-03-17"
+}

--- a/web-frontend/modules/core/moment.js
+++ b/web-frontend/modules/core/moment.js
@@ -2,5 +2,13 @@
 // is always included. There were some problems when Baserow is installed as a
 // dependency and then moment-timezone does not work. Still will resolve that issue.
 import moment from 'moment-timezone'
+import 'moment/dist/locale/fr'
+import 'moment/dist/locale/nl'
+import 'moment/dist/locale/de'
+import 'moment/dist/locale/es'
+import 'moment/dist/locale/it'
+import 'moment/dist/locale/pl'
+import 'moment/dist/locale/ko'
+import 'moment/dist/locale/uk'
 
 export default moment


### PR DESCRIPTION
### What is in this PR

The date formating localization is broken after the nuxt 3 migration.

### How to test this PR

Create a page with a formula that show a date in localized version for instance: `datetime_format(now(),'LLLL')`. This string show the name of the day and these names should match the current chosen locale but if you switch to a non english language, this is not the case anymore. With this branch it should work.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
