### PR TITLE
Fix DatatypeMismatch on bulk insert for tables with formula fields

### DIFF
--- a/backend/src/baserow/contrib/database/fields/fields.py
+++ b/backend/src/baserow/contrib/database/fields/fields.py
@@ -223,6 +223,9 @@ class BaserowExpressionField(models.Field):
         # expression field.
         return self.expression_field.__class__
 
+    def get_placeholder(self, value, compiler, connection):
+        return "%s"
+
     def get_transform(self, name):
         # When a model field of this type is pickled and stored in the Baserow model
         # cache, the lookups on the class setup in the __init__ are not persisted.

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -16,6 +16,7 @@ from baserow.contrib.database.api.utils import (
     extract_user_field_names_from_params,
     get_include_exclude_fields,
 )
+from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import SelectOption
 from baserow.contrib.database.rows.exceptions import RowDoesNotExist
 from baserow.contrib.database.rows.handler import RowHandler
@@ -1080,6 +1081,42 @@ def test_import_rows_with_read_only_field(
     model = table.get_model()
     rows = list(model.objects.all())
     assert len(rows) == 0
+
+
+@pytest.mark.django_db
+def test_import_rows_with_broken_lookup_field(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    table2 = data_fixture.create_database_table(user=user, database=table.database)
+    data_fixture.create_text_field(name="primary", table=table, primary=True)
+    target_field = data_fixture.create_text_field(
+        name="target", table=table2, primary=True
+    )
+
+    linkrowfield = FieldHandler().create_field(
+        user, table, "link_row", name="link", link_row_table=table2
+    )
+    FieldHandler().create_field(
+        user,
+        table,
+        "lookup",
+        name="lookup",
+        through_field_id=linkrowfield.id,
+        target_field_id=target_field.id,
+    )
+
+    FieldHandler().update_field(user, linkrowfield.specific, new_type_name="text")
+
+    handler = RowHandler()
+    rows, report = handler.import_rows(
+        user=user,
+        table=table,
+        data=[["row1", ""], ["row2", ""]],
+        send_realtime_update=False,
+    )
+
+    assert len(rows) == 2
+    assert report == {}
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/4992_fix_datatypemismatch_on_bulk_insert_for_tables_with_formula_.json
+++ b/changelog/entries/unreleased/bug/4992_fix_datatypemismatch_on_bulk_insert_for_tables_with_formula_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix DatatypeMismatch on bulk insert for tables with formula fields",
+    "issue_origin": "github",
+    "issue_number": 4992,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-03-17"
+}


### PR DESCRIPTION
### What is in this PR
Closes #4992 

Django 5.2 introduced an UNNEST-based `bulk_create` for PostgreSQL. It skips `UNNEST` when any field's `get_internal_type()` is not in `connection.data_types`. Because `BaserowExpressionField` overrides `__class__` to mimic its inner expression field, it was returning standard type names causing Django to use `UNNEST` with explicit type casts that may not match the actual database column type.

This can happen if we i.e. change link row field into text field - if we have lookup field created, it's not going to be updated (and marked as broken formula). Prior 5.2 it was harmless but now it breaks because `UNNEST` forces explicit typing

This PR adds a `get_placeholder` method to `BaserowExpressionField`. The method returns the standard `%s` placeholder so `INSERT` behavior is unchanged, but its presence causes Django's PostgreSQL compiler to skip the `UNNEST` optimization for tables containing formula fields and fall back to the standard `INSERT INTO ... VALUES (...)` approach.

### How to test this PR

Follow steps to reproduce in issue description and observe import works as expected.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
