### PR TITLE
fix: moving rows should not update the last_modified field

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -1523,6 +1523,7 @@ class DateFieldType(FieldType):
 class CreatedOnLastModifiedBaseFieldType(ReadOnlyFieldType, DateFieldType):
     can_be_in_form_view = False
     field_data_is_derived_from_attrs = True
+    include_in_row_move_updated_fields = False
 
     source_field_name = None
     model_field_class = SyncedDateTimeField

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -2715,7 +2715,7 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
         )
 
         row.order = self.get_unique_orders_before_row(before_row, model)[0]
-        row.save(update_fields=["order", "updated_on"])
+        row.save(update_fields=["order"])
 
         # All fields must be marked as updated because the lookup fields can depend
         # on the row order. Only fields that are specifically marked as


### PR DESCRIPTION
## Summary

Fixes #3054

When rows are moved (reordered), the `last_modified` field was incorrectly being updated. Since position changes are not tracked in row history, moving a row should not affect the `last_modified` timestamp.

## Changes

- **`backend/src/baserow/contrib/database/rows/handler.py`**: Remove `updated_on` from the `update_fields` list in `move_row()`, so only `order` is persisted when a row is moved.
- **`backend/src/baserow/contrib/database/fields/field_types.py`**: Set `include_in_row_move_updated_fields = False` on `CreatedOnLastModifiedBaseFieldType`, which is the base class for both `CreatedOnFieldType` and `LastModifiedFieldType`. This excludes these fields from the set of fields marked as updated during a row move.

## Test plan

- Move a row in a table that has a `last_modified` field and verify the timestamp does not change.
- Verify that actual row data edits still update the `last_modified` field as expected.
- Verify that lookup fields that depend on row order still update correctly after a move.

---

Developed with AI assistance (Claude Code)