### PR TITLE
Resolve a bug which causes the AI field formula to appear twice.

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_an_issue_which_caused_ai_field_formulas_to_appear_t.json
+++ b/changelog/entries/unreleased/bug/resolved_an_issue_which_caused_ai_field_formulas_to_appear_t.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved an issue which caused AI field formulas to appear twice in the UI.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-03-18"
+}

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -165,6 +165,7 @@ export default {
       hoveredFunctionNode: null,
       isHandlingModeChange: false,
       intersectionObserver: null,
+      isEditorInitialized: false,
     }
   },
   computed: {
@@ -348,6 +349,11 @@ export default {
     },
 
     mode(newMode, oldMode) {
+      // In Vue 3, watchers can fire during the initial render cycle before
+      // mounted() completes. Skip if editor hasn't been initialized yet.
+      if (!this.isEditorInitialized) {
+        return
+      }
       // Skip automatic recreation if we're handling it manually in handleModeChange
       if (this.isHandlingModeChange) {
         return
@@ -437,6 +443,7 @@ export default {
           }),
         },
       })
+      this.isEditorInitialized = true
     },
     recreateEditor(formula = null) {
       const currentFormula =


### PR DESCRIPTION
### What is in this PR

Resolves a bug which causes the AI field `FormulaInputField` to duplicate its formula, *visually*, in the UI. Behind the scenes we are still working with a single formula however.

<img width="425" height="207" alt="Screenshot 2026-03-18 at 13 50 27" src="https://github.com/user-attachments/assets/e0798e25-5350-4c3b-b488-8b15e3b0ff19" />

The root cause was that `FormulaInputField`'s `mode` watcher could fire during Vue 3's initial render cycle, before `mounted` completed, triggering `recreateEditor` and creating a second TipTap editor.

It only affects the AI field form's usage of `FormulaInputField`, and not `AutomationBuilderFormulaInput` / `ApplicationBuilderFormulaInput`. `FieldAISubForm`'s `immediate:true` on `values.ai_prompt.mode` triggers the problem, it causes `FormulaInputField`'s `mode` prop, which triggers the watcher *before* `mounted` has been called. You then end up with two calls to `createEditor`, instead of one.

The fix is to add a check, `isEditorInitialized`, to ensure that we don't call `recreateEditor` until we've created the editor in the first place.

### How to test this PR

- In `develop`:
    1. Add an AI field to your table
    2. Choose expert mode and add `concat('foo', 'bar')`
    3. Save the field
    4. Re-open the field context
    5. You will see `concat('foo', 'bar')` twice, as there are *two* prose mirrors.
 - In this branch:
    - It'll appear once.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
