### PR TITLE
Filter out unactionable AxiosErrors from sentry

### DIFF
--- a/changelog/entries/unreleased/refactor/5008_filter_out_unactionable_axioserrors_from_sentry.json
+++ b/changelog/entries/unreleased/refactor/5008_filter_out_unactionable_axioserrors_from_sentry.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Filter out unactionable AxiosErrors from sentry",
+    "issue_origin": "github",
+    "issue_number": 5008,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-03-19"
+}

--- a/web-frontend/sentry.client.config.ts
+++ b/web-frontend/sentry.client.config.ts
@@ -31,6 +31,13 @@ if (dsn && dsn !== '') {
     beforeSend(event, hint) {
       const err = hint?.originalException
       if (err?.fatal === false || err?.response?.status === 401) return null
+
+      // Filter out axios errors without a response like
+      // network error, timeout, aborted, cancelled requests
+      if (err?.name === 'AxiosError' && !err?.response) {
+        return null
+      }
+
       if (isDev) {
         console.error('[Sentry captured error]', `${err}`)
         return null


### PR DESCRIPTION
### What is in this PR
Closes #5008 

This PR silence some unactionable axios errors and reduce sentry noise

### How to test this PR

Check on `develop` first

1. Have sentry set up
2. Load application (any table)
3. Open console and run i.e. `window.useNuxtApp().$client.get('http://localhost:1/fake-timeout')`
4. Note that there will be error reported in your sentry

Then on this branch do the same steps and note that error is not reported.

For checking that it was actually filtered out - you can change config lines to something like:

```
      if (err?.name === 'AxiosError' && !err?.response) {
        console.warn('[Sentry] Ignoring Axios error without response:', err)
        return null
      }
```

Then to the same testing steps and note message in console

<img width="738" height="254" alt="console" src="https://github.com/user-attachments/assets/62f6bfa4-38f0-436a-abff-1b0dc10adbd4" />





### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
