### PR TITLE
Silence defined error codes

### DIFF
--- a/changelog/entries/unreleased/refactor/5011_silence_defined_error_codes_in_sentry.json
+++ b/changelog/entries/unreleased/refactor/5011_silence_defined_error_codes_in_sentry.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Silence defined error codes in Sentry",
+    "issue_origin": "github",
+    "issue_number": 5011,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-03-19"
+}

--- a/web-frontend/modules/core/utils/sentryErrors.js
+++ b/web-frontend/modules/core/utils/sentryErrors.js
@@ -1,0 +1,5 @@
+// API error codes to silence in Sentry, keyed by HTTP status code.
+// These are handled by the application (e.g. forceLogoff) and are not bugs.
+export const SILENCED_API_ERRORS = {
+  401: ['ERROR_INVALID_ACCESS_TOKEN', 'ERROR_INVALID_REFRESH_TOKEN'],
+}

--- a/web-frontend/sentry.client.config.ts
+++ b/web-frontend/sentry.client.config.ts
@@ -1,5 +1,6 @@
 import { useRuntimeConfig, useAppConfig, useRouter } from '#imports'
 import { makeFakeTransport } from './modules/core/utils/sentryFakeTransport'
+import { SILENCED_API_ERRORS } from './modules/core/utils/sentryErrors'
 import * as Sentry from '@sentry/nuxt'
 
 const config = useRuntimeConfig()
@@ -30,11 +31,18 @@ if (dsn && dsn !== '') {
     ...(isDev ? { transport: makeFakeTransport } : {}),
     beforeSend(event, hint) {
       const err = hint?.originalException
-      if (err?.fatal === false || err?.response?.status === 401) return null
+      if (err?.fatal === false) return null
 
       // Filter out axios errors without a response like
       // network error, timeout, aborted, cancelled requests
       if (err?.name === 'AxiosError' && !err?.response) {
+        return null
+      }
+
+      // Filter known API errors that are handled by the application (e.g. forceLogoff).
+      const status = err?.response?.status || err?.statusCode
+      const errorCode = err?.response?.data?.error || err?.data?.error
+      if (SILENCED_API_ERRORS[status]?.includes(errorCode)) {
         return null
       }
 

--- a/web-frontend/sentry.server.config.ts
+++ b/web-frontend/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import { useRuntimeConfig } from '#imports'
 import * as Sentry from '@sentry/nuxt'
 import { makeFakeTransport } from './modules/core/utils/sentryFakeTransport'
+import { SILENCED_API_ERRORS } from './modules/core/utils/sentryErrors'
 
 const config = useRuntimeConfig()
 const dsn =
@@ -18,7 +19,14 @@ if (dsn && dsn !== '') {
     ...(isDev ? { transport: makeFakeTransport } : {}),
     beforeSend(event, hint) {
       const err = hint?.originalException
-      if (err?.fatal === false || err?.response?.status === 401) return null
+      if (err?.fatal === false) return null
+
+      // Filter known API errors that are handled by the application (e.g. forceLogoff).
+      const status = err?.response?.status || err?.statusCode
+      const errorCode = err?.response?.data?.error || err?.data?.error
+      if (SILENCED_API_ERRORS[status]?.includes(errorCode)) {
+        return null
+      }
       if (isDev) {
         console.error('[Sentry captured error]', err)
         return null


### PR DESCRIPTION
### What is in this PR

Closes #5011 

This PR allows silencing custom errors that come from backend.
Provided configuration silence errors with status 401 related to token refresh flow


### How to test this PR

Test on `develop` branch first

1. Have sentry set up
2. Login into application
3. Break auth token: `window.useNuxtApp().$store.state.auth.token = 'invalid-token'`
4. Break refresh token: `window.useNuxtApp().$store.state.auth.refreshToken = 'invalid-refresh'`
5. Try any action and observe error being shown that user session expired and that sentry entry is created

Test the same flow on this branch and notice that no sentry entry was created.

Add `console.log(`[Sentry] Silenced API error ${status} ${errorCode}`)` in `if` condition to observe that error was handled in `beforeSend`


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
