### PR TITLE
fix: update example data in JSON and XML import dialogs

### DIFF
--- a/changelog/entries/unreleased/bug/2953_fix_example_data_json_xml_import_dialogs.json
+++ b/changelog/entries/unreleased/bug/2953_fix_example_data_json_xml_import_dialogs.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Replace placeholder example data in the JSON and XML import dialogs with clearer contact records so users can see a typical table import format",
+    "issue_origin": "github",
+    "issue_number": 2953,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-16"
+}

--- a/web-frontend/modules/database/components/table/TableJSONImporter.vue
+++ b/web-frontend/modules/database/components/table/TableJSONImporter.vue
@@ -10,16 +10,14 @@
           <pre>
 [
   {
-    "to": "Tove",
-    "from": "Jani",
-    "heading": "Reminder",
-    "body": "Don't forget me this weekend!"
+    "name": "John Doe",
+    "email": "john@example.com",
+    "phone": "123-456-7890"
   },
   {
-    "to": "Bram",
-    "from": "Nigel",
-    "heading": "Reminder",
-    "body": "Don't forget about the export feature this week"
+    "name": "Jane Smith",
+    "email": "jane@example.com",
+    "phone": "987-654-3210"
   }
 ]
         </pre

--- a/web-frontend/modules/database/components/table/TableXMLImporter.vue
+++ b/web-frontend/modules/database/components/table/TableXMLImporter.vue
@@ -8,21 +8,18 @@
         <div class="control__description">
           {{ $t('tableXMLImporter.fileDescription') }}
           <pre>
-&lt;notes&gt;
-  &lt;note&gt;
-    &lt;to&gt;Tove&lt;/to&gt;
-    &lt;from&gt;Jani&lt;/from&gt;
-    &lt;heading&gt;Reminder&lt;/heading&gt;
-    &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;
-  &lt;/note&gt;
-  &lt;note&gt;
-    &lt;heading&gt;Reminder&lt;/heading&gt;
-    &lt;heading2&gt;Reminder2&lt;/heading2&gt;
-    &lt;to&gt;Tove&lt;/to&gt;
-    &lt;from&gt;Jani&lt;/from&gt;
-    &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;
-  &lt;/note&gt;
-&lt;/notes&gt;</pre
+&lt;data&gt;
+  &lt;record&gt;
+    &lt;name&gt;John Doe&lt;/name&gt;
+    &lt;email&gt;john@example.com&lt;/email&gt;
+    &lt;phone&gt;123-456-7890&lt;/phone&gt;
+  &lt;/record&gt;
+  &lt;record&gt;
+    &lt;name&gt;Jane Smith&lt;/name&gt;
+    &lt;email&gt;jane@example.com&lt;/email&gt;
+    &lt;phone&gt;987-654-3210&lt;/phone&gt;
+  &lt;/record&gt;
+&lt;/data&gt;</pre
           >
         </div>
       </template>


### PR DESCRIPTION
## Summary

Replaces the placeholder example data in the JSON and XML import dialogs with clearer contact records.

## Why this matters

The current example data ("Tove", "Jani", "Don't forget me this weekend!") is taken from a generic XML tutorial and doesn't clearly demonstrate a typical table import format. New users see this when importing data for the first time (#2953).

## Changes

- `TableJSONImporter.vue`: Replaced note-style example with contact records (name, email, phone)
- `TableXMLImporter.vue`: Same replacement - contact records with consistent field names

Uses the exact example data suggested in the issue by @cwinhall_baserow.

## Testing

Frontend-only change to static template strings. No logic modified.

Fixes #2953

This contribution was developed with AI assistance (Claude Code).