### PR TITLE
fix: resolve a path import bug in row-change triggers.

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -2373,11 +2373,13 @@ class LocalBaserowRowsSignalServiceType(
         Import Local Baserow signal service types paths.
         """
 
-        # All Local Baserow signal service types have a length of 3:
-        # {previousNodeId}.{rowIndex}.{fieldName}. By this point, we should
-        # only have two parts: {rowIndex}.{fieldName}.
-        if len(path) == 2:
-            index, field_dbname = path
+        # If we receive:
+        # {previousNodeId}.{rowIndex}.{fieldName}, or
+        # {previousNodeId}.{rowIndex}.{fieldName}.{fieldValueIndex}.{value}
+        #   (e.g. a `link_row`)
+        # then pluck out the row index / field name and use it.
+        if len(path) >= 2:
+            index, field_dbname, *rest = path
         else:
             # In any other scenario, we have a formula that is not a format we
             # can currently import properly, so we return the path as is.
@@ -2392,7 +2394,7 @@ class LocalBaserowRowsSignalServiceType(
             self.import_property_name(field_dbname, id_mapping) or field_dbname
         )
 
-        return [index, imported_field_dbname]
+        return [index, imported_field_dbname, *rest]
 
 
 class LocalBaserowRowsCreatedServiceType(LocalBaserowRowsSignalServiceType):

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_rows_signal_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_rows_signal_service_type.py
@@ -1,0 +1,34 @@
+import pytest
+
+from baserow.contrib.integrations.local_baserow.service_types import (
+    LocalBaserowRowsCreatedServiceType,
+)
+
+
+@pytest.mark.parametrize(
+    "path,id_mapping,expected",
+    [
+        # When path has fewer than 2 elements, return as is
+        ([], {}, []),
+        (["0"], {}, ["0"]),
+        # When field_dbname doesn't start with "field_", return path as is
+        (["0", "id"], {}, ["0", "id"]),
+        (["0", "foo"], {}, ["0", "foo"]),
+        # {rowIndex}.{fieldName} and field not in mapping
+        (["0", "field_1"], {}, ["0", "field_1"]),
+        # {rowIndex}.{fieldName} and field in mapping
+        (["0", "field_1"], {"database_fields": {1: 2}}, ["0", "field_2"]),
+        # {rowIndex}.{fieldName}.{fieldValueIndex}.{value} and field not in mapping
+        (["0", "field_1", "0", "value"], {}, ["0", "field_1", "0", "value"]),
+        # {rowIndex}.{fieldName}.{fieldValueIndex}.{value} and field in mapping
+        (
+            ["0", "field_1", "0", "value"],
+            {"database_fields": {1: 2}},
+            ["0", "field_2", "0", "value"],
+        ),
+    ],
+)
+def test_local_baserow_rows_signal_service_type_import_path(path, id_mapping, expected):
+    assert (
+        LocalBaserowRowsCreatedServiceType().import_path(path, id_mapping) == expected
+    )

--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_certain_baserow_field_types_f.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_certain_baserow_field_types_f.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented certain Baserow field types from being used after a row-change trigger.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-03-20"
+}


### PR DESCRIPTION
### What is in this PR

Resolving a bug which prevents previous node formulas referencing a row-signal trigger from being imported correctly if they're multi-valued field types (e.g. link_row).

### How to test this PR

Use this: [review-import-path-bug.zip](https://github.com/user-attachments/files/26137986/review-import-path-bug.zip), or feel free to do the steps below.

- Add a `link_row` field type to a database table.
- Swap back to your workflow, and add a `rows_updated` trigger, test it.
- Add any row action node (I went with update row). Configure it so that one of its field mappings points to `previous_node.{triggerId}.0.{linkRowFieldId}.0.value`.
- Export your workspace
- Create a new workspace, import your export
- Visit your workflow
- In `develop`:
    - The action node's formula has a bad reference (because `linkRowFieldId` wasn't migrated).
 - In this branch:
    - It'll work.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
