### PR TITLE
fix: accept AzureAD SAML metadata with non-standard RoleDescriptor elements

### DIFF
--- a/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
+++ b/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
@@ -1,4 +1,5 @@
 import io
+import re
 
 from django.db.models import QuerySet
 
@@ -24,6 +25,32 @@ def validate_unique_saml_domain(
     return domain
 
 
+def _strip_non_standard_saml_elements(xml_string: str) -> str:
+    """
+    Remove non-standard elements from SAML metadata XML before strict schema
+    validation.
+
+    AzureAD Federation Metadata XML includes ``<RoleDescriptor>`` elements
+    with proprietary ``xsi:type`` extensions (e.g.
+    ``fed:SecurityTokenServiceType``) that reference schemas outside the
+    SAML 2.0 metadata XSD.  The strict ``saml2.xml.schema.validate`` call
+    rejects these, even though the rest of the metadata is perfectly valid.
+
+    This function strips any ``RoleDescriptor`` elements (with or without a
+    namespace prefix) so that the cleaned XML passes schema validation.  The
+    **original** value is always stored and used for actual SAML operations —
+    pysaml2's runtime parser is tolerant of these extensions.
+
+    Returns the cleaned XML string, or the original if parsing fails.
+    """
+    return re.sub(
+        r"<(?:[\w-]+:)?RoleDescriptor[^>]*>.*?</(?:[\w-]+:)?RoleDescriptor>",
+        "",
+        xml_string,
+        flags=re.DOTALL,
+    )
+
+
 def validate_saml_metadata(value):
     from saml2.xml.schema import XMLSchemaError
     from saml2.xml.schema import validate as validate_saml_metadata_schema
@@ -32,8 +59,16 @@ def validate_saml_metadata(value):
     try:
         validate_saml_metadata_schema(metadata)
     except XMLSchemaError:
-        raise serializers.ValidationError(
-            "The metadata is not valid according to the XML schema."
-        )
+        # Retry after stripping non-standard elements such as AzureAD's
+        # <RoleDescriptor> with proprietary xsi:type extensions.  If the
+        # stripped version validates successfully, accept the original value
+        # (pysaml2 handles these elements at runtime without issues).
+        cleaned = _strip_non_standard_saml_elements(value)
+        try:
+            validate_saml_metadata_schema(io.StringIO(cleaned))
+        except XMLSchemaError:
+            raise serializers.ValidationError(
+                "The metadata is not valid according to the XML schema."
+            )
 
     return value


### PR DESCRIPTION
## Summary

Fixes #1673

AzureAD Federation Metadata XML includes `<RoleDescriptor>` elements with proprietary `xsi:type` extensions (e.g. `fed:SecurityTokenServiceType`) that reference schemas outside the SAML 2.0 metadata XSD. The strict `saml2.xml.schema.validate` call in `validate_saml_metadata` rejects these, making it impossible to create a SAML SSO AuthProvider for AzureAD without manually editing the downloaded XML.

## What changed

**`enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py`**

- Added `_strip_non_standard_saml_elements()` — strips `<RoleDescriptor>` blocks (any namespace prefix) via regex.
- In `validate_saml_metadata()`: on `XMLSchemaError`, strip and retry. If cleaned version passes, accept the original value (pysaml2 handles these at runtime).
- If cleaned version also fails, the existing error is raised as before.

## Why this approach

- Original metadata stored unchanged — pysaml2 is tolerant of unknown elements at runtime.
- Minimal change confined to a single file.
- Silently accepts non-standard-but-otherwise-valid metadata rather than rejecting it outright.

## Test plan

- [ ] Download Federation Metadata XML from an AzureAD app registration
- [ ] Create a SAML SSO AuthProvider in Baserow using the unmodified XML — should now succeed
- [ ] Verify genuinely invalid SAML metadata still raises a validation error
