### PR TITLE
chore(frontend): ignore .claude dir in vite watcher and fix Nitro EMFILE

### DIFF
--- a/web-frontend/config/nuxt.config.base.ts
+++ b/web-frontend/config/nuxt.config.base.ts
@@ -98,6 +98,14 @@ export default defineNuxtConfig({
     },
     server: {
       sourcemapIgnoreList: (sourcePath) => sourcePath.includes('node_modules'),
+      watch: {
+        ignored: [
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/.nuxt/**',
+          '**/.claude/**',
+        ],
+      },
     },
     optimizeDeps: {
       // Pre-bundle moment-guess to avoid missing source map warning

--- a/web-frontend/config/nuxt.config.dev.ts
+++ b/web-frontend/config/nuxt.config.dev.ts
@@ -5,4 +5,17 @@ export default defineNuxtConfig({
   ...baseConfig,
   modules: [...(baseConfig.modules || []), '@nuxt/eslint'],
   devtools: { enabled: true },
+  hooks: {
+    // Prevent Nitro's devStorage from watching the entire repo root with
+    // chokidar, which causes EMFILE on macOS in large monorepos / worktrees.
+    // See https://github.com/nuxt/nuxt/issues/30481
+    'nitro:config'(nitroConfig) {
+      nitroConfig.devStorage ??= {}
+      nitroConfig.devStorage['root'] = {
+        driver: 'fs-lite',
+        readOnly: true,
+        base: nitroConfig.rootDir,
+      }
+    },
+  },
 })


### PR DESCRIPTION
## Summary

- Add `.claude/` to vite server watch ignore list (alongside `node_modules`, `.git`, `.nuxt`) to avoid unnecessary file watching in worktrees
- Override Nitro's `devStorage` to use the `fs-lite` driver in dev mode, preventing chokidar from watching the entire repo root which causes `EMFILE` (too many open files) on macOS in large monorepos/worktrees

## Why

Without these changes, the frontend dev server won't work inside a worktree, and you'll see this error:

<img width="772" height="284" alt="image" src="https://github.com/user-attachments/assets/e3aed870-3f74-4951-904c-6721507222e2" />

## Test plan

**Prerequisites:** macOS with the Baserow monorepo checked out. A Claude Code worktree (`.claude/worktrees/`) is helpful but not required.

**1. Verify vite watch ignore works:**
- Run the dev frontend: `yarn dev` (or however you start it locally)
- Confirm the dev server starts without errors
- Create/modify a file inside `.claude/` — the dev server should **not** trigger a rebuild or HMR update
- Modify a real source file (e.g. a `.vue` component) — HMR should still work as expected

**2. Verify Nitro EMFILE fix (best tested in a worktree):**
- Check out this branch in a git worktree (e.g. `git worktree add .claude/worktrees/test-branch fix-nitro-errors-in-worktrees`)
- From the worktree's `web-frontend/`, run `yarn dev`
- The dev server should start successfully **without** `EMFILE: too many open files` errors
- Without this fix, Nitro's chokidar watcher opens file descriptors for the entire repo root, exhausting the macOS fd limit in large repos

**3. Regression check:**
- SSR pages load correctly (Nitro serves them)
- API proxy / server routes still work (Nitro handles these)
- No console warnings about storage driver or watch config
