### PR TITLE
chore(ci): fix for external contributors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,12 @@ jobs:
       - name: Check if PR is from a fork
         id: fork-check
         run: |
-          # TEMPORARY: force fork path for testing — revert before merging
-          echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -141,8 +145,12 @@ jobs:
       - name: Check if PR is from a fork
         id: fork-check
         run: |
-          # TEMPORARY: force fork path for testing — revert before merging
-          echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "pull_request" && \
+                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_fork=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

Fork PRs fail at the Docker image build step because `GITHUB_TOKEN` cannot write to the org's container registry (`denied: installation not allowed to Write organization package`).

This fixes CI for external contributors by detecting fork PRs and transferring Docker images via GHA artifacts instead of the registry:

- Build jobs detect forks and use `load` (local) instead of `push` (registry)
- Images are gzipped and uploaded as artifacts (1-day retention)
- Downstream jobs download and load from artifacts
- GHA `cache-to` is skipped for forks (no write access)

Non-fork PR behavior is completely unchanged.

## How to test

The commit 5f5316b2cba66d4e72fa8c02e99dcb039bee14d6 hardcodes `is_fork=true` to force the artifact path — will be reverted before merge.

