### PR TITLE
fix: automation template replacing editor content and other template bugs

### DIFF
--- a/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/builder/elementTypes.spec.js
@@ -1,0 +1,11 @@
+describe('Enterprise builder element types', () => {
+  test('file input deactivation checks tolerate a missing workspace', () => {
+    const testApp = useNuxtApp()
+    const elementType = testApp.$registry.get('element', 'input_file')
+
+    expect(elementType.isDeactivatedReason({ workspace: undefined })).toBeNull()
+    expect(elementType.getDeactivatedClickModal({ workspace: undefined })).toBe(
+      null
+    )
+  })
+})

--- a/web-frontend/modules/automation/components/AutomationHeader.vue
+++ b/web-frontend/modules/automation/components/AutomationHeader.vue
@@ -114,8 +114,8 @@
             testRunEnabled
               ? $t('automationHeader.stopTestRun')
               : $t('automationHeader.startTestRun')
-          }}</Button
-        >
+          }}
+        </Button>
         <Button
           data-highlight="automation-publish"
           :loading="isPublishing"
@@ -159,20 +159,10 @@ export default defineComponent({
     const store = useStore()
     const app = useNuxtApp()
     const isDev = inject('isDev')
+    const workflow = inject('workflow')
 
     const debug = ref(false)
     const isPublishing = ref(false)
-
-    const workflow = inject('workflow')
-
-    const selectedWorkflow = computed(() => {
-      if (!props.automation) return null
-      try {
-        return store.getters['automationWorkflow/getSelected']
-      } catch {
-        return null
-      }
-    })
 
     const testRunDisabled = computed(() => {
       if (!workflow.value?.graph) {
@@ -207,12 +197,12 @@ export default defineComponent({
     })
 
     const publishedOn = computed(() => {
-      if (!selectedWorkflow.value?.published_on || isPublishing.value) {
+      if (!workflow.value?.published_on || isPublishing.value) {
         return null
       }
 
       return moment
-        .utc(selectedWorkflow.value.published_on)
+        .utc(workflow.value.published_on)
         .tz(getUserTimeZone())
         .format('MMM D, YYYY HH:mm:ss')
     })
@@ -313,7 +303,6 @@ export default defineComponent({
       isPublishing,
       isPaused,
       isDisabled,
-      selectedWorkflow,
       workflow,
       activeSidePanel,
       testRunDisabled,

--- a/web-frontend/modules/automation/components/workflow/WorkflowTemplate.vue
+++ b/web-frontend/modules/automation/components/workflow/WorkflowTemplate.vue
@@ -34,17 +34,11 @@ export default {
   },
   watch: {
     'pageValue.workflow.id': {
-      handler() {
+      handler(newValue) {
         this.loadData()
       },
       immediate: true,
     },
-  },
-  unmounted() {
-    // Restore the current application to the selected application if any
-    this.$store.dispatch('userSourceUser/setCurrentApplication', {
-      application: this.$store.getters['application/getSelected'],
-    })
   },
   methods: {
     async loadData() {
@@ -52,12 +46,9 @@ export default {
 
       try {
         const automation = this.pageValue.automation
-        const workflow = await this.$store.dispatch(
-          'automationWorkflow/selectById',
-          {
-            automation,
-            workflowId: this.pageValue.workflow.id,
-          }
+        const workflow = this.$store.getters['automationWorkflow/getById'](
+          automation,
+          this.pageValue.workflow.id
         )
 
         const automationApplicationType = this.$registry.get(

--- a/web-frontend/modules/automation/pages/automationWorkflow.vue
+++ b/web-frontend/modules/automation/pages/automationWorkflow.vue
@@ -119,9 +119,7 @@ if (error.value) {
 // Computed properties from async data
 const automation = computed(() => pageData.value?.automation ?? null)
 const workspace = computed(() => pageData.value?.workspace ?? null)
-const workflow = computed(
-  () => $store.getters['automationWorkflow/getSelected']
-)
+const workflow = computed(() => pageData.value?.workflow ?? null)
 
 function onRouteChange(from) {
   const currentAutomation = $store.getters['application/get'](

--- a/web-frontend/modules/builder/components/page/PagePreview.vue
+++ b/web-frontend/modules/builder/components/page/PagePreview.vue
@@ -315,7 +315,7 @@ export default {
       })
     },
     elementSelectedId(newValue) {
-      if (newValue) {
+      if (newValue && this.$refs.previewScaled) {
         this.$refs.previewScaled.focus()
       }
     },

--- a/web-frontend/modules/builder/components/page/PageTemplateContent.vue
+++ b/web-frontend/modules/builder/components/page/PageTemplateContent.vue
@@ -36,7 +36,9 @@ export default {
       mode,
       formulaComponent: ApplicationBuilderFormulaInput,
       applicationContext: {
+        workspace: this.workspace,
         builder: this.builder,
+        page: this.currentPage,
         mode,
       },
     }
@@ -65,6 +67,7 @@ export default {
   computed: {
     applicationContext() {
       return {
+        workspace: this.workspace,
         builder: this.builder,
         page: this.currentPage,
         mode,

--- a/web-frontend/modules/core/components/template/TemplateModal.vue
+++ b/web-frontend/modules/core/components/template/TemplateModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <Modal ref="modal" :full-screen="true" :close-button="false">
+  <Modal ref="modal" :full-screen="true" :close-button="false" keep-content>
     <div v-if="loading" class="loading-absolute-center"></div>
     <template v-else>
       <TemplateHeader

--- a/web-frontend/test/unit/core/components/templateModal.spec.js
+++ b/web-frontend/test/unit/core/components/templateModal.spec.js
@@ -1,0 +1,36 @@
+import { defineComponent } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+
+import TemplateModal from '@baserow/modules/core/components/template/TemplateModal'
+
+describe('TemplateModal', () => {
+  const mountComponent = () => {
+    return shallowMount(TemplateModal, {
+      propsData: {
+        workspace: {
+          id: 1,
+        },
+      },
+      global: {
+        stubs: {
+          Modal: defineComponent({
+            name: 'Modal',
+            props: ['keepContent', 'fullScreen', 'closeButton'],
+            template: '<div><slot /></div>',
+          }),
+          TemplateHeader: true,
+          TemplateCategories: true,
+          TemplatePreview: true,
+        },
+      },
+    })
+  }
+
+  it('keeps the root modal content mounted while closed', () => {
+    const wrapper = mountComponent()
+
+    expect(wrapper.findComponent({ name: 'Modal' }).props('keepContent')).toBe(
+      ''
+    )
+  })
+})


### PR DESCRIPTION
### What is in this PR

This PR fixes multiple bugs with the templates.

### How to test this PR

- on develop first import the template I join to the related slack message
- Then create and show a workflow in the editor
- Then open the loaded template and select one of the workflow.
- Close the modal and notice that the workflow content has been replace with the content of the template 
- Reopen this template and navigate from one workflow to the other and check that the publish button of the editor behind the overlay changes because of that.
- Now after swtiching between the two workflows, close the modal. You should see an error page (or an error in the console I don't remember).
- Reload the page and open again the template but the application section, Choose the page "Task files". It should crash or at least not show the page.
- Checkout this branch and check all three bugs are gone.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~ No changelog as it was never released.
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
