### PR TITLE
fix: Slack Bot Form translation placeholders

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_the_slack_bot_forms_translations_to_use_the_correct_pl.json
+++ b/changelog/entries/unreleased/bug/fixed_the_slack_bot_forms_translations_to_use_the_correct_pl.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed the Slack Bot Form's translations to use the correct placeholders.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-03-26"
+}

--- a/web-frontend/modules/integrations/locales/en.json
+++ b/web-frontend/modules/integrations/locales/en.json
@@ -206,14 +206,15 @@
     "supportDescription": "If you need any assistance with pairing with your Slack app, please refer to the steps below.",
     "supportSetupHeading": "1. Setting up the app",
     "supportSetupDescription": "Depending on your Slack workspace settings, you may be able to create a new Slack app. Otherwise, an admin will need to do this for you. If you are re-using an existing app which can write messages, skip to the section called 'Pairing with your Slack app'.",
-    "supportSetupStep1": "Navigate to your workspace's &lt;a href=\"https://api.slack.com/apps\" target=\"_blank\"&gt;apps page&lt;/a&gt;.",
+    "supportSetupStep1": "Navigate to your workspace's {link}.",
+    "supportSetupStep1Link": "apps page",
     "supportSetupStep2": "Create a new app, choose 'From scratch' and enter a name. Select the workspace your app should operate in, and click 'Create'.",
-    "supportSetupStep3": "In the left sidebar, navigate to 'OAuth &amp; Permissions', scroll down to Scopes and under 'Bot Token Scopes', select 'Add an OAuth Scope'.",
-    "supportSetupStep4": "To allow your app to post messages, add the &lt;pre&gt;chat:write&lt;/pre&gt; scope.",
+    "supportSetupStep3": "In the left sidebar, navigate to 'OAuth > Permissions', scroll down to Scopes and under 'Bot Token Scopes', select 'Add an OAuth Scope'.",
+    "supportSetupStep4": "To allow your app to post messages, add the {scope} scope.",
     "supportPairingHeading": "2. Pairing with your Slack app",
-    "supportPairingStep1": "If your app is new: navigate to the 'Settings' &gt; 'Install App'. Click the green button to install the app to your workspace.",
+    "supportPairingStep1": "If your app is new: navigate to 'Settings' > 'Install App'. Click the green button to install the app to your workspace.",
     "supportPairingStep2": "Copy your 'Bot User OAuth Token' and store it in the 'Bot User Token' field in this form.",
-    "supportPairingStep3": "Finally, if your app is new: in Slack, invite your app to your chosen channel with &lt;pre&gt;/invite {'@'}yourAppName yourChannel&lt;/pre&gt;"
+    "supportPairingStep3": "Finally, if your app is new: in Slack, invite your app to your chosen channel with {command}"
   },
   "slackWriteMessageServiceForm": {
     "alertMessage": "This action must be paired with a Slack app. Please follow the guide in the integrations popup to get started.",


### PR DESCRIPTION
### What is in this PR
This PR fixes some translation placeholders for the Slack Bot Form.

| Before | After |
| - | - |
| <img width="550" height="584" alt="image" src="https://github.com/user-attachments/assets/0df6e0b1-daba-45fe-8216-68ef6c9a04fb" /> | <img width="549" height="556" alt="Screenshot 2026-03-26 at 11 31 48 AM" src="https://github.com/user-attachments/assets/06c7e203-fcb5-42f6-88ca-58799b9600bf" /> |

### How to test this PR
In `develop`, open the Slack Bot Form (via Builder or Automation). You'll notice the issues in the "before" screenshot are present. In this branch the placeholders should be fixed.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
