### PR TITLE
fix (CI): use correct GitHub label names in database project workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ This workflow automatically updates the Database Team's GitHub Project board bas
 
 The workflow triggers on PR events (opened, review requested, review submitted, merged, etc.) and automatically:
 
-1. **Checks domain labels** - Only processes PRs with labels starting with `domain::database` or `domain::core`
+1. **Checks domain labels** - Only processes PRs with labels starting with `database 🗄`
 2. **Adds PR to project** - Ensures the PR is added to the Database Team project board
 3. **Updates Status field** - Sets the PR status based on its state:
    - `In Progress` - PR is a draft

--- a/.github/workflows/database-projects-issues-workflow.yml
+++ b/.github/workflows/database-projects-issues-workflow.yml
@@ -2,7 +2,7 @@ name: Update Database Team Project Fields
 
 env:
   PROJECT_NUMBER: '3'
-  DOMAIN_LABELS: '["domain::database"]'
+  DOMAIN_LABELS: '["database 🗄️"]'
   STATUS_FIELD_NAME: 'Status'
   STATUS_TODO: 'Todo'
 
@@ -91,7 +91,7 @@ jobs:
               return;
             }
 
-            console.log(`Issue has domain label: ${labels.filter(l => l.startsWith('domain::')).join(', ')}`);
+            console.log(`Issue has domain label: ${labels.filter(l => domainLabels.some(d => l.startsWith(d))).join(', ')}`);
 
             // ============================================================
             // CHECK IF ALREADY IN PROJECT

--- a/.github/workflows/database-projects-pr-workflow.yml
+++ b/.github/workflows/database-projects-pr-workflow.yml
@@ -2,7 +2,7 @@ name: Database Team PR Automation
 
 env:
   PROJECT_NUMBER: '3'
-  DOMAIN_LABELS: '["domain::database"]'
+  DOMAIN_LABELS: '["database 🗄️"]'
   STATUS_FIELD_NAME: 'Status'
   REVIEW_STATUS_FIELD_NAME: 'Review Status'
   STATUS_IN_PROGRESS: 'In Progress'
@@ -26,6 +26,7 @@ on:
 
 jobs:
   update-status:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Update PR Project Status
@@ -114,7 +115,7 @@ jobs:
               return;
             }
 
-            console.log(`PR has domain label: ${labels.filter(l => l.startsWith('domain::')).join(', ')}`);
+            console.log(`PR has domain label: ${labels.filter(l => domainLabels.some(d => l.startsWith(d))).join(', ')}`);
 
             const statusField = project.fields.nodes.find(f => f.name === '${{ env.STATUS_FIELD_NAME }}');
             const reviewStatusField = project.fields.nodes.find(f => f.name === '${{ env.REVIEW_STATUS_FIELD_NAME }}');


### PR DESCRIPTION
The workflows were filtering on `domain::database` which doesn't exist. Updated to match the actual label `database 🗄️`. Also skip Dependabot PRs to avoid failures when the project token secret is unavailable.
