### PR TITLE
fix: ensure correct error is shown when exceeding the max publish job count

### DIFF
--- a/backend/src/baserow/contrib/builder/api/domains/views.py
+++ b/backend/src/baserow/contrib/builder/api/domains/views.py
@@ -17,6 +17,7 @@ from baserow.api.decorators import (
     validate_body,
     validate_body_custom_fields,
 )
+from baserow.api.jobs.errors import ERROR_MAX_JOB_COUNT_EXCEEDED
 from baserow.api.jobs.serializers import JobSerializer
 from baserow.api.schemas import CLIENT_SESSION_ID_SCHEMA_PARAMETER, get_error_schema
 from baserow.api.utils import (
@@ -49,6 +50,7 @@ from baserow.contrib.builder.domains.service import DomainService
 from baserow.contrib.builder.exceptions import BuilderDoesNotExist
 from baserow.contrib.builder.handler import BuilderHandler
 from baserow.core.exceptions import ApplicationDoesNotExist
+from baserow.core.jobs.exceptions import MaxJobCountExceeded
 from baserow.core.jobs.registries import job_type_registry
 
 
@@ -331,6 +333,7 @@ class AsyncPublishDomainView(APIView):
             400: get_error_schema(
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_MAX_JOB_COUNT_EXCEEDED",
                 ]
             ),
             404: get_error_schema(["ERROR_APPLICATION_DOES_NOT_EXIST"]),
@@ -341,6 +344,7 @@ class AsyncPublishDomainView(APIView):
         {
             ApplicationDoesNotExist: ERROR_APPLICATION_DOES_NOT_EXIST,
             DomainDoesNotExist: ERROR_DOMAIN_DOES_NOT_EXIST,
+            MaxJobCountExceeded: ERROR_MAX_JOB_COUNT_EXCEEDED,
         }
     )
     def post(self, request, domain_id: int):

--- a/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
+++ b/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
@@ -373,6 +373,41 @@ def test_publish_builder(mock_run_async_job, api_client, data_fixture):
     assert args[0][0] == response_json["id"]
 
 
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.core.jobs.handler.run_async_job")
+def test_publish_builder_max_job_count_exceeded(
+    mock_run_async_job, api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    builder = data_fixture.create_builder_application(user=user)
+    data_fixture.create_builder_page(builder=builder, user=user)
+    domain = data_fixture.create_builder_custom_domain(
+        domain_name="test.getbaserow.io", builder=builder
+    )
+    url = reverse(
+        "api:builder:domains:publish",
+        kwargs={"domain_id": domain.id},
+    )
+
+    # Simulate publishing 2 builder apps. Since we're patching run_async_job,
+    # the jobs will never complete.
+    api_client.post(
+        url, {"domain_id": domain.id}, format="json", HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+    api_client.post(
+        url, {"domain_id": domain.id}, format="json", HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+    response = api_client.post(
+        url,
+        {"domain_id": domain.id},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_MAX_JOB_COUNT_EXCEEDED"
+
+
 @pytest.mark.django_db
 def test_get_elements_of_public_builder(api_client, data_fixture):
     user = data_fixture.create_user()

--- a/changelog/entries/unreleased/bug/ensure_that_the_correct_error_is_shown_when_exceeding_the_ma.json
+++ b/changelog/entries/unreleased/bug/ensure_that_the_correct_error_is_shown_when_exceeding_the_ma.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ensure that the correct error is shown when exceeding the max publish job count.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-30"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes the error message shown when publishing a Builder app and the max publish job count is exceeded.

Resolves Sentry issue 97971623.

We already have a clean up job that clears pending jobs after `BASEROW_JOB_SOFT_TIME_LIMIT` expires (which seems to be 30 minutes). Ideally, I think we should expose the pending jobs in the frontend, and let the user manually cancel/clear jobs.

### How to test this PR
In `develop`, update the `core_job` table and ensure at least two rows have their `state` set to `started`. Then attempt to publish a Builder app. You'll see a generic error in the frontend, and the backend container crash with:
```
  File "/baserow/backend/src/baserow/core/jobs/registries.py", line 74, in can_schedule_or_raise
    raise MaxJobCountExceeded(
    ...<2 lines>...
    )
baserow.core.jobs.exceptions.MaxJobCountExceeded: You can only launch 2 publish_domain job(s) at the same time.
```

In this branch, you'll see a more specific error message, and the backend won't crash.

| Before | After |
| - | - |
| <img width="305" height="122" alt="Screenshot 2026-03-30 at 11 14 59 AM" src="https://github.com/user-attachments/assets/da541db0-fa12-4f88-a774-877ba1632c6a" /> | <img width="306" height="156" alt="Screenshot 2026-03-30 at 11 14 09 AM" src="https://github.com/user-attachments/assets/dfa0687a-d101-489c-bbd8-8296f133c800" /> |

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
