### PR TITLE
fix: clear polling when publish modal is re-opened or domain is changed

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_bug_where_reopening_the_publish_modal_while_the_buil.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_where_reopening_the_publish_modal_while_the_buil.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where reopening the Publish modal while the builder is still publishing can cause an error.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-30"
+}

--- a/web-frontend/modules/builder/components/page/header/PublishActionModal.vue
+++ b/web-frontend/modules/builder/components/page/header/PublishActionModal.vue
@@ -130,6 +130,7 @@ export default {
   },
   watch: {
     selectedDomainId() {
+      this.stopPollIfRunning()
       this.job = null
     },
     domains() {
@@ -147,6 +148,7 @@ export default {
       actionForceUpdateDomain: 'domain/forceUpdate',
     }),
     async onShow() {
+      this.stopPollIfRunning()
       this.hideError()
       this.job = null
       this.loading = false


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in the Builder's Publish modal.

When publishing a Builder app, a poller is started that periodically checks to see if the app has been published. If you publish the domain, then close and re-open the publish modal before the publishing completes, you'll see this error in the console:
```
jobProgress.js:68 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'id')
    at Proxy.getLatestJobInfo (jobProgress.js:68:75)
```

Fixes Sentry issue 97591285.

### How to test this PR
To test this, you'll need to simulate a long running publish. In `builder/domains/job_types.py::PublishDomainJobType::run`, add a delay before running the job:
```
def run(...):
    ...
    import time
    time.sleep(5)
    DomainService().publish(job.user, job.domain, progress)
```

Then in `develop`:
- Add a domain
- Publish the app and close the modal
- Quickly re-open the modal

You can also see the same error if you have two domains:
- Add two domains
- Publish the app to the first domain, but do not close the modal
- While the publish is still working, select the second domain in the same modal

In this branch, you shouldn't see any errors.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
