### PR TITLE
fix: ensure correct error is shown when builder page isn't found

### DIFF
--- a/changelog/entries/unreleased/bug/ensure_the_correct_error_is_shown_when_a_page_is_not_found.json
+++ b/changelog/entries/unreleased/bug/ensure_the_correct_error_is_shown_when_a_page_is_not_found.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ensure the correct error is shown when a page is not found.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-30"
+}

--- a/web-frontend/modules/builder/pages/publicPage.vue
+++ b/web-frontend/modules/builder/pages/publicPage.vue
@@ -232,7 +232,7 @@ const {
         await logOffAndReturnToLogin({ builder, store, redirect: navigateTo })
       } else if (
         error.response?.status === 404 &&
-        error.response?.data?.error === 'ERROR_PAGE_NOT_FOUND'
+        error.response?.data?.error === 'ERROR_PAGE_DOES_NOT_EXIST'
       ) {
         // This case is when you had a tab open on the site and the site has been
         // published in the meantime. Page IDs aren't valid anymore


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug that causes a generic error to be shown when a Builder page doesn't exist for a published app.

It looks like the bug was introduced when we changed the error code in the backend to `ERROR_PAGE_DOES_NOT_EXIST`, but we forgot to update the frontend. This caused the error handling to fall through to the `else` block when fetching data sources, causing two issues:
- We show a generic error instead of a more useful specific one
- A Sentry issue is logged

Resolves Sentry issues: 104015294, 97483965, 104434460, 104434450.

### How to test this PR
Create a Builder app with two pages, one of them should have a data source. You can just use the default pages of a new Builder app as well.

Publish the app and view it, but don't close the tab.

Re-publish the app. Now in the existing tab, navigate to the other page (which will trigger a data source dispatch). You should see a generic error.

The error itself is self-correcting; the user just needs to reload the page. But we shouldn't be logging to Sentry.

In this branch, you should see a more specific error:
| Before | After |
| - | - |
| <img width="625" height="410" alt="Screenshot 2026-03-30 at 2 44 50 PM" src="https://github.com/user-attachments/assets/bc9f7c9e-aec0-4423-8f7a-b852acf19e51" /> |  <img width="622" height="354" alt="Screenshot 2026-03-30 at 2 45 24 PM" src="https://github.com/user-attachments/assets/29ed06c1-a2ef-418e-a41c-f150c107e1c7" /> |

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
