### PR TITLE
chore: silence frontend deprecation warnings for sass

### DIFF
--- a/web-frontend/config/nuxt.config.base.ts
+++ b/web-frontend/config/nuxt.config.base.ts
@@ -81,6 +81,22 @@ export default defineNuxtConfig({
     },
   },
   vite: {
+    css: {
+      preprocessorOptions: {
+        scss: {
+          // TODO: Migrate all @import rules to @use/@forward (Dart Sass 3.0 will remove @import).
+          //  Also fix global-builtin (unquote → string.unquote in colors.module.scss)
+          //  and if-function (old if() syntax in abstracts/_helpers.scss).
+          //  See https://sass-lang.com/d/import for the migration guide and automated migrator.
+          silenceDeprecations: [
+            'import',
+            'global-builtin',
+            'if-function',
+            'color-functions',
+          ],
+        },
+      },
+    },
     plugins: [
       nodePolyfills({
         include: ['util'],


### PR DESCRIPTION
## Summary
- Silence Dart Sass deprecation warnings (`import`, `global-builtin`, `if-function`, `color-functions`) introduced by the sass 1.98 upgrade
- Added TODO with migration notes for when we properly move to `@use`/`@forward`

## Context
Sass 1.98 emits deprecation warnings for features being removed in Dart Sass 3.0. The warnings are noisy but harmless — silencing them keeps the dev console clean while we plan the actual migration.

## Test plan
- [x] `npx nuxt dev` starts without sass deprecation warnings
