### PR TITLE
fix: ensure local baserow upsert service handles field constraint errors

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -2146,7 +2146,7 @@ class LocalBaserowUpsertRowServiceType(
                 ) from exc
             except FieldDataConstraintException as exc:
                 raise InvalidContextContentDispatchException(
-                    f"The row with id {row_id} violates a unique constraint."
+                    f"The row with id {row_id} violates a field constraint."
                 ) from exc
         else:
             try:
@@ -2164,7 +2164,7 @@ class LocalBaserowUpsertRowServiceType(
             except FieldDataConstraintException as exc:
                 raise InvalidContextContentDispatchException(
                     f"Cannot create rows in table {table.id} because "
-                    "it violates a unique constraint."
+                    "it violates a field constraint."
                 ) from exc
 
         return {

--- a/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
+++ b/backend/tests/baserow/contrib/builder/api/workflow_actions/test_workflow_actions_views.py
@@ -643,13 +643,13 @@ def test_dispatch_local_baserow_create_row_workflow_action(api_client, data_fixt
 
 
 @pytest.mark.django_db
-def test_dispatch_local_baserow_create_row_workflow_action_unique_constraint(
+def test_dispatch_local_baserow_create_row_workflow_action_field_constraint(
     api_client, data_fixture
 ):
     user, token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)
 
-    # Create a field that has a unique constraint
+    # Create a field that has a constraint, e.g. unique
     fruit_field = FieldHandler().create_field(
         user=user,
         table=table,
@@ -690,7 +690,7 @@ def test_dispatch_local_baserow_create_row_workflow_action_unique_constraint(
     assert response_json["error"] == "ERROR_SERVICE_INVALID_DISPATCH_CONTEXT_CONTENT"
     assert (
         response_json["detail"]
-        == f"Cannot create rows in table {table.id} because it violates a unique constraint."
+        == f"Cannot create rows in table {table.id} because it violates a field constraint."
     )
 
 
@@ -753,13 +753,13 @@ def test_dispatch_local_baserow_update_row_workflow_action(api_client, data_fixt
 
 
 @pytest.mark.django_db
-def test_dispatch_local_baserow_update_row_workflow_action_unique_constraint(
+def test_dispatch_local_baserow_update_row_workflow_action_field_constraint(
     api_client, data_fixture
 ):
     user, token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)
 
-    # Create a field that has a unique constraint
+    # Create a field that has a constraint, e.g. unique
     fruit_field = FieldHandler().create_field(
         user=user,
         table=table,
@@ -803,7 +803,7 @@ def test_dispatch_local_baserow_update_row_workflow_action_unique_constraint(
     assert response_json["error"] == "ERROR_SERVICE_INVALID_DISPATCH_CONTEXT_CONTENT"
     assert (
         response_json["detail"]
-        == f"The row with id {second_row.id} violates a unique constraint."
+        == f"The row with id {second_row.id} violates a field constraint."
     )
 
 

--- a/changelog/entries/unreleased/bug/ensure_local_baserow_upsert_integration_handles_unique_const.json
+++ b/changelog/entries/unreleased/bug/ensure_local_baserow_upsert_integration_handles_unique_const.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Ensure Local Baserow Upsert integration handles unique constraint errors.",
+    "message": "Ensure Local Baserow Upsert integration handles field constraint errors.",
     "issue_origin": "github",
     "issue_number": null,
     "domain": "integration",


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug in the local baserow upsert service. When creating/updating a row, e.g. via a Builder Workflow Action and it causes a field constraint violation (e.g. unique constraint), we currently crash hard. This is because we're currently not handling the `FieldDataConstraintException` exception from the DB code.

Resolves Sentry issue 95410954

### How to test this PR
Since Silk interferes with the exception chain, you'll first want to disable Silk in `dev.py`:
```
# BASEROW_ENABLE_SILK = str_to_bool(os.getenv("BASEROW_ENABLE_SILK", "on"))
BASEROW_ENABLE_SILK = False
```

In `develop`:
- In a Database table, create a text field with a unique constraint.
  - Add 2 rows.
  - For the first row, set the text field to any string value, e.g. `Apple`.
- In Builder, create a Button that has a Workflow Action -> Create Row event.
  - Set the service's field to create a new row with a value of `Apple`.
- Also in Builder, create another Button that has a Workflow Action -> Update Row event.
  - Set the service to update row 2 with a new value of `Apple`.

In preview mode, click either buttons and you'll see the backend crashes with:
```
  File "/baserow/backend/src/baserow/contrib/database/rows/handler.py", line 1399, in force_create_rows
    raise FieldDataConstraintException()
baserow.contrib.database.fields.exceptions.FieldDataConstraintException
```

While the frontend shows a generic error.

In this branch, the exception is handled and the UI shows a more friendly error:
| Before | After |
| - | - |
| <img width="303" height="130" alt="Screenshot 2026-03-30 at 4 37 00 PM" src="https://github.com/user-attachments/assets/4d992edd-0918-4667-b848-ee66d103f713" /> | <img width="311" height="198" alt="Screenshot 2026-03-30 at 4 54 28 PM" src="https://github.com/user-attachments/assets/021a0c8f-fae1-4e2f-a659-7882d832e124" /> |

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
