### PR TITLE
fix: data provider should use UTC if timezone is unknown

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_bug_where_an_unknown_timezone_could_cause_a_data_sou.json
+++ b/changelog/entries/unreleased/bug/fixed_a_bug_where_an_unknown_timezone_could_cause_a_data_sou.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where an unknown timezone could cause a data source dispatch to fail.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-03-31"
+}

--- a/web-frontend/modules/builder/dataProviderTypes.js
+++ b/web-frontend/modules/builder/dataProviderTypes.js
@@ -941,7 +941,10 @@ export class UserDataProviderType extends DataProviderType {
     const { is_authenticated: isAuthenticated, id } =
       this.getDataContent(applicationContext)
 
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    if (!timezone || timezone.toLowerCase().includes('unknown')) {
+      timezone = 'UTC'
+    }
 
     if (isAuthenticated) {
       return {


### PR DESCRIPTION
### What is in this PR
Sentry's stack trace shows an invalid timezone being sent to the backend:
```
{
arguments: [
Moment Timezone found Etc/Unknown from the Intl api, but did not have that data loaded.
],
logger: console
}
```

The PR updates the `UserDataProviderType` to send `UTC` when the timezone is unknown, instead of the invalid `Etc/Unknown` timezone.

I considered refactoring the backend `DispatchDataSourceUserContextSerializer` serializer to coerce unknown timezone's to UTC, but maybe this fix is sufficient? The backend already returns a valid 400 message:
```
{"user":{"timezone":["\"Etc/Unknown\" is not a valid choice."]}}
```

Resolves Sentry issue 97323857.

### How to test this PR
It's a bit tricky to test this, since the error appears to be caused by a user specific browser/OS setting causing moment.js to return `Etc/Unknown` as the timezone.

Still, you can reproduce the "error" (in quotes, because the backend is returning the correct 400 response), by just copying a network request to `dispatch-data-sources/`, then in your console modifying the payload to send the invalid timezone:
```
{
    "metadata": {
        "user": {
            "id": null,
            "timezone": "Etc/Unknown"
        },
        ...
    }
}
```

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
