### PR TITLE
chore: add claude configuration from generic files

### DIFF
--- a/.agents/skills/add-django-config-env-var/SKILL.md
+++ b/.agents/skills/add-django-config-env-var/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: add-django-config-env-var
+name: Add Django Config Env Var
 description: Add a new environment variable for a Django setting in Baserow and propagate it to the few repo files that usually need it. Use this when a request says a config env var must be added in several places or references `INTEGRATION_LOCAL_BASEROW_PAGE_SIZE_LIMIT` as the pattern to follow.
+version: 1.0.0
 ---
 
 # Add Django Config Env Var
@@ -17,6 +18,7 @@ When adding a new setting, usually check these files:
 - `docker-compose.yml`
 - `docker-compose.no-caddy.yml`
 - `web-frontend/env-remap.mjs`
+- `docs/installation/configuration.md` — the canonical env-var reference table; add a row in the right section
 - Backend or frontend code that uses the setting
 - A focused test if behavior changes
 
@@ -44,7 +46,7 @@ MY_SETTING = int(os.getenv("BASEROW_MY_SETTING", 123))
 
 5. Add or update a targeted test if the setting changes behavior.
 
-6. Add the related documentation
+6. Add the related documentation in `docs/installation/configuration.md` — find the right section (e.g. Backend Configuration, Integration Configuration) and add a table row matching the format of the nearest existing entry.
 
 ## Quick Checklist
 
@@ -53,7 +55,7 @@ MY_SETTING = int(os.getenv("BASEROW_MY_SETTING", 123))
 3. Add the Nuxt remap if frontend code needs it
 4. Use `settings.<NAME>` in code
 5. Add a focused test if needed
-6. Add the documentation
+6. Add a row to `docs/installation/configuration.md`
 
 ## Guardrails
 

--- a/.agents/skills/create-update-service/SKILL.md
+++ b/.agents/skills/create-update-service/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: create-update-service
-description: Allow to create or update Baserow Integrations and Services
+name: Integrations and Services
+description: Create or update Baserow integration types and service types in `contrib/integrations`. Use when adding a new ServiceType/IntegrationType subclass, registering one in `apps.py` or `plugin.js`, or updating an existing dispatch/auth flow.
+version: 1.0.0
 ---
 
 # Create Or Update Baserow Services And Integrations

--- a/.agents/skills/write-frontend-unit-test/SKILL.md
+++ b/.agents/skills/write-frontend-unit-test/SKILL.md
@@ -1,6 +1,7 @@
 ---
-name: write-frontend-unit-test
+name: Write Frontend Unit Test
 description: Write or update Baserow frontend unit tests for core, premium, or enterprise code using the repo's existing Vitest, Nuxt, Vue Test Utils, TestApp, and snapshot patterns.
+version: 1.0.0
 ---
 
 # Write Baserow Frontend Unit Tests

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ Examples: `just b test backend/tests/path/`, `just b test-coverage`, `just f tes
 
 Recent history favors short, imperative subjects, often with Conventional Commit prefixes such as `fix:`, `feat:`, and `chore(deps):`. Branch from `develop`, keep PRs focused, and link the related issue or discussion. Include a clear summary, note schema or env changes, attach screenshots for UI work, add a changelog entry when required, and make sure the relevant lint and test commands pass before opening the PR.
 
+## Project Skills
+
+Reusable skills live in `.agents/skills/`. Each subdirectory is a self-contained skill with a `SKILL.md` that describes when and how to apply it. Use these instead of re-deriving the same workflow from scratch.
+
+| Skill directory | When to use |
+|---|---|
+| `add-django-config-env-var` | Adding a new Django setting backed by an env var and propagating it to `base.py`, docker-compose files, `env-remap.mjs`, and `docs/installation/configuration.md` |
+| `write-frontend-unit-test` | Writing or fixing frontend unit tests in `web-frontend`, `premium/web-frontend`, or `enterprise/web-frontend` |
+| `create-update-service` | Creating or updating an integration type or service type in `contrib/integrations` |
+
 ## Security & Configuration Tips
 
 Do not commit secrets or local overrides. Use `.env.local` for development, keep production settings in the documented deploy configs, and report vulnerabilities privately via the contact path in `CONTRIBUTING.md` rather than opening a public issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+@AGENTS.md
+
+## Skills
+
+`.claude/skills` is a symlink to `.agents/skills`, the canonical location for project skills. Both paths resolve to the same directory.


### PR DESCRIPTION
### What is in this PR

I recently introduced the `AGENTS.md` and `.agents/skills` to the repository to optimize work with AI. This paths/files work by default with `codex` but not with `claude`. This PR fixes that by using the generic file as specific `claude` configuration files.

### How to test this PR

Start 'claude' code and use `/skills` command to check that the existing skills are listed.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
