### PR TITLE
skill: add the silk-profiler skill to investigate backend bottlenecks

### DIFF
--- a/.agents/skills/silk-profiler/SKILL.md
+++ b/.agents/skills/silk-profiler/SKILL.md
@@ -280,4 +280,6 @@ Once you've identified the problematic query and its origin in the stack trace:
 - **Use read-only queries only.** Never run INSERT, UPDATE, DELETE, or DDL on any table.
 - **Never enable `SILKY_ANALYZE_QUERIES`** (`BASEROW_DANGEROUS_SILKY_ANALYZE_QUERIES`). It runs every UPDATE twice and breaks data integrity.
 - **Do not truncate Silk tables** without asking the user first.
+- **Ground every claim in data.** Always quote the specific evidence (EXPLAIN output, stack trace lines, source code with file path and line number) when making a diagnosis. Never state that a query is slow, an index is missing, or a `select_related` is needed without showing the data that supports it.
 - When proposing fixes, always read the actual source code first — don't guess from the query text alone.
+- **Confirm findings with the user.** When a user describes a problem without a Silk URL or request ID, confirm the matching request was found and provide its Silk URL (e.g. `http://localhost:8000/silk/request/<uuid>/`) so the user can verify before proceeding.


### PR DESCRIPTION
## Summary

Adds a `silk-profiler` Claude Code skill that helps developers investigate slow endpoints by querying Django Silk profiling data directly from the dev database. It identifies N+1 queries, slow individual queries, and traces them to source code via stack traces.
