### PR TITLE
fix: ensure Automation Workflow max publish job count error is handled

### DIFF
--- a/backend/src/baserow/contrib/automation/api/workflows/views.py
+++ b/backend/src/baserow/contrib/automation/api/workflows/views.py
@@ -379,6 +379,7 @@ class AsyncPublishAutomationWorkflowView(APIView):
             400: get_error_schema(
                 [
                     "ERROR_REQUEST_BODY_VALIDATION",
+                    "ERROR_MAX_JOB_COUNT_EXCEEDED",
                 ]
             ),
             404: get_error_schema(["ERROR_AUTOMATION_WORKFLOW_DOES_NOT_EXIST"]),
@@ -388,6 +389,7 @@ class AsyncPublishAutomationWorkflowView(APIView):
     @map_exceptions(
         {
             AutomationWorkflowDoesNotExist: ERROR_AUTOMATION_WORKFLOW_DOES_NOT_EXIST,
+            MaxJobCountExceeded: ERROR_MAX_JOB_COUNT_EXCEEDED,
         }
     )
     def post(self, request, workflow_id: int):

--- a/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
+++ b/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
@@ -526,6 +526,43 @@ def test_publish_workflow(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_publish_workflow_error_max_job_count_exceeded(api_client, data_fixture):
+    user = data_fixture.create_user()
+    automation = data_fixture.create_automation_application(user)
+    workflow_1 = data_fixture.create_automation_workflow(
+        user, automation=automation, name="test1"
+    )
+    workflow_2 = data_fixture.create_automation_workflow(
+        user, automation=automation, name="test2"
+    )
+    workflow_3 = data_fixture.create_automation_workflow(
+        user, automation=automation, name="test3"
+    )
+
+    token = data_fixture.generate_token(user)
+    for workflow_id in [workflow_1.id, workflow_2.id]:
+        url = reverse(API_URL_WORKFLOW_PUBLISH, kwargs={"workflow_id": workflow_id})
+        response = api_client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_202_ACCEPTED
+
+    url = reverse(API_URL_WORKFLOW_PUBLISH, kwargs={"workflow_id": workflow_3.id})
+    response = api_client.post(
+        url,
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "detail": "Max running job count for this type is exceeded.",
+        "error": "ERROR_MAX_JOB_COUNT_EXCEEDED",
+    }
+
+
+@pytest.mark.django_db
 def test_publish_workflow_error_invalid_workflow(api_client, data_fixture):
     _, token = data_fixture.create_user_and_token()
 

--- a/changelog/entries/unreleased/bug/ensure_the_max_publish_job_count_error_is_shown_when_exceedi.json
+++ b/changelog/entries/unreleased/bug/ensure_the_max_publish_job_count_error_is_shown_when_exceedi.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ensure the max publish job count error is shown when exceeding the limit for publishing an Automation Workflow.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-04-01"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes the error message shown when publishing an Automation Workflow and the max publish job count is exceeded.

This is similar to the [fix for Builder](https://github.com/baserow/baserow/pull/5073).

We already have a clean up job that clears pending jobs after `BASEROW_JOB_SOFT_TIME_LIMIT` expires (which seems to be 30 minutes). Ideally, I think we should expose the pending jobs in the frontend, and let the user manually cancel/clear jobs.

Resolves Sentry issue 99452681.

### How to test this PR
In develop, update the `core_job` table and ensure at least two rows have their state set to `started`. Then attempt to publish a Workflow. You'll see a generic error in the frontend, and the backend container crash with:
```
  File "/baserow/backend/src/baserow/core/jobs/registries.py", line 74, in can_schedule_or_raise
    raise MaxJobCountExceeded(
    ...<2 lines>...
    )
baserow.core.jobs.exceptions.MaxJobCountExceeded: You can only launch 2 publish_automation_workflow job(s) at the same time.
```

In this branch, you'll see a more specific error message, and the backend won't crash.

| Before | After |
| - | - |
| <img width="305" height="122" alt="Screenshot 2026-03-30 at 11 14 59 AM" src="https://github.com/user-attachments/assets/da541db0-fa12-4f88-a774-877ba1632c6a" /> | <img width="306" height="156" alt="Screenshot 2026-03-30 at 11 14 09 AM" src="https://github.com/user-attachments/assets/dfa0687a-d101-489c-bbd8-8296f133c800" /> |

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
