### PR TITLE
chore: update contributing guidelines and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
-name: 🪲 Bug Report
+name: Bug Report
 description: Report a reproducible bug in Baserow.
-labels: ["needs feedback ⚠️", "bug 🪲"]
+type: "Bug"
 body:
   - type: markdown
     attributes:
@@ -19,8 +19,8 @@ body:
   - type: textarea
     id: steps
     attributes:
-      label: Steps to reproduce
-      description: List the steps required to reproduce the error.
+      label: Steps to reproduce and actual result
+      description: List the steps required to reproduce the error and what currently happens.
       placeholder: |
         1. Go to '...'
         2. Click on '...'
@@ -29,20 +29,10 @@ body:
       required: true
 
   - type: textarea
-    id: actual-result
-    attributes:
-      label: Actual result
-      description: What currently happens in Baserow.
-    validations:
-      required: true
-
-  - type: textarea
     id: expected-result
     attributes:
       label: Expected result
       description: What you expected to happen instead.
-    validations:
-      required: true
 
   - type: textarea
     id: environment

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
-name: 💡 Feature Request
+name: Feature Request
 description: Suggest an idea or feature for Baserow.
-labels: ["needs feedback ⚠️", "feature request 💡"]
+type: "Feature"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,17 @@
+name: Task
+description: Documentation updates, refactoring, dependency bumps, or other non-feature, non-bug work.
+type: "Task"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for tasks that aren't bug fixes or new features.
+        Small tasks (typos, broken links) can go straight to a PR without an issue — see [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why.
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,76 +1,110 @@
-# Contributing
+# Contributing to Baserow
 
-We love your input! We want to make contributing to this project as easy and
-transparent as possible. If you wish to contribute please first discuss the change
-you wish to make via an issue, email, contact form at https://baserow.io/contact or
-any other method with us. If you do not know on what to contribute, please send us a
-small overview of your experience and optionally what you would like to learn. We will
-get back to you as soon as possible with proposed issues.
+We appreciate your interest in contributing to Baserow. To make the process smooth for everyone, please read these guidelines before opening a pull request.
 
-## We develop with GitLab
+We're a small team. Creating a PR with some changes is easy — reviewing it thoroughly and ensuring it meets our standards takes significantly more time. These guidelines exist to make sure that effort is well spent on both sides.
 
-We use GitLab to host code, to track issues and to make feature requests. The official
-repository can be found on https://github.com/baserow/baserow/. 
+## Types of contributions
 
-## The merge request process
+### Bug fixes
 
-1. Open a new Feature Request/Change Request/Bug issue by selecting the corresponding 
-   issue type when creating an issue, or comment on an existing issue.
-1. Propose your plans and discuss them with the community on the issue.
-1. Fork the repository and create a branch from `develop`.
-1. Make the changes described in the issue.
-1. Ensure that your code meets the quality standards.
-1. Submit your merge request!
-1. Usually we enable the following GitLab merge options:
-    1. "Delete source branch when merge request is accepted. "
-    1. "Squash commits when merge request is accepted."
-1. A maintainer will review your code and merge your code.
+1. **Open a bug issue first** with steps to reproduce and expected behavior
+2. If the fix is obvious, open a PR right away. If you're unsure about the expected behavior or the right approach, wait for confirmation on the issue first.
+
+PRs without a corresponding issue will be closed.
+
+### Features and behavior changes
+
+Any PR that adds new functionality or changes existing behavior — no matter how small — requires prior approval.
+
+1. **Open a feature request issue** using the [feature request template](https://github.com/baserow/baserow/issues/new?template=feature_request.yml)
+2. Describe what you want to build, why and your proposed approach
+3. **Wait for explicit approval** from a maintainer before writing code
+4. Open your PR referencing the approved issue
+
+PRs for features without an approved issue will be closed. This isn't about gatekeeping — it's about making sure you don't invest time in something that won't be merged.
+
+### Tasks
+
+Tasks cover everything that isn't a feature or bug fix: typo corrections, broken links, documentation updates, refactoring, dependency bumps, etc.
+
+- **Small tasks** where the correctness is obvious on sight (typos, broken links, minor doc edits) can be submitted directly as a PR without an issue.
+- **Larger tasks** that touch multiple files or require design decisions need an issue and likely approval, same as features.
+
+If you're unsure, check whether a related issue already exists — if not, open one.
+
+## Before you start
+
+- Make sure your contribution either doesn't require an issue (small task) or has an approved issue (bug fix, feature, or large task). Don't write code before that.
+- Check [existing issues](https://github.com/baserow/baserow/issues) to avoid duplicate work
+- Fork the repository and create your branch from `develop`
+- Read the quality standards below
+
+## Pull request requirements
+
+Your PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format — it becomes the commit message in our git history. Keep it short and focused on the **intent** of the change, not what files were touched.
+
+Allowed prefixes: `fix:`, `feat:`, `chore:`, `docs:`. An optional scope in parentheses is encouraged: `fix(grid):`, `feat(formulas):`, `chore(deps):`.
+
+Examples:
+- `fix(forms): prevent submission with invalid rating value`
+- `feat: add Cloudflare Turnstile captcha to auth`
+- `chore(deps): bump requests to 2.33.0`
+- `docs: update contribution guidelines`
+
+Your PR must also include:
+
+- **A clear description** of what was changed and why
+- **How to test it** — steps a reviewer can follow to verify your changes
+- **A link to the issue** in the description (e.g., `Closes #123`), when applicable
+- **Tests** — backend changes need tests
+- **A changelog entry** generated using the script in `changelog/`
+
+### What will get your PR closed
+
+- **Modifying premium or enterprise code.** The `premium/` and `enterprise/` directories contain licensed code that is not open to external contributions. PRs that touch these directories — including moving code from them into core — will be closed immediately.
+- **No linked issue** for bug fixes or features (see above)
+- **No description or test instructions**
+- **Not following these guidelines** after being asked to
+
+### Size guideline
+
+Aim for focused, well-scoped PRs. As a rough guideline, we look at **lines of useful code (LOUC)** — excluding tests, boilerplate, translations, docs. A PR touching ~10 files with ~10 LOUC each is a reasonable upper bound, but complexity matters more than line count — a few lines in a critical path can be harder to review than hundreds of boilerplate. Tests and docs are excluded from LOUC but still need to be reviewed, so keep them concise and follow existing patterns. We may ask you to split a PR, reduce scope, or remove scope creep at our discretion.
+
+## What happens after you submit
+
+We review PRs as capacity allows.
+
+Possible outcomes:
+
+- **Approved and merged** — your PR meets our standards
+- **Changes requested** — we'll list what needs to change. Please respond within 2 weeks; PRs with no activity after that will be closed. You can always reopen later.
+- **Closed** — with an explanation of why. This is not personal — it's about priorities, alignment, and capacity. You can reopen if you resolve the issues, or open a fresh PR after incorporating our feedback.
+
+## Help us finish it
+
+If you've started something useful but don't have the time or context to bring it to our full quality standards, you can ask us to take it over. We may also proactively offer this on promising PRs.
+
+How it works:
+
+- Let us know in the PR that you'd like us to finish it
+- If the feature aligns with our priorities and the code is a solid foundation, we'll take it from there
+- **You get credited** as a contributor in the release. Let us know if you'd also like to be mentioned in the release blog post.
+
+We can't guarantee we'll do this for every PR. If the timing isn't right or the PR needs too many changes, we may decline. But we'll always do our best to recognize your work and, where possible, incorporate your contribution.
 
 ## Quality standards
 
-* Backend code must have unit tests.
-* Python code must be compliant with the PEP 8 standard.
-* In code Python docs must be in reStructured style.
-* SCSS code must be compliant with BEM.
-* JavaScript code must be compliant with the eslint:recommended rules.
-* In code documentation is required for every function or class that is not self-evident.
-* Documentation for every concept that can used by a plugin.
-* A new changelog entry file should be generated using the script found in the changelog folder.
-* The pipeline must pass.
-* Try to apply the **rule of 10s**: MRs should aim to have no more than 10 code files with more than 10 lines modified. 
-  A code file doesn't include tests/css/text/migrations/translations/configuration/ etc.
+See [Code quality](docs/development/code-quality.md) for the full list of standards, linters, and testing expectations. The CI pipeline must pass and security impact must be considered.
 
-## Any contributions you make will be under the MIT Software License
+## License
 
-In short, when you submit code changes, your submissions are understood to be under
-the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the
-project. Feel free to contact us if that is a concern.
+When you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project.
 
-## Bug reports
+## Security vulnerabilities
 
-We use GitHub issues to track public bugs. You can report a bug by opening a new issue
-at https://github.com/baserow/baserow/issues and selecting the Bug issue type. You may 
-also reach out to us via the community on https://community.baserow.io.
+If you find a security vulnerability, please report it privately via email or the contact form at https://baserow.io/contact — do not open a public issue.
 
-**Great Bug Reports** tend to have:
+## Questions?
 
-* A quick summary and/or background.
-* Steps to reproduce.
-  * Be specific!
-  * Give sample code if you can.
-* What you expected would happen.
-* What actually happens.
-* Notes (possibly including why you think this might be happening, or stuff you tried
-  that did not work)
-  
-People love thorough bug reports.
-
-## Vulnerability
-
-If you have found a vulnerability in Baserow we would appreciate it if you would notify
-us via email or via the contact form at https://baserow.io/contact instead of publicly
-as the vulnerability might need to be addressed first.
-
-## Updating Documentation
-
-The Baserow documentation can be updated by editing Markdown files in the `docs` directory. We use [CommonMark](https://commonmark.org/) specification rendered using [markdown-it](https://www.npmjs.com/package/markdown-it) library. The documentation site cannot be previewed at the moment, use a compatible Markdown editor to verify changes.
+For general questions about Baserow, use the [community forum](https://community.baserow.io/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ See [Code quality](docs/development/code-quality.md) for the full list of standa
 
 ## License
 
-When you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project.
+When you submit code changes, your submissions are understood to be under the same [MIT License](https://choosealicense.com/licenses/mit/) that covers the project.
 
 ## Security vulnerabilities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,18 +82,6 @@ Possible outcomes:
 - **Changes requested** — we'll list what needs to change. Please respond within 2 weeks; PRs with no activity after that will be closed. You can always reopen later.
 - **Closed** — with an explanation of why. This is not personal — it's about priorities, alignment, and capacity. You can reopen if you resolve the issues, or open a fresh PR after incorporating our feedback.
 
-## Help us finish it
-
-If you've started something useful but don't have the time or context to bring it to our full quality standards, you can ask us to take it over. We may also proactively offer this on promising PRs.
-
-How it works:
-
-- Let us know in the PR that you'd like us to finish it
-- If the feature aligns with our priorities and the code is a solid foundation, we'll take it from there
-- **You get credited** as a contributor in the release. Let us know if you'd also like to be mentioned in the release blog post.
-
-We can't guarantee we'll do this for every PR. If the timing isn't right or the PR needs too many changes, we may decline. But we'll always do our best to recognize your work and, where possible, incorporate your contribution.
-
 ## Quality standards
 
 See [Code quality](docs/development/code-quality.md) for the full list of standards, linters, and testing expectations. The CI pipeline must pass and security impact must be considered.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,11 @@ PRs without a corresponding issue will be closed.
 
 Any PR that adds new functionality or changes existing behavior — no matter how small — requires prior approval.
 
-1. **Open a feature request issue** using the [feature request template](https://github.com/baserow/baserow/issues/new?template=feature_request.yml)
-2. Describe what you want to build, why and your proposed approach
-3. **Wait for explicit approval** from a maintainer before writing code
-4. Open your PR referencing the approved issue
+1. Check [existing issues](https://github.com/baserow/baserow/issues) first — if an approved issue for the feature already exists, reference it in your PR instead of opening a new one. Only open a new feature request if no matching issue exists.
+2. **Open a feature request issue** using the [feature request template](https://github.com/baserow/baserow/issues/new?template=feature_request.yml)
+3. Describe what you want to build, why and your proposed approach
+4. **Wait for explicit approval** from a maintainer before writing code
+5. Open your PR referencing the approved issue
 
 PRs for features without an approved issue will be closed. This isn't about gatekeeping — it's about making sure you don't invest time in something that won't be merged.
 

--- a/docs/development/external-contributions.md
+++ b/docs/development/external-contributions.md
@@ -1,0 +1,176 @@
+# Handling External Contributions
+
+Internal guidelines for triaging and reviewing pull requests from external contributors.
+
+## Contribution categories
+
+Every external PR falls into one of three categories. The category determines what we require before reviewing.
+
+| Category | Requires issue? | Requires approval? | Can close immediately? |
+|----------|----------------|--------------------|-----------------------|
+| **Feature** | Yes | Yes (tech lead or product manager) | If no approved issue exists |
+| **Bug fix** | Yes (with repro steps) | No, but approach must be sound | If no issue or approach is wrong |
+| **Task** (small) | No | No | At our discretion |
+| **Task** (large) | Yes | Likely yes | If no issue or approach is wrong |
+
+**Tasks** cover anything that isn't a feature or bug fix: typo corrections, documentation updates, refactoring, dependency bumps, CI improvements, etc. Small tasks (obvious correctness, trivial scope) can go straight to a PR. Larger tasks that touch multiple files or require design decisions need an issue and likely approval, same as features.
+
+## Evaluation criteria
+
+For each PR, assess these criteria. The combination drives the decision — not any single criterion in isolation.
+
+| Criterion | Assessment |
+|-----------|-----------|
+| **Type** | Bug fix / feature / task (small or large) |
+| **Size** | Small (< 10 LOUC) / medium (10-100) / large (> 100). LOUC = lines of useful code, excluding tests, comments, translations, docs |
+| **Complexity** | Trivial / moderate / touches high-risk area |
+| **Utility** | Addresses known need / nice-to-have / not aligned with roadmap |
+| **Approach** | Approved in issue / sound / needs rework / fundamentally wrong |
+| **Code quality** | Matches our standards / needs polish / AI slop |
+| **Scope** | Open-source only / touches premium or enterprise code |
+
+### Immediate closure rules
+
+Close the PR right away (with the appropriate response template) if any of these apply:
+
+- Touches `premium/` or `enterprise/` code, or moves code from those directories to core
+- Feature PR without a pre-approved issue
+- Bug fix PR without an issue containing reproduction steps
+- Not aligned with product direction
+- AI-generated low-quality code with no meaningful effort from the contributor
+
+### Review signals
+
+Favor reviewing when:
+- Contributor discussed the approach beforehand and got approval
+- Addresses a known, prioritized issue
+- Small, well-scoped, well-described
+- Code quality is close to what we'd write ourselves
+
+Favor closing when:
+- Large PR with no prior discussion
+- Reviewing + guiding would cost more than reimplementing
+- Contributor shows no willingness to iterate
+
+### Mixed signals
+
+When the assessment is mixed (e.g., good approach but large size, or useful but needs significant rework), discuss with the tech lead before responding.
+
+## Response templates
+
+Use differentiated messages depending on the situation. Do not use the same message for every closure.
+
+### Not aligned / closing
+
+Close the PR immediately. The contributor can still respond on the closed PR.
+
+```
+Hi,
+
+Thanks for your contribution. After reviewing this PR, we've decided not to move forward with it because [specific reason: not aligned with our roadmap / addresses a use case we don't plan to support / etc.].
+
+If you'd like to contribute in the future, please check our [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on how we evaluate contributions.
+
+Thanks for your interest in Baserow.
+```
+
+### No prior issue (feature or bug)
+
+Close the PR immediately with a pointer to the process.
+
+```
+Hi,
+
+Thanks for taking the time to submit this. [Features require an approved issue / Bug fixes require an issue with reproduction steps] before opening a PR. This helps us align on the approach early and avoid wasted effort on both sides.
+
+Please open an issue first following our [contribution guidelines](../CONTRIBUTING.md), and we'll take it from there.
+```
+
+### Touches premium/enterprise code
+
+Close immediately.
+
+```
+Hi,
+
+Thanks for your contribution. Unfortunately, this PR modifies code in the `premium/` or `enterprise/` directories, which are not open to external contributions.
+
+If the rest of your changes are valid for the open-source core, please resubmit a PR without those modifications.
+```
+
+### Promising but needs work
+
+Do **not** close. List what's needed and set a deadline.
+
+```
+Hi,
+
+Thanks for this PR. The direction looks [good / promising], but it needs some changes before we can merge it:
+
+- [Specific item 1]
+- [Specific item 2]
+- [...]
+
+Please address these within the next 2 weeks. If we don't hear back, we'll close the PR. You can always reopen it later if you want to pick it back up.
+
+If you'd prefer, you can also ask us to finish it — see the "Help us finish it" section in our [CONTRIBUTING.md](../CONTRIBUTING.md).
+```
+
+### Offering to finish it (proactive)
+
+When we see a promising PR that the contributor may not be able to bring to our standards:
+
+```
+Hi,
+
+Thanks for this contribution. The idea and direction are good, but bringing it to our quality standards would require [significant rework / additional changes].
+
+If you'd like, we can take it from here and finish it ourselves. We'd include your name as a contributor in the release. Let us know if that works for you, or if you'd prefer to continue working on it yourself.
+```
+
+## Stale PR policy
+
+- After a review with requested changes: wait **2 weeks** for a response
+- If no response after 2 weeks: close with a brief message
+- The contributor can reopen or submit a new PR later
+
+```
+Hi,
+
+Closing this PR due to inactivity. If you'd like to pick this up again, feel free to reopen it or submit a new PR.
+```
+
+## "We'll finish it" flow
+
+This can be triggered two ways:
+1. The **contributor asks** us to finish their PR
+2. We **proactively offer** when the PR is promising but needs more work than the contributor can deliver
+
+### When to accept
+
+- The feature/fix is something we actually want
+- The existing code is good enough to build on (not a full rewrite)
+- We have capacity to finish it in a reasonable timeframe
+
+### When to decline
+
+- The PR requires a near-complete rewrite
+- The feature isn't aligned with our priorities
+- We don't have capacity right now
+
+### How to credit
+
+- Mention the contributor by name in the changelog entry
+- Include them in release notes as a contributor
+- Use co-author in the commit if we build on their code directly
+
+### No guarantees
+
+We don't commit to finishing every PR that's offered. If it's not the right time or requires too many changes, we decline politely and explain why.
+
+## General principles
+
+- **Impact vs. cost**: prioritize PRs where the value is high relative to the review effort
+- **Push back early**: it's better to close quickly with clear guidance than to let a PR linger for months
+- **Don't leave PRs undecided**: triage within a week, respond within two. Silence is worse than a "no"
+- **When in doubt, ask the tech lead**

--- a/docs/development/external-contributions.md
+++ b/docs/development/external-contributions.md
@@ -29,7 +29,7 @@ For each PR, assess these criteria. The combination drives the decision — not 
 | **Code quality** | Matches our standards / needs polish / AI slop |
 | **Scope** | Open-source only / touches premium or enterprise code |
 
-### Immediate closure rules
+### Closure rules
 
 Close the PR right away (with the appropriate response template) if any of these apply:
 
@@ -69,7 +69,7 @@ Hi,
 
 Thanks for your contribution. After reviewing this PR, we've decided not to move forward with it because [specific reason: not aligned with our roadmap / addresses a use case we don't plan to support / etc.].
 
-If you'd like to contribute in the future, please check our [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines on how we evaluate contributions.
+If you'd like to contribute in the future, please check our [CONTRIBUTING.md](https://github.com/baserow/baserow/blob/develop/CONTRIBUTING.md) for guidelines on how we evaluate contributions.
 
 Thanks for your interest in Baserow.
 ```
@@ -83,7 +83,7 @@ Hi,
 
 Thanks for taking the time to submit this. [Features require an approved issue / Bug fixes require an issue with reproduction steps] before opening a PR. This helps us align on the approach early and avoid wasted effort on both sides.
 
-Please open an issue first following our [contribution guidelines](../../CONTRIBUTING.md), and we'll take it from there.
+Please open an issue first following our [contribution guidelines](https://github.com/baserow/baserow/blob/develop/CONTRIBUTING.md), and we'll take it from there.
 ```
 
 ### Touches premium/enterprise code
@@ -113,19 +113,7 @@ Thanks for this PR. The direction looks [good / promising], but it needs some ch
 
 Please address these within the next 2 weeks. If we don't hear back, we'll close the PR. You can always reopen it later if you want to pick it back up.
 
-If you'd prefer, you can also ask us to finish it — see the "Help us finish it" section in our [CONTRIBUTING.md](../../CONTRIBUTING.md).
-```
-
-### Offering to finish it (proactive)
-
-When we see a promising PR that the contributor may not be able to bring to our standards:
-
-```
-Hi,
-
-Thanks for this contribution. The idea and direction are good, but bringing it to our quality standards would require [significant rework / additional changes].
-
-If you'd like, we can take it from here and finish it ourselves. We'd include your name as a contributor in the release. Let us know if that works for you, or if you'd prefer to continue working on it yourself.
+If you'd prefer, you can also ask us to finish it — see the "Help us finish it" section in our [CONTRIBUTING.md](https://github.com/baserow/baserow/blob/develop/CONTRIBUTING.md).
 ```
 
 ## Stale PR policy

--- a/docs/development/external-contributions.md
+++ b/docs/development/external-contributions.md
@@ -140,37 +140,9 @@ Hi,
 Closing this PR due to inactivity. If you'd like to pick this up again, feel free to reopen it or submit a new PR.
 ```
 
-## "We'll finish it" flow
-
-This can be triggered two ways:
-1. The **contributor asks** us to finish their PR
-2. We **proactively offer** when the PR is promising but needs more work than the contributor can deliver
-
-### When to accept
-
-- The feature/fix is something we actually want
-- The existing code is good enough to build on (not a full rewrite)
-- We have capacity to finish it in a reasonable timeframe
-
-### When to decline
-
-- The PR requires a near-complete rewrite
-- The feature isn't aligned with our priorities
-- We don't have capacity right now
-
 ### How to credit
 
 - Mention the contributor by name in the changelog entry
 - Include them in release notes as a contributor
 - Use co-author in the commit if we build on their code directly
 
-### No guarantees
-
-We don't commit to finishing every PR that's offered. If it's not the right time or requires too many changes, we decline politely and explain why.
-
-## General principles
-
-- **Impact vs. cost**: prioritize PRs where the value is high relative to the review effort
-- **Push back early**: it's better to close quickly with clear guidance than to let a PR linger for months
-- **Don't leave PRs undecided**: triage within a week, respond within two. Silence is worse than a "no"
-- **When in doubt, ask the tech lead**

--- a/docs/development/external-contributions.md
+++ b/docs/development/external-contributions.md
@@ -69,7 +69,7 @@ Hi,
 
 Thanks for your contribution. After reviewing this PR, we've decided not to move forward with it because [specific reason: not aligned with our roadmap / addresses a use case we don't plan to support / etc.].
 
-If you'd like to contribute in the future, please check our [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on how we evaluate contributions.
+If you'd like to contribute in the future, please check our [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines on how we evaluate contributions.
 
 Thanks for your interest in Baserow.
 ```
@@ -83,7 +83,7 @@ Hi,
 
 Thanks for taking the time to submit this. [Features require an approved issue / Bug fixes require an issue with reproduction steps] before opening a PR. This helps us align on the approach early and avoid wasted effort on both sides.
 
-Please open an issue first following our [contribution guidelines](../CONTRIBUTING.md), and we'll take it from there.
+Please open an issue first following our [contribution guidelines](../../CONTRIBUTING.md), and we'll take it from there.
 ```
 
 ### Touches premium/enterprise code
@@ -113,7 +113,7 @@ Thanks for this PR. The direction looks [good / promising], but it needs some ch
 
 Please address these within the next 2 weeks. If we don't hear back, we'll close the PR. You can always reopen it later if you want to pick it back up.
 
-If you'd prefer, you can also ask us to finish it — see the "Help us finish it" section in our [CONTRIBUTING.md](../CONTRIBUTING.md).
+If you'd prefer, you can also ask us to finish it — see the "Help us finish it" section in our [CONTRIBUTING.md](../../CONTRIBUTING.md).
 ```
 
 ### Offering to finish it (proactive)

--- a/docs/development/external-contributions.md
+++ b/docs/development/external-contributions.md
@@ -22,7 +22,7 @@ For each PR, assess these criteria. The combination drives the decision — not 
 | Criterion | Assessment |
 |-----------|-----------|
 | **Type** | Bug fix / feature / task (small or large) |
-| **Size** | Small (< 10 LOUC) / medium (10-100) / large (> 100). LOUC = lines of useful code, excluding tests, comments, translations, docs |
+| **Size** | Small (< 10 LOUC) / medium (10-100) / large (> 100). LOUC = lines of useful code, excluding tests, comments, translations, docs and boilerplate |
 | **Complexity** | Trivial / moderate / touches high-risk area |
 | **Utility** | Addresses known need / nice-to-have / not aligned with roadmap |
 | **Approach** | Approved in issue / sound / needs rework / fundamentally wrong |


### PR DESCRIPTION
## Summary

- Rewrite `CONTRIBUTING.md` with clear contribution categories (bug fixes, features, tasks), PR requirements (Conventional Commits titles, issue links, size guidelines using LOUC), and a "help us finish it" option for promising but incomplete PRs
- Add internal triage guide (`docs/development/external-contributions.md`) with evaluation criteria, immediate closure rules, differentiated response templates, and stale PR policy
- Update issue templates: replace labels with GitHub issue types (`Bug`, `Feature`, `Task`), add new task template, simplify bug template (merge "actual result" into repro steps, make expected result optional)