### PR TITLE
Fix survey form navigation with required fields

### DIFF
--- a/changelog/entries/unreleased/bug/fix_survey_form_next.json
+++ b/changelog/entries/unreleased/bug/fix_survey_form_next.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed survey form navigation with required fields",
+    "issue_origin": "github",
+    "issue_number": 3188,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-06"
+}

--- a/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModeSurvey.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModeSurvey.vue
@@ -38,7 +38,6 @@
                   "
                   type="primary"
                   size="large"
-                  @click="validateAndNext(index)"
                   >Next</Button
                 >
 


### PR DESCRIPTION
Fixes https://github.com/baserow/baserow/issues/3188

The problem was not related to just rating field, but surfaces when clicking on "next" in the required field step. In that case the form would increment to field index twice and any following field would be skipped.
