### PR TITLE
feat Show matching restricted view filters and allow setting default values

### DIFF
--- a/backend/src/baserow/contrib/database/api/rows/views.py
+++ b/backend/src/baserow/contrib/database/api/rows/views.py
@@ -558,7 +558,11 @@ class RowsView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )

--- a/backend/src/baserow/contrib/database/api/rows/views.py
+++ b/backend/src/baserow/contrib/database/api/rows/views.py
@@ -821,7 +821,11 @@ class RowView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -830,6 +834,7 @@ class RowView(APIView):
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             NoPermissionToTable: ERROR_NO_PERMISSION_TO_TABLE,
             TokenCannotIncludeRowMetadata: ERROR_CANNOT_INCLUDE_ROW_METADATA,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,
@@ -956,7 +961,11 @@ class RowView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -965,6 +974,7 @@ class RowView(APIView):
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             NoPermissionToTable: ERROR_NO_PERMISSION_TO_TABLE,
             DeadlockException: ERROR_DATABASE_DEADLOCK,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,
@@ -1088,7 +1098,11 @@ class RowView(APIView):
                 ["ERROR_USER_NOT_IN_GROUP", "ERROR_CANNOT_DELETE_ALREADY_DELETED_ITEM"]
             ),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -1097,6 +1111,7 @@ class RowView(APIView):
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             NoPermissionToTable: ERROR_NO_PERMISSION_TO_TABLE,
             CannotDeleteAlreadyDeletedItem: ERROR_CANNOT_DELETE_ALREADY_DELETED_ITEM,
             CannotDeleteRowsInTable: ERROR_CANNOT_DELETE_ROWS_IN_TABLE,
@@ -1337,7 +1352,11 @@ class BatchRowsView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -1347,6 +1366,7 @@ class BatchRowsView(APIView):
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
             RowIdsNotUnique: ERROR_ROW_IDS_NOT_UNIQUE,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             NoPermissionToTable: ERROR_NO_PERMISSION_TO_TABLE,
             CannotCreateRowsInTable: ERROR_CANNOT_CREATE_ROWS_IN_TABLE,
             DeadlockException: ERROR_DATABASE_DEADLOCK,
@@ -1501,7 +1521,11 @@ class BatchRowsView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -1511,6 +1535,7 @@ class BatchRowsView(APIView):
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
             RowIdsNotUnique: ERROR_ROW_IDS_NOT_UNIQUE,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             NoPermissionToTable: ERROR_NO_PERMISSION_TO_TABLE,
             DeadlockException: ERROR_DATABASE_DEADLOCK,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,

--- a/changelog/entries/unreleased/feature/4926_show_matching_restricted_view_filters.json
+++ b/changelog/entries/unreleased/feature/4926_show_matching_restricted_view_filters.json
@@ -1,0 +1,9 @@
+{
+  "type": "feature",
+  "message": "Show matching restricted view filters and allow setting default values",
+  "issue_origin": "github",
+  "issue_number": 4926,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-04-08"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/all.scss
@@ -25,3 +25,4 @@
 @import 'assistant_onboarding';
 @import 'date_dependency';
 @import 'data_scanner';
+@import 'restricted_view_filter_context';

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/restricted_view_filter_context.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/restricted_view_filter_context.scss
@@ -1,0 +1,89 @@
+.restricted-view-filter-context {
+  .expandable__content--card {
+    padding: 0;
+  }
+}
+
+.restricted-view-filter-context__head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.restricted-view-filter-context__icon {
+  flex: 0 0 20px;
+  font-size: 16px;
+  position: relative;
+  top: 1px;
+
+  &--warning {
+    color: $palette-yellow-800;
+  }
+
+  &--success {
+    color: $palette-green-700;
+  }
+}
+
+.restricted-view-filter-context__text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.restricted-view-filter-context__title {
+  font-weight: 500;
+  font-size: 13px;
+  line-height: 20px;
+  margin-bottom: 4px;
+}
+
+.restricted-view-filter-context__subtitle {
+  font-size: 12px;
+  color: $palette-neutral-900;
+  margin-top: 2px;
+  line-height: 16px;
+}
+
+.restricted-view-filter-context__toggle {
+  flex: 0 0 auto;
+  font-size: 14px;
+  color: $color-neutral-500;
+  position: relative;
+  top: 3px;
+}
+
+.restricted-view-filter-context__body {
+  padding: 20px 16px 20px 46px;
+}
+
+.restricted-view-filter-context__field {
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  &:not(:last-child) {
+    margin-bottom: 24px;
+  }
+}
+
+.restricted-view-filter-context__field-label {
+  @extend %ellipsis;
+
+  width: 110px;
+  flex: 0 0 110px;
+  margin-right: 20px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 20px;
+  color: $palette-neutral-1200;
+}
+
+.restricted-view-filter-context__field-icon {
+  width: 16px;
+  color: $palette-neutral-600;
+  font-size: 14px;
+}
+
+.restricted-view-filter-context__field-input {
+  width: 100%;
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/restricted_view_filter_context.scss
+++ b/enterprise/web-frontend/modules/baserow_enterprise/assets/scss/components/restricted_view_filter_context.scss
@@ -87,3 +87,9 @@
 .restricted-view-filter-context__field-input {
   width: 100%;
 }
+
+.restricted-view-filter-context__remove {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 12px;
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -204,21 +204,28 @@ export default {
           return false
         }
         const fieldType = this.$registry.get('field', field.type)
-        return fieldType.canBeDefaultValue()
+        return !fieldType.isReadOnlyField(field) && fieldType.canBeDefaultValue()
       })
     },
     // Build a values object that resolves functions to their actual values,
-    // so that matchSearchFilters can check them against the filters.
+    // so that matchSearchFilters can check them against the filters. Includes
+    // all filtered fields (even read-only ones that aren't editable) so the
+    // filter matching doesn't hit undefined values.
     resolvedDefaultViewRowValues() {
       const resolved = {}
-      for (const field of this.visibleFields) {
+      for (const field of this.fields) {
+        if (!this.filteredFieldIds.has(field.id) && !this.fieldModes[field.id]) {
+          continue
+        }
         const name = `field_${field.id}`
         const mode = this.fieldModes[field.id]
         if (mode && mode !== 'static') {
           const fieldType = this.$registry.get('field', field.type)
           resolved[name] = fieldType.resolveDefaultValueFunction(mode, field)
         } else {
-          resolved[name] = this.defaultViewRowValues[name]
+          const fieldType = this.$registry.get('field', field.type)
+          resolved[name] =
+            this.defaultViewRowValues[name] ?? fieldType.getEmptyValue(field)
         }
       }
       return resolved
@@ -277,7 +284,8 @@ export default {
           continue
         }
         const fieldType = this.$registry.get('field', field.type)
-        if (!fieldType.canBeDefaultValue()) continue
+        if (fieldType.isReadOnlyField(field) || !fieldType.canBeDefaultValue())
+          continue
 
         const name = `field_${field.id}`
         newValues[name] = fieldType.getEmptyValue(field)

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -1,0 +1,231 @@
+<template>
+  <div v-if="filteredFields.length > 0" class="restricted-view-filter-context">
+    <Expandable card toggle-on-click>
+      <template #header="{ expanded }">
+        <div class="restricted-view-filter-context__head">
+          <div class="restricted-view-filter-context__icon">
+            <i
+              :class="
+                matches
+                  ? 'iconoir-check-circle restricted-view-filter-context__icon--success'
+                  : 'iconoir-warning-triangle restricted-view-filter-context__icon--warning'
+              "
+            ></i>
+          </div>
+          <div class="restricted-view-filter-context__text">
+            <div class="restricted-view-filter-context__title">
+              {{
+                matches
+                  ? $t('restrictedViewFilterContext.matchTitle')
+                  : $t('restrictedViewFilterContext.mismatchTitle')
+              }}
+            </div>
+            <div class="restricted-view-filter-context__subtitle">
+              {{
+                matches
+                  ? $t('restrictedViewFilterContext.matchSubtitle')
+                  : $t('restrictedViewFilterContext.mismatchSubtitle')
+              }}
+            </div>
+          </div>
+          <i
+            class="restricted-view-filter-context__toggle"
+            :class="
+              expanded ? 'iconoir-nav-arrow-up' : 'iconoir-nav-arrow-down'
+            "
+          ></i>
+        </div>
+      </template>
+      <div class="restricted-view-filter-context__body">
+        <div
+          v-for="field in filteredFields"
+          :key="field.id"
+          class="restricted-view-filter-context__field"
+        >
+          <div class="restricted-view-filter-context__field-label">
+            <i
+              :class="field._.type.iconClass"
+              class="restricted-view-filter-context__field-icon"
+            ></i>
+            {{ field.name }}
+          </div>
+          <div class="restricted-view-filter-context__field-input">
+            <component
+              :is="getFieldComponent(field)"
+              :ref="'field-' + field.id"
+              :slug="false"
+              :field="field"
+              :value="defaultViewRowValues[`field_${field.id}`]"
+              :read-only="readOnly"
+              :workspace-id="database.workspace.id"
+              :row="defaultViewRowValues"
+              :all-fields-in-table="fields"
+              @update="onFieldUpdate(field, $event)"
+            />
+          </div>
+        </div>
+      </div>
+    </Expandable>
+  </div>
+</template>
+
+<script>
+import debounce from 'lodash/debounce'
+import { notifyIf } from '@baserow/modules/core/utils/error'
+import { matchSearchFilters } from '@baserow/modules/database/utils/view'
+import ViewService from '@baserow/modules/database/services/view'
+
+export default {
+  name: 'RestrictedViewFilterContext',
+  props: {
+    view: {
+      type: Object,
+      required: true,
+    },
+    fields: {
+      type: Array,
+      required: true,
+    },
+    database: {
+      type: Object,
+      required: true,
+    },
+    readOnly: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      defaultViewRowValues: {},
+      oldDefaultViewRowValues: null,
+      saving: false,
+    }
+  },
+  computed: {
+    filteredFieldIds() {
+      const ids = new Set()
+      for (const filter of this.view.filters) {
+        ids.add(filter.field)
+      }
+      return ids
+    },
+    filteredFields() {
+      return this.fields.filter((field) => {
+        if (!this.filteredFieldIds.has(field.id)) return false
+        const fieldType = this.$registry.get('field', field.type)
+        return fieldType.canBeDefaultValue()
+      })
+    },
+    matches() {
+      return matchSearchFilters(
+        this.$registry,
+        this.view.filter_type,
+        this.view.filters,
+        this.view.filter_groups,
+        this.fields,
+        this.defaultViewRowValues
+      )
+    },
+  },
+  watch: {
+    'view.default_row_values': {
+      handler() {
+        this.parseDefaultValues()
+      },
+      deep: true,
+    },
+    'view.filters': {
+      handler() {
+        this.parseDefaultValues()
+      },
+      deep: true,
+    },
+  },
+  created() {
+    this.parseDefaultValues()
+    this.debouncedSave = debounce(this.save, 2000)
+  },
+  methods: {
+    parseDefaultValues() {
+      const items = this.view.default_row_values || []
+      const itemsByFieldId = {}
+      for (const item of items) {
+        itemsByFieldId[item.field] = item
+      }
+
+      const newValues = {}
+      for (const field of this.filteredFields) {
+        const fieldType = this.$registry.get('field', field.type)
+        const name = `field_${field.id}`
+        newValues[name] = fieldType.getEmptyValue(field)
+
+        const item = itemsByFieldId[field.id]
+        if (
+          item &&
+          item.enabled &&
+          item.value != null &&
+          (!item.field_type || item.field_type === field.type)
+        ) {
+          newValues[name] = fieldType.parseDefaultRowValue(field, item.value)
+        }
+      }
+      this.defaultViewRowValues = newValues
+    },
+    getFieldComponent(field) {
+      const fieldType = this.$registry.get('field', field.type)
+      return fieldType.getRowEditFieldComponent(field)
+    },
+    onFieldUpdate(field, value) {
+      if (!this.oldDefaultViewRowValues) {
+        this.oldDefaultViewRowValues = { ...this.defaultViewRowValues }
+      }
+      this.defaultViewRowValues = {
+        ...this.defaultViewRowValues,
+        [`field_${field.id}`]: value,
+      }
+      this.debouncedSave()
+    },
+    async save() {
+      if (this.saving) return
+      this.saving = true
+
+      try {
+        const items = this.filteredFields.map((field) => {
+          const fieldType = this.$registry.get('field', field.type)
+          const value = fieldType.prepareValueForUpdate(
+            field,
+            this.defaultViewRowValues[`field_${field.id}`]
+          )
+          return {
+            field: field.id,
+            enabled: true,
+            value,
+            function: null,
+          }
+        })
+
+        const { data } = await ViewService(this.$client).updateDefaultValues(
+          this.view.id,
+          items
+        )
+
+        await this.$store.dispatch('view/forceUpdate', {
+          view: this.view,
+          values: { default_row_values: data },
+        })
+        this.oldDefaultViewRowValues = null
+      } catch (err) {
+        if (this.oldDefaultViewRowValues) {
+          this.defaultViewRowValues = this.oldDefaultViewRowValues
+          this.oldDefaultViewRowValues = null
+        }
+        notifyIf(err, 'view')
+      } finally {
+        this.saving = false
+      }
+    },
+  },
+}
+</script>

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="filteredFields.length > 0" class="restricted-view-filter-context">
+  <div v-if="visibleFields.length > 0" class="restricted-view-filter-context">
     <Expandable card toggle-on-click>
       <template #header="{ expanded }">
         <div class="restricted-view-filter-context__head">
@@ -38,7 +38,7 @@
       </template>
       <div class="restricted-view-filter-context__body">
         <div
-          v-for="field in filteredFields"
+          v-for="field in visibleFields"
           :key="field.id"
           class="restricted-view-filter-context__field"
         >
@@ -85,6 +85,29 @@
               :all-fields-in-table="fields"
               @update="onFieldUpdate(field, $event)"
             />
+            <div
+              v-if="canRemoveDefaultValue(field)"
+              class="flex align-items-center margin-top-1"
+              style="--gap: 4px"
+            >
+              <a
+                class="restricted-view-filter-context__remove"
+                @click.prevent="removeDefaultValue(field)"
+              >
+                {{ $t('restrictedViewFilterContext.removeDefaultValue') }}
+              </a>
+              <HelpIcon
+                :tooltip="
+                  $t('restrictedViewFilterContext.removeDefaultValueHelper')
+                "
+                tooltip-content-type="plain"
+                :tooltip-content-classes="[
+                  'tooltip__content--expandable',
+                  'tooltip__content--expandable-plain-text',
+                ]"
+                icon="info-empty"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -97,6 +120,22 @@ import debounce from 'lodash/debounce'
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import { matchSearchFilters } from '@baserow/modules/database/utils/view'
 import ViewService from '@baserow/modules/database/services/view'
+import { clone } from '@baserow/modules/core/utils/object'
+
+/**
+ * Builds the API payload from a default_row_values snapshot, applying local
+ * overrides (value/mode changes and removals) on top.
+ */
+function buildPayload(baseItems, overrides, removedFieldIds) {
+  const itemsByFieldId = new Map(baseItems.map((item) => [item.field, item]))
+  for (const fieldId of removedFieldIds) {
+    itemsByFieldId.delete(fieldId)
+  }
+  for (const override of overrides) {
+    itemsByFieldId.set(override.field, override)
+  }
+  return Array.from(itemsByFieldId.values())
+}
 
 export default {
   name: 'RestrictedViewFilterContext',
@@ -121,10 +160,17 @@ export default {
   },
   data() {
     return {
+      // Local UI state derived from view.default_row_values.
       defaultViewRowValues: {},
       fieldModes: {},
-      oldDefaultViewRowValues: null,
-      oldFieldModes: null,
+      removedFieldIds: [],
+      // Snapshot of view.default_row_values taken before the first local edit
+      // in a batch. Used to revert if the in-flight request fails.
+      requestSnapshot: null,
+      // Snapshot taken when edits arrive while a request is in flight. If the
+      // in-flight request succeeds, this becomes the new requestSnapshot for
+      // the queued save.
+      pendingSnapshot: null,
       saving: false,
       saveQueued: false,
     }
@@ -137,9 +183,26 @@ export default {
       }
       return ids
     },
-    filteredFields() {
+    enabledDefaultFieldIds() {
+      const ids = new Set()
+      for (const item of this.view.default_row_values || []) {
+        if (item.enabled) {
+          ids.add(item.field)
+        }
+      }
+      return ids
+    },
+    // Fields that are either used in a filter or have an enabled default value,
+    // excluding fields the user has locally removed.
+    visibleFields() {
       return this.fields.filter((field) => {
-        if (!this.filteredFieldIds.has(field.id)) return false
+        if (this.removedFieldIds.includes(field.id)) return false
+        if (
+          !this.filteredFieldIds.has(field.id) &&
+          !this.enabledDefaultFieldIds.has(field.id)
+        ) {
+          return false
+        }
         const fieldType = this.$registry.get('field', field.type)
         return fieldType.canBeDefaultValue()
       })
@@ -148,7 +211,7 @@ export default {
     // so that matchSearchFilters can check them against the filters.
     resolvedDefaultViewRowValues() {
       const resolved = {}
-      for (const field of this.filteredFields) {
+      for (const field of this.visibleFields) {
         const name = `field_${field.id}`
         const mode = this.fieldModes[field.id]
         if (mode && mode !== 'static') {
@@ -174,7 +237,6 @@ export default {
   watch: {
     'view.default_row_values': {
       handler() {
-        // Don't overwrite local edits while a save is in flight or queued.
         if (!this.saving && !this.saveQueued) {
           this.parseDefaultValues()
         }
@@ -195,8 +257,6 @@ export default {
     this.debouncedSave = debounce(this.save, 400)
   },
   beforeUnmount() {
-    // Flush any pending debounced save so edits aren't lost when the filter context
-    // menu is removed.
     this.debouncedSave.flush()
   },
   methods: {
@@ -209,16 +269,22 @@ export default {
 
       const newValues = {}
       const newModes = {}
-      for (const field of this.filteredFields) {
+      for (const field of this.fields) {
+        if (
+          !this.filteredFieldIds.has(field.id) &&
+          !itemsByFieldId[field.id]?.enabled
+        ) {
+          continue
+        }
         const fieldType = this.$registry.get('field', field.type)
+        if (!fieldType.canBeDefaultValue()) continue
+
         const name = `field_${field.id}`
         newValues[name] = fieldType.getEmptyValue(field)
         newModes[field.id] = 'static'
 
         const item = itemsByFieldId[field.id]
-        if (!item || !item.enabled) {
-          continue
-        }
+        if (!item || !item.enabled) continue
 
         if (
           item.value != null &&
@@ -236,6 +302,7 @@ export default {
       }
       this.defaultViewRowValues = newValues
       this.fieldModes = newModes
+      this.removedFieldIds = []
     },
     getFieldComponent(field) {
       const fieldType = this.$registry.get('field', field.type)
@@ -245,24 +312,75 @@ export default {
       const fieldType = this.$registry.get('field', field.type)
       return fieldType.getSupportedDefaultValueFunctions()
     },
-    onModeChange(field, mode) {
-      if (!this.oldDefaultViewRowValues) {
-        this.oldDefaultViewRowValues = { ...this.defaultViewRowValues }
-        this.oldFieldModes = { ...this.fieldModes }
+    canRemoveDefaultValue(field) {
+      return (
+        !this.readOnly &&
+        !this.filteredFieldIds.has(field.id) &&
+        this.enabledDefaultFieldIds.has(field.id)
+      )
+    },
+    /**
+     * Takes a snapshot of view.default_row_values before the first local edit.
+     * If a request is already in flight, the snapshot goes into pendingSnapshot
+     * (so that a queued save can use it). Otherwise it goes into requestSnapshot.
+     */
+    snapshotBeforeEdit() {
+      if (this.saving) {
+        if (!this.pendingSnapshot) {
+          this.pendingSnapshot = clone(this.view.default_row_values || [])
+        }
+      } else if (!this.requestSnapshot) {
+        this.requestSnapshot = clone(this.view.default_row_values || [])
       }
+    },
+    removeDefaultValue(field) {
+      this.snapshotBeforeEdit()
+      this.removedFieldIds = [...this.removedFieldIds, field.id]
+      const newValues = { ...this.defaultViewRowValues }
+      delete newValues[`field_${field.id}`]
+      this.defaultViewRowValues = newValues
+      const newModes = { ...this.fieldModes }
+      delete newModes[field.id]
+      this.fieldModes = newModes
+      this.debouncedSave()
+    },
+    onModeChange(field, mode) {
+      this.snapshotBeforeEdit()
       this.fieldModes = { ...this.fieldModes, [field.id]: mode }
       this.debouncedSave()
     },
     onFieldUpdate(field, value) {
-      if (!this.oldDefaultViewRowValues) {
-        this.oldDefaultViewRowValues = { ...this.defaultViewRowValues }
-        this.oldFieldModes = { ...this.fieldModes }
-      }
+      this.snapshotBeforeEdit()
       this.defaultViewRowValues = {
         ...this.defaultViewRowValues,
         [`field_${field.id}`]: value,
       }
       this.debouncedSave()
+    },
+    /**
+     * Builds the list of local overrides from the current UI state for fields
+     * that are visible (not removed).
+     */
+    buildOverrides() {
+      return this.visibleFields.map((field) => {
+        const fieldType = this.$registry.get('field', field.type)
+        const mode = this.fieldModes[field.id]
+        const funcName = mode && mode !== 'static' ? mode : null
+
+        let value = null
+        if (!funcName) {
+          value = fieldType.prepareValueForUpdate(
+            field,
+            this.defaultViewRowValues[`field_${field.id}`]
+          )
+        }
+        return {
+          field: field.id,
+          enabled: true,
+          value,
+          function: funcName,
+        }
+      })
     },
     async save() {
       if (this.saving) {
@@ -271,39 +389,12 @@ export default {
       }
       this.saving = true
 
-      // Capture the local state we're about to send so we can detect if more
-      // edits arrived while the request was in flight.
-      const sentValues = { ...this.defaultViewRowValues }
-      const sentModes = { ...this.fieldModes }
+      const overrides = this.buildOverrides()
+      const removedIds = [...this.removedFieldIds]
+      const baseItems = clone(this.view.default_row_values || [])
 
       try {
-        // Preserve existing default values for non-filtered fields, only
-        // overwrite the entries for fields that are currently being filtered on.
-        const itemsByFieldId = new Map(
-          (this.view.default_row_values || []).map((item) => [item.field, item])
-        )
-        this.filteredFields.forEach((field) => {
-          const fieldType = this.$registry.get('field', field.type)
-          const mode = sentModes[field.id]
-          const funcName = mode !== 'static' ? mode : null
-
-          let value = null
-          if (!funcName) {
-            value = fieldType.prepareValueForUpdate(
-              field,
-              sentValues[`field_${field.id}`]
-            )
-          }
-
-          itemsByFieldId.set(field.id, {
-            field: field.id,
-            enabled: true,
-            value,
-            function: funcName,
-          })
-        })
-        const items = Array.from(itemsByFieldId.values())
-
+        const items = buildPayload(baseItems, overrides, removedIds)
         const { data } = await ViewService(this.$client).updateDefaultValues(
           this.view.id,
           items
@@ -313,24 +404,32 @@ export default {
           view: this.view,
           values: { default_row_values: data },
         })
-        // Wait for the watcher to flush so it doesn't overwrite local edits
-        // that arrived while the request was in flight.
         await this.$nextTick()
 
-        // If no further edits happened during the request, the snapshot is
-        // no longer needed. Otherwise keep it for the queued save.
-        if (!this.saveQueued) {
-          this.oldDefaultViewRowValues = null
-          this.oldFieldModes = null
+        if (this.saveQueued) {
+          // More edits arrived during the request. The pendingSnapshot
+          // becomes the requestSnapshot for the next save.
+          this.requestSnapshot = this.pendingSnapshot
+          this.pendingSnapshot = null
+        } else {
+          this.requestSnapshot = null
+          this.pendingSnapshot = null
+          this.removedFieldIds = []
         }
       } catch (err) {
-        if (this.oldDefaultViewRowValues) {
-          this.defaultViewRowValues = this.oldDefaultViewRowValues
-          this.fieldModes = this.oldFieldModes
-          this.oldDefaultViewRowValues = null
-          this.oldFieldModes = null
-        }
+        // Revert to the snapshot taken before the edits that triggered this
+        // save, cancel any queued save, and re-parse from it.
+        this.debouncedSave.cancel()
         this.saveQueued = false
+        if (this.requestSnapshot) {
+          await this.$store.dispatch('view/forceUpdate', {
+            view: this.view,
+            values: { default_row_values: this.requestSnapshot },
+          })
+        }
+        this.requestSnapshot = null
+        this.pendingSnapshot = null
+        this.parseDefaultValues()
         notifyIf(err, 'view')
       } finally {
         this.saving = false

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -204,7 +204,9 @@ export default {
           return false
         }
         const fieldType = this.$registry.get('field', field.type)
-        return !fieldType.isReadOnlyField(field) && fieldType.canBeDefaultValue()
+        return (
+          !fieldType.isReadOnlyField(field) && fieldType.canBeDefaultValue()
+        )
       })
     },
     // Build a values object that resolves functions to their actual values,
@@ -214,7 +216,10 @@ export default {
     resolvedDefaultViewRowValues() {
       const resolved = {}
       for (const field of this.fields) {
-        if (!this.filteredFieldIds.has(field.id) && !this.fieldModes[field.id]) {
+        if (
+          !this.filteredFieldIds.has(field.id) &&
+          !this.fieldModes[field.id]
+        ) {
           continue
         }
         const name = `field_${field.id}`

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -50,8 +50,31 @@
             {{ field.name }}
           </div>
           <div class="restricted-view-filter-context__field-input">
+            <div
+              v-if="getFieldFunctions(field).length > 0"
+              class="margin-bottom-1"
+            >
+              <RadioButton
+                :model-value="fieldModes[field.id]"
+                value="static"
+                @input="onModeChange(field, 'static')"
+              >
+                {{ $t('defaultValuesModal.staticValue') }}
+              </RadioButton>
+              <RadioButton
+                v-for="func in getFieldFunctions(field)"
+                :key="func.name"
+                :model-value="fieldModes[field.id]"
+                :value="func.name"
+                class="margin-left-1"
+                @input="onModeChange(field, func.name)"
+              >
+                {{ func.label }}
+              </RadioButton>
+            </div>
             <component
               :is="getFieldComponent(field)"
+              v-if="fieldModes[field.id] === 'static'"
               :ref="'field-' + field.id"
               :slug="false"
               :field="field"
@@ -99,8 +122,11 @@ export default {
   data() {
     return {
       defaultViewRowValues: {},
+      fieldModes: {},
       oldDefaultViewRowValues: null,
+      oldFieldModes: null,
       saving: false,
+      saveQueued: false,
     }
   },
   computed: {
@@ -118,6 +144,22 @@ export default {
         return fieldType.canBeDefaultValue()
       })
     },
+    // Build a values object that resolves functions to their actual values,
+    // so that matchSearchFilters can check them against the filters.
+    resolvedDefaultViewRowValues() {
+      const resolved = {}
+      for (const field of this.filteredFields) {
+        const name = `field_${field.id}`
+        const mode = this.fieldModes[field.id]
+        if (mode && mode !== 'static') {
+          const fieldType = this.$registry.get('field', field.type)
+          resolved[name] = fieldType.resolveDefaultValueFunction(mode, field)
+        } else {
+          resolved[name] = this.defaultViewRowValues[name]
+        }
+      }
+      return resolved
+    },
     matches() {
       return matchSearchFilters(
         this.$registry,
@@ -125,27 +167,37 @@ export default {
         this.view.filters,
         this.view.filter_groups,
         this.fields,
-        this.defaultViewRowValues
+        this.resolvedDefaultViewRowValues
       )
     },
   },
   watch: {
     'view.default_row_values': {
       handler() {
-        this.parseDefaultValues()
+        // Don't overwrite local edits while a save is in flight or queued.
+        if (!this.saving && !this.saveQueued) {
+          this.parseDefaultValues()
+        }
       },
       deep: true,
     },
     'view.filters': {
       handler() {
-        this.parseDefaultValues()
+        if (!this.saving && !this.saveQueued) {
+          this.parseDefaultValues()
+        }
       },
       deep: true,
     },
   },
   created() {
     this.parseDefaultValues()
-    this.debouncedSave = debounce(this.save, 2000)
+    this.debouncedSave = debounce(this.save, 400)
+  },
+  beforeUnmount() {
+    // Flush any pending debounced save so edits aren't lost when the filter context
+    // menu is removed.
+    this.debouncedSave.flush()
   },
   methods: {
     parseDefaultValues() {
@@ -156,30 +208,55 @@ export default {
       }
 
       const newValues = {}
+      const newModes = {}
       for (const field of this.filteredFields) {
         const fieldType = this.$registry.get('field', field.type)
         const name = `field_${field.id}`
         newValues[name] = fieldType.getEmptyValue(field)
+        newModes[field.id] = 'static'
 
         const item = itemsByFieldId[field.id]
+        if (!item || !item.enabled) {
+          continue
+        }
+
         if (
-          item &&
-          item.enabled &&
           item.value != null &&
           (!item.field_type || item.field_type === field.type)
         ) {
           newValues[name] = fieldType.parseDefaultRowValue(field, item.value)
         }
+
+        const supportedFunctions = fieldType
+          .getSupportedDefaultValueFunctions()
+          .map((f) => f.name)
+        if (item.function && supportedFunctions.includes(item.function)) {
+          newModes[field.id] = item.function
+        }
       }
       this.defaultViewRowValues = newValues
+      this.fieldModes = newModes
     },
     getFieldComponent(field) {
       const fieldType = this.$registry.get('field', field.type)
       return fieldType.getRowEditFieldComponent(field)
     },
+    getFieldFunctions(field) {
+      const fieldType = this.$registry.get('field', field.type)
+      return fieldType.getSupportedDefaultValueFunctions()
+    },
+    onModeChange(field, mode) {
+      if (!this.oldDefaultViewRowValues) {
+        this.oldDefaultViewRowValues = { ...this.defaultViewRowValues }
+        this.oldFieldModes = { ...this.fieldModes }
+      }
+      this.fieldModes = { ...this.fieldModes, [field.id]: mode }
+      this.debouncedSave()
+    },
     onFieldUpdate(field, value) {
       if (!this.oldDefaultViewRowValues) {
         this.oldDefaultViewRowValues = { ...this.defaultViewRowValues }
+        this.oldFieldModes = { ...this.fieldModes }
       }
       this.defaultViewRowValues = {
         ...this.defaultViewRowValues,
@@ -188,23 +265,44 @@ export default {
       this.debouncedSave()
     },
     async save() {
-      if (this.saving) return
+      if (this.saving) {
+        this.saveQueued = true
+        return
+      }
       this.saving = true
 
+      // Capture the local state we're about to send so we can detect if more
+      // edits arrived while the request was in flight.
+      const sentValues = { ...this.defaultViewRowValues }
+      const sentModes = { ...this.fieldModes }
+
       try {
-        const items = this.filteredFields.map((field) => {
+        // Preserve existing default values for non-filtered fields, only
+        // overwrite the entries for fields that are currently being filtered on.
+        const itemsByFieldId = new Map(
+          (this.view.default_row_values || []).map((item) => [item.field, item])
+        )
+        this.filteredFields.forEach((field) => {
           const fieldType = this.$registry.get('field', field.type)
-          const value = fieldType.prepareValueForUpdate(
-            field,
-            this.defaultViewRowValues[`field_${field.id}`]
-          )
-          return {
+          const mode = sentModes[field.id]
+          const funcName = mode !== 'static' ? mode : null
+
+          let value = null
+          if (!funcName) {
+            value = fieldType.prepareValueForUpdate(
+              field,
+              sentValues[`field_${field.id}`]
+            )
+          }
+
+          itemsByFieldId.set(field.id, {
             field: field.id,
             enabled: true,
             value,
-            function: null,
-          }
+            function: funcName,
+          })
         })
+        const items = Array.from(itemsByFieldId.values())
 
         const { data } = await ViewService(this.$client).updateDefaultValues(
           this.view.id,
@@ -215,15 +313,31 @@ export default {
           view: this.view,
           values: { default_row_values: data },
         })
-        this.oldDefaultViewRowValues = null
+        // Wait for the watcher to flush so it doesn't overwrite local edits
+        // that arrived while the request was in flight.
+        await this.$nextTick()
+
+        // If no further edits happened during the request, the snapshot is
+        // no longer needed. Otherwise keep it for the queued save.
+        if (!this.saveQueued) {
+          this.oldDefaultViewRowValues = null
+          this.oldFieldModes = null
+        }
       } catch (err) {
         if (this.oldDefaultViewRowValues) {
           this.defaultViewRowValues = this.oldDefaultViewRowValues
+          this.fieldModes = this.oldFieldModes
           this.oldDefaultViewRowValues = null
+          this.oldFieldModes = null
         }
+        this.saveQueued = false
         notifyIf(err, 'view')
       } finally {
         this.saving = false
+        if (this.saveQueued) {
+          this.saveQueued = false
+          this.save()
+        }
       }
     },
   },

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/views/RestrictedViewFilterContext.vue
@@ -299,10 +299,7 @@ export default {
         const item = itemsByFieldId[field.id]
         if (!item || !item.enabled) continue
 
-        if (
-          item.value != null &&
-          (!item.field_type || item.field_type === field.type)
-        ) {
+        if (item.value != null && item.field_type === field.type) {
           newValues[name] = fieldType.parseDefaultRowValue(field, item.value)
         }
 

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -802,10 +802,12 @@
     "restrictedDescription": "Editors and lower can only see the filtered data and visible fields. It's possible to manage the members."
   },
   "restrictedViewFilterContext": {
-    "matchTitle": "Default values match the filters",
+    "matchTitle": "Default view values match the filters",
     "matchSubtitle": "Editors will see the rows they create.",
     "mismatchTitle": "Default values don't match the filters",
-    "mismatchSubtitle": "Editors will be able to create rows but won't see them."
+    "mismatchSubtitle": "Editors will be able to create rows but won't see them.",
+    "removeDefaultValue": "Remove default value",
+    "removeDefaultValueHelper": "This field has a default value but no filter. You can remove it here, or manage all default values by clicking the three dots next to the view and then on \"Default row values\"."
   },
   "databaseStep": {
     "ai": "Kuma AI"

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -801,6 +801,12 @@
     "restricted": "Restricted",
     "restrictedDescription": "Editors and lower can only see the filtered data and visible fields. It's possible to manage the members."
   },
+  "restrictedViewFilterContext": {
+    "matchTitle": "Default values match the filters",
+    "matchSubtitle": "Editors will see the rows they create.",
+    "mismatchTitle": "Default values don't match the filters",
+    "mismatchSubtitle": "Editors will be able to create rows but won't see them."
+  },
   "databaseStep": {
     "ai": "Kuma AI"
   },

--- a/enterprise/web-frontend/modules/baserow_enterprise/viewOwnershipTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/viewOwnershipTypes.js
@@ -3,6 +3,7 @@ import EnterpriseFeatures from '@baserow_enterprise/features'
 import PaidFeaturesModal from '@baserow_premium/components/PaidFeaturesModal'
 import { RBACPaidFeature } from '@baserow_enterprise/paidFeatures'
 import { FormViewType } from '@baserow/modules/database/viewTypes.js'
+import RestrictedViewFilterContext from '@baserow_enterprise/components/views/RestrictedViewFilterContext'
 
 export class RestrictedViewOwnershipType extends ViewOwnershipType {
   static getType() {
@@ -81,6 +82,10 @@ export class RestrictedViewOwnershipType extends ViewOwnershipType {
     // list all the fields of the table. If the view param is added, it will only list
     // the fields related to this view.
     return !canListFields
+  }
+
+  getFilterContextComponent() {
+    return RestrictedViewFilterContext
   }
 
   _canUpdateFieldOptions(view, database) {

--- a/enterprise/web-frontend/modules/baserow_enterprise/viewOwnershipTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/viewOwnershipTypes.js
@@ -84,7 +84,16 @@ export class RestrictedViewOwnershipType extends ViewOwnershipType {
     return !canListFields
   }
 
-  getFilterContextComponent() {
+  getFilterContextComponent(view, database) {
+    if (
+      !this.app.$hasPermission(
+        'database.table.view.update_default_values',
+        view,
+        database.workspace.id
+      )
+    ) {
+      return null
+    }
     return RestrictedViewFilterContext
   }
 

--- a/premium/backend/src/baserow_premium/api/row_comments/views.py
+++ b/premium/backend/src/baserow_premium/api/row_comments/views.py
@@ -18,8 +18,10 @@ from baserow.api.schemas import get_error_schema
 from baserow.api.serializers import get_example_pagination_serializer_class
 from baserow.contrib.database.api.rows.errors import ERROR_ROW_DOES_NOT_EXIST
 from baserow.contrib.database.api.tables.errors import ERROR_TABLE_DOES_NOT_EXIST
+from baserow.contrib.database.api.views.errors import ERROR_VIEW_DOES_NOT_EXIST
 from baserow.contrib.database.rows.exceptions import RowDoesNotExist
 from baserow.contrib.database.table.exceptions import TableDoesNotExist
+from baserow.contrib.database.views.exceptions import ViewDoesNotExist
 from baserow.core.action.registries import action_type_registry
 from baserow.core.exceptions import UserNotInWorkspace
 from baserow_premium.api.row_comments.errors import (
@@ -117,6 +119,7 @@ class RowCommentsView(APIView):
                 [
                     "ERROR_TABLE_DOES_NOT_EXIST",
                     "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
                 ]
             ),
         },
@@ -125,6 +128,7 @@ class RowCommentsView(APIView):
         {
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
         }
     )
@@ -176,7 +180,11 @@ class RowCommentsView(APIView):
                 ["ERROR_USER_NOT_IN_GROUP", "ERROR_INVALID_COMMENT_MENTION"]
             ),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -184,6 +192,7 @@ class RowCommentsView(APIView):
         {
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             InvalidRowCommentMentionException: ERROR_INVALID_COMMENT_MENTION,
         }
@@ -233,7 +242,11 @@ class RowCommentView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_COMMENT_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_COMMENT_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -241,6 +254,7 @@ class RowCommentView(APIView):
         {
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowCommentDoesNotExist: ERROR_ROW_COMMENT_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             UserNotRowCommentAuthorException: ERROR_USER_NOT_COMMENT_AUTHOR,
             InvalidRowCommentMentionException: ERROR_INVALID_COMMENT_MENTION,
@@ -285,7 +299,11 @@ class RowCommentView(APIView):
             ),
             401: get_error_schema(["ERROR_NO_PERMISSION_TO_TABLE"]),
             404: get_error_schema(
-                ["ERROR_TABLE_DOES_NOT_EXIST", "ERROR_ROW_COMMENT_DOES_NOT_EXIST"]
+                [
+                    "ERROR_TABLE_DOES_NOT_EXIST",
+                    "ERROR_ROW_COMMENT_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
+                ]
             ),
         },
     )
@@ -293,6 +311,7 @@ class RowCommentView(APIView):
         {
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowCommentDoesNotExist: ERROR_ROW_COMMENT_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
             UserNotRowCommentAuthorException: ERROR_USER_NOT_COMMENT_AUTHOR,
         }
@@ -340,6 +359,7 @@ class RowCommentsNotificationModeView(APIView):
                 [
                     "ERROR_TABLE_DOES_NOT_EXIST",
                     "ERROR_ROW_DOES_NOT_EXIST",
+                    "ERROR_VIEW_DOES_NOT_EXIST",
                 ]
             ),
         },
@@ -348,6 +368,7 @@ class RowCommentsNotificationModeView(APIView):
         {
             TableDoesNotExist: ERROR_TABLE_DOES_NOT_EXIST,
             RowDoesNotExist: ERROR_ROW_DOES_NOT_EXIST,
+            ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
             UserNotInWorkspace: ERROR_USER_NOT_IN_GROUP,
         }
     )

--- a/web-frontend/modules/core/assets/scss/components/fields/multiple_select.scss
+++ b/web-frontend/modules/core/assets/scss/components/fields/multiple_select.scss
@@ -4,6 +4,10 @@
   list-style: none;
   margin: 0 0 10px;
   padding: 0;
+
+  &--empty {
+    margin-bottom: 0;
+  }
 }
 
 .field-multiple-select__item {

--- a/web-frontend/modules/database/components/field/FieldMultipleSelectOptionsSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldMultipleSelectOptionsSubForm.vue
@@ -29,6 +29,13 @@
             :value="option.id"
           />
         </Dropdown>
+        <div v-if="hasViewLevelDefaultValue" class="control__messages">
+          <p
+            class="warning control__helper-text control__helper-text--warning field-context__inner-element-width"
+          >
+            {{ $t('fieldForm.defaultValueOverriddenByView') }}
+          </p>
+        </div>
       </FormGroup>
     </template>
   </div>

--- a/web-frontend/modules/database/components/field/FieldNumberSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldNumberSubForm.vue
@@ -93,6 +93,13 @@
           {{ $t('fieldForm.defaultValueDisabledByConstraint') }}
         </p>
       </div>
+      <div v-if="hasViewLevelDefaultValue" class="control__messages">
+        <p
+          class="warning control__helper-text control__helper-text--warning field-context__inner-element-width"
+        >
+          {{ $t('fieldForm.defaultValueOverriddenByView') }}
+        </p>
+      </div>
     </FormGroup>
   </div>
 </template>

--- a/web-frontend/modules/database/components/field/FieldSingleSelectOptionsSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldSingleSelectOptionsSubForm.vue
@@ -40,6 +40,13 @@
             {{ $t('fieldForm.defaultValueDisabledByConstraint') }}
           </p>
         </div>
+        <div v-if="hasViewLevelDefaultValue" class="control__messages">
+          <p
+            class="warning control__helper-text control__helper-text--warning field-context__inner-element-width"
+          >
+            {{ $t('fieldForm.defaultValueOverriddenByView') }}
+          </p>
+        </div>
       </FormGroup>
     </template>
   </div>

--- a/web-frontend/modules/database/components/field/FieldTextSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldTextSubForm.vue
@@ -17,6 +17,13 @@
         {{ $t('fieldForm.defaultValueDisabledByConstraint') }}
       </p>
     </div>
+    <div v-if="hasViewLevelDefaultValue" class="control__messages">
+      <p
+        class="warning control__helper-text control__helper-text--warning field-context__inner-element-width"
+      >
+        {{ $t('fieldForm.defaultValueOverriddenByView') }}
+      </p>
+    </div>
   </FormGroup>
 </template>
 

--- a/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
@@ -2,7 +2,7 @@
   <div class="control__elements">
     <ul
       class="field-multiple-select__items"
-      :class="{ 'field-multiple-select__items--empty': !!value }"
+      :class="{ 'field-multiple-select__items--empty': value.length === 0 }"
     >
       <li
         v-for="item in value"

--- a/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="control__elements">
-    <ul class="field-multiple-select__items">
+    <ul
+      class="field-multiple-select__items"
+      :class="{ 'field-multiple-select__items--empty': !!value }"
+    >
       <li
         v-for="item in value"
         :key="item.id"
@@ -31,6 +34,7 @@
       :disabled="readOnly"
       :show-input="false"
       :show-empty-value="false"
+      :fixed-items="true"
       :error="touched && !valid"
       @input="updateValue($event, value)"
       @create-option="createOption($event)"

--- a/web-frontend/modules/database/components/row/RowEditFieldSingleSelect.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldSingleSelect.vue
@@ -6,6 +6,7 @@
       :allow-create-option="allowCreateOptions"
       :disabled="readOnly"
       :error="touched && !valid"
+      :fixed-items="true"
       size="large"
       @input="updateValue($event, value)"
       @create-option="createOption($event)"

--- a/web-frontend/modules/database/components/table/Table.vue
+++ b/web-frontend/modules/database/components/table/Table.vue
@@ -107,6 +107,7 @@
             :view="view"
             :is-public-view="isPublic"
             :fields="fields"
+            :database="database"
             :read-only="adhocFiltering"
             :disable-filter="disableFilter"
             @changed="refresh()"

--- a/web-frontend/modules/database/components/view/DefaultValuesModal.vue
+++ b/web-frontend/modules/database/components/view/DefaultValuesModal.vue
@@ -177,10 +177,7 @@ export default {
           this.enabledFieldIds.push(field.id)
         }
 
-        if (
-          item.value != null &&
-          (!item.field_type || item.field_type === field.type)
-        ) {
+        if (item.value != null && item.field_type === field.type) {
           this.rowValues[name] = fieldType.parseDefaultRowValue(
             field,
             item.value

--- a/web-frontend/modules/database/components/view/ViewContext.vue
+++ b/web-frontend/modules/database/components/view/ViewContext.vue
@@ -103,6 +103,12 @@
         <a class="context__menu-item-link" @click="openDefaultValuesModal()">
           <i class="context__menu-item-icon iconoir-settings"></i>
           {{ $t('viewContext.defaultRowValues') }}
+          <Badge
+            v-if="enabledDefaultRowValues.length >= 1"
+            color="neutral"
+            size="small"
+            >{{ enabledDefaultRowValues.length }}</Badge
+          >
         </a>
       </li>
       <li
@@ -244,6 +250,11 @@ export default {
           []
         )
         .filter((component) => component !== null)
+    },
+    enabledDefaultRowValues() {
+      return this.view.default_row_values.filter(
+        (defaultRowValue) => defaultRowValue.enabled
+      )
     },
   },
   methods: {

--- a/web-frontend/modules/database/components/view/ViewFieldConditionsForm.vue
+++ b/web-frontend/modules/database/components/view/ViewFieldConditionsForm.vue
@@ -71,6 +71,7 @@
       >
       </ViewFieldConditionGroup>
     </div>
+    <slot></slot>
   </div>
 </template>
 

--- a/web-frontend/modules/database/components/view/ViewFilter.vue
+++ b/web-frontend/modules/database/components/view/ViewFilter.vue
@@ -24,6 +24,7 @@
       <ViewFilterForm
         :fields="fields"
         :view="view"
+        :database="database"
         :is-public-view="isPublicView"
         :read-only="readOnly"
         :disable-filter="disableFilter"
@@ -45,6 +46,10 @@ export default {
       required: true,
     },
     view: {
+      type: Object,
+      required: true,
+    },
+    database: {
       type: Object,
       required: true,
     },

--- a/web-frontend/modules/database/components/view/ViewFilterForm.vue
+++ b/web-frontend/modules/database/components/view/ViewFilterForm.vue
@@ -33,7 +33,16 @@
       @delete-filter-group="deleteFilterGroup($event)"
       @update-filter="updateFilter($event)"
       @update-filter-type="updateFilterType(view, $event)"
-    />
+    >
+      <component
+        :is="filterContextComponent"
+        v-if="filterContextComponent"
+        :view="view"
+        :fields="fields"
+        :database="database"
+        :read-only="readOnly"
+      />
+    </ViewFieldConditionsForm>
     <div v-if="!disableFilter" class="context__footer">
       <ButtonText icon="iconoir-plus" @click.prevent="addFilter()">
         {{ $t('viewFilterContext.addFilter') }}</ButtonText
@@ -80,6 +89,10 @@ export default {
       type: Object,
       required: true,
     },
+    database: {
+      type: Object,
+      required: true,
+    },
     isPublicView: {
       type: Boolean,
       required: false,
@@ -95,6 +108,15 @@ export default {
     },
   },
   emits: ['changed'],
+  computed: {
+    filterContextComponent() {
+      const ownershipType = this.$registry.get(
+        'viewOwnershipType',
+        this.view.ownership_type
+      )
+      return ownershipType.getFilterContextComponent()
+    },
+  },
   methods: {
     sortableUid: ulid,
     async addFilter({ filterGroupId = null, parentGroupId = null } = {}) {

--- a/web-frontend/modules/database/components/view/ViewFilterForm.vue
+++ b/web-frontend/modules/database/components/view/ViewFilterForm.vue
@@ -110,12 +110,12 @@ export default {
   emits: ['changed'],
   computed: {
     filterContextComponent() {
-      if (!this.view.ownership_type) return null
+      if (!this.view.ownership_type || !this.database) return null
       const ownershipType = this.$registry.get(
         'viewOwnershipType',
         this.view.ownership_type
       )
-      return ownershipType.getFilterContextComponent()
+      return ownershipType.getFilterContextComponent(this.view, this.database)
     },
   },
   methods: {

--- a/web-frontend/modules/database/components/view/ViewFilterForm.vue
+++ b/web-frontend/modules/database/components/view/ViewFilterForm.vue
@@ -110,6 +110,7 @@ export default {
   emits: ['changed'],
   computed: {
     filterContextComponent() {
+      if (!this.view.ownership_type) return null
       const ownershipType = this.$registry.get(
         'viewOwnershipType',
         this.view.ownership_type

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -328,6 +328,7 @@
     "dbIndexError": "This field type cannot have an index. Please remove it before saving or change the field type.",
     "dbIndexDescription": "Indexing can significantly improve filtering performance, but slows down create, update, and delete operations.",
     "defaultValueDisabledByConstraint": "Cannot set a default value with a unique constraint",
+    "defaultValueOverriddenByView": "A view-level default value is set for this field and will take precedence over this default value.",
     "dbIndexDisabledTooltip": "Indexing is not available for this field type."
   },
   "fieldSelectThroughFieldSubForm": {

--- a/web-frontend/modules/database/mixins/fieldSubForm.js
+++ b/web-frontend/modules/database/mixins/fieldSubForm.js
@@ -31,6 +31,15 @@ export default {
     },
   },
   computed: {
+    hasViewLevelDefaultValue() {
+      const fieldId = this.defaultValues?.id
+      if (!fieldId || !this.view?.default_row_values) {
+        return false
+      }
+      return this.view.default_row_values.some(
+        (item) => item.field === fieldId && item.enabled
+      )
+    },
     isDefaultValueFieldDisabled() {
       if (!this.fieldConstraints || this.fieldConstraints.length === 0) {
         return false

--- a/web-frontend/modules/database/viewOwnershipTypes.js
+++ b/web-frontend/modules/database/viewOwnershipTypes.js
@@ -162,8 +162,12 @@ export class ViewOwnershipType extends Registerable {
    * Returns a component to display below the filter form, or `null` if nothing extra
    * is needed. This lets ownership types inject contextual UI (e.g. default-value
    * warnings) into the filter context menu.
+   *
+   * @param {Object} view - The view object.
+   * @param {Object} database - The database object.
+   * @returns {Object|null} A Vue component or null.
    */
-  getFilterContextComponent() {
+  getFilterContextComponent(view, database) {
     return null
   }
 }

--- a/web-frontend/modules/database/viewOwnershipTypes.js
+++ b/web-frontend/modules/database/viewOwnershipTypes.js
@@ -157,6 +157,15 @@ export class ViewOwnershipType extends Registerable {
   getDecoratorContextWarning(view, fields, visibleFields, database) {
     return null
   }
+
+  /**
+   * Returns a component to display below the filter form, or `null` if nothing extra
+   * is needed. This lets ownership types inject contextual UI (e.g. default-value
+   * warnings) into the filter context menu.
+   */
+  getFilterContextComponent() {
+    return null
+  }
 }
 
 export class CollaborativeViewOwnershipType extends ViewOwnershipType {

--- a/web-frontend/modules/integrations/localBaserow/components/integrations/LocalBaserowAdhocHeader.vue
+++ b/web-frontend/modules/integrations/localBaserow/components/integrations/LocalBaserowAdhocHeader.vue
@@ -7,6 +7,7 @@
           read-only
           :view="view"
           :fields="filterableFields"
+          :database="database"
           :disable-filter="false"
           @changed="handleFiltersChange"
         ></ViewFilter>

--- a/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
+++ b/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
@@ -1105,6 +1105,8 @@ exports[`ViewFilterForm match snapshots > Full view filter component 1`] = `
     
     
     
+    
+    
   </div>
   <div
     class="context__footer"
@@ -1601,6 +1603,8 @@ exports[`ViewFilterForm match snapshots > rating filter 1`] = `
         </div>
       </div>
     </div>
+    
+    
     
     
     


### PR DESCRIPTION
### What is in this PR

This PR introduces a small helper when setting the filter values in the restricted view. If an editor looks at the restricted view, they're not able to see the unfiltered rows and hidden fields. In order to make sure that they can create rows, the user must set the default values for the view. With these changes, it's directly clear which default values the user should set when setting the filters. This makes it much easier for them.

https://github.com/user-attachments/assets/e5847654-711a-48c6-86a2-5a9b14398149

### How to test this PR

- Confirm that this box is only visible for the admin and builder in a restricted view.
- Changing the filters should update the default value matching state immediately.
- Changing a default value should update the default value matching state when after clicking outside of the input (this is how the input works unfortunately).
- There is a debounced to update the actual default values.
- Real-time updates of the default values should immediately be applied.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered

Closes #4926 