### PR TITLE
chore: respect BASEROW_BACKEND_LOG_LEVEL setting in tests and management tasks

### DIFF
--- a/backend/src/baserow/config/asgi.py
+++ b/backend/src/baserow/config/asgi.py
@@ -10,17 +10,13 @@ from baserow.config.helpers import (
     log_env_warnings,
 )
 from baserow.core.mcp import get_baserow_mcp_server
-from baserow.core.telemetry.telemetry import setup_logging, setup_telemetry
+from baserow.core.telemetry.telemetry import setup_telemetry
 from baserow.ws.routers import websocket_router
 
 # The telemetry instrumentation library setup needs to run prior to django's setup.
 setup_telemetry(add_django_instrumentation=True)
 
 django_asgi_app = get_asgi_application()
-
-# It is critical to setup our own logging after django has been setup and done its own
-# logging setup. Otherwise Django will try to destroy and log handlers we added prior.
-setup_logging()
 
 # Check that libraries meant to be lazy-loaded haven't been imported at startup.
 # This runs after Django is fully loaded, so it catches imports from all apps.

--- a/backend/src/baserow/config/settings/test.py
+++ b/backend/src/baserow/config/settings/test.py
@@ -26,7 +26,11 @@ else:
     TEST_ENV_VARS = {}
 
 # Prefixes for vars that can be overridden via env vars (for DB/Redis configuration)
-ALLOWED_ENV_PREFIXES = ("DATABASE_", "BASEROW_EMBEDDINGS_API_URL")
+ALLOWED_ENV_PREFIXES = (
+    "DATABASE_",
+    "BASEROW_EMBEDDINGS_API_URL",
+    "BASEROW_BACKEND_LOG_LEVEL",
+)
 
 
 def getenv_for_tests(key: str, default: str = "") -> str:

--- a/backend/src/baserow/config/wsgi.py
+++ b/backend/src/baserow/config/wsgi.py
@@ -11,16 +11,12 @@ from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 
 from baserow.config.helpers import check_lazy_loaded_libraries, log_env_warnings
-from baserow.core.telemetry.telemetry import setup_logging, setup_telemetry
+from baserow.core.telemetry.telemetry import setup_telemetry
 
 # The telemetry instrumentation library setup needs to run prior to django's setup.
 setup_telemetry(add_django_instrumentation=True)
 
 application = get_wsgi_application()
-
-# It is critical to setup our own logging after django has been setup and done its own
-# logging setup. Otherwise Django will try to destroy and log handlers we added prior.
-setup_logging()
 
 # This is only needed in asgi.py
 settings.BASEROW_LAZY_LOADED_LIBRARIES.append("mcp")

--- a/backend/src/baserow/core/apps.py
+++ b/backend/src/baserow/core/apps.py
@@ -491,6 +491,10 @@ class CoreConfig(AppConfig):
         if settings.SENTRY_DSN:
             patch_user_model_str()
 
+        from baserow.core.telemetry.telemetry import setup_logging
+
+        setup_logging()
+
     def _setup_health_checks(self):
         from health_check.plugins import plugin_dir
 

--- a/backend/src/baserow/core/telemetry/tasks.py
+++ b/backend/src/baserow/core/telemetry/tasks.py
@@ -1,7 +1,7 @@
 from celery import Task
 from celery.signals import worker_process_init
 
-from baserow.core.telemetry.telemetry import setup_logging, setup_telemetry
+from baserow.core.telemetry.telemetry import setup_telemetry
 from baserow.core.telemetry.utils import otel_is_enabled
 
 TASK_NAME_KEY = "celery.task_name"
@@ -10,7 +10,6 @@ TASK_NAME_KEY = "celery.task_name"
 @worker_process_init.connect
 def initialize_otel(**kwargs):
     setup_telemetry(add_django_instrumentation=False)
-    setup_logging()
 
 
 class BaserowTelemetryTask(Task):

--- a/backend/src/baserow/core/telemetry/telemetry.py
+++ b/backend/src/baserow/core/telemetry/telemetry.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import sys
 
 from celery import signals
@@ -43,7 +42,7 @@ def setup_logging():
 
     # A slightly customized default loguru format which includes the process id.
     loguru_format = (
-        f"<magenta>{os.getpid()}|</magenta>"
+        "<magenta>{process}|</magenta>"
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>|"
         "<level>{level}</level>|"
         "<cyan>{name}</cyan>:"

--- a/docs/testing/ai-assistant-evals.md
+++ b/docs/testing/ai-assistant-evals.md
@@ -21,6 +21,9 @@ local test runs.
 # Set your API key (Groq example — works with any pydantic-ai provider)
 export GROQ_API_KEY=gsk_...
 
+# Suppress noisy framework-level log messages (Celery task registration, etc.)
+export BASEROW_BACKEND_LOG_LEVEL=WARNING
+
 # Run all evals with the default model (groq:openai/gpt-oss-120b)
 just b test ../enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/ \
   -m eval -v

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/conftest.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/evals/conftest.py
@@ -1,21 +1,12 @@
 import asyncio
 import logging
 import os
-import sys
 
 from django.conf import settings
 
 import pytest
-from loguru import logger
 
 from baserow.config.settings.test import TEST_ENV_VARS
-
-# Suppress DEBUG-level loguru output during evals.  Baserow's cache layer logs
-# every cache hit/miss at DEBUG, which floods the output when using -s.  Agent
-# message history is printed via print() and is captured by pytest: it appears
-# in the failure report automatically without needing -s.
-logger.remove()
-logger.add(sys.stderr, level="WARNING")
 
 # Expose API keys from TEST_ENV_FILE to os.environ so that LLM provider
 # SDKs (which read os.getenv() at import/construction time) can find them.


### PR DESCRIPTION
## Summary

- `setup_logging()` (which replaces loguru's default DEBUG sink with the configured `BASEROW_BACKEND_LOG_LEVEL`) was only called from wsgi, asgi, and Celery worker init — never during management commands or tests
- Moved the call to `CoreConfig.ready()` so it runs for all Django entry points
- Removed the now-redundant calls from `wsgi.py`, `asgi.py`, and `tasks.py`

## Test plan
- Run `just b test backend/tests/baserow/core/ -s` and confirm no DEBUG cache hit/miss spam
- Run a management command (e.g. `manage.py sync_templates`) and confirm clean output
- Set `BASEROW_BACKEND_LOG_LEVEL=DEBUG` and verify debug messages reappear
