### PR TITLE
fix: notification panel crash when a periodic_data_sync_deactivated notification is rendered

### DIFF
--- a/changelog/entries/unreleased/bug/5171_fix_notification_panel_crash_when_a_periodic_data_sync_deact.json
+++ b/changelog/entries/unreleased/bug/5171_fix_notification_panel_crash_when_a_periodic_data_sync_deact.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix notification panel crash when a periodic_data_sync_deactivated notification is rendered",
+    "issue_origin": "github",
+    "issue_number": 5171,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-13"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/notifications/PeriodicDataSyncDeactivatedNotification.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/notifications/PeriodicDataSyncDeactivatedNotification.vue
@@ -6,7 +6,7 @@
   >
     <div class="notification-panel__notification-content-title">
       <i18n-t
-        :path="
+        :keypath="
           isLicenseUnavailable
             ? 'periodicDataSyncDeactivatedNotification.licenseUnavailable'
             : 'periodicDataSyncDeactivatedNotification.failure'


### PR DESCRIPTION
### What is in this PR
Closes #5171 

This is caused by breaking change in vue18n - https://vue-i18n.intlify.dev/guide/migration/breaking#rename-to-i18n-tfrom-i18n

### How to test this PR
Follow steps in issue and observe it works as expected

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
