### PR TITLE
fix: link-row group-by crash in grid view with more than 20 linked items

### DIFF
--- a/changelog/entries/unreleased/bug/5184_fix_linkrow_groupby_crash_in_grid_view_with_more_than_20_lin.json
+++ b/changelog/entries/unreleased/bug/5184_fix_linkrow_groupby_crash_in_grid_view_with_more_than_20_lin.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix link-row group-by crash in grid view with more than 20 linked items",
+    "issue_origin": "github",
+    "issue_number": 5184,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-13"
+}

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupValueLinkRow.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupValueLinkRow.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="card-many-to-many__list-wrapper">
+    <div class="card-many-to-many__list">
+      <div
+        v-for="item in value"
+        :key="item.id"
+        class="card-many-to-many__item card-link-row"
+        :class="{
+          'card-link-row--unnamed': item.value === null || item.value === '',
+        }"
+      >
+        <span class="card-many-to-many__name">
+          {{
+            item.value || $t('gridViewFieldLinkRow.unnamed', { value: item.id })
+          }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GridViewGroupValueLinkRow',
+  props: {
+    value: {
+      type: Array,
+      default: () => [],
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1403,7 +1403,7 @@ export class LinkRowFieldType extends FieldType {
     return RowCardFieldLinkRow
   }
 
-  getGroupByComponent() {
+  getGroupByComponent(field) {
     return GridViewGroupValueLinkRow
   }
 

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -114,6 +114,7 @@ import RowCardFieldEmail from '@baserow/modules/database/components/card/RowCard
 import RowCardFieldFile from '@baserow/modules/database/components/card/RowCardFieldFile'
 import RowCardFieldFormula from '@baserow/modules/database/components/card/RowCardFieldFormula'
 import RowCardFieldLinkRow from '@baserow/modules/database/components/card/RowCardFieldLinkRow'
+import GridViewGroupValueLinkRow from '@baserow/modules/database/components/view/grid/GridViewGroupValueLinkRow'
 import RowCardFieldMultipleSelect from '@baserow/modules/database/components/card/RowCardFieldMultipleSelect'
 import RowCardFieldNumber from '@baserow/modules/database/components/card/RowCardFieldNumber'
 import RowCardFieldRating from '@baserow/modules/database/components/card/RowCardFieldRating'
@@ -1400,6 +1401,10 @@ export class LinkRowFieldType extends FieldType {
 
   getCardComponent() {
     return RowCardFieldLinkRow
+  }
+
+  getGroupByComponent() {
+    return GridViewGroupValueLinkRow
   }
 
   getRowHistoryEntryComponent() {


### PR DESCRIPTION
### What is in this PR

This PR fixes issue described in #5184 

### How to test this PR
Follow steps described in issue and observe it works as expected

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
