### PR TITLE
fix: field drag-and-drop offset and text selection with group-by active

### DIFF
--- a/changelog/entries/unreleased/bug/fix_field_drag_placeholder_offset_with_group_by.json
+++ b/changelog/entries/unreleased/bug/fix_field_drag_placeholder_offset_with_group_by.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix field drag-and-drop placeholder being offset by the group-by column width when a group by is active.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-14"
+}

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -632,6 +632,7 @@ export default {
     crossSectionDraggingOffset() {
       const primary = this.fields.find((f) => f.primary)
       return (
+        this.activeGroupByWidth +
         this.gridViewRowDetailsWidth +
         (primary ? this.getFieldWidth(primary) : 0)
       )

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldDragging.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldDragging.vue
@@ -134,6 +134,7 @@ export default {
      * the correct position.
      */
     start(field, event) {
+      event.preventDefault()
       this.field = field
       this.targetFieldId = field.id
       this.dragging = true


### PR DESCRIPTION
## Summary                                                   

- Fix drag placeholder and target indicator being offset by the group-by column width when a group-by is active                                                      
- Prevent browser text selection while dragging column headers
                                                                                                                                                                       
## How to test
                        
- Add a group by, try drag and drop a field and notice that the placeholder is off on develop, while is in the right position in this branch
- Verify that drag and drop still works correctly without group bys, with 1 or more pinned columns, etc.                                                                                                                                               

