### PR TITLE
fix: guard stale rollup field relations

### DIFF
--- a/backend/src/baserow/contrib/database/fields/models.py
+++ b/backend/src/baserow/contrib/database/fields/models.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, NewType
 
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import ArrayField
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.functional import cached_property
@@ -809,10 +810,15 @@ class CountField(FormulaField):
         from baserow.contrib.database.formula.ast.function_defs import BaserowCount
         from baserow.contrib.database.formula.ast.tree import BaserowFieldReference
 
-        field_reference = BaserowFieldReference(
-            getattr(self.through_field, "name", ""), None, None
-        )
-        self.formula = f"{BaserowCount.type}({field_reference})"
+        try:
+            through_field = getattr(self, "through_field")
+            field_name = getattr(through_field, "name", "")
+        except ObjectDoesNotExist:
+            field_name = "'invalid through'"
+
+        field_ref = BaserowFieldReference(field_name, None, None)
+        self.formula = f"{BaserowCount.type}({field_ref})"
+
         super().save(*args, **kwargs)
 
     def __str__(self):
@@ -852,13 +858,23 @@ class RollupField(FormulaField):
             formula_function_registry,
         )
 
+        try:
+            through_field = getattr(self, "through_field")
+            through_name = getattr(through_field, "name", "")
+        except ObjectDoesNotExist:
+            self.through_field = None
+            through_name = "'invalid through'"
+
+        try:
+            target_field = getattr(self, "target_field")
+            target_name = getattr(target_field, "name", "")
+        except ObjectDoesNotExist:
+            self.target_field = None
+            target_name = "'invalid target'"
+
         formula_function = formula_function_registry.get(self.rollup_function)
-        field_reference = BaserowFieldReference(
-            getattr(self.through_field, "name", ""),
-            getattr(self.target_field, "name", ""),
-            None,
-        )
-        self.formula = f"{formula_function.type}({field_reference})"
+        field_ref = BaserowFieldReference(through_name, target_name, None)
+        self.formula = f"{formula_function.type}({field_ref})"
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/changelog/entries/unreleased/bug/fix_rollup_field_missing_relation_crash.json
+++ b/changelog/entries/unreleased/bug/fix_rollup_field_missing_relation_crash.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix rollup and count fields crashing when a stale in-memory relation points to a deleted field during formula recalculation.",
+    "issue_origin": "github",
+    "issue_number": 5214,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-17"
+}


### PR DESCRIPTION
## Summary
- fix rollup and count formula rebuilds so stale in-memory relations to deleted fields no longer crash field updates


## Testing
This is a bit difficult to test manually because it's a race condition, and a reliable test would be some sort of hack to simulate the conditions.

I tried putting `raise ObjectDoesNotExist()` inside the new try to verify that the frontend correctly reports the formula error

## References
- Sentry: `BASEROW-SAAS-BACKEND-7M`

Closes #5214