### PR TITLE
fix: prevent database null filter crash

### DIFF
--- a/changelog/entries/unreleased/bug/fix_database_filter_crash_for_null_select_values.json
+++ b/changelog/entries/unreleased/bug/fix_database_filter_crash_for_null_select_values.json
@@ -2,7 +2,7 @@
     "type": "bug",
     "message": "Fix database filters crashing when select option cells are temporarily null during row evaluation.",
     "issue_origin": "github",
-    "issue_number": null,
+    "issue_number": 5217,
     "domain": "database",
     "bullet_points": [],
     "created_at": "2026-04-16"

--- a/changelog/entries/unreleased/bug/fix_database_filter_crash_for_null_select_values.json
+++ b/changelog/entries/unreleased/bug/fix_database_filter_crash_for_null_select_values.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix database filters crashing when select option cells are temporarily null during row evaluation.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-16"
+}

--- a/web-frontend/modules/database/arrayFilterMixins.js
+++ b/web-frontend/modules/database/arrayFilterMixins.js
@@ -260,13 +260,17 @@ export const baserowFormulaArrayTypeFilterMixin = {
   },
 }
 
+const getArrayFilterCellValue = (cellValue) => {
+  return Array.isArray(cellValue) ? cellValue : []
+}
+
 export const hasSelectOptionIdEqualMixin = Object.assign(
   {},
   hasValueEqualFilterMixin,
   {
     getHasValueEqualFilterFunction(field) {
       const mapOptionIdsToValues = (cellVal) =>
-        cellVal.map((v) => ({
+        getArrayFilterCellValue(cellVal).map((v) => ({
           id: v.id,
           value: String(v.value?.id ?? ''),
         }))
@@ -292,7 +296,10 @@ export const hasSelectOptionValueContainsFilterMixin = Object.assign(
     getHasValueContainsFilterFunction(field) {
       return (cellValue, filterValue) =>
         genericHasValueContainsFilter(
-          cellValue.map((v) => ({ id: v.id, value: v.value?.value || '' })),
+          getArrayFilterCellValue(cellValue).map((v) => ({
+            id: v.id,
+            value: v.value?.value || '',
+          })),
           filterValue
         )
     },
@@ -306,7 +313,10 @@ export const hasSelectOptionValueContainsWordFilterMixin = Object.assign(
     getHasValueContainsWordFilterFunction(field) {
       return (cellValue, filterValue) =>
         genericHasValueContainsWordFilter(
-          cellValue.map((v) => ({ id: v.id, value: v.value?.value || '' })),
+          getArrayFilterCellValue(cellValue).map((v) => ({
+            id: v.id,
+            value: v.value?.value || '',
+          })),
           filterValue
         )
     },


### PR DESCRIPTION
## Summary
- fix database select-option filter helpers so they no longer crash when a cell value is temporarily `null`
- normalize non-array filter cell values to an empty list before mapping option ids and labels

## Root cause
Shared database filter logic in `arrayFilterMixins.js` assumed select-option cell values were always arrays and called `.map()` directly. In production, row values can be transiently `null` while table rows and conditional decorators are being recomputed.

## References
- Sentry: `BASEROW-SAAS-WEB-FRONTEND-1K9`

Closes #5217