### PR TITLE
fix: guard workspace dashboard usage data

### DIFF
--- a/changelog/entries/unreleased/bug/fix_workspace_dashboard_missing_usage_data.json
+++ b/changelog/entries/unreleased/bug/fix_workspace_dashboard_missing_usage_data.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix workspace dashboard crashes when dashboard usage components render before usage data for the selected workspace is available.",
+    "issue_origin": "github",
+    "issue_number": 5219,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-04-17"
+}

--- a/web-frontend/modules/core/pages/workspace.vue
+++ b/web-frontend/modules/core/pages/workspace.vue
@@ -360,6 +360,30 @@ const workspaceInvitations = computed(
   () => $store.getters['auth/getWorkspaceInvitations']
 )
 
+const dashboardWorkspaceUsageReady = computed(() => {
+  if (!selectedWorkspace.value) {
+    return false
+  }
+
+  const usageData = workspaceComponentArguments.value?.usageData
+  console.log('Dashboard workspace usage data:', usageData)
+
+  if (Array.isArray(usageData)) {
+    return usageData.some((usage) => {
+      return (
+        usage?.workspace?.id === selectedWorkspace.value.id ||
+        usage?.id === selectedWorkspace.value.id
+      )
+    })
+  }
+
+  if (usageData && typeof usageData === 'object') {
+    return Boolean(usageData[selectedWorkspace.value.id])
+  }
+
+  return false
+})
+
 const getAllOfWorkspace = (ws) =>
   $store.getters['application/getAllOfWorkspace'](ws)
 
@@ -373,17 +397,26 @@ const dashboardHelpComponents = computed(() =>
     .filter((c) => c !== null)
 )
 
-const dashboardWorkspaceRowUsageComponent = computed(() =>
-  Object.values($registry.getAll('plugin'))
-    .map((p) => p.getDashboardWorkspaceRowUsageComponent())
-    .filter((c) => c !== null)
-)
+const dashboardWorkspaceRowUsageComponent = computed(() => {
 
-const dashboardWorkspacePlanBadge = computed(() =>
-  Object.values($registry.getAll('plugin'))
+  if (!dashboardWorkspaceUsageReady.value) {
+    return []
+  }
+
+  return Object.values($registry.getAll('plugin'))
+  .map((p) => p.getDashboardWorkspaceRowUsageComponent())
+  .filter((c) => c !== null)
+})
+
+const dashboardWorkspacePlanBadge = computed(() => {
+  if (!dashboardWorkspaceUsageReady.value) {
+    return []
+  }
+
+  return Object.values($registry.getAll('plugin'))
     .map((p) => p.getDashboardWorkspacePlanBadge())
     .filter((c) => c !== null)
-)
+})
 
 const resourceLinksComponents = computed(() =>
   Object.values($registry.getAll('plugin'))


### PR DESCRIPTION
## Summary
- fix workspace dashboard crashes by rendering usage-related plugin components only after usage data exists for the selected workspace
- guard both dashboard row usage and plan badge plugin slots through the shared core workspace page

## Root cause
The core workspace page always renders dashboard plugin components immediately, but the SaaS dashboard components assume usage data for the selected workspace is already present in `workspaceComponentArguments`. When that payload is missing during dashboard transitions, those components dereference properties like `row_count` and `plan_tier` on `undefined` and crash.

## Verification
- `./web-frontend/node_modules/.bin/eslint "web-frontend/modules/core/pages/workspace.vue"`

## References
- Sentry: `BASEROW-SAAS-WEB-FRONTEND-Y`

Closes #5219