### PR TITLE
fix: guard grid quick edit permissions

### DIFF
--- a/changelog/entries/unreleased/bug/fix_grid_field_quick_edit_without_update_permission.json
+++ b/changelog/entries/unreleased/bug/fix_grid_field_quick_edit_without_update_permission.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix grid field quick edit crashing when the field update context is unavailable because the user lacks field update permission.",
+    "issue_origin": "github",
+    "issue_number": 5216,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-16"
+}

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
@@ -397,6 +397,13 @@ export default {
         )
       )
     },
+    canUpdateField() {
+      return this.$hasPermission(
+        'database.table.field.update',
+        this.field,
+        this.database.workspace.id
+      )
+    },
     synced() {
       if (!this.table.data_sync) {
         return false
@@ -431,7 +438,10 @@ export default {
       this.$refs.context.hide()
     },
     async handleQuickEdit() {
-      if (this.readOnly) return false
+      if (this.readOnly || !this.canUpdateField || !this.$refs.context) {
+        return false
+      }
+
       await this.$refs.context.toggle(
         this.$refs.quickEditLink,
         'bottom',


### PR DESCRIPTION
## Summary

- fix grid field quick edit so it no longer crashes when the update field context is unavailable for the current user
- require field update permission before the quick edit path opens the nested update context

## Root cause

`GridViewFieldType.handleQuickEdit()` only checked whether the grid was read-only. It then opened `FieldContext` and immediately called `showUpdateFieldContext()`.

The problem is that `FieldContext` only renders `UpdateFieldContext` when `database.table.field.update` permission is granted. That meant users with other field-context permissions could still trigger quick edit into a ref that did not exist.

## Testing

- `yarn test:core --run test/unit/database/components/view/grid/gridViewFieldType.spec.js`
- `./node_modules/.bin/eslint "modules/database/components/view/grid/GridViewFieldType.vue" "test/unit/database/components/view/grid/gridViewFieldType.spec.js"`

## Sentry
- `BASEROW-SAAS-WEB-FRONTEND-KC`

Closes #5216 