### PR TITLE
fix: drop expected websocket keepalive timeout Sentry noise

### DIFF
--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -1374,6 +1374,10 @@ if SENTRY_DSN:
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.scrubber import DEFAULT_DENYLIST, EventScrubber
 
+    from baserow.core.sentry import (
+        drop_expected_asyncio_websocket_ping_timeout_events,
+    )
+
     # Exclude integrations whose module-level imports are incompatible:
     # - pydantic_ai: sentry-sdk patches ToolManager._call_tool which was
     #   removed in pydantic-ai >= 1.x (now execute_tool_call)
@@ -1390,6 +1394,7 @@ if SENTRY_DSN:
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration(signals_spans=False, middleware_spans=False)],
         send_default_pii=False,
+        before_send=drop_expected_asyncio_websocket_ping_timeout_events,
         event_scrubber=EventScrubber(recursive=True, denylist=SENTRY_DENYLIST),
         environment=os.getenv("SENTRY_ENVIRONMENT", ""),
     )

--- a/backend/src/baserow/core/sentry.py
+++ b/backend/src/baserow/core/sentry.py
@@ -1,4 +1,35 @@
+import logging
+from typing import Any
+
 from django.contrib.auth import get_user_model
+
+
+def drop_expected_asyncio_websocket_ping_timeout_events(
+    event: dict[str, Any], hint: dict[str, Any]
+) -> dict[str, Any] | None:
+    """
+    Ignore websocket keepalive timeouts logged by asyncio.
+
+    These are emitted by the websockets stack when a client disappears without a
+    clean close handshake. They are noisy, expected in production, and don't
+    point to an application error in Baserow itself.
+    """
+
+    log_record = hint.get("log_record")
+    if not isinstance(log_record, logging.LogRecord):
+        return event
+
+    if log_record.name != "asyncio":
+        return event
+
+    message = log_record.getMessage()
+    if (
+        "ConnectionClosedError exception in shielded future" in message
+        and "keepalive ping timeout" in message
+    ):
+        return None
+
+    return event
 
 
 def setup_user_in_sentry(user):

--- a/backend/tests/baserow/core/test_sentry.py
+++ b/backend/tests/baserow/core/test_sentry.py
@@ -1,0 +1,46 @@
+import logging
+
+from baserow.core.sentry import drop_expected_asyncio_websocket_ping_timeout_events
+
+
+def test_drop_expected_asyncio_websocket_ping_timeout_events():
+    event = {"logger": "asyncio"}
+    record = logging.makeLogRecord(
+        {
+            "name": "asyncio",
+            "levelno": logging.ERROR,
+            "levelname": "ERROR",
+            "msg": (
+                "ConnectionClosedError exception in shielded future future: "
+                "<Future finished exception=ConnectionClosedError(None, "
+                "Close(code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive "
+                "ping timeout'), None)>"
+            ),
+        }
+    )
+
+    assert (
+        drop_expected_asyncio_websocket_ping_timeout_events(
+            event, {"log_record": record}
+        )
+        is None
+    )
+
+
+def test_drop_expected_asyncio_websocket_ping_timeout_events_keeps_other_errors():
+    event = {"logger": "asyncio"}
+    record = logging.makeLogRecord(
+        {
+            "name": "asyncio",
+            "levelno": logging.ERROR,
+            "levelname": "ERROR",
+            "msg": "Task exception was never retrieved",
+        }
+    )
+
+    assert (
+        drop_expected_asyncio_websocket_ping_timeout_events(
+            event, {"log_record": record}
+        )
+        == event
+    )

--- a/changelog/entries/unreleased/bug/5224_suppress_expected_websocket_keepalive_timeout_sentry_noise.json
+++ b/changelog/entries/unreleased/bug/5224_suppress_expected_websocket_keepalive_timeout_sentry_noise.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Prevent expected websocket keepalive timeout logs from being reported to Sentry.",
+    "issue_origin": "github",
+    "issue_number": 5224,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-04-17"
+}


### PR DESCRIPTION
## Summary
- drop only the handled `asyncio` websocket keepalive timeout log before Sentry sends it
- keep unrelated `asyncio` and websocket failures reportable, and cover the filter with tests
- add a changelog entry for #5224

Closes #5224

## How to test
- Configure `SENTRY_BACKEND_DSN` to point at a test Sentry project and run the backend with this branch.
- Open a realtime websocket connection in Baserow, then interrupt it without a clean close long enough for the keepalive ping to time out.
- On `develop`, that should create a Sentry event matching `ConnectionClosedError exception in shielded future` and `keepalive ping timeout`.
- On this branch, reproduce the same disconnect: the websocket should still close, but that specific handled `asyncio` event should no longer be reported to Sentry.
- Run `just b test tests/baserow/core/test_sentry.py`.