### PR TITLE
fix: Comments preview in notification panel

### DIFF
--- a/changelog/entries/unreleased/bug/5230_fix_richeditor_display_in_row_comment_notifications.json
+++ b/changelog/entries/unreleased/bug/5230_fix_richeditor_display_in_row_comment_notifications.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "fix RichEditor display in row comment notifications",
+    "message": "Fix RichTextEditor display in row comment notifications",
     "issue_origin": "github",
     "issue_number": 5230,
     "domain": "core",

--- a/changelog/entries/unreleased/bug/5230_fix_richeditor_display_in_row_comment_notifications.json
+++ b/changelog/entries/unreleased/bug/5230_fix_richeditor_display_in_row_comment_notifications.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "fix RichEditor display in row comment notifications",
+    "issue_origin": "github",
+    "issue_number": 5230,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-04-20"
+}

--- a/premium/web-frontend/modules/baserow_premium/components/row_comments/RowCommentMentionNotification.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/row_comments/RowCommentMentionNotification.vue
@@ -27,7 +27,7 @@
     <RichTextEditor
       :editable="false"
       :mentionable-users="workspace.users"
-      :value="notification.data.message"
+      :model-value="notification.data.message"
     />
   </nuxt-link>
 </template>

--- a/premium/web-frontend/modules/baserow_premium/components/row_comments/RowCommentNotification.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/row_comments/RowCommentNotification.vue
@@ -25,7 +25,7 @@
     <RichTextEditor
       :editable="false"
       :mentionable-users="workspace.users"
-      :value="notification.data.message"
+      :model-value="notification.data.message"
     />
   </nuxt-link>
 </template>


### PR DESCRIPTION
### What is in this PR
- Fix comment preview in comment notifications


Before:
<img width="584" height="223" alt="image" src="https://github.com/user-attachments/assets/25db1d90-e35e-4280-81e5-ee3b3917e668" />

Now:
<img width="521" height="377" alt="image" src="https://github.com/user-attachments/assets/3137db1e-6cbc-4a1d-a1d9-e644204fe8a1" />



### How to test this PR
- Comment on a row in a table tagging yourself.
- Toggle the notification panel, observe you can see the comment preview in the notification


Fixes #5230 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
