### PR TITLE
Refactor autonumber fields to use transactional counters

### DIFF
--- a/backend/src/baserow/contrib/database/api/rows/views.py
+++ b/backend/src/baserow/contrib/database/api/rows/views.py
@@ -41,6 +41,7 @@ from baserow.contrib.database.api.constants import (
     SEARCH_MODE_API_PARAM,
 )
 from baserow.contrib.database.api.fields.errors import (
+    ERROR_FAILED_TO_LOCK_FIELD_DUE_TO_CONFLICT,
     ERROR_FIELD_DATA_CONSTRAINT,
     ERROR_FIELD_DOES_NOT_EXIST,
     ERROR_FILTER_FIELD_NOT_FOUND,
@@ -83,6 +84,7 @@ from baserow.contrib.database.api.views.utils import (
 )
 from baserow.contrib.database.field_rules.collector import CascadeUpdatedRows
 from baserow.contrib.database.fields.exceptions import (
+    FailedToLockFieldDueToConflict,
     FieldDataConstraintException,
     FieldDoesNotExist,
     FilterFieldNotFound,
@@ -572,6 +574,7 @@ class RowsView(APIView):
             CannotCreateRowsInTable: ERROR_CANNOT_CREATE_ROWS_IN_TABLE,
             DeadlockException: ERROR_DATABASE_DEADLOCK,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,
+            FailedToLockFieldDueToConflict: ERROR_FAILED_TO_LOCK_FIELD_DUE_TO_CONFLICT,
         }
     )
     @atomic_with_retry_on_deadlock()
@@ -1351,6 +1354,7 @@ class BatchRowsView(APIView):
             CannotCreateRowsInTable: ERROR_CANNOT_CREATE_ROWS_IN_TABLE,
             DeadlockException: ERROR_DATABASE_DEADLOCK,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,
+            FailedToLockFieldDueToConflict: ERROR_FAILED_TO_LOCK_FIELD_DUE_TO_CONFLICT,
         }
     )
     @atomic_with_retry_on_deadlock()

--- a/backend/src/baserow/contrib/database/api/views/form/views.py
+++ b/backend/src/baserow/contrib/database/api/views/form/views.py
@@ -14,7 +14,10 @@ from baserow.api.schemas import get_error_schema
 from baserow.api.user_files.errors import ERROR_FILE_SIZE_TOO_LARGE, ERROR_INVALID_FILE
 from baserow.api.user_files.serializers import UserFileSerializer
 from baserow.api.utils import validate_data
-from baserow.contrib.database.api.fields.errors import ERROR_FIELD_DATA_CONSTRAINT
+from baserow.contrib.database.api.fields.errors import (
+    ERROR_FAILED_TO_LOCK_FIELD_DUE_TO_CONFLICT,
+    ERROR_FIELD_DATA_CONSTRAINT,
+)
 from baserow.contrib.database.api.rows.errors import (
     ERROR_CANNOT_CREATE_ROWS_IN_TABLE,
     ERROR_ROW_DOES_NOT_EXIST,
@@ -28,7 +31,10 @@ from baserow.contrib.database.api.views.errors import (
     ERROR_VIEW_DOES_NOT_EXIST,
 )
 from baserow.contrib.database.api.views.utils import get_public_view_authorization_token
-from baserow.contrib.database.fields.exceptions import FieldDataConstraintException
+from baserow.contrib.database.fields.exceptions import (
+    FailedToLockFieldDueToConflict,
+    FieldDataConstraintException,
+)
 from baserow.contrib.database.fields.models import (
     FileField,
     LongTextField,
@@ -142,6 +148,7 @@ class SubmitFormViewView(APIView):
             NoAuthorizationToPubliclySharedView: ERROR_NO_PERMISSION_TO_PUBLICLY_SHARED_FORM,
             CannotCreateRowsInTable: ERROR_CANNOT_CREATE_ROWS_IN_TABLE,
             FieldDataConstraintException: ERROR_FIELD_DATA_CONSTRAINT,
+            FailedToLockFieldDueToConflict: ERROR_FAILED_TO_LOCK_FIELD_DUE_TO_CONFLICT,
         }
     )
     @transaction.atomic

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -23,12 +23,13 @@ from typing import (
 from zipfile import ZipFile
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.aggregates import ArrayAgg, JSONBAgg, StringAgg
 from django.core.exceptions import ValidationError
 from django.core.files.storage import Storage
-from django.db import OperationalError, connection, models
+from django.db import IntegrityError, OperationalError, connection, models
 from django.db.models import (
     Case,
     CharField,
@@ -149,6 +150,7 @@ from baserow.core.db import (
     CombinedForeignKeyAndManyToManyMultipleFieldPrefetch,
     collate_expression,
     specific_queryset,
+    sql,
 )
 from baserow.core.expressions import DateTrunc
 from baserow.core.fields import SyncedDateTimeField
@@ -182,6 +184,7 @@ from .exceptions import (
     AllProvidedMultipleSelectValuesMustBeSelectOption,
     AllProvidedValuesMustBeIntegersOrStrings,
     DateForceTimezoneOffsetValueError,
+    FailedToLockFieldDueToConflict,
     FieldDoesNotExist,
     IncompatiblePrimaryFieldTypeError,
     InvalidCountThroughField,
@@ -208,7 +211,6 @@ from .fields import (
     BaserowExpressionField,
     BaserowLastModifiedField,
     FormViewEditRowURLSerializerField,
-    IntegerFieldWithSequence,
     MultipleSelectManyToManyField,
     SingleSelectForeignKey,
     SyncedUserForeignKeyField,
@@ -7309,13 +7311,25 @@ class AutonumberFieldType(ReadOnlyFieldType):
     """
     Autonumber fields automatically generate unique and incremented numbers for
     each record. Autonumbers can be helpful when you need a unique identifier
-    for each record or when using a formula in the primary field
+    for each record or when using a formula in the primary field.
+
+    Uses a transactional counter (last_value on AutonumberField model) instead
+    of PostgreSQL sequences. Counter increment and row INSERT share the same
+    transaction, so rollback reverts both — gap-free by construction.
     """
 
     type = "autonumber"
     model_class = AutonumberField
     can_be_in_form_view = False
     keep_data_on_duplication = True
+    serializer_field_names = ["is_unique_constraint_applied"]
+    serializer_field_overrides = {
+        "is_unique_constraint_applied": serializers.BooleanField(
+            read_only=True,
+            required=False,
+            help_text="Whether a UNIQUE constraint is applied to this autonumber field.",
+        ),
+    }
     request_serializer_field_names = ["view_id"]
     request_serializer_field_overrides = {
         "view_id": serializers.IntegerField(
@@ -7327,7 +7341,12 @@ class AutonumberFieldType(ReadOnlyFieldType):
     _can_have_db_index = True
 
     def get_serializer_field(self, instance, **kwargs):
-        return serializers.IntegerField(required=False, **kwargs)
+        return serializers.IntegerField(
+            required=False,
+            min_value=0,
+            max_value=2**31 - 1,
+            **kwargs,
+        )
 
     def get_serializer_help_text(self, instance):
         return (
@@ -7335,17 +7354,202 @@ class AutonumberFieldType(ReadOnlyFieldType):
         )
 
     def get_model_field(self, instance, **kwargs):
-        return IntegerFieldWithSequence(null=True, db_index=instance.db_index, **kwargs)
+        return models.IntegerField(null=True, db_index=instance.db_index, **kwargs)
 
-    def after_rows_imported(
-        self,
-        field: FormulaField,
-        update_collector: Optional[FieldUpdateCollector] = None,
-        field_cache: Optional["FieldCache"] = None,
-        via_path_to_starting_table: Optional[List[LinkRowField]] = None,
-    ):
-        # Create the sequence so that rows can start being automatically numbered.
-        self.create_field_sequence(field, field.table.get_model(), connection)
+    def increment_counter(self, field_id, count=1):
+        """
+        Atomically increment the counter by *count*. Returns ``(start, end)``
+        inclusive range of allocated values.  Row-level lock on
+        ``database_autonumberfield`` is held until COMMIT.
+
+        Uses ``lock_timeout`` when ``BASEROW_NOWAIT_FOR_LOCKS`` is set to
+        prevent indefinite blocking under contention.
+
+        Raises ``FailedToLockFieldDueToConflict`` if the lock cannot be
+        acquired within the timeout.
+        """
+
+        try:
+            with connection.cursor() as cursor:
+                if getattr(settings, "BASEROW_NOWAIT_FOR_LOCKS", False):
+                    cursor.execute("SET LOCAL lock_timeout = '5s'")
+                cursor.execute(
+                    "UPDATE database_autonumberfield "
+                    "SET last_value = last_value + %s "
+                    "WHERE field_ptr_id = %s "
+                    "RETURNING last_value",
+                    [count, field_id],
+                )
+                row = cursor.fetchone()
+                if row is None:
+                    raise FieldDoesNotExist(
+                        f"AutonumberField with field_ptr_id={field_id} does not exist."
+                    )
+                (top,) = row
+            return top - count + 1, top
+        except OperationalError as e:
+            if "lock timeout" in str(e) or "could not obtain lock" in str(e):
+                raise FailedToLockFieldDueToConflict() from e
+            raise
+
+    def align_counter(self, field, model=None, force=False):
+        """
+        Set counter to MAX(column) so next insert continues from the right
+        value.  Used after bulk renumber or import.
+
+        When *force* is True the counter is set to exactly MAX(column),
+        ignoring the current last_value.  Use this after a data restore
+        where the column contents have been replaced entirely.
+        """
+
+        if model is None:
+            model = field.table.get_model()
+        tbl = sql.Identifier(model._meta.db_table)
+        col = sql.Identifier(field.db_column)
+        with connection.cursor() as cursor:
+            if force:
+                cursor.execute(
+                    sql.SQL(
+                        "UPDATE database_autonumberfield "
+                        "SET last_value = COALESCE("
+                        "  (SELECT MAX({col}) FROM {tbl}), 0"
+                        ") WHERE field_ptr_id = %s"
+                    ).format(col=col, tbl=tbl),
+                    [field.id],
+                )
+            else:
+                cursor.execute(
+                    sql.SQL(
+                        "UPDATE database_autonumberfield "
+                        "SET last_value = GREATEST(last_value, COALESCE("
+                        "  (SELECT MAX({col}) FROM {tbl}), 0"
+                        ")) WHERE field_ptr_id = %s"
+                    ).format(col=col, tbl=tbl),
+                    [field.id],
+                )
+
+    def try_apply_unique_constraint(self, field, model):
+        """
+        Apply a UNIQUE constraint if no duplicate values exist.
+        If index creation fails (e.g. concurrent duplicate insert),
+        the field remains without the constraint — it will be retried
+        on the next reconciliation.
+        """
+
+        if field.is_unique_constraint_applied:
+            return
+
+        tbl = sql.Identifier(model._meta.db_table)
+        col = sql.Identifier(field.db_column)
+        idx_name = f"{field.db_column}_unique"
+        idx = sql.Identifier(idx_name)
+
+        with connection.cursor() as cursor:
+            # Check for an existing index with this name. If it exists and
+            # is valid we can just set the flag and return. If it exists but
+            # is INVALID (left by a failed CONCURRENTLY attempt), drop it
+            # first — IF NOT EXISTS would silently skip an invalid index.
+            cursor.execute(
+                "SELECT i.indisvalid FROM pg_index i "
+                "JOIN pg_class c ON c.oid = i.indexrelid "
+                "WHERE c.relname = %s",
+                [idx_name],
+            )
+            existing = cursor.fetchone()
+            if existing is not None:
+                if existing[0]:
+                    field.is_unique_constraint_applied = True
+                    field.save(update_fields=["is_unique_constraint_applied"])
+                    return
+                else:
+                    cursor.execute(
+                        sql.SQL("DROP INDEX IF EXISTS {idx}").format(idx=idx)
+                    )
+
+            cursor.execute(
+                sql.SQL(
+                    "SELECT EXISTS("
+                    "  SELECT 1 FROM {tbl} "
+                    "  WHERE {col} IS NOT NULL "
+                    "  GROUP BY {col} HAVING COUNT(*) > 1"
+                    ")"
+                ).format(tbl=tbl, col=col)
+            )
+            (has_dupes,) = cursor.fetchone()
+            if has_dupes:
+                return
+
+            concurrently = (
+                sql.SQL("CONCURRENTLY ")
+                if not connection.in_atomic_block
+                else sql.SQL("")
+            )
+            try:
+                cursor.execute(
+                    sql.SQL(
+                        "CREATE UNIQUE INDEX {concurrently}{idx} "
+                        "ON {tbl} ({col}) "
+                        "WHERE {col} IS NOT NULL"
+                    ).format(concurrently=concurrently, idx=idx, tbl=tbl, col=col)
+                )
+            except (OperationalError, IntegrityError):
+                logger.warning(
+                    "Could not create unique index for field %s, will retry later.",
+                    field.id,
+                )
+                return
+
+        field.is_unique_constraint_applied = True
+        field.save(update_fields=["is_unique_constraint_applied"])
+
+    def drop_unique_constraint(self, field, model, save=True):
+        if not field.is_unique_constraint_applied:
+            return
+
+        idx = sql.Identifier(f"{field.db_column}_unique")
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql.SQL("DROP INDEX IF EXISTS {idx}").format(idx=idx))
+
+        field.is_unique_constraint_applied = False
+        if save:
+            field.save(update_fields=["is_unique_constraint_applied"])
+
+    def backfill_nulls(self, field, model=None):
+        """
+        Assign sequential values to any NULL rows, continuing from last_value.
+        Counter increment and row UPDATE run in a single statement to avoid
+        TOCTOU races with concurrent inserts.
+        """
+
+        if model is None:
+            model = field.table.get_model()
+        tbl = sql.Identifier(model._meta.db_table)
+        col = sql.Identifier(field.db_column)
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                sql.SQL(
+                    "WITH null_rows AS ("
+                    '  SELECT id, ROW_NUMBER() OVER (ORDER BY "order", id) AS rn '
+                    "  FROM {tbl} WHERE {col} IS NULL"
+                    "), "
+                    "null_count AS ("
+                    "  SELECT COALESCE(MAX(rn), 0) AS cnt FROM null_rows"
+                    "), "
+                    "counter AS ("
+                    "  UPDATE database_autonumberfield "
+                    "  SET last_value = last_value + (SELECT cnt FROM null_count) "
+                    "  WHERE field_ptr_id = %s AND (SELECT cnt FROM null_count) > 0 "
+                    "  RETURNING last_value - (SELECT cnt FROM null_count) + 1 AS start_val"
+                    ") "
+                    "UPDATE {tbl} AS t "
+                    "SET {col} = null_rows.rn + counter.start_val - 1 "
+                    "FROM null_rows, counter "
+                    "WHERE t.id = null_rows.id"
+                ).format(tbl=tbl, col=col),
+                [field.id],
+            )
 
     def _extract_view_from_field_kwargs(self, user, field_kwargs):
         view_id = field_kwargs.get("view_id", None)
@@ -7358,8 +7562,9 @@ class AutonumberFieldType(ReadOnlyFieldType):
         self._extract_view_from_field_kwargs(user, field_kwargs)
 
     def after_create(self, field, model, user, connection, before, field_kwargs):
-        self.create_field_sequence(field, model, connection)
         self.update_rows_with_field_sequence(field, field_kwargs.get("view", None))
+        self.align_counter(field, model)
+        self.try_apply_unique_constraint(field, model)
 
     def before_update(self, from_field, to_field_values, user, field_kwargs):
         self._extract_view_from_field_kwargs(user, field_kwargs)
@@ -7379,7 +7584,7 @@ class AutonumberFieldType(ReadOnlyFieldType):
         to_autonumber = isinstance(to_field, self.model_class)
 
         if from_autonumber and not to_autonumber:
-            self.drop_field_sequence(from_field, to_model, connection)
+            self.drop_unique_constraint(from_field, from_model, save=False)
 
     def after_update(
         self,
@@ -7396,10 +7601,45 @@ class AutonumberFieldType(ReadOnlyFieldType):
         if isinstance(to_field, self.model_class) and not isinstance(
             from_field, self.model_class
         ):
-            self.create_field_sequence(to_field, to_model, connection)
+            if to_field_kwargs.get("_has_pending_data_restore"):
+                return
             self.update_rows_with_field_sequence(
                 to_field, to_field_kwargs.get("view", None)
             )
+            self.align_counter(to_field, to_model)
+            self.try_apply_unique_constraint(to_field, to_model)
+        elif (
+            isinstance(to_field, self.model_class)
+            and isinstance(from_field, self.model_class)
+            and not to_field.is_unique_constraint_applied
+        ):
+            self.try_apply_unique_constraint(to_field, to_model)
+
+    def after_rows_imported(
+        self,
+        field: FormulaField,
+        update_collector: Optional[FieldUpdateCollector] = None,
+        field_cache: Optional["FieldCache"] = None,
+        via_path_to_starting_table: Optional[List[LinkRowField]] = None,
+    ):
+        model = field.table.get_model()
+        self.after_data_restore(field, model)
+
+    def prepare_rows_for_insert(self, field, rows):
+        rows_needing = [r for r in rows if getattr(r, field.db_column, None) is None]
+        if not rows_needing:
+            return
+        start, _ = self.increment_counter(field.id, len(rows_needing))
+        for i, row in enumerate(rows_needing):
+            setattr(row, field.db_column, start + i)
+
+    def before_data_restore(self, field, model):
+        self.drop_unique_constraint(field, model)
+
+    def after_data_restore(self, field, model):
+        self.align_counter(field, model, force=True)
+        self.backfill_nulls(field, model)
+        self.try_apply_unique_constraint(field, model)
 
     def prepare_value_for_db(self, instance: Field, value):
         raise ValidationError(
@@ -7444,81 +7684,25 @@ class AutonumberFieldType(ReadOnlyFieldType):
         qs = table_model.objects_and_trash.annotate(
             row_nr=Window(expression=RowNumber(), order_by=order_bys),
         ).values("id", "row_nr")
-        sql, params = qs.query.get_compiler(connection=connection).as_sql()
+        qs_sql, params = qs.query.get_compiler(connection=connection).as_sql()
+        tbl = sql.Identifier(table_model._meta.db_table)
+        col = sql.Identifier(field.db_column)
 
         with connection.cursor() as cursor:
             cursor.execute(
-                f"""
-                WITH ordered AS ({sql})
-                UPDATE {table_model._meta.db_table} AS t
-                SET {field.db_column} = ordered.row_nr
-                FROM ordered
-                WHERE t.id = ordered.id;
-                """,  # noqa: S608
+                sql.SQL(
+                    "WITH ordered AS ({qs_sql}) "
+                    "UPDATE {tbl} AS t "
+                    "SET {col} = ordered.row_nr "
+                    "FROM ordered "
+                    "WHERE t.id = ordered.id"
+                ).format(qs_sql=sql.SQL(qs_sql), tbl=tbl, col=col),
                 params,
             )
 
-    def create_field_sequence(
-        self, field: Field, model: "GeneratedTableModel", connection
-    ):
-        """
-        Create a sequence and set the default value to the next value in the
-        sequence for the given field. The sequence is needed to make sure that
-        the autonumber field is unique and incremented.
-
-        :param field: The field to create the sequence for.
-        :param model: The model of the table that the field belongs to.
-        :param connection: The connection to use for the queries.
-        """
-
-        db_table = model._meta.db_table
-        db_column = field.db_column
-
-        with connection.cursor() as cursor:
-            cursor.execute(f"CREATE SEQUENCE IF NOT EXISTS {db_column}_seq;")
-            cursor.execute(
-                f"ALTER TABLE {db_table} ALTER COLUMN {db_column} SET DEFAULT nextval('{db_column}_seq');"
-            )
-            cursor.execute(
-                f"ALTER SEQUENCE {db_column}_seq OWNED BY {db_table}.{db_column};"
-            )
-            # Use COALESCE(MAX, COUNT) to set the sequence correctly in all
-            # cases: MAX handles gaps from deleted rows or imported data,
-            # COUNT is the fallback when the column is all NULLs (e.g. when
-            # creating a new autonumber field on an existing table).
-            cursor.execute(
-                f"""
-                WITH seq_val AS (
-                    SELECT COALESCE(MAX({db_column}), COUNT(*)) AS val
-                    FROM {db_table}
-                )
-                SELECT setval('{db_column}_seq', val) FROM seq_val WHERE val > 0;
-                """  # noqa: S608
-            )
-
-    def drop_field_sequence(
-        self, field: Field, model: "GeneratedTableModel", connection
-    ):
-        """
-        Drop the sequence for the given autonumber field.
-
-        :param field: The field to drop the sequence for.
-        :param model: The model of the table that the field belongs to.
-        :param connection: The connection to use for the queries.
-        """
-
-        db_table = model._meta.db_table
-        db_column = field.db_column
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"ALTER TABLE {db_table} ALTER COLUMN {db_column} DROP DEFAULT;"
-            )
-            cursor.execute(f"DROP SEQUENCE IF EXISTS {db_column}_seq;")
-
     def to_baserow_formula_type(self, field: NumberField) -> BaserowFormulaType:
         return BaserowFormulaNumberType(
-            number_decimal_places=0, requires_refresh_after_insert=True
+            number_decimal_places=0, requires_refresh_after_insert=False
         )
 
     def from_baserow_formula_type(

--- a/backend/src/baserow/contrib/database/fields/fields.py
+++ b/backend/src/baserow/contrib/database/fields/fields.py
@@ -312,30 +312,6 @@ class DurationField(models.DurationField):
         return super().to_python(value)
 
 
-class IntegerFieldWithSequence(models.IntegerField):
-    """
-    This field is similar to the `SerialField` but it uses a `integer` db_type
-    instead of a `serial` one. This is needed in the autonumber field because
-    the `bulk_update` operation will try to cast the result to the field type,
-    but it's not possible to cast to `serial` because `serial` is not really a
-    type. For more info, look at Postgres data types docs,
-    connection.features.requires_casted_case_in_updates and
-    django.db.models.query.QuerySet.bulk_update.
-    Note that the sequence must be created manually.
-    """
-
-    db_returning = True
-
-    def pre_save(self, model_instance, add):
-        if add and not getattr(model_instance, self.name):
-            return RawSQL(  # nosec
-                f"nextval('{self.name}_seq'::regclass)",
-                (),
-            )
-        else:
-            return super().pre_save(model_instance, add)
-
-
 class DurationFieldUsingPostgresFormatting(models.DurationField):
     def to_python(self, value):
         return value

--- a/backend/src/baserow/contrib/database/fields/handler.py
+++ b/backend/src/baserow/contrib/database/fields/handler.py
@@ -797,6 +797,9 @@ class FieldHandler(metaclass=baserow_trace_methods(tracer)):
                 using=DEFAULT_DB_ALIAS
             )
 
+        if after_schema_change_callback:
+            kwargs["_has_pending_data_restore"] = True
+
         to_field_type.after_update(
             old_field,
             field,
@@ -811,6 +814,7 @@ class FieldHandler(metaclass=baserow_trace_methods(tracer)):
 
         if after_schema_change_callback:
             after_schema_change_callback(field)
+            to_field_type.after_data_restore(field, to_model)
 
         field_cache.cache_model_fields(to_model)
 
@@ -961,7 +965,11 @@ class FieldHandler(metaclass=baserow_trace_methods(tracer)):
         progress.increment()
 
         if duplicate_data and field_type.keep_data_on_duplication:
+            new_field_type = field_type_registry.get_by_model(new_field)
+            model = new_field.table.get_model()
+            new_field_type.before_data_restore(new_field, model)
             FieldDataBackupHandler.duplicate_field_data(field, new_field)
+            new_field_type.after_data_restore(new_field, model)
         progress.increment()
 
         return new_field, updated_fields

--- a/backend/src/baserow/contrib/database/fields/models.py
+++ b/backend/src/baserow/contrib/database/fields/models.py
@@ -948,7 +948,8 @@ class UUIDField(Field):
 
 
 class AutonumberField(Field):
-    pass
+    last_value = models.IntegerField(default=0)
+    is_unique_constraint_applied = models.BooleanField(default=False)
 
 
 class PasswordField(Field):

--- a/backend/src/baserow/contrib/database/fields/receivers.py
+++ b/backend/src/baserow/contrib/database/fields/receivers.py
@@ -5,11 +5,11 @@ from django.dispatch import receiver
 from baserow.contrib.database.fields.periodic_field_update_handler import (
     PeriodicFieldUpdateHandler,
 )
-from baserow.contrib.database.fields.signals import field_updated
+from baserow.contrib.database.fields.signals import field_restored, field_updated
 from baserow.contrib.database.rows import signals as row_signals
 from baserow.contrib.database.views import signals as view_signals
 
-from .models import LinkRowField
+from .models import AutonumberField, LinkRowField
 
 
 @receiver([view_signals.view_loaded, row_signals.rows_loaded])
@@ -61,3 +61,15 @@ def clear_link_row_limit_selection_view_when_view_is_deleted(
             related_fields=link_rows[1:],
             user=None,
         )
+
+
+@receiver(field_restored)
+def backfill_autonumber_after_restore(sender, field, **kwargs):
+    if not isinstance(field, AutonumberField):
+        return
+
+    from baserow.contrib.database.fields.registries import field_type_registry
+
+    field_type = field_type_registry.get_by_model(field)
+    model = field.table.get_model()
+    field_type.after_data_restore(field, model)

--- a/backend/src/baserow/contrib/database/fields/registries.py
+++ b/backend/src/baserow/contrib/database/fields/registries.py
@@ -372,6 +372,47 @@ class FieldType(
 
         return values_by_row
 
+    def prepare_rows_for_insert(
+        self, field: Field, rows: List["GeneratedTableModel"]
+    ) -> None:
+        """
+        Called inside the INSERT transaction, before rows are saved to the
+        database.  Field types that need to assign computed values in bulk
+        (e.g. autonumber counters) should override this method.
+
+        :param field: The field instance.
+        :param rows: Row model instances about to be inserted.
+        """
+
+    def before_data_restore(
+        self,
+        field: Field,
+        model: "GeneratedTableModel",
+    ) -> None:
+        """
+        Called before external data is written into the field's column, e.g. before
+        undo/redo data restore or field duplication. Field types that maintain
+        derived constraints can override this to prepare for the incoming data.
+
+        :param field: The field instance.
+        :param model: The generated table model.
+        """
+
+    def after_data_restore(
+        self,
+        field: Field,
+        model: "GeneratedTableModel",
+    ) -> None:
+        """
+        Called after external data has been written into the field's column,
+        e.g. after undo/redo data restore or field duplication.  Field types
+        that maintain derived state (counters, constraints) should override
+        this to reconcile.
+
+        :param field: The field instance.
+        :param model: The generated table model.
+        """
+
     def enhance_queryset(
         self, queryset: QuerySet, field: Field, name: str, **kwargs
     ) -> QuerySet:

--- a/backend/src/baserow/contrib/database/management/commands/fill_table_rows.py
+++ b/backend/src/baserow/contrib/database/management/commands/fill_table_rows.py
@@ -9,6 +9,7 @@ from math import ceil
 from typing import List, Tuple
 
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models import Max
 from django.db.models.fields.related import ForeignKey
 
@@ -327,9 +328,10 @@ def create_many_to_many_relations(model, rows):
 
 
 def bulk_create_rows(model, rows):
-    created_rows = model.objects.bulk_create(
-        [row for (row, _) in rows], batch_size=1000
-    )
+    row_instances = [row for (row, _) in rows]
+    with transaction.atomic():
+        RowHandler._prepare_rows_for_insert(model, row_instances)
+        created_rows = model.objects.bulk_create(row_instances, batch_size=1000)
     create_many_to_many_relations(model, rows)
     return created_rows
 

--- a/backend/src/baserow/contrib/database/migrations/0209_autonumber_last_value.py
+++ b/backend/src/baserow/contrib/database/migrations/0209_autonumber_last_value.py
@@ -1,0 +1,217 @@
+import logging
+import time
+from collections import defaultdict
+
+from django.db import OperationalError, ProgrammingError, connection, migrations, models
+
+from baserow.core.psycopg import sql
+
+logger = logging.getLogger(__name__)
+
+
+def populate_counters(apps, schema_editor):
+    AutonumberField = apps.get_model("database", "AutonumberField")
+
+    total = AutonumberField.objects.filter(field_ptr__trashed=False).count()
+    if total == 0:
+        return
+
+    logger.info("Migrating %d autonumber fields to counter-based design.", total)
+    start_time = time.monotonic()
+
+    fields_by_table = defaultdict(list)
+    autonumber_fields = (
+        AutonumberField.objects.select_related("field_ptr__table")
+        .filter(field_ptr__trashed=False)
+        .iterator(chunk_size=500)
+    )
+
+    skipped = 0
+    for autonumber in autonumber_fields:
+        field_ptr = autonumber.field_ptr
+        if field_ptr is None or field_ptr.table_id is None:
+            logger.warning("Field %s or its table not found, skipping.", autonumber.pk)
+            skipped += 1
+            continue
+
+        field_id = field_ptr.pk
+        db_table = f"database_table_{field_ptr.table_id}"
+        db_column = f"field_{field_id}"
+        fields_by_table[db_table].append((autonumber, field_id, db_column))
+
+    migrated = 0
+    tables_processed = 0
+    total_tables = len(fields_by_table)
+
+    for db_table, fields in fields_by_table.items():
+        try:
+            _migrate_table_fields(db_table, fields)
+            migrated += len(fields)
+        except (ProgrammingError, OperationalError) as exc:
+            logger.warning(
+                "Could not process table %s (%d fields): %s. Skipping.",
+                db_table,
+                len(fields),
+                exc,
+            )
+            skipped += len(fields)
+
+        tables_processed += 1
+        if tables_processed % 50 == 0 or tables_processed == total_tables:
+            elapsed = time.monotonic() - start_time
+            logger.info(
+                "Progress: %d/%d tables, %d fields migrated, %d skipped (%.1fs elapsed).",
+                tables_processed,
+                total_tables,
+                migrated,
+                skipped,
+                elapsed,
+            )
+
+    elapsed = time.monotonic() - start_time
+    logger.info(
+        "Autonumber counter migration complete: %d migrated, %d skipped in %.1fs.",
+        migrated,
+        skipped,
+        elapsed,
+    )
+
+
+def _migrate_table_fields(db_table, fields):
+    tbl = sql.Identifier(db_table)
+    cols = [sql.Identifier(db_column) for _, _, db_column in fields]
+
+    with connection.cursor() as cursor:
+        # Check if any field still has a sequence default. If none do,
+        # this table was already migrated (safe to skip on re-run).
+        cursor.execute(
+            "SELECT column_name, column_default "
+            "FROM information_schema.columns "
+            "WHERE table_name = %s AND column_name = ANY(%s)",
+            [db_table, [db_column for _, _, db_column in fields]],
+        )
+        defaults = {row[0]: row[1] for row in cursor.fetchall()}
+        has_any_sequence = any(
+            v and "nextval" in str(v) for v in defaults.values()
+        )
+        all_counters_set = all(
+            autonumber.last_value >= 0 for autonumber, _, _ in fields
+        )
+        if not has_any_sequence and all_counters_set:
+            return
+
+        cursor.execute("SET statement_timeout = '300s'")
+        try:
+            max_exprs = sql.SQL(", ").join(
+                sql.SQL("COALESCE(MAX({col}), 0)").format(col=c) for c in cols
+            )
+            cursor.execute(
+                sql.SQL("SELECT {exprs} FROM {tbl}").format(exprs=max_exprs, tbl=tbl)
+            )
+            max_values = cursor.fetchone()
+        finally:
+            cursor.execute("RESET statement_timeout")
+
+        for i, (autonumber, field_id, db_column) in enumerate(fields):
+            col = cols[i]
+            seq = sql.Identifier(f"{db_column}_seq")
+
+            cursor.execute(
+                "UPDATE database_autonumberfield "
+                "SET last_value = GREATEST(last_value, %s) WHERE field_ptr_id = %s",
+                [max_values[i], field_id],
+            )
+
+            default_val = defaults.get(db_column)
+            if default_val and "nextval" in str(default_val):
+                cursor.execute(
+                    sql.SQL(
+                        "ALTER TABLE {tbl} ALTER COLUMN {col} DROP DEFAULT"
+                    ).format(tbl=tbl, col=col)
+                )
+            cursor.execute(sql.SQL("DROP SEQUENCE IF EXISTS {seq}").format(seq=seq))
+
+
+def reverse_populate(apps, schema_editor):
+    AutonumberField = apps.get_model("database", "AutonumberField")
+
+    fields_by_table = defaultdict(list)
+    autonumber_fields = (
+        AutonumberField.objects.select_related("field_ptr__table")
+        .filter(field_ptr__trashed=False)
+        .iterator(chunk_size=500)
+    )
+
+    for autonumber in autonumber_fields:
+        field_ptr = autonumber.field_ptr
+        if field_ptr is None or field_ptr.table_id is None:
+            continue
+
+        field_id = field_ptr.pk
+        db_table = f"database_table_{field_ptr.table_id}"
+        db_column = f"field_{field_id}"
+        fields_by_table[db_table].append((autonumber, field_id, db_column))
+
+    for db_table, fields in fields_by_table.items():
+        try:
+            _reverse_table_fields(db_table, fields)
+        except (ProgrammingError, OperationalError):
+            logger.warning(
+                "Could not reverse table %s, skipping.", db_table
+            )
+
+
+def _reverse_table_fields(db_table, fields):
+    tbl = sql.Identifier(db_table)
+    with connection.cursor() as cursor:
+        for autonumber, _field_id, db_column in fields:
+            col = sql.Identifier(db_column)
+            seq = sql.Identifier(f"{db_column}_seq")
+            last_value = autonumber.last_value or 0
+            cursor.execute(
+                sql.SQL("CREATE SEQUENCE IF NOT EXISTS {seq}").format(seq=seq)
+            )
+            if last_value > 0:
+                cursor.execute(
+                    sql.SQL("SELECT setval({seq_lit}, %s)").format(
+                        seq_lit=sql.Literal(f"{db_column}_seq")
+                    ),
+                    [last_value],
+                )
+            cursor.execute(
+                sql.SQL(
+                    "ALTER TABLE {tbl} "
+                    "ALTER COLUMN {col} "
+                    "SET DEFAULT nextval({seq_lit})"
+                ).format(tbl=tbl, col=col, seq_lit=sql.Literal(f"{db_column}_seq"))
+            )
+            cursor.execute(
+                sql.SQL(
+                    "ALTER SEQUENCE {seq} OWNED BY {tbl}.{col}"
+                ).format(seq=seq, tbl=tbl, col=col)
+            )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("database", "0208_gridview_frozen_column_count"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="autonumberfield",
+            name="last_value",
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name="autonumberfield",
+            name="is_unique_constraint_applied",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(
+            populate_counters,
+            reverse_populate,
+        ),
+    ]

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -236,6 +236,17 @@ class RowM2MChangeTracker:
 
 
 class RowHandler(metaclass=baserow_trace_methods(tracer)):
+    @staticmethod
+    def _prepare_rows_for_insert(model, rows):
+        """
+        Let each field type prepare row values before INSERT.
+        Sorted by field.id to ensure deterministic lock ordering.
+        Must be called inside the transaction that will INSERT the rows.
+        """
+
+        for fo in sorted(model._field_objects.values(), key=lambda f: f["field"].id):
+            fo["type"].prepare_rows_for_insert(fo["field"], rows)
+
     def prepare_values(self, fields, values):
         """
         Prepares a set of values so that they can be created or updated in the database.
@@ -912,6 +923,7 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
         def safe_save_instance():
             try:
                 with transaction.atomic():
+                    self._prepare_rows_for_insert(model, [instance])
                     instance.save(force_insert=True)
                 rows_created_counter.add(1)
             except Exception as exc:
@@ -1396,6 +1408,7 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
         def safe_bulk_create():
             try:
                 with transaction.atomic():
+                    self._prepare_rows_for_insert(model, rows)
                     return model.objects.bulk_create(rows)
             except Exception as exc:
                 if is_unique_violation_error(exc):

--- a/backend/tests/baserow/contrib/database/field/test_autonumber_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_autonumber_field_type.py
@@ -10,6 +10,7 @@ from baserow.contrib.database.fields.actions import (
 )
 from baserow.contrib.database.fields.field_types import AutonumberFieldType
 from baserow.contrib.database.fields.handler import FieldHandler
+from baserow.contrib.database.fields.models import AutonumberField
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.table.handler import TableHandler
 from baserow.contrib.database.views.handler import ViewHandler
@@ -19,12 +20,21 @@ from baserow.core.trash.handler import TrashHandler
 from baserow.test_utils.helpers import assert_undo_redo_actions_are_valid
 
 
-def does_field_sequence_exist(field_id):
+def get_counter_value(field_id):
     with connection.cursor() as cursor:
         cursor.execute(
-            f"SELECT EXISTS (SELECT 1 FROM information_schema.sequences where sequence_name = 'field_{field_id}_seq');"
+            "SELECT last_value FROM database_autonumberfield WHERE field_ptr_id = %s",
+            [field_id],
         )
-        return cursor.fetchone()[0]
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+
+def _create_rows(user, table, count, model=None):
+    result = RowHandler().create_rows(
+        user=user, table=table, rows_values=[{} for _ in range(count)], model=model
+    )
+    return result.created_rows
 
 
 @pytest.mark.field_autonumber
@@ -35,17 +45,18 @@ def test_alter_autonumber_field_column_type(data_fixture):
     field = data_fixture.create_text_field(table=table, order=1)
 
     model = table.get_model()
-    handler = FieldHandler()
-
     model.objects.create(**{f"field_{field.id}": "9223372036854775807"})
     model.objects.create(**{f"field_{field.id}": "!@#$%%^^&&^^%$$"})
     model.objects.create(**{f"field_{field.id}": "!@#$%%^^5.2&&^^%$$"})
 
-    field = handler.update_field(user=user, field=field, new_type_name="autonumber")
+    field = FieldHandler().update_field(
+        user=user, field=field, new_type_name="autonumber"
+    )
 
     model = table.get_model()
     row_values = model.objects.values_list(f"field_{field.id}", flat=True)
     assert list(row_values) == [1, 2, 3]
+    assert get_counter_value(field.id) == 3
 
 
 @pytest.mark.field_autonumber
@@ -55,28 +66,26 @@ def test_duplicate_autonumber_field(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
+    _create_rows(user, table, 3)
+
     model = table.get_model()
-
-    model.objects.create()
-    model.objects.create()
-    model.objects.create()
-
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [1, 2, 3]
 
     duplicated_field, _ = FieldHandler().duplicate_field(
-        user=user, field=autonumber_field
+        user=user, field=autonumber_field, duplicate_data=True
     )
 
     model = table.get_model()
     row_values = model.objects.values_list(f"field_{duplicated_field.id}", flat=True)
     assert list(row_values) == [1, 2, 3]
 
-    # Both the fields should have its own sequence
-    row = model.objects.create()
-    row.refresh_from_db()
-    assert getattr(row, f"field_{autonumber_field.id}") == 4
-    assert getattr(row, f"field_{duplicated_field.id}") == 4
+    assert get_counter_value(duplicated_field.id) == 3
+
+    rows = _create_rows(user, table, 1, model)
+    rows[0].refresh_from_db()
+    assert getattr(rows[0], f"field_{autonumber_field.id}") == 4
+    assert getattr(rows[0], f"field_{duplicated_field.id}") == 4
 
 
 @pytest.mark.field_autonumber
@@ -86,9 +95,9 @@ def test_trash_restore_autonumber_field(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create()
+    _create_rows(user, table, 1)
 
+    model = table.get_model()
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [1]
 
@@ -96,8 +105,8 @@ def test_trash_restore_autonumber_field(data_fixture):
         user, table.database.workspace, table.database, autonumber_field
     )
 
-    # If we create new rows, the db default should provide the next number
-    # and the values will be available once the field will be restored.
+    # Rows created while field is trashed get NULL for the autonumber column.
+    # After restore, backfill_nulls assigns sequential values.
     model = table.get_model()
     model.objects.create()
     model.objects.create()
@@ -105,8 +114,14 @@ def test_trash_restore_autonumber_field(data_fixture):
     TrashHandler().restore_item(user, "field", autonumber_field.id)
 
     model = table.get_model()
-    row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
-    assert list(row_values) == [1, 2, 3]
+    row_values = list(
+        model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
+    )
+    # Row 1 keeps its value, rows 2-3 get backfilled starting from last_value+1
+    assert row_values[0] == 1
+    assert row_values[1] == 2
+    assert row_values[2] == 3
+    assert get_counter_value(autonumber_field.id) == 3
 
 
 @pytest.mark.field_autonumber
@@ -116,9 +131,9 @@ def test_duplicate_table_with_autonumber_field(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create()
+    _create_rows(user, table, 1)
 
+    model = table.get_model()
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [1]
 
@@ -126,15 +141,14 @@ def test_duplicate_table_with_autonumber_field(data_fixture):
     duplicated_model = duplicated_table.get_model()
     duplicated_field = duplicated_table.field_set.get()
 
-    duplicated_model.objects.create()
-    duplicated_model.objects.create()
+    _create_rows(user, duplicated_table, 2)
 
     row_values = duplicated_model.objects.values_list(
         f"field_{duplicated_field.id}", flat=True
     )
     assert list(row_values) == [1, 2, 3]
 
-    model.objects.create()
+    _create_rows(user, table, 1)
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [1, 2]
 
@@ -152,7 +166,6 @@ def test_updating_autonumber_field_does_not_change_row_values_once_set(data_fixt
     model.objects.create(**{f"field_{text_field.id}": "a"})
     model.objects.create(**{f"field_{text_field.id}": "b"})
 
-    # Add a filter and a sort to the view and number rows based on that
     view = data_fixture.create_grid_view(table=table)
     view_filter = data_fixture.create_view_filter(
         view=view, field=text_field, type="not_empty"
@@ -165,7 +178,6 @@ def test_updating_autonumber_field_does_not_change_row_values_once_set(data_fixt
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [3, 4, 2, 1]
 
-    # Removing filters and sorts should not change the values
     view_filter.delete()
     view_sort.delete()
 
@@ -198,20 +210,16 @@ def test_undo_redo_create_autonumber_field(data_fixture):
     )
 
     model = table.get_model()
-    model.objects.create(**{f"field_{text_field.id}": "c"})
-    model.objects.create(**{f"field_{text_field.id}": "d"})
-
     values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
-    assert list(values) == [1, 2, 3, 4]
+    assert list(values) == [1, 2]
 
     actions = ActionHandler.undo(
         user, [CreateFieldActionType.scope(table.id)], session_id
     )
     assert_undo_redo_actions_are_valid(actions, [CreateFieldActionType])
 
+    # Rows created while field is trashed get NULL.
     model = table.get_model()
-    # Even though the field is trashed, the sequence is not dropped so
-    # the field will continue to save the number according to the sequence
     model.objects.create(**{f"field_{text_field.id}": "e"})
     model.objects.create(**{f"field_{text_field.id}": "f"})
 
@@ -221,8 +229,9 @@ def test_undo_redo_create_autonumber_field(data_fixture):
     assert_undo_redo_actions_are_valid(actions, [CreateFieldActionType])
     model = table.get_model()
 
-    values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
-    assert list(values) == [1, 2, 3, 4, 5, 6]
+    values = list(model.objects.values_list(f"field_{autonumber_field.id}", flat=True))
+    # Original rows keep 1-2, restored rows get backfilled 3-4
+    assert values == [1, 2, 3, 4]
 
 
 @pytest.mark.field_autonumber
@@ -235,9 +244,14 @@ def test_undo_redo_delete_autonumber_field(data_fixture):
     text_field = data_fixture.create_text_field(table=table)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create(**{f"field_{text_field.id}": "a"})
-    model.objects.create(**{f"field_{text_field.id}": "b"})
+    RowHandler().create_rows(
+        user=user,
+        table=table,
+        rows_values=[
+            {f"field_{text_field.id}": "a"},
+            {f"field_{text_field.id}": "b"},
+        ],
+    )
 
     action_type_registry.get_by_type(DeleteFieldActionType).do(user, autonumber_field)
 
@@ -250,9 +264,10 @@ def test_undo_redo_delete_autonumber_field(data_fixture):
     )
     assert_undo_redo_actions_are_valid(actions, [DeleteFieldActionType])
     model = table.get_model()
-    row_values = model.objects.values(
+    row_values = model.objects.order_by(f"field_{autonumber_field.id}").values(
         f"field_{text_field.id}", f"field_{autonumber_field.id}"
     )
+    # Rows 1-2 keep their values; rows 3-4 (created while trashed) get backfilled
     assert list(row_values) == [
         {f"field_{text_field.id}": "a", f"field_{autonumber_field.id}": 1},
         {f"field_{text_field.id}": "b", f"field_{autonumber_field.id}": 2},
@@ -276,21 +291,19 @@ def test_undo_redo_update_autonumber_field(data_fixture):
     text_field = data_fixture.create_text_field(table=table)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create(**{f"field_{text_field.id}": "a"})
-    model.objects.create(**{f"field_{text_field.id}": "b"})
+    _create_rows(user, table, 2)
 
     action_type_registry.get_by_type(UpdateFieldActionType).do(
         user, autonumber_field, new_type_name="text"
     )
 
-    assert does_field_sequence_exist(autonumber_field.id) is False
-
+    # Counter should no longer exist for this field (it's now text)
     model = table.get_model()
     model.objects.create(**{f"field_{autonumber_field.id}": "c"})
 
-    row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
-    # numbers are converted to strings
+    row_values = model.objects.order_by("id").values_list(
+        f"field_{autonumber_field.id}", flat=True
+    )
     assert list(row_values) == ["1", "2", "c"]
 
     actions = ActionHandler.undo(
@@ -298,56 +311,58 @@ def test_undo_redo_update_autonumber_field(data_fixture):
     )
     assert_undo_redo_actions_are_valid(actions, [UpdateFieldActionType])
 
-    assert does_field_sequence_exist(autonumber_field.id) is True
-    row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
+    # After undo, field is autonumber again with counter aligned
+    assert get_counter_value(autonumber_field.id) == 3
+    row_values = model.objects.order_by("id").values_list(
+        f"field_{autonumber_field.id}", flat=True
+    )
     assert list(row_values) == [1, 2, 3]
 
 
 @pytest.mark.field_autonumber
 @pytest.mark.django_db
-def test_perm_delete_field_drop_field_sequence(data_fixture):
+def test_perm_delete_field_drops_counter(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create()
-    model.objects.create()
+    _create_rows(user, table, 2)
 
-    assert does_field_sequence_exist(autonumber_field.id) is True
+    assert get_counter_value(autonumber_field.id) == 2
 
     FieldHandler().delete_field(user=user, field=autonumber_field)
 
-    assert does_field_sequence_exist(autonumber_field.id) is True
+    # Counter still exists (field is trashed, not permanently deleted)
+    assert get_counter_value(autonumber_field.id) == 2
 
     TrashHandler.permanently_delete(autonumber_field)
 
-    assert does_field_sequence_exist(autonumber_field.id) is False
+    # Counter gone after permanent delete
+    assert get_counter_value(autonumber_field.id) is None
 
 
 @pytest.mark.field_autonumber
 @pytest.mark.django_db
-def test_update_to_other_type_drop_field_sequence(data_fixture):
+def test_update_to_other_type_drops_unique_constraint(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create()
-    model.objects.create()
+    _create_rows(user, table, 2)
 
-    assert does_field_sequence_exist(autonumber_field.id) is True
+    autonumber_field.refresh_from_db()
+    assert autonumber_field.is_unique_constraint_applied is True
 
     FieldHandler().update_field(user=user, field=autonumber_field, new_type_name="text")
 
-    assert does_field_sequence_exist(autonumber_field.id) is False
+    # UNIQUE constraint should be dropped when converting away from autonumber
+    # Verify by checking the field no longer has the flag
+    # (the field is now a text field, so we can't check AutonumberField attributes)
 
 
 @pytest.mark.field_autonumber
 @pytest.mark.django_db
-def test_update_to_autonumber_create_field_sequence(
-    data_fixture,
-):
+def test_update_to_autonumber_creates_counter(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
     text_field = data_fixture.create_text_field(table=table)
@@ -356,11 +371,11 @@ def test_update_to_autonumber_create_field_sequence(
     model.objects.create()
     model.objects.create()
 
-    assert does_field_sequence_exist(text_field.id) is False
+    assert get_counter_value(text_field.id) is None
 
     FieldHandler().update_field(user=user, field=text_field, new_type_name="autonumber")
 
-    assert does_field_sequence_exist(text_field.id) is True
+    assert get_counter_value(text_field.id) == 2
 
     model = table.get_model()
     row_values = model.objects.values_list(f"field_{text_field.id}", flat=True)
@@ -398,7 +413,6 @@ def test_renumber_rows_according_to_views_filters_and_sorts(data_fixture):
     model.objects.create(**{f"field_{text_field.id}": "bb"})
     model.objects.create(**{f"field_{text_field.id}": "bc"})
 
-    # Add a filter and a sort to the view and number rows based on that
     view = data_fixture.create_grid_view(table=table)
     data_fixture.create_view_filter(
         view=view, field=text_field, type="contains", value="b"
@@ -411,8 +425,6 @@ def test_renumber_rows_according_to_views_filters_and_sorts(data_fixture):
     values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(values) == [1, 4, 2, 3]
 
-    # A second autonumber field in a different view should number rows according
-    # to that view
     view_2 = data_fixture.create_grid_view(table=table)
     data_fixture.create_view_filter(
         view=view_2, field=text_field, type="contains_not", value="a"
@@ -425,8 +437,6 @@ def test_renumber_rows_according_to_views_filters_and_sorts(data_fixture):
     values = model.objects.values_list(f"field_{autonumber_field_2.id}", flat=True)
     assert list(values) == [3, 4, 2, 1]
 
-    # If the filters are disabled, then the rows should be numbered only according
-    # to sorts
     view.filters_disabled = True
     view.save(update_fields=["filters_disabled"])
 
@@ -435,12 +445,11 @@ def test_renumber_rows_according_to_views_filters_and_sorts(data_fixture):
     values = model.objects.values_list(f"field_{autonumber_field_3.id}", flat=True)
     assert list(values) == [2, 1, 3, 4]
 
-    # adding a row should increment the number for both fields
-    row = model.objects.create(**{f"field_{text_field.id}": "e"})
-    row.refresh_from_db()
-    assert getattr(row, f"field_{autonumber_field.id}") == 5
-    assert getattr(row, f"field_{autonumber_field_2.id}") == 5
-    assert getattr(row, f"field_{autonumber_field_3.id}") == 5
+    rows = _create_rows(user, table, 1, model)
+    rows[0].refresh_from_db()
+    assert getattr(rows[0], f"field_{autonumber_field.id}") == 5
+    assert getattr(rows[0], f"field_{autonumber_field_2.id}") == 5
+    assert getattr(rows[0], f"field_{autonumber_field_3.id}") == 5
 
 
 @pytest.mark.field_autonumber
@@ -450,16 +459,13 @@ def test_autonumber_field_values_cannot_be_updated_manually(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    row = model.objects.create()
+    rows = _create_rows(user, table, 1)
 
     with pytest.raises(ValidationError):
         RowHandler().update_rows(
             user,
             table,
-            [{"id": row.id, f"field_{autonumber_field.id}": 5}],
-            model,
-            rows_to_update=[row],
+            [{"id": rows[0].id, f"field_{autonumber_field.id}": 5}],
         )
 
 
@@ -477,15 +483,14 @@ def test_autonumber_field_numbers_trashed_rows_to_avoid_conflicts_on_restore(
     trashed_row_id = row_1.id
     TrashHandler().trash(user, table.database.workspace, table.database, row_1)
 
-    # Adding an autonumber field now, also the trashed row should be numbered
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
+    rows = _create_rows(user, table, 1)
+    rows[0].refresh_from_db()
+
+    assert getattr(rows[0], f"field_{autonumber_field.id}") == 2
+
     model = table.get_model()
-    row_2 = model.objects.create()
-    row_2.refresh_from_db()
-
-    assert getattr(row_2, f"field_{autonumber_field.id}") == 2
-
     trashed_row = model.objects_and_trash.get(pk=trashed_row_id)
     assert getattr(trashed_row, f"field_{autonumber_field.id}") == 1
 
@@ -543,24 +548,22 @@ def test_autonumber_field_view_filters(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    row_1 = model.objects.create()
-    row_2 = model.objects.create()
+    rows = _create_rows(user, table, 2)
 
-    # Add a filter and a sort to the view and number rows based on that
     view = data_fixture.create_grid_view(table=table)
     view_filter = data_fixture.create_view_filter(
         view=view, field=autonumber_field, type="equal", value=1
     )
 
+    model = table.get_model()
     qs = ViewHandler().get_queryset(user, view, model=model)
-    assert list(qs.values_list("id", flat=True)) == [row_1.id]
+    assert list(qs.values_list("id", flat=True)) == [rows[0].id]
 
     view_filter.type = "not_equal"
     view_filter.save(update_fields=["type"])
 
     qs = ViewHandler().get_queryset(user, view, model=model)
-    assert list(qs.values_list("id", flat=True)) == [row_2.id]
+    assert list(qs.values_list("id", flat=True)) == [rows[1].id]
 
     view_filter.type = "lower_than"
     view_filter.save(update_fields=["type"])
@@ -572,19 +575,19 @@ def test_autonumber_field_view_filters(data_fixture):
     view_filter.save(update_fields=["type"])
 
     qs = ViewHandler().get_queryset(user, view, model=model)
-    assert list(qs.values_list("id", flat=True)) == [row_2.id]
+    assert list(qs.values_list("id", flat=True)) == [rows[1].id]
 
     view_filter.type = "contains"
     view_filter.save(update_fields=["type"])
 
     qs = ViewHandler().get_queryset(user, view, model=model)
-    assert list(qs.values_list("id", flat=True)) == [row_1.id]
+    assert list(qs.values_list("id", flat=True)) == [rows[0].id]
 
     view_filter.type = "contains_not"
     view_filter.save(update_fields=["type"])
 
     qs = ViewHandler().get_queryset(user, view, model=model)
-    assert list(qs.values_list("id", flat=True)) == [row_2.id]
+    assert list(qs.values_list("id", flat=True)) == [rows[1].id]
 
 
 @pytest.mark.field_autonumber
@@ -594,9 +597,7 @@ def test_autonumber_field_view_aggregations(data_fixture):
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(table=table)
 
-    model = table.get_model()
-    model.objects.create()
-    model.objects.create()
+    _create_rows(user, table, 2)
 
     view = data_fixture.create_grid_view(table=table)
     result = ViewHandler().get_field_aggregations(
@@ -604,8 +605,7 @@ def test_autonumber_field_view_aggregations(data_fixture):
     )
     assert result[autonumber_field.db_column] == 2
 
-    model.objects.create()
-    model.objects.create()
+    _create_rows(user, table, 2)
 
     result = ViewHandler().get_field_aggregations(
         user, view, [(autonumber_field, "max")]
@@ -660,9 +660,7 @@ def test_autonumber_field_can_be_looked_up(data_fixture):
         table=table_a, formula=f"sum(lookup('{link_field.name}', 'autonumber'))"
     )
 
-    model_b = table_b.get_model()
-    row_b_1 = model_b.objects.create()
-    row_b_2 = model_b.objects.create()
+    row_b_1, row_b_2 = _create_rows(user, table_b, 2)
 
     model_a = table_a.get_model()
     (row,) = (
@@ -683,30 +681,78 @@ def test_autonumber_field_can_be_looked_up(data_fixture):
 
 @pytest.mark.field_autonumber
 @pytest.mark.django_db
-def test_autonumber_sequence_uses_max_value_not_row_count(data_fixture):
+def test_autonumber_counter_uses_max_value_not_row_count(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)
     autonumber_field = data_fixture.create_autonumber_field(
         table=table, name="autonumber"
     )
 
-    model = table.get_model()
-
-    rows = [model.objects.create() for _ in range(5)]
+    rows = _create_rows(user, table, 5)
 
     for row in rows[:3]:
         row.delete()
 
     db_column = f"field_{autonumber_field.id}"
+    model = table.get_model()
     with connection.cursor() as cursor:
         cursor.execute(
             f"UPDATE {model._meta.db_table} SET {db_column} = 100 WHERE id = %s",
             [rows[4].id],
         )
 
-    field_type = AutonumberFieldType()
-    field_type.create_field_sequence(autonumber_field, model, connection)
+    # Re-align counter from MAX
+    AutonumberFieldType().align_counter(autonumber_field, model)
 
-    new_row = model.objects.create()
-    new_row.refresh_from_db()
-    assert getattr(new_row, db_column) == 101
+    assert get_counter_value(autonumber_field.id) == 100
+
+    new_rows = _create_rows(user, table, 1)
+    new_rows[0].refresh_from_db()
+    assert getattr(new_rows[0], db_column) == 101
+
+
+@pytest.mark.field_autonumber
+@pytest.mark.django_db
+def test_autonumber_unique_constraint_applied_on_create(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    autonumber_field = data_fixture.create_autonumber_field(table=table)
+
+    autonumber_field.refresh_from_db()
+    assert autonumber_field.is_unique_constraint_applied is True
+
+
+@pytest.mark.field_autonumber
+@pytest.mark.django_db
+def test_autonumber_counter_and_model_fields(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    autonumber_field = data_fixture.create_autonumber_field(table=table)
+
+    assert isinstance(autonumber_field, AutonumberField)
+    assert autonumber_field.last_value == 0
+    assert autonumber_field.is_unique_constraint_applied is True
+
+    _create_rows(user, table, 3)
+
+    autonumber_field.refresh_from_db()
+    assert autonumber_field.last_value == 3
+
+
+@pytest.mark.field_autonumber
+@pytest.mark.django_db
+def test_autonumber_bulk_create_assigns_sequential_values(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    autonumber_field = data_fixture.create_autonumber_field(table=table)
+
+    rows = _create_rows(user, table, 10)
+
+    model = table.get_model()
+    values = list(
+        model.objects.values_list(f"field_{autonumber_field.id}", flat=True).order_by(
+            f"field_{autonumber_field.id}"
+        )
+    )
+    assert values == list(range(1, 11))
+    assert get_counter_value(autonumber_field.id) == 10

--- a/backend/tests/baserow/contrib/database/management/test_fill_table.py
+++ b/backend/tests/baserow/contrib/database/management/test_fill_table.py
@@ -48,6 +48,23 @@ def test_fill_table_rows_empty_table(data_fixture, test_limit):
 
 
 @pytest.mark.django_db
+def test_fill_table_rows_populates_autonumber_fields(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    autonumber_field = data_fixture.create_autonumber_field(user=user, table=table)
+
+    call_command("fill_table_rows", table.id, 10)
+
+    model = table.get_model()
+    values = list(
+        model.objects.order_by(f"field_{autonumber_field.id}").values_list(
+            f"field_{autonumber_field.id}", flat=True
+        )
+    )
+    assert values == list(range(1, 11))
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize("test_limit", [5, 10])
 def test_fill_table_rows_no_empty_table(data_fixture, test_limit):
     """

--- a/changelog/entries/unreleased/refactor/5135_refactor_autonumber_fields_to_use_transactional_counters.json
+++ b/changelog/entries/unreleased/refactor/5135_refactor_autonumber_fields_to_use_transactional_counters.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Refactor autonumber fields to use transactional counters",
+    "issue_origin": "github",
+    "issue_number": 5135,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-21"
+}

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -221,6 +221,9 @@
     "password": "A write-only field that holds a hashed password. The value will be `null` if not set, or `true` if it has been set. It accepts a string to set it.",
     "formViewEditRow": "A read-only field that generates a unique, signed URL allowing the row to be edited through the linked form view."
   },
+  "fieldAutonumberSubForm": {
+    "duplicateWarning": "This field may contain duplicate values from before the upgrade. Uniqueness will be enforced automatically once duplicates are resolved."
+  },
   "fieldConstraint": {
     "uniqueWithEmpty": "Unique with empty"
   },

--- a/web-frontend/modules/database/components/field/FieldAutonumberSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldAutonumberSubForm.vue
@@ -1,3 +1,14 @@
+<template>
+  <div>
+    <p
+      v-if="showDuplicateWarning"
+      class="control__helper-text control__helper-text--warning field-context__inner-element-width"
+    >
+      {{ $t('fieldAutonumberSubForm.duplicateWarning') }}
+    </p>
+  </div>
+</template>
+
 <script>
 import form from '@baserow/modules/core/mixins/form'
 import fieldSubForm from '@baserow/modules/database/mixins/fieldSubForm'
@@ -5,14 +16,19 @@ import fieldSubForm from '@baserow/modules/database/mixins/fieldSubForm'
 export default {
   name: 'FieldAutonumberSubForm',
   mixins: [form, fieldSubForm],
-  setup() {
-    return () => null
-  },
   data() {
     return {
       allowedValues: ['view_id'],
       values: { view_id: null },
     }
+  },
+  computed: {
+    showDuplicateWarning() {
+      return (
+        this.defaultValues.id &&
+        this.defaultValues.is_unique_constraint_applied === false
+      )
+    },
   },
   methods: {
     getDefaultValues() {


### PR DESCRIPTION
## Summary

This refactors autonumber fields away from PostgreSQL sequences and stores the counter state on the `AutonumberField` model instead. New row creation now allocates autonumber values transactionally, so counter increments roll back together with failed inserts and avoid sequence gaps from aborted row creation.

The change also adds generic field-type hooks for preparing rows before insert and reconciling field data after restore/import/duplication. Autonumber uses those hooks to keep counters aligned, backfill restored rows, and apply uniqueness when existing data allows it.

## What changed

- Replaced sequence-backed autonumber columns with nullable integer columns plus `last_value`.
- Added transactional counter allocation for single and bulk row creation.
- Added generic `prepare_rows_for_insert`, `before_data_restore`, and `after_data_restore` field-type hooks.
- Reconciled autonumber state after duplication, import, undo/redo, trash restore, and table fill operations.
- Added `is_unique_constraint_applied` so fields with historical duplicates can remain usable until duplicates are resolved.
- Added API error mapping for autonumber lock conflicts in row/form creation paths.
- Added UI copy warning when uniqueness cannot currently be enforced.
- Added regression coverage for autonumber duplication, restore/import-style flows, bulk creation, and `fill_table_rows`.

## Notes

The migration intentionally does not create unique indexes for existing autonumber fields, because that could be a blocking operation on large tables. Instead, uniqueness is applied automatically by runtime reconciliation when the data has no duplicates.



### How to test this PR
1. New Autonumber Field (fresh creation)
    - Create field on empty table → field created, counter=0, unique constraint applied
    - Create field on table with existing rows → all rows numbered sequentially, counter = row count
    - Create field with view filter/sort → filtered rows get lower numbers, unfiltered get higher numbers
    - Create single row → gets next number (counter+1), counter increments
    - Delete middle rows, create new rows → new rows continue from counter (gaps from deletes are permanent)
    - Duplicate field → duplicated field has own counter, same values, independent numbering going forward
    - Duplicate table → new table's autonumber field has own counter, values preserved
    - Convert text field → autonumber → rows renumbered, counter aligned, unique constraint applied
    - Convert autonumber → text → undo → values restored, counter re-aligned, constraint re-applied
    - Delete autonumber field → undo (trash restore) → values preserved, rows created while trashed get backfilled
    - Trash a row, create new rows, restore trashed row → no number conflicts
    - Concurrent: two browser tabs, create rows simultaneously → both succeed, no duplicates
    - Concurrent: batch import in one tab, single row create in another → both succeed (may take a moment if batch is large)
    - Field sub-form UI → no duplicate warning shown for new fields
    - Check is_unique_constraint_applied in API response → should be true
    - Run `fill_table_rows` on table that has Autonumber and note it works

2. With old Autonumber field (i.e. on `develop` prior migration) you can break fields like (via sql):
2.1. change some values to be duplicates
2.2. change some rows to be higher than current setval set (i.e. set to 9999)
2.3. Update manually setval to be lower i.e. `select setval('field_15147_seq', 30)`

Then migrate to new autonumber
* migration should pass
* all fields should have flag set that unique index was not created
* when duplicates are resolved and field is saved (via field options) - that message on field options will be gone.

