### PR TITLE
fix: if() formulas in the Application Builder silently rendering nothing when the condition references an empty field 

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_if_formulas_in_the_application_builder_silently_render.json
+++ b/changelog/entries/unreleased/bug/fixes_if_formulas_in_the_application_builder_silently_render.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes if() formulas in the Application Builder silently rendering nothing when the condition references an empty field",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-04-21"
+}

--- a/web-frontend/modules/core/utils/object.js
+++ b/web-frontend/modules/core/utils/object.js
@@ -111,12 +111,12 @@ export function isPromise(p) {
 /**
  * Get the value at `path` of `obj`, similar to Lodash `get` function.
  *
- * @param {Object} obj The object that holds the value
+ * @param {Object} context The object that holds the value
  * @param {string | Array[string]} path The path to the value or a list with the path parts
- * @param {any} defaultValue The value to return if the path is not found
- * @return {Object} The value held by the path
+ * @param {any} defaultValue The value to return if the path is not found (defaults to `null`)
+ * @return {Object} The value held by the path, or `defaultValue` if not found
  */
-export function getValueAtPath(context, path) {
+export function getValueAtPath(context, path, defaultValue = null) {
   function _getValueAtPath(obj, keys) {
     const [first, ...rest] = keys
     if (first === undefined || first === null) {
@@ -124,13 +124,18 @@ export function getValueAtPath(context, path) {
     }
 
     if (obj === null || obj === undefined) {
-      return null
+      return defaultValue
     }
 
     if (first in obj) {
       return _getValueAtPath(obj[first], rest)
     }
     if (Array.isArray(obj) && first === '*') {
+      // When wildcarding an empty array with no remaining path parts,
+      // return an empty list (mirrors the backend's `get_value_at_path`).
+      if (obj.length === 0 && rest.length === 0) {
+        return []
+      }
       const results = obj
         // Call recursively this function transforming the `*` in the path in a list
         // of indexes present in the object, e.g:
@@ -139,10 +144,9 @@ export function getValueAtPath(context, path) {
         // Remove empty results
         // Note: Don't exclude false values such as booleans, empty strings, etc.
         .filter((result) => result !== null && result !== undefined)
-      // Return null in case there are no results
-      return results.length ? results : null
+      return results.length ? results : defaultValue
     }
-    return null
+    return defaultValue
   }
   const keys = typeof path === 'string' ? _.toPath(path) : path
   return _getValueAtPath(context, keys)

--- a/web-frontend/modules/core/utils/object.js
+++ b/web-frontend/modules/core/utils/object.js
@@ -124,7 +124,7 @@ export function getValueAtPath(context, path) {
     }
 
     if (obj === null || obj === undefined) {
-      throw new Error(`Path '${path}' not found in context '${obj}'`)
+      return null
     }
 
     if (first in obj) {

--- a/web-frontend/test/unit/core/utils/object.spec.js
+++ b/web-frontend/test/unit/core/utils/object.spec.js
@@ -110,4 +110,86 @@ describe('test utils object', () => {
     }
     expect(getValueAtPath(obj, path)).toStrictEqual(result)
   })
+
+  describe('getValueAtPath defaultValue', () => {
+    const obj = {
+      a: { b: { c: 123 } },
+      nullable: null,
+      list: [{ d: 456 }, { d: 789, e: 111 }],
+      nested: [{ nested: [{ a: 1 }, { a: 2 }] }, { nested: [{ a: 3 }] }],
+    }
+
+    test('returns null by default when the path is not found', () => {
+      expect(getValueAtPath(obj, 'a.b.x')).toBe(null)
+      expect(getValueAtPath(obj, 'a.x.b')).toBe(null)
+      expect(getValueAtPath(obj, 'list.5.d')).toBe(null)
+      expect(getValueAtPath(obj, 'list.0.x')).toBe(null)
+      expect(getValueAtPath(obj, 'nested.0.nested.5.a')).toBe(null)
+      expect(getValueAtPath(obj, 'nested.5.nested.0.a')).toBe(null)
+    })
+
+    test('returns the provided default value when the path is not found', () => {
+      expect(getValueAtPath(obj, 'a.b.x', 'fallback')).toBe('fallback')
+      expect(getValueAtPath(obj, 'a.b.x', 0)).toBe(0)
+      expect(getValueAtPath(obj, 'a.b.x', '')).toBe('')
+      expect(getValueAtPath(obj, 'a.b.x', false)).toBe(false)
+      expect(getValueAtPath(obj, 'list.5.d', 'fallback')).toBe('fallback')
+      expect(getValueAtPath(obj, 'list.0.x', 'fallback')).toBe('fallback')
+      expect(getValueAtPath(obj, 'nested.0.nested.5.a', 'fallback')).toBe(
+        'fallback'
+      )
+      expect(getValueAtPath(obj, 'nested.5.nested.0.a', 'fallback')).toBe(
+        'fallback'
+      )
+    })
+  })
+
+  describe('getValueAtPath defaultValue with wildcards', () => {
+    const obj = {
+      list: [{ d: 456 }, { d: 789, e: 111 }],
+      nested: [{ nested: [{ a: 1 }, { a: 2 }] }, { nested: [{ a: 3 }] }],
+      empty: [],
+    }
+
+    test('returns null when every wildcard branch misses (default)', () => {
+      expect(getValueAtPath(obj, 'list.*.x')).toBe(null)
+      expect(getValueAtPath(obj, 'nested.*.nested.*.x')).toBe(null)
+    })
+
+    test('substitutes the default value at every missing leaf (backend-aligned)', () => {
+      expect(getValueAtPath(obj, 'list.*.x', 'fallback')).toStrictEqual([
+        'fallback',
+        'fallback',
+      ])
+      expect(
+        getValueAtPath(obj, 'nested.*.nested.*.x', 'fallback')
+      ).toStrictEqual([['fallback', 'fallback'], ['fallback']])
+    })
+
+    test('mixes existing values with the default value when only some branches miss', () => {
+      expect(getValueAtPath(obj, 'list.*.e', 'fallback')).toStrictEqual([
+        'fallback',
+        111,
+      ])
+    })
+
+    test('does not substitute the default value when wildcard branches all exist', () => {
+      expect(getValueAtPath(obj, 'list.*.d', 'fallback')).toStrictEqual([
+        456, 789,
+      ])
+      expect(
+        getValueAtPath(obj, 'nested.*.nested.*.a', 'fallback')
+      ).toStrictEqual([[1, 2], [3]])
+    })
+
+    test('returns an empty list when wildcarding an empty array with no remaining path', () => {
+      expect(getValueAtPath(obj, 'empty.*')).toStrictEqual([])
+      expect(getValueAtPath(obj, 'empty.*', 'fallback')).toStrictEqual([])
+    })
+
+    test('returns the default value when wildcarding an empty array with a remaining path', () => {
+      expect(getValueAtPath(obj, 'empty.*.x')).toBe(null)
+      expect(getValueAtPath(obj, 'empty.*.x', 'fallback')).toBe('fallback')
+    })
+  })
 })


### PR DESCRIPTION
### What is in this PR
- Fixes `if()` formulas in the Application Builder silently rendering nothing when the condition references  an empty field . 

original Slack thread: https://baserow.slack.com/archives/C04UTAEMS77/p1776699853766129

- Root cause: `getValueAtPath` threw when traversing a `null`/`undefined` intermediate value.

- Fix: return `null` instead of throwing in `utils/object.js`

### How to test this PR
1. On develop branch, Import the following workspace that replicates the test environment : 
[90d876d8-6e25-4dc0-a71d-ebe2a24ccb84.zip](https://github.com/user-attachments/files/26931454/90d876d8-6e25-4dc0-a71d-ebe2a24ccb84.zip)
2. Open the `incidents` page within `myApp` application.
3. Preview the page variants (`/incidents/1` `incidents/2` `incidents/3` ) and observe on the `incidents/3` page the title text value is empty. 
4. checkout this branch, replay the scenario above and observe on `incidents/3` title text is displaying "No value" as per the element formula. 


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
