### PR TITLE
exclude autonumber sequences from schema dump to prevent restore failure

### DIFF
--- a/backend/src/baserow/core/management/backup/backup_runner.py
+++ b/backend/src/baserow/core/management/backup/backup_runner.py
@@ -172,6 +172,7 @@ class BaserowBackupRunner:
             f"--exclude-table={MultipleSelectField.THROUGH_DATABASE_TABLE_PREFIX}*",
             f"--exclude-table={USER_TABLE_DATABASE_NAME_PREFIX}*",
             f"--exclude-table={LinkRowField.THROUGH_DATABASE_TABLE_PREFIX}*",
+            "--exclude-table=field_*_seq",
             f"--file={temporary_directory_name}/everything_but_user_tables/",
         ]
         self._run_command_in_sub_process(

--- a/backend/src/baserow/test_utils/pytest_conftest.py
+++ b/backend/src/baserow/test_utils/pytest_conftest.py
@@ -3,6 +3,7 @@ import contextlib
 import os
 import sys
 import threading
+import uuid
 from contextlib import ExitStack, contextmanager
 from datetime import date, datetime
 from decimal import Decimal
@@ -38,6 +39,7 @@ from baserow.core.context import clear_current_workspace_id
 from baserow.core.exceptions import PermissionDenied
 from baserow.core.jobs.registries import job_type_registry
 from baserow.core.permission_manager import CorePermissionManagerType
+from baserow.core.psycopg import is_psycopg3, psycopg
 from baserow.core.services.dispatch_context import DispatchContext
 from baserow.core.services.utils import ServiceAdhocRefinements
 from baserow.core.trash.trash_types import WorkspaceTrashableItemType
@@ -217,6 +219,41 @@ def environ():
     yield os.environ
     for key, value in original_env.items():
         os.environ[key] = value
+
+
+@pytest.fixture()
+def temporary_database():
+    """
+    Creates a temporary PostgreSQL database with a unique name,
+    yields its name, and drops it on teardown.
+    """
+
+    settings = connection.settings_dict
+    db_name = f"test_tmp_{uuid.uuid4().hex[:10]}"
+
+    def _connect_autocommit():
+        conn = psycopg.connect(
+            host=settings["HOST"],
+            port=settings["PORT"],
+            dbname=settings["NAME"],
+            user=settings["USER"],
+            password=settings["PASSWORD"],
+        )
+        if is_psycopg3:
+            conn.autocommit = True
+        else:
+            conn.set_isolation_level(0)  # ISOLATION_LEVEL_AUTOCOMMIT
+        return conn
+
+    admin_conn = _connect_autocommit()
+    admin_conn.cursor().execute(f"CREATE DATABASE {db_name}")
+    admin_conn.close()
+    try:
+        yield db_name
+    finally:
+        cleanup_conn = _connect_autocommit()
+        cleanup_conn.cursor().execute(f"DROP DATABASE IF EXISTS {db_name}")
+        cleanup_conn.close()
 
 
 @pytest.fixture()

--- a/backend/tests/baserow/core/management/test_backup_runner.py
+++ b/backend/tests/baserow/core/management/test_backup_runner.py
@@ -3,72 +3,72 @@ import tempfile
 from pathlib import Path
 from unittest.mock import call, patch
 
-from django.db import connection, transaction
+from django.db import connection
 
 import pytest
 from freezegun import freeze_time
 
-from baserow.contrib.database.table.models import Table
 from baserow.core.management.backup.backup_runner import BaserowBackupRunner
 from baserow.core.management.backup.exceptions import InvalidBaserowBackupArchive
-from baserow.core.psycopg import is_psycopg3
-from baserow.core.trash.handler import TrashHandler
+from baserow.core.psycopg import is_psycopg3, psycopg
+from baserow.test_utils.helpers import setup_interesting_test_table
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.once_per_day_in_ci
-def test_can_backup_and_restore_baserow_reverting_changes(data_fixture, environ):
+def test_can_backup_and_restore_baserow_reverting_changes(
+    data_fixture, environ, temporary_database
+):
+    host = connection.settings_dict["HOST"]
+    dbname = connection.settings_dict["NAME"]
+    username = connection.settings_dict["USER"]
+    port = connection.settings_dict["PORT"]
+    password = connection.settings_dict["PASSWORD"]
+    environ["PGPASSWORD"] = password
+
     runner = BaserowBackupRunner(
-        host=connection.settings_dict["HOST"],
-        database=connection.settings_dict["NAME"],
-        username=connection.settings_dict["USER"],
-        port=connection.settings_dict["PORT"],
+        host=host,
+        database=dbname,
+        username=username,
+        port=port,
         jobs=1,
     )
-    environ["PGPASSWORD"] = connection.settings_dict["PASSWORD"]
 
-    table, fields, rows = data_fixture.build_table(
-        columns=[
-            ("Name", "text"),
-        ],
-        rows=[["A"], ["B"], ["C"], ["D"]],
-    )
-    table_to_delete, _, _ = data_fixture.build_table(
-        columns=[
-            ("Name", "text"),
-        ],
-        rows=[["A"], ["B"], ["C"], ["D"]],
-    )
-    deleted_table_name = table_to_delete.get_database_table_name()
+    table, _, _, _, context = setup_interesting_test_table(data_fixture)
+
+    model = table.get_model()
+    original_row_count = model.objects.count()
+    user_table_name = table.get_database_table_name()
 
     with tempfile.TemporaryDirectory() as temporary_directory_name:
         backup_loc = temporary_directory_name + "/backup.tar.gz"
-        # With a batch size of 1 we expect 3 separate pg_dumps to be run.
-        runner.backup_baserow(backup_loc, 1)
+        runner.backup_baserow(backup_loc, batch_size=1)
         assert Path(backup_loc).is_file()
 
-        model = table.get_model(attribute_names=True)
+        restore_runner = BaserowBackupRunner(
+            host=host,
+            database=temporary_database,
+            username=username,
+            port=port,
+            jobs=1,
+        )
+        restore_runner.restore_baserow(backup_loc)
 
-        # Add a new row after we took the back-up that we want to reset by restoring.
-        model.objects.create(**{"name": "E"})
-        # Delete a table to check it is recreated.
-        with transaction.atomic():
-            TrashHandler.permanently_delete(table_to_delete)
+        with psycopg.connect(
+            host=host,
+            port=port,
+            dbname=temporary_database,
+            user=username,
+            password=password,
+        ) as verify_conn:
+            with verify_conn.cursor() as cur:
+                cur.execute(f"SELECT COUNT(*) FROM {user_table_name}")
+                assert cur.fetchone()[0] == original_row_count
 
-        assert model.objects.count() == 5
-        assert Table.objects.count() == 1
-        assert deleted_table_name not in connection.introspection.table_names()
-
-        # --clean will make pg_restore overwrite existing db objects, not safe for
-        # general usage as it will not delete tables/relations created after the
-        # backup.
-        runner.restore_baserow(backup_loc, ["--clean", "--if-exists"])
-
-        # The row we made after the backup has gone
-        assert model.objects.count() == 4
-        # The table we deleted has been restored
-        assert Table.objects.count() == 2
-        assert deleted_table_name in connection.introspection.table_names()
+                autonumber_field_id = context["name_to_field_id"]["autonumber"]
+                seq_name = f"field_{autonumber_field_id}_seq"
+                cur.execute(f"SELECT last_value FROM {seq_name}")
+                assert cur.fetchone()[0] > 0
 
 
 @patch("tempfile.TemporaryDirectory")
@@ -119,6 +119,7 @@ def test_backup_baserow_dumps_database_in_batches(
                     "--exclude-table=database_multipleselect_*",
                     "--exclude-table=database_table_*",
                     "--exclude-table=database_relation_*",
+                    "--exclude-table=field_*_seq",
                     "--file=/fake_tmp_dir/everything_but_user_tables/",
                 ]
             ),
@@ -200,6 +201,7 @@ def test_can_change_num_jobs_and_insert_extra_args_for_baserow_backup(
                     "--exclude-table=database_multipleselect_*",
                     "--exclude-table=database_table_*",
                     "--exclude-table=database_relation_*",
+                    "--exclude-table=field_*_seq",
                     "--file=/fake_tmp_dir/everything_but_user_tables/",
                     extra_arg,
                 ]
@@ -597,6 +599,7 @@ def a_pg_dump_for_everything_else():
             "--exclude-table=database_multipleselect_*",
             "--exclude-table=database_table_*",
             "--exclude-table=database_relation_*",
+            "--exclude-table=field_*_seq",
             "--file=/fake_tmp_dir/everything_but_user_tables/",
         ]
     )

--- a/changelog/entries/unreleased/bug/3855_exclude_autonumber_sequences_from_schema_dump_to_prevent_res.json
+++ b/changelog/entries/unreleased/bug/3855_exclude_autonumber_sequences_from_schema_dump_to_prevent_res.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Exclude autonumber sequences from schema dump to prevent restore failure",
+    "issue_origin": "github",
+    "issue_number": 3855,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-21"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes issue #3855 

Root cause was that `Autonumber` field sequences (`field_*_seq`) were included in both the `everything_but_user_tables` dump and user table batch dumps, causing `"relation already exists"` errors during restore into a fresh database.

As temporary workaround when restoring backup `--clean --if-exists` can be added to `baserow_restore` command (but it can have side effects)

There is also added test for testing backup/restore process using interesting table. Note it's marked with `once_per_day_in_ci` as normal runner has no `pg_dump`


### How to test this PR
Easiest way to test (using `just`).

1. On develop (where issue exist) - create table with `AutoNumber` field
2. Create backup of baserow table i.e. 

```
PGPASSWORD=<pwd> just backend manage backup_baserow  \
-h <host> -d <db> -U <user> -p 5432 \
 -f /tmp/baserow_test_backup.tar.gz 
```

3. Create empty database to restore i.e.

```
PGPASSWORD=<pwd> psql -h <host> -U <user> -d postgres -p 5432 \
-c "CREATE DATABASE baserow_restore_test;"
```

4. Restore db

```
PGPASSWORD=<pwd> just backend manage restore_baserow \
  -h <host> -d baserow_restore_test -U <user> -p 5432 \
  -f /tmp/baserow_test_backup.tar.gz
```

On develop you should notice entries like

```

pg_restore: error: could not execute query: ERROR:  relation "field_15222_seq" already exists
Command was: CREATE SEQUENCE public.field_15222_seq
    START WITH 1
    INCREMENT BY 1
    NO MINVALUE
    NO MAXVALUE
    CACHE 1;
```

On this branch those errors does not occur as sequence is exported only once


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
