### PR TITLE
Add a 'clear' button on the right of the date input element

### DIFF
--- a/changelog/entries/unreleased/feature/5202_add_clear_button_to_the_date_input_element.json
+++ b/changelog/entries/unreleased/feature/5202_add_clear_button_to_the_date_input_element.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add 'clear' button to the date input element.",
+    "issue_origin": "github",
+    "issue_number": 5202,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-04-21"
+}

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
@@ -26,6 +26,11 @@
         @blur="handleTimeBlur($event)"
       />
     </div>
+    <i
+      v-if="dateInputValue"
+      class="ab-datetime-picker__clear button-icon__icon iconoir-cancel"
+      @click="clearValue"
+    />
     <Context
       ref="dateContext"
       :hide-on-click-outside="true"
@@ -245,6 +250,13 @@ export default {
     handleTimeBlur(event) {
       this.updateTime(event.target.value)
       this.$refs.timeContext.hide()
+    },
+    clearValue() {
+      this.$refs.dateContext.hide()
+      if (this.includeTime) {
+        this.$refs.timeContext.hide()
+      }
+      this.$emit('update:modelValue', null)
     },
   },
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
@@ -8,6 +8,17 @@
     var(--input-horizontal-padding, 12px);
 }
 
+.ab-datetime-picker__clear {
+  cursor: pointer;
+  color: var(--input-text-color, $black);
+  flex-shrink: 0;
+  margin-left: auto;
+
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
 .ab-datetime-picker__input {
   &.ab-input {
     border: none;

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/DateTimePickerElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/DateTimePickerElement.spec.js.snap
@@ -37,6 +37,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             <div>
               <!--v-if-->
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -90,6 +91,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             <div>
               <!--v-if-->
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -143,6 +145,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             <div>
               <!--v-if-->
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -201,6 +204,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -259,6 +263,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -317,6 +322,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -375,6 +381,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -433,6 +440,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->
@@ -491,6 +499,7 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
                 value=""
               />
             </div>
+            <!--v-if-->
           </div>
           
           <!--v-if-->


### PR DESCRIPTION
The date input element in the app builder had no visible way to clear a set value - the only option was backspacing through the field. This adds a `×` button that appears on the right side of the picker whenever a date value is present. Clicking it clears the value and dismisses any open calendar or time picker context.

Closes #5202

<img width="531" height="363" alt="clear" src="https://github.com/user-attachments/assets/c2fab630-d1c1-4574-b07b-bcc5382ed7b1" />


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
