### PR TITLE
fix: create row history entries in batches to avoid memory spikes

### DIFF
--- a/backend/src/baserow/contrib/database/rows/history.py
+++ b/backend/src/baserow/contrib/database/rows/history.py
@@ -37,7 +37,9 @@ class RowHistoryHandler:
         row_history_entries = row_history_provider.get_row_history(user, action)
 
         if row_history_entries:
-            row_history_entries = RowHistory.objects.bulk_create(row_history_entries)
+            row_history_entries = RowHistory.objects.bulk_create(
+                row_history_entries, batch_size=1000
+            )
             for table_id, per_table_row_history_entries in groupby(
                 row_history_entries, lambda e: e.table_id
             ):

--- a/changelog/entries/unreleased/bug/create_row_history_entries_in_batches_to_avoid_big_memory_sp.json
+++ b/changelog/entries/unreleased/bug/create_row_history_entries_in_batches_to_avoid_big_memory_sp.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Create row history entries in batches to avoid memory spikes",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-22"
+}


### PR DESCRIPTION
### What is in this PR

Simply adds batch_size=1000 to `RowHistory.objects.bulk_create` to handle scenarios where 200 rows are deleted and hundreds of entries per row need to be written to the linked rows.