### PR TITLE
fix: stop infinite `/dispatch-data-sources/` refetch loop in application builder page editor

### DIFF
--- a/changelog/entries/unreleased/bug/stop_infinite_dispatchdatasources_refetch_loop_in_page_edito.json
+++ b/changelog/entries/unreleased/bug/stop_infinite_dispatchdatasources_refetch_loop_in_page_edito.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "stop infinite `/dispatch-data-sources/` refetch loop in page editor",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-04-22"
+}

--- a/web-frontend/modules/builder/components/PageEditorContent.vue
+++ b/web-frontend/modules/builder/components/PageEditorContent.vue
@@ -83,54 +83,37 @@ provide('mode', mode)
 provide('formulaComponent', ApplicationBuilderFormulaInput)
 provide('applicationContext', applicationContext)
 
-// Watchers
-watch(
-  dataSources,
-  () => {
+watch(dataSources, () => {
+  $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+    page: props.page,
+    data: dispatchContext.value,
+    mode,
+  })
+})
+
+watch(sharedDataSources, () => {
+  $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+    page: sharedPage.value,
+    data: dispatchContext.value,
+  })
+})
+
+watch(dispatchContext, (newCtx, oldCtx) => {
+  if (!_.isEqual(newCtx, oldCtx)) {
     $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
       page: props.page,
-      data: dispatchContext.value,
+      data: newCtx,
       mode,
     })
-  },
-  { deep: true }
-)
+  }
+})
 
-watch(
-  sharedDataSources,
-  () => {
+watch(applicationDispatchContext, (newCtx, oldCtx) => {
+  if (!_.isEqual(newCtx, oldCtx)) {
     $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
       page: sharedPage.value,
-      data: dispatchContext.value,
+      data: newCtx,
     })
-  },
-  { deep: true }
-)
-
-watch(
-  dispatchContext,
-  (newDispatchContext, oldDispatchContext) => {
-    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
-      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-        page: props.page,
-        data: newDispatchContext,
-        mode,
-      })
-    }
-  },
-  { deep: true }
-)
-
-watch(
-  applicationDispatchContext,
-  (newDispatchContext, oldDispatchContext) => {
-    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
-      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-        page: sharedPage.value,
-        data: newDispatchContext,
-      })
-    }
-  },
-  { deep: true }
-)
+  }
+})
 </script>

--- a/web-frontend/modules/builder/components/PageEditorContent.vue
+++ b/web-frontend/modules/builder/components/PageEditorContent.vue
@@ -83,6 +83,7 @@ provide('mode', mode)
 provide('formulaComponent', ApplicationBuilderFormulaInput)
 provide('applicationContext', applicationContext)
 
+// Watchers
 watch(
   dataSources,
   () => {
@@ -108,11 +109,11 @@ watch(
 
 watch(
   dispatchContext,
-  (newCtx, oldCtx) => {
-    if (!_.isEqual(newCtx, oldCtx)) {
+  (newDispatchContext, oldDispatchContext) => {
+    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
       $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
         page: props.page,
-        data: newCtx,
+        data: newDispatchContext,
         mode,
       })
     }
@@ -122,11 +123,11 @@ watch(
 
 watch(
   applicationDispatchContext,
-  (newCtx, oldCtx) => {
-    if (!_.isEqual(newCtx, oldCtx)) {
+  (newDispatchContext, oldDispatchContext) => {
+    if (!_.isEqual(newDispatchContext, oldDispatchContext)) {
       $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
         page: sharedPage.value,
-        data: newCtx,
+        data: newDispatchContext,
       })
     }
   },

--- a/web-frontend/modules/builder/components/PageEditorContent.vue
+++ b/web-frontend/modules/builder/components/PageEditorContent.vue
@@ -83,37 +83,53 @@ provide('mode', mode)
 provide('formulaComponent', ApplicationBuilderFormulaInput)
 provide('applicationContext', applicationContext)
 
-watch(dataSources, () => {
-  $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-    page: props.page,
-    data: dispatchContext.value,
-    mode,
-  })
-})
-
-watch(sharedDataSources, () => {
-  $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
-    page: sharedPage.value,
-    data: dispatchContext.value,
-  })
-})
-
-watch(dispatchContext, (newCtx, oldCtx) => {
-  if (!_.isEqual(newCtx, oldCtx)) {
+watch(
+  dataSources,
+  () => {
     $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
       page: props.page,
-      data: newCtx,
+      data: dispatchContext.value,
       mode,
     })
-  }
-})
+  },
+  { deep: true }
+)
 
-watch(applicationDispatchContext, (newCtx, oldCtx) => {
-  if (!_.isEqual(newCtx, oldCtx)) {
+watch(
+  sharedDataSources,
+  () => {
     $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
       page: sharedPage.value,
-      data: newCtx,
+      data: dispatchContext.value,
     })
-  }
-})
+  },
+  { deep: true }
+)
+
+watch(
+  dispatchContext,
+  (newCtx, oldCtx) => {
+    if (!_.isEqual(newCtx, oldCtx)) {
+      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+        page: props.page,
+        data: newCtx,
+        mode,
+      })
+    }
+  },
+  { deep: true }
+)
+
+watch(
+  applicationDispatchContext,
+  (newCtx, oldCtx) => {
+    if (!_.isEqual(newCtx, oldCtx)) {
+      $store.dispatch('dataSourceContent/debouncedFetchPageDataSourceContent', {
+        page: sharedPage.value,
+        data: newCtx,
+      })
+    }
+  },
+  { deep: true }
+)
 </script>

--- a/web-frontend/modules/builder/dataProviderTypes.js
+++ b/web-frontend/modules/builder/dataProviderTypes.js
@@ -311,9 +311,9 @@ export class DataSourceContextDataProviderType extends DataProviderType {
             .getContextDataSchema(dataSource)
 
           if (dsSchema) {
-            dsSchema.order = index
+            return [dataSource.id, { ...dsSchema, order: index }]
           }
-          return [dataSource.id, dsSchema]
+          return [dataSource.id, null]
         })
         .filter(([, schema]) => schema)
     )


### PR DESCRIPTION
### What is in this PR
- Fixes an infinite `/dispatch-data-sources/` refetch loop in the application builder page editor that could leave `FormulaInputExplorerContext` stuck on a loading spinner.
- Root cause: the four `watch(..., { deep: true })` watchers in `PageEditorContent.vue` (on `dataSources`, `sharedDataSources`, `dispatchContext`, `applicationDispatchContext`)
- Removes `deep: true` from the four watchers. 

### How to test this PR
On develop branch, replicate the bug with:
- Create a database with single select or multiple select field.
- Create an application and add a local baserow data source pointing to the previously created database.
- Share this data source between pages
- On a fresh page, add a multi-page header element and then add a heading element into the header. 
- Try to edit the heading element text and observe the infinite loop in the `FormulaInputExplorerContext`, if you open the devtool network tab you will also see infinite calls to the `dispatch-data-sources` endpoint.

Checkout this branch, try to edit the heading text, the infinite loop should be gone. 
Regression check: create, rename, delete data sources on the page — the content still refetches correctly after each of these actions.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
