### PR TITLE
fix: import preview 

### DIFF
--- a/changelog/entries/unreleased/bug/fix_import_preview.json
+++ b/changelog/entries/unreleased/bug/fix_import_preview.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "fix import preview",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-22"
+}

--- a/web-frontend/modules/database/components/table/ImportFileModal.vue
+++ b/web-frontend/modules/database/components/table/ImportFileModal.vue
@@ -99,6 +99,7 @@
             class="import-modal__preview"
             :rows="previewImportData"
             :fields="sortedFields"
+            :field-options="importFieldOptions"
           />
         </Tab>
         <Tab :title="$t('importFileModal.filePreview')">
@@ -106,6 +107,7 @@
             class="import-modal__preview"
             :rows="previewFileData"
             :fields="fileFields"
+            :field-options="fileFieldOptions"
           />
         </Tab>
       </Tabs>
@@ -292,6 +294,16 @@ export default {
         id: uuid(),
         order: index,
       }))
+    },
+    importFieldOptions() {
+      return Object.fromEntries(
+        this.sortedFields.map((field) => [field.id, { hidden: false }])
+      )
+    },
+    fileFieldOptions() {
+      return Object.fromEntries(
+        this.fileFields.map((field) => [field.id, { hidden: false }])
+      )
     },
     /**
      * All writable fields.


### PR DESCRIPTION
### What is in this PR
- FIx the database import preview 

### How to test this PR
- In a database table, try to import a CSV file and observe the preview is working as expected.  

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
