### PR TITLE
Update example text on file imports (#2953)

### DIFF
--- a/web-frontend/modules/database/components/table/TableJSONImporter.vue
+++ b/web-frontend/modules/database/components/table/TableJSONImporter.vue
@@ -10,16 +10,14 @@
           <pre>
 [
   {
-    "to": "Tove",
-    "from": "Jani",
-    "heading": "Reminder",
-    "body": "Don't forget me this weekend!"
+    "name": "John Doe",
+    "email": "john@example.com",
+    "phone": "123-456-7890"
   },
   {
-    "to": "Bram",
-    "from": "Nigel",
-    "heading": "Reminder",
-    "body": "Don't forget about the export feature this week"
+    "name": "Jane Smith",
+    "email": "jane@example.com",
+    "phone": "098-765-4321"
   }
 ]
         </pre

--- a/web-frontend/modules/database/components/table/TableXMLImporter.vue
+++ b/web-frontend/modules/database/components/table/TableXMLImporter.vue
@@ -8,21 +8,18 @@
         <div class="control__description">
           {{ $t('tableXMLImporter.fileDescription') }}
           <pre>
-&lt;notes&gt;
-  &lt;note&gt;
-    &lt;to&gt;Tove&lt;/to&gt;
-    &lt;from&gt;Jani&lt;/from&gt;
-    &lt;heading&gt;Reminder&lt;/heading&gt;
-    &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;
-  &lt;/note&gt;
-  &lt;note&gt;
-    &lt;heading&gt;Reminder&lt;/heading&gt;
-    &lt;heading2&gt;Reminder2&lt;/heading2&gt;
-    &lt;to&gt;Tove&lt;/to&gt;
-    &lt;from&gt;Jani&lt;/from&gt;
-    &lt;body&gt;Don't forget me this weekend!&lt;/body&gt;
-  &lt;/note&gt;
-&lt;/notes&gt;</pre
+&lt;data&gt;
+  &lt;record&gt;
+    &lt;name&gt;John Doe&lt;/name&gt;
+    &lt;email&gt;john@example.com&lt;/email&gt;
+    &lt;phone&gt;123-456-7890&lt;/phone&gt;
+  &lt;/record&gt;
+  &lt;record&gt;
+    &lt;name&gt;Jane Smith&lt;/name&gt;
+    &lt;email&gt;jane@example.com&lt;/email&gt;
+    &lt;phone&gt;098-765-4321&lt;/phone&gt;
+  &lt;/record&gt;
+&lt;/data&gt;</pre
           >
         </div>
       </template>


### PR DESCRIPTION
Good day

Updates the example text shown in the JSON and XML file import UIs to use more generic and representative field names (name, email, phone) instead of the previous note-specific fields (to, from, heading, body).

This matches the expected result described in issue #2953.

## Changes

- **TableJSONImporter.vue**: Updated the example JSON from a note-style format to a contact-style format with name, email, and phone fields.
- **TableXMLImporter.vue**: Updated the example XML from a note-style format to a contact-style format with name, email, and phone fields, and changed root/record element names from notes/note to data/record.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly, Jah-yee