### PR TITLE
fix: data source creation from the DataSourceDropdown footer

### DIFF
--- a/changelog/entries/unreleased/bug/5118_resolved_a_bug_which_prevented_users_from_creating_data_sour.json
+++ b/changelog/entries/unreleased/bug/5118_resolved_a_bug_which_prevented_users_from_creating_data_sour.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented users from creating data sources from the data source dropdown's footer.",
+    "issue_origin": "github",
+    "issue_number": 5118,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-04-22"
+}

--- a/web-frontend/modules/builder/components/dataSource/DataSourceDropdown.vue
+++ b/web-frontend/modules/builder/components/dataSource/DataSourceDropdown.vue
@@ -48,7 +48,10 @@
     <DataSourceCreateEditModal
       :key="modalKey"
       ref="dataSourceCreateEditModal"
+      :data-source-id="currentDataSourceId"
+      @data-source-created="currentDataSourceId = $event.id"
       @updated="onDataSourceUpdated"
+      @hidden="currentDataSourceId = null"
     />
   </div>
 </template>
@@ -84,6 +87,7 @@ export default {
   data() {
     return {
       modalKey: 0,
+      currentDataSourceId: null,
     }
   },
   computed: {
@@ -112,8 +116,11 @@ export default {
         : this.$t('integrationsCommon.singleRow')
       return `${dataSource.name} (${suffix})`
     },
-    openDataSourceModal() {
-      this.$refs.dataSourceCreateEditModal.show()
+    async openDataSourceModal() {
+      this.currentDataSourceId = null
+      this.modalKey++
+      await this.$nextTick()
+      this.$refs.dataSourceCreateEditModal?.show()
     },
     /**
      * When a data source is updated (i.e. the user has created the record,


### PR DESCRIPTION
 ### What is in this PR                                                                                                                             
                                                                                                                                                     
 Fixes creating a data source from the `DataSourceDropdown` footer. PR #4911 refactored the create→edit modal transition to be parent-driven (via `@data-source-created`), updating `DataSourceContext` but leaving `DataSourceDropdown` behind. This PR brings `DataSourceDropdown` up to parity: 
                                                                                       
 - Adds `:data-source-id`, `@data-source-created`, and `@hidden` wiring so the modal transitions from create mode to edit mode after the record is created, allowing the service-specific sub-form to appear.
 - Resets `currentDataSourceId` and increments `modalKey` on each footer open so subsequent creations always start with a clean form. The reset is necessary because `modalKey` key-cycling unmounts the old modal before `this.hide()` runs, severing the `@hidden` event path and leaving `currentDataSourceId` stale.                                                                                                                       
                              
  ### How to test this PR                                                                                                                            
                                                                                                                                                     
1. Open a page in AB and add a table element (or any element with a data source selector)
2. Click the data source dropdown and then "Add new" in the footer                                                                                 
3. Select "List rows" as the action and pick an integration — the "Create" button should enable once you've made changes
4. Click "Create" — the modal should stay open and show the service-specific form (e.g. table selector)                                            
5. Configure the service fields and click "Save" — the data source should now be selected in the dropdown                                          
6. Click "Add new" again — the modal should open with a completely empty form, not pre-filled from step 3                                          
7. Also verify the existing path: open the data source panel from the page header (DataSourceContext), create a data source - should still work the same way

In `develop` you will find that creating a datasource via the footer results in a modal form which is "stuck" at the create step.

  ### Checklist                                                                                                                                      
                                                                                                                                                     
  - [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
  - [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder                                      
  - [ ] The latest **Chrome and Firefox** have been used to test any new frontend features                     
  - [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated                                               
  - [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met                                
  - [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables                                                                    
  - [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes                                          
  - [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for
   changes to endpoints accessed via API tokens                                                                                                      
  - [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)                                                    
  - [x] Security impact of change has been considered 