### PR TITLE
fix: use real IP in OTEL traces

### DIFF
--- a/backend/src/baserow/api/sessions.py
+++ b/backend/src/baserow/api/sessions.py
@@ -9,6 +9,7 @@ from baserow.api.exceptions import (
     InvalidClientSessionIdAPIException,
     InvalidUndoRedoActionGroupIdAPIException,
 )
+from baserow.core.utils import get_user_remote_ip_address_from_request
 
 UNTRUSTED_CLIENT_SESSION_ID_USER_ATTR = "untrusted_client_session_id"
 UNDO_REDO_ACTION_GROUP_ID = "untrusted_client_action_group"
@@ -93,20 +94,6 @@ def set_user_websocket_id(user, request):
 
 def _set_user_websocket_id(user, websocket_id):
     user.web_socket_id = websocket_id
-
-
-def get_user_remote_ip_address_from_request(request):
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        # X-Forwarded-For can contain multiple IPs: client, proxy1, proxy2.
-        # The first one is the original client IP.
-        return x_forwarded_for.split(",")[0].strip()
-
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-
-    return request.META.get("REMOTE_ADDR")
 
 
 def set_user_remote_addr_ip_from_request(user, request):

--- a/backend/src/baserow/api/user/views.py
+++ b/backend/src/baserow/api/user/views.py
@@ -36,7 +36,6 @@ from baserow.api.errors import (
 from baserow.api.schemas import get_error_schema
 from baserow.api.sessions import (
     get_untrusted_client_session_id,
-    get_user_remote_ip_address_from_request,
     set_user_session_data_from_request,
 )
 from baserow.api.user.registries import user_data_registry
@@ -90,6 +89,7 @@ from baserow.core.user.exceptions import (
 )
 from baserow.core.user.handler import UserHandler
 from baserow.core.user.utils import generate_session_tokens_for_user
+from baserow.core.utils import get_user_remote_ip_address_from_request
 
 from .errors import (
     ERROR_ALREADY_EXISTS,

--- a/backend/src/baserow/core/telemetry/telemetry.py
+++ b/backend/src/baserow/core/telemetry/telemetry.py
@@ -12,6 +12,7 @@ from opentelemetry.trace import Span
 from baserow.core.psycopg import is_psycopg3
 from baserow.core.telemetry.provider import DifferentSamplerPerLibraryTracerProvider
 from baserow.core.telemetry.utils import BatchBaggageSpanProcessor, otel_is_enabled
+from baserow.core.utils import get_user_remote_ip_address_from_request
 
 OTEL_CLIENT_IP_ATTRIBUTE_NAMES = ("client.address", "net.peer.ip")
 
@@ -177,8 +178,6 @@ def _setup_django_process_instrumentation():
 
 def _set_real_client_ip_on_request_span(span: Span, request: HttpRequest):
     if span and span.is_recording():
-        from baserow.core.utils import get_user_remote_ip_address_from_request
-
         ip_address = get_user_remote_ip_address_from_request(request)
         if ip_address:
             for attribute_name in OTEL_CLIENT_IP_ATTRIBUTE_NAMES:

--- a/backend/src/baserow/core/telemetry/telemetry.py
+++ b/backend/src/baserow/core/telemetry/telemetry.py
@@ -1,14 +1,19 @@
 import logging
 import sys
 
+from django.http import HttpRequest
+
 from celery import signals
 from opentelemetry import metrics, trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.trace import Span
 
 from baserow.core.psycopg import is_psycopg3
 from baserow.core.telemetry.provider import DifferentSamplerPerLibraryTracerProvider
 from baserow.core.telemetry.utils import BatchBaggageSpanProcessor, otel_is_enabled
+
+OTEL_CLIENT_IP_ATTRIBUTE_NAMES = ("client.address", "net.peer.ip")
 
 
 class LogGuruCompatibleLoggerHandler(LoggingHandler):
@@ -167,4 +172,14 @@ def _setup_standard_backend_instrumentation():
 def _setup_django_process_instrumentation():
     from opentelemetry.instrumentation.django import DjangoInstrumentor
 
-    DjangoInstrumentor().instrument()
+    DjangoInstrumentor().instrument(request_hook=_set_real_client_ip_on_request_span)
+
+
+def _set_real_client_ip_on_request_span(span: Span, request: HttpRequest):
+    if span and span.is_recording():
+        from baserow.core.utils import get_user_remote_ip_address_from_request
+
+        ip_address = get_user_remote_ip_address_from_request(request)
+        if ip_address:
+            for attribute_name in OTEL_CLIENT_IP_ATTRIBUTE_NAMES:
+                span.set_attribute(attribute_name, ip_address)

--- a/backend/src/baserow/core/utils.py
+++ b/backend/src/baserow/core/utils.py
@@ -16,7 +16,18 @@ from decimal import Decimal
 from fractions import Fraction
 from itertools import chain, islice
 from numbers import Number
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 from django.conf import settings
 from django.db import transaction
@@ -29,6 +40,9 @@ from requests.utils import guess_json_utf
 from baserow.contrib.database.db.schema import optional_atomic
 
 from .exceptions import CannotCalculateIntermediateOrder
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 RE_ESCAPE_CHAR = re.compile(r"\\(\\)?")
 RE_PROP_NAME = re.compile(
@@ -59,6 +73,31 @@ def flatten(nested_list: List[Any]):
         for sublist in nested_list
         for element in (flatten(sublist) if isinstance(sublist, list) else [sublist])
     ]
+
+
+def get_user_remote_ip_address_from_request(
+    request: HttpRequest,
+) -> Optional[str]:
+    """
+    Extracts the remote IP address of the user from the request. It checks for
+    X-Forwarded-For and X-Real-IP headers first (commonly set by proxies), and falls
+    back to the REMOTE_ADDR if neither is available.
+
+    :param request: The HTTP request object.
+    :return: The remote IP address as a string, or None if it is unavailable.
+    """
+
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+    if x_forwarded_for:
+        # X-Forwarded-For can contain multiple IPs: client, proxy1, proxy2.
+        # The first one is the original client IP.
+        return x_forwarded_for.split(",")[0].strip()
+
+    x_real_ip = request.META.get("HTTP_X_REAL_IP")
+    if x_real_ip:
+        return x_real_ip.strip()
+
+    return request.META.get("REMOTE_ADDR")
 
 
 def split_attrs_and_m2m_fields(

--- a/backend/src/baserow/throttling/handler.py
+++ b/backend/src/baserow/throttling/handler.py
@@ -11,7 +11,7 @@ from loguru import logger
 from rest_framework.throttling import SimpleRateThrottle
 
 from baserow.api.exceptions import ThrottledAPIException
-from baserow.api.sessions import get_user_remote_ip_address_from_request
+from baserow.core.utils import get_user_remote_ip_address_from_request
 
 from .blacklist import blacklist_ip, blacklist_token
 from .exceptions import RateLimitExceededException

--- a/backend/src/baserow/throttling/middleware.py
+++ b/backend/src/baserow/throttling/middleware.py
@@ -7,7 +7,7 @@ from baserow.api.exceptions import (
     ThrottledAPIException,
     api_exception_to_json_response,
 )
-from baserow.api.sessions import get_user_remote_ip_address_from_request
+from baserow.core.utils import get_user_remote_ip_address_from_request
 from baserow.throttling.handler import ConcurrentUserRequestsThrottle
 
 from .blacklist import get_token_cooldown_time, is_ip_blacklisted

--- a/backend/tests/baserow/core/telemetry/test_telemetry.py
+++ b/backend/tests/baserow/core/telemetry/test_telemetry.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+from baserow.core.telemetry.telemetry import (
+    _set_real_client_ip_on_request_span,
+    _setup_django_process_instrumentation,
+)
+
+
+def test_set_real_client_ip_on_request_span_uses_forwarded_for(api_request_factory):
+    request = api_request_factory.get(
+        "/api/workspaces/",
+        REMOTE_ADDR="10.0.0.1",
+        HTTP_X_FORWARDED_FOR="203.0.113.50, 70.41.3.18",
+    )
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    _set_real_client_ip_on_request_span(span, request)
+
+    span.set_attribute.assert_any_call("client.address", "203.0.113.50")
+    span.set_attribute.assert_any_call("net.peer.ip", "203.0.113.50")
+    assert span.set_attribute.call_count == 2
+
+
+def test_set_real_client_ip_on_request_span_falls_back_to_real_ip(api_request_factory):
+    request = api_request_factory.get(
+        "/api/workspaces/",
+        REMOTE_ADDR="10.0.0.1",
+        HTTP_X_REAL_IP="203.0.113.51",
+    )
+    span = MagicMock()
+    span.is_recording.return_value = True
+
+    _set_real_client_ip_on_request_span(span, request)
+
+    span.set_attribute.assert_any_call("client.address", "203.0.113.51")
+    span.set_attribute.assert_any_call("net.peer.ip", "203.0.113.51")
+    assert span.set_attribute.call_count == 2
+
+
+def test_setup_django_process_instrumentation_registers_real_ip_request_hook():
+    with patch(
+        "opentelemetry.instrumentation.django.DjangoInstrumentor.instrument"
+    ) as instrument:
+        _setup_django_process_instrumentation()
+
+    instrument.assert_called_once_with(request_hook=_set_real_client_ip_on_request_span)

--- a/changelog/entries/unreleased/bug/5277_use_real_client_ip_in_opentelemetry_request_traces.json
+++ b/changelog/entries/unreleased/bug/5277_use_real_client_ip_in_opentelemetry_request_traces.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Use the real client IP address in OpenTelemetry request traces when proxy headers are present.",
+    "issue_origin": "github",
+    "issue_number": 5277,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-04-29"
+}


### PR DESCRIPTION
### What is in this PR
- Moves request client IP extraction to a shared core helper.
- Uses that helper in Django OpenTelemetry request instrumentation so request spans prefer X-Forwarded-For and X-Real-IP over REMOTE_ADDR.
- Updates existing API/throttling imports to use the shared helper and adds focused telemetry tests.

Closes #5277

### How to test this PR
- Run `just b test tests/baserow/core/telemetry/test_telemetry.py tests/baserow/api/test_throttle_blacklist.py`.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] Security impact of change has been considered