### PR TITLE
fix: count linked array primary fields

### DIFF
--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -2423,7 +2423,7 @@ class BaserowCount(OneArgumentBaserowFunction):
         func_call: BaserowFunctionCall[UnTyped],
         arg: BaserowExpression[BaserowFormulaValidType],
     ) -> BaserowExpression[BaserowFormulaType]:
-        if BaserowGetFileCount().can_accept_arg(arg):
+        if BaserowGetFileCount().can_accept_arg(arg) and not arg.many:
             return BaserowGetFileCount()(arg)
 
         if isinstance(arg.expression_type, BaserowFormulaArrayType) and not arg.many:

--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -2426,7 +2426,7 @@ class BaserowCount(OneArgumentBaserowFunction):
         if BaserowGetFileCount().can_accept_arg(arg):
             return BaserowGetFileCount()(arg)
 
-        if isinstance(arg.expression_type, BaserowFormulaArrayType):
+        if isinstance(arg.expression_type, BaserowFormulaArrayType) and not arg.many:
             return BaserowArrayLength()(arg)
 
         return arg.expression_type.count(func_call, arg).with_valid_type(

--- a/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
@@ -2346,7 +2346,7 @@ def test_count_formula_for_link_row_field_with_null_values(data_fixture):
 def test_count_formula_for_link_row_field_with_array_primary_field(data_fixture):
     """
     A links to B, and B's primary field is a lookup array through a B to C link.
-    count(field('A to B link')) must count linked B rows, not each B row's inner
+    count(field('<link field>')) must count linked B rows, not each B row's inner
     primary lookup array length (github issue #5276)
     """
 
@@ -2391,6 +2391,57 @@ def test_count_formula_for_link_row_field_with_array_primary_field(data_fixture)
         rows_values=[
             {link_b_to_c.db_column: [rows_c[0].id]},
             {link_b_to_c.db_column: [rows_c[1].id]},
+        ],
+        model=table_b.get_model(),
+    ).created_rows
+    row_a = row_handler.force_create_rows(
+        user=user,
+        table=table_a,
+        rows_values=[{link_a_to_b.db_column: [row.id for row in rows_b]}],
+        model=table_a.get_model(),
+    ).created_rows[0]
+
+    assert getattr(row_a, count_formula.db_column) == 2
+
+
+@pytest.mark.django_db
+def test_count_formula_for_link_row_field_with_file_primary_field(data_fixture):
+    """
+    A links to B, and B's primary field is a file field. count(field('<link field>'))
+    must count linked B rows, not each B row's primary file count.
+    """
+
+    user = data_fixture.create_user()
+
+    table_a, table_b, link_a_to_b = data_fixture.create_two_linked_tables(user=user)
+    table_b_primary = table_b.field_set.get(primary=True)
+    table_b_primary.primary = False
+    table_b_primary.save()
+
+    primary_b = data_fixture.create_file_field(
+        table=table_b, name="Files", primary=True
+    )
+    count_formula = data_fixture.create_formula_field(
+        table=table_a,
+        name="Count",
+        formula=f"count(field('{link_a_to_b.name}'))",
+    )
+
+    user_file_1 = data_fixture.create_user_file()
+    user_file_2 = data_fixture.create_user_file()
+    user_file_3 = data_fixture.create_user_file()
+    row_handler = RowHandler()
+    rows_b = row_handler.force_create_rows(
+        user=user,
+        table=table_b,
+        rows_values=[
+            {
+                primary_b.db_column: [
+                    {"name": user_file_1.name},
+                    {"name": user_file_2.name},
+                ]
+            },
+            {primary_b.db_column: [{"name": user_file_3.name}]},
         ],
         model=table_b.get_model(),
     ).created_rows

--- a/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
@@ -2340,3 +2340,65 @@ def test_count_formula_for_link_row_field_with_null_values(data_fixture):
     )
 
     assert getattr(row_a, formula_field.db_column) == 3
+
+
+@pytest.mark.django_db
+def test_count_formula_for_link_row_field_with_array_primary_field(data_fixture):
+    """
+    A links to B, and B's primary field is a lookup array through a B to C link.
+    count(field('A to B link')) must count linked B rows, not each B row's inner
+    primary lookup array length (github issue #5276)
+    """
+
+    user = data_fixture.create_user()
+
+    table_a, table_b, link_a_to_b = data_fixture.create_two_linked_tables(user=user)
+    table_b_primary = table_b.field_set.get(primary=True)
+    table_b_primary.primary = False
+    table_b_primary.save()
+
+    table_c = data_fixture.create_database_table(user=user)
+    primary_c = data_fixture.create_text_field(
+        table=table_c, name="Field C", primary=True
+    )
+    link_b_to_c = data_fixture.create_link_row_field(
+        table=table_b,
+        link_row_table=table_c,
+        name="Link C",
+    )
+    data_fixture.create_formula_field(
+        table=table_b,
+        name="Primary lookup",
+        primary=True,
+        formula=f"lookup('{link_b_to_c.name}', '{primary_c.name}')",
+    )
+    count_formula = data_fixture.create_formula_field(
+        table=table_a,
+        name="Count",
+        formula=f"count(field('{link_a_to_b.name}'))",
+    )
+
+    row_handler = RowHandler()
+    rows_c = row_handler.force_create_rows(
+        user=user,
+        table=table_c,
+        rows_values=[{primary_c.db_column: "C1"}, {primary_c.db_column: "C2"}],
+        model=table_c.get_model(),
+    ).created_rows
+    rows_b = row_handler.force_create_rows(
+        user=user,
+        table=table_b,
+        rows_values=[
+            {link_b_to_c.db_column: [rows_c[0].id]},
+            {link_b_to_c.db_column: [rows_c[1].id]},
+        ],
+        model=table_b.get_model(),
+    ).created_rows
+    row_a = row_handler.force_create_rows(
+        user=user,
+        table=table_a,
+        rows_values=[{link_a_to_b.db_column: [row.id for row in rows_b]}],
+        model=table_a.get_model(),
+    ).created_rows[0]
+
+    assert getattr(row_a, count_formula.db_column) == 2

--- a/changelog/entries/unreleased/bug/5276_fix_count_formula_returning_array_for_linked_array_primary_fields.json
+++ b/changelog/entries/unreleased/bug/5276_fix_count_formula_returning_array_for_linked_array_primary_fields.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed count() returning an array instead of a number for link row fields whose linked primary field is an array formula or lookup.",
+    "issue_origin": "github",
+    "issue_number": 5276,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-29"
+}


### PR DESCRIPTION
### What is in this PR
- Fixes `count()` for link row fields whose linked primary field is an array formula or lookup.
- Keeps plain array inputs using array length, while many lookup/link expressions use the aggregate count path.
- Adds a regression test for a table A -> table B link where table B's primary field is a lookup array through table C.

Closes #5276

### How to test this PR
- Verify the issue is gone in this branch and the new test cover the problematic scneario

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered