### PR TITLE
fix: keep primary grid field visible

### DIFF
--- a/changelog/entries/unreleased/bug/5288_fix_hidden_primary_field_in_grid_view.json
+++ b/changelog/entries/unreleased/bug/5288_fix_hidden_primary_field_in_grid_view.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where changing the primary field to a hidden field could keep it hidden in the grid view.",
+    "issue_origin": "github",
+    "issue_number": 5288,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-04-30"
+}

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -455,11 +455,8 @@ import GridViewFreezeHandle from '@baserow/modules/database/components/view/grid
 import GridViewRowDragging from '@baserow/modules/database/components/view/grid/GridViewRowDragging'
 import RowEditModal from '@baserow/modules/database/components/row/RowEditModal'
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
-import {
-  filterHiddenFieldsFunction,
-  filterVisibleFieldsFunction,
-  sortFieldsByOrderAndIdFunction,
-} from '@baserow/modules/database/utils/view'
+import { sortFieldsByOrderAndIdFunction } from '@baserow/modules/database/utils/view'
+import { filterGridViewVisibleFieldsFunction } from '@baserow/modules/database/components/view/grid/utils'
 import viewHelpers from '@baserow/modules/database/mixins/viewHelpers'
 import { isElement } from '@baserow/modules/core/utils/dom'
 import viewDecoration from '@baserow/modules/database/mixins/viewDecoration'
@@ -548,7 +545,7 @@ export default {
     rightVisibleFields() {
       const fieldOptions = this.fieldOptions
       return this.rightFields
-        .filter(filterVisibleFieldsFunction(fieldOptions))
+        .filter(filterGridViewVisibleFieldsFunction(fieldOptions))
         .sort(sortFieldsByOrderAndIdFunction(fieldOptions, true))
     },
     /**
@@ -556,8 +553,9 @@ export default {
      */
     hiddenFields() {
       const fieldOptions = this.fieldOptions
+      const isFieldVisible = filterGridViewVisibleFieldsFunction(fieldOptions)
       return this.rightFields
-        .filter(filterHiddenFieldsFunction(fieldOptions))
+        .filter((field) => !isFieldVisible(field))
         .sort(sortFieldsByOrderAndIdFunction(fieldOptions))
     },
     viewHasGroupBys() {
@@ -585,7 +583,8 @@ export default {
     },
     /**
      * Returns the fields that should be displayed in the frozen left section.
-     * Takes the first N *visible* fields in sort order (primary always first).
+     * Takes the first N fields visible in the grid in sort order. The primary
+     * field is always included, even if its field options mark it as hidden.
      */
     leftFields() {
       if (!this.hasFrozenColumns) {
@@ -594,7 +593,7 @@ export default {
       const fieldOptions = this.fieldOptions
       const sorted = this.fields
         .slice()
-        .filter(filterVisibleFieldsFunction(fieldOptions))
+        .filter(filterGridViewVisibleFieldsFunction(fieldOptions))
         .sort(sortFieldsByOrderAndIdFunction(fieldOptions, true))
       return sorted.slice(0, this.frozenColumnCount)
     },
@@ -1790,7 +1789,7 @@ export default {
       const fieldOptions = this.fieldOptions
       const sorted = this.fields
         .slice()
-        .filter(filterVisibleFieldsFunction(fieldOptions))
+        .filter(filterGridViewVisibleFieldsFunction(fieldOptions))
         .sort(sortFieldsByOrderAndIdFunction(fieldOptions, true))
       const frozenWidth = sorted
         .slice(0, this.frozenColumnCount)

--- a/web-frontend/modules/database/components/view/grid/GridViewFreezeHandle.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFreezeHandle.vue
@@ -32,10 +32,8 @@
 
 <script>
 import { notifyIf } from '@baserow/modules/core/utils/error'
-import {
-  filterVisibleFieldsFunction,
-  sortFieldsByOrderAndIdFunction,
-} from '@baserow/modules/database/utils/view'
+import { sortFieldsByOrderAndIdFunction } from '@baserow/modules/database/utils/view'
+import { filterGridViewVisibleFieldsFunction } from '@baserow/modules/database/components/view/grid/utils'
 
 const MAX_FROZEN_COLUMNS = 4
 const HANDLE_PADDING = 20
@@ -104,7 +102,7 @@ export default {
     sortedFields() {
       return this.fields
         .slice()
-        .filter(filterVisibleFieldsFunction(this.fieldOptions))
+        .filter(filterGridViewVisibleFieldsFunction(this.fieldOptions))
         .sort(sortFieldsByOrderAndIdFunction(this.fieldOptions, true))
     },
     maxFrozenColumns() {

--- a/web-frontend/modules/database/components/view/grid/utils.js
+++ b/web-frontend/modules/database/components/view/grid/utils.js
@@ -1,0 +1,10 @@
+import { filterVisibleFieldsFunction } from '@baserow/modules/database/utils/view'
+
+/**
+ * In the grid view, the primary field is always rendered even when its field
+ * options mark it as hidden.
+ */
+export function filterGridViewVisibleFieldsFunction(fieldOptions) {
+  const isFieldVisible = filterVisibleFieldsFunction(fieldOptions)
+  return (field) => field.primary || isFieldVisible(field)
+}

--- a/web-frontend/test/unit/database/components/view/grid/gridView.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridView.spec.js
@@ -1,0 +1,53 @@
+import GridView from '@baserow/modules/database/components/view/grid/GridView'
+import GridViewFreezeHandle from '@baserow/modules/database/components/view/grid/GridViewFreezeHandle'
+
+describe('GridView component', () => {
+  const fields = [
+    { id: 1, name: 'Primary', primary: true },
+    { id: 2, name: 'Hidden', primary: false },
+    { id: 3, name: 'Visible', primary: false },
+  ]
+  const fieldOptions = {
+    1: { order: 0, hidden: true },
+    2: { order: 1, hidden: true },
+    3: { order: 2, hidden: false },
+  }
+
+  test('leftFields includes the primary field when it is hidden', () => {
+    const leftFields = GridView.computed.leftFields.call({
+      fields,
+      fieldOptions,
+      frozenColumnCount: 2,
+      hasFrozenColumns: true,
+    })
+
+    expect(leftFields.map((field) => field.id)).toEqual([1, 3])
+  })
+
+  test('rightVisibleFields includes the primary field when frozen columns are disabled', () => {
+    const rightVisibleFields = GridView.computed.rightVisibleFields.call({
+      rightFields: fields,
+      fieldOptions,
+    })
+
+    expect(rightVisibleFields.map((field) => field.id)).toEqual([1, 3])
+  })
+
+  test('hiddenFields excludes the primary field when it is hidden', () => {
+    const hiddenFields = GridView.computed.hiddenFields.call({
+      rightFields: fields,
+      fieldOptions,
+    })
+
+    expect(hiddenFields.map((field) => field.id)).toEqual([2])
+  })
+
+  test('freeze handle sortedFields includes the primary field when it is hidden', () => {
+    const sortedFields = GridViewFreezeHandle.computed.sortedFields.call({
+      fields,
+      fieldOptions,
+    })
+
+    expect(sortedFields.map((field) => field.id)).toEqual([1, 3])
+  })
+})


### PR DESCRIPTION
### What is in this PR
- Fixes #5288.
- Ensures grid field visibility treats the primary field as visible even when its field option is hidden.
- Reuses the same grid-local visibility predicate for the grid body and freeze handle.
- Adds regression coverage for hidden primary field visibility.

### How to test this PR
- Create a table with a grid view.
- Hide all fields.
- Change the primary field to one of the hidden fields.
- Confirm the new primary field remains visible in the grid.
- Run: `just f yarn test:core --run test/unit/database/components/view/grid/gridView.spec.js`

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered