### PR TITLE
chore: Replace Node ID with label in dispatch errors

### DIFF
--- a/backend/src/baserow/contrib/automation/nodes/handler.py
+++ b/backend/src/baserow/contrib/automation/nodes/handler.py
@@ -483,7 +483,7 @@ class AutomationNodeHandler(metaclass=baserow_trace_methods(tracer)):
         try:
             dispatch_result = node_type.dispatch(node, dispatch_context)
         except ServiceImproperlyConfiguredDispatchException as e:
-            error = f"The node {node.id} is misconfigured and cannot be dispatched. {str(e)}"
+            error = f"The node is misconfigured and cannot be dispatched. {str(e)}"
             self._handle_workflow_error(node_history, iteration_path, error)
             self._handle_simulation_notify(simulate_until_node, node)
             return None

--- a/changelog/entries/unreleased/refactor/4800_replace_node_id_with_node_label_in_dispatch_errors.json
+++ b/changelog/entries/unreleased/refactor/4800_replace_node_id_with_node_label_in_dispatch_errors.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Remove Node ID in dispatch errors since the error is scoped to the node history.",
+    "issue_origin": "github",
+    "issue_number": 4800,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-05-01"
+}

--- a/web-frontend/modules/integrations/locales/en.json
+++ b/web-frontend/modules/integrations/locales/en.json
@@ -23,7 +23,7 @@
     "slackBotNoToken": "Slack Bot - Not configured"
   },
   "serviceType": {
-    "localBaserowGetRow": "Get single row",
+    "localBaserowGetRow": "Get a single row",
     "localBaserowGetRowDescription": "Read a single row from a Baserow table.",
     "localBaserowListRows": "List multiple rows",
     "localBaserowListRowsDescription": "Reads multiple rows from a Baserow table.",


### PR DESCRIPTION
### What is in this PR
This PR improves the error messages for node dispatch errors.

Currently, we display the published node ID in the error message. Since we don't show the node ID in the editor, the ID itself is not that useful as an identifier. Since the node itself is already scoped to the node history entry, we can remove the ID from the error message.

| Before | After |
| - | - |
| <img width="308" height="133" alt="image" src="https://github.com/user-attachments/assets/2490fd87-4f66-49e9-9a49-2d23d8e05ed2" /> | <img width="307" height="133" alt="image" src="https://github.com/user-attachments/assets/2b321ea4-29b6-4838-a06a-4552ad03476f" /> |

Closes https://github.com/baserow/baserow/issues/4800

### How to test this PR
Create a "Update a row" node and for the Row ID, set a non-existent row, e.g. 99999. Publish the workflow and trigger the workflow.

In `develop`, you should see the history shows the Node ID (which is the published node's ID). In this branch, you should see the ID was removed.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
