### PR TITLE
fix(builder): clear single-select record selector + truncate dropdown…

### DIFF
--- a/changelog/entries/unreleased/feature/3719_clear_singleselect_record_selector.json
+++ b/changelog/entries/unreleased/feature/3719_clear_singleselect_record_selector.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "clear single-select record selector",
+    "issue_origin": "github",
+    "issue_number": 3719,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-05"
+}

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDropdownItem.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDropdownItem.vue
@@ -2,6 +2,7 @@
   <li
     class="ab-dropdownitem__item ab-dropdownitem__item--no-options"
     :class="{
+      'ab-dropdownitem__item--single': !multiple.value,
       hidden: !isVisible(query),
       active: isActive(value),
       disabled: disabled,
@@ -15,7 +16,7 @@
       @mousemove="hover(value, disabled)"
     >
       <div class="ab-dropdownitem__item-name">
-        <div v-if="multiple.value">
+        <div v-if="multiple.value" class="ab-dropdownitem__item-name-checkbox">
           <Checkbox :disabled="disabled" :checked="isActive(value)"></Checkbox>
         </div>
         <slot>

--- a/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ChoiceElement.vue
@@ -14,6 +14,7 @@
       "
       :show-search="false"
       :multiple="element.multiple"
+      :clearable="!element.multiple && !element.required"
       @hide="onFormElementTouch"
     >
       <ABDropdownItem

--- a/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RecordSelectorElement.vue
@@ -13,6 +13,7 @@
       class="choice-element"
       :placeholder="resolvedPlaceholder"
       :multiple="element.multiple"
+      :clearable="!element.multiple && !element.required"
       :before-show="beforeShow"
       @hide="onFormElementTouch"
       @query-change="adhocSearch = $event"

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_dropdownitem.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_dropdownitem.scss
@@ -135,6 +135,10 @@
     text-decoration: none;
   }
 
+  .ab-dropdownitem__item--single & {
+    padding-right: calc(var(--input-horizontal-padding, 12px) + 1.25em);
+  }
+
   .ab-dropdownitem__item.disabled & {
     color: $palette-neutral-700;
 
@@ -150,8 +154,12 @@
   font-weight: 500;
   line-height: 120%;
   gap: 0.5em;
+  min-width: 0;
+  max-width: 100%;
 
-  @extend %ellipsis;
+  .ab-dropdownitem__item-name-checkbox {
+    flex-shrink: 0;
+  }
 
   .ab-dropdownitem__item-link:active & {
     color: color-mix(
@@ -160,4 +168,10 @@
       var(--input-text-color-complement, white) 20%
     );
   }
+}
+
+.ab-dropdownitem__item-name-text {
+  @extend %ellipsis;
+  flex: 1 1 auto;
+  min-width: 0;
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_dropdownitem.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_dropdownitem.scss
@@ -172,6 +172,7 @@
 
 .ab-dropdownitem__item-name-text {
   @extend %ellipsis;
+
   flex: 1 1 auto;
   min-width: 0;
 }

--- a/web-frontend/modules/core/mixins/dropdown.js
+++ b/web-frontend/modules/core/mixins/dropdown.js
@@ -139,6 +139,15 @@ export default {
       default: false,
     },
     /**
+     * If true (single-select only), choosing the already selected value clears the
+     * selection (emits `null`).
+     */
+    clearable: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    /**
      * Before show let the opportunity to execute something before actually opening the
      * dropdown. Useful when, for instance, you want to populate the item on demand only
      * when the items are dynamic and you want to avoid the non reactivity issue with
@@ -487,11 +496,21 @@ export default {
         this.$emit('update:modelValue', newValue) // Vue 3 compatibility
         this.$emit('change', newValue)
       } else {
-        // emitting the updated value Vue 2 style.
-        this.$emit('input', value)
-        // emitting the updated value Vue 3 style.
-        this.$emit('update:modelValue', value) // Vue 3 compatibility
-        this.$emit('change', value)
+        const hasSingleValue =
+          this.currentValue !== null && this.currentValue !== undefined
+        if (
+          this.clearable &&
+          hasSingleValue &&
+          _.isEqual(value, this.currentValue)
+        ) {
+          this.$emit('input', null)
+          this.$emit('update:modelValue', null)
+          this.$emit('change', null)
+        } else {
+          this.$emit('input', value)
+          this.$emit('update:modelValue', value)
+          this.$emit('change', value)
+        }
         this.hide()
       }
     },

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
@@ -203,7 +203,7 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                 
                 
                 <li
-                  class="ab-dropdownitem__item ab-dropdownitem__item--no-options"
+                  class="ab-dropdownitem__item ab-dropdownitem__item--no-options ab-dropdownitem__item--single"
                 >
                   <a
                     class="ab-dropdownitem__item-link"
@@ -228,7 +228,7 @@ exports[`ChoiceElement > as manual dropdown 1`] = `
                   />
                 </li>
                 <li
-                  class="ab-dropdownitem__item ab-dropdownitem__item--no-options"
+                  class="ab-dropdownitem__item ab-dropdownitem__item--no-options ab-dropdownitem__item--single"
                 >
                   <a
                     class="ab-dropdownitem__item-link"

--- a/web-frontend/test/unit/core/components/dropdown.spec.js
+++ b/web-frontend/test/unit/core/components/dropdown.spec.js
@@ -117,6 +117,33 @@ describe('Dropdown component', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
+  test('clearable single select clears when choosing the active value', async () => {
+    let wrapper = null
+
+    const onInput = vi.fn(async (newVal) => {
+      wrapper.setProps({ value: newVal })
+      await wrapper.vm.$nextTick()
+    })
+
+    wrapper = await mountComponent({
+      props: { value: 'a', clearable: true },
+      slots: {
+        default: `<DropdownItem value="a" name="A"/>
+          <DropdownItem value="b" name="B"/>`,
+      },
+      listeners: { input: onInput },
+    })
+
+    await wrapper.find('.dropdown__selected').trigger('click')
+    await wrapper
+      .find('.select__items :nth-child(1)')
+      .find('.select__item-link')
+      .trigger('click')
+    await wrapper.vm.$nextTick()
+
+    expect(onInput).toHaveBeenLastCalledWith(null)
+  })
+
   test('focus', async () => {
     let wrapper = null
 


### PR DESCRIPTION
### What is in this PR

- Single-select record selectors can be cleared by choosing the same value again
- AB dropdown items: long labels ellipsis, no overlap with the checkmark.

### How to test this PR

- Record selector: single, not required → select a row → open list → click that row again → value clears.
- Same with required → clearing via re-click should not happen.
- Multi record selector → still works as before.
- Single-select list with a very long label → text truncates; checkmark stays readable.

Closes #3719

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
