### PR TITLE
fix(builder): ignore hidden form fields when validating form container submit

### DIFF
--- a/changelog/entries/unreleased/bug/5203_ignore_hidden_form_field_when_validation_form_container_subm.json
+++ b/changelog/entries/unreleased/bug/5203_ignore_hidden_form_field_when_validation_form_container_subm.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ignore hidden form field when validation form container submit",
+    "issue_origin": "github",
+    "issue_number": 5203,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-05"
+}

--- a/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
@@ -118,6 +118,8 @@ export default {
   },
   methods: {
     isFormFieldDisplayed(descendant, descendantType) {
+      // In the published app PageElement hides misconfigured
+      // elements, so we exclude them from  validation here too.
       if (
         this.mode !== 'editing' &&
         descendantType.isInError(descendant, this.applicationContext)

--- a/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/FormContainerElement.vue
@@ -101,6 +101,9 @@ export default {
     formElementChildrenAreInvalid() {
       return this.getFormElementDescendants.some(
         ({ descendant, descendantType }) => {
+          if (!this.isFormFieldDisplayed(descendant, descendantType)) {
+            return false
+          }
           const uniqueElementId = descendantType.uniqueElementId({
             element: descendant,
             applicationContext: this.applicationContext,
@@ -114,6 +117,18 @@ export default {
     },
   },
   methods: {
+    isFormFieldDisplayed(descendant, descendantType) {
+      if (
+        this.mode !== 'editing' &&
+        descendantType.isInError(descendant, this.applicationContext)
+      ) {
+        return false
+      }
+      return descendantType.isVisible({
+        element: descendant,
+        applicationContext: this.applicationContext,
+      })
+    },
     /*
      * Responsible for marking all form element descendents in this form container
      * as touched, or not touched, depending on what we're achieving in validation.
@@ -121,6 +136,9 @@ export default {
     setFormElementDescendantsTouched(wasTouched) {
       this.getFormElementDescendants.forEach(
         ({ descendant, descendantType }) => {
+          if (!this.isFormFieldDisplayed(descendant, descendantType)) {
+            return
+          }
           const uniqueElementId = descendantType.uniqueElementId({
             element: descendant,
             applicationContext: this.applicationContext,

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -1396,13 +1396,6 @@ export class FormElementType extends ElementType {
     return resolvedName || this.name
   }
 
-  afterDelete(element, page) {
-    return this.app.$store.dispatch('formData/removeFormData', {
-      page,
-      elementId: element.id,
-    })
-  }
-
   getDataSchema(element) {
     return {
       type: this.formDataType(element),

--- a/web-frontend/modules/builder/mixins/formElement.js
+++ b/web-frontend/modules/builder/mixins/formElement.js
@@ -64,7 +64,7 @@ export default {
     },
   },
   beforeUnmount() {
-    this.setFormData()
+    this.unsetFormData()
   },
   methods: {
     ...mapActions({

--- a/web-frontend/modules/builder/mixins/formElement.js
+++ b/web-frontend/modules/builder/mixins/formElement.js
@@ -63,9 +63,13 @@ export default {
       ).some(({ type }) => type === FormContainerElementType.getType())
     },
   },
+  beforeUnmount() {
+    this.setFormData()
+  },
   methods: {
     ...mapActions({
       actionSetFormData: 'formData/setFormData',
+      actionRemoveFormData: 'formData/removeFormData',
     }),
     /*
      * When a form element has been modified (e.g. a user has inputted a value),
@@ -94,6 +98,12 @@ export default {
             this.applicationContext
           ),
         },
+      })
+    },
+    unsetFormData() {
+      return this.actionRemoveFormData({
+        page: this.elementPage,
+        uniqueElementId: this.uniqueElementId,
       })
     },
     /**

--- a/web-frontend/modules/builder/store/formData.js
+++ b/web-frontend/modules/builder/store/formData.js
@@ -1,4 +1,5 @@
 import {
+  deleteValueAtPath,
   getValueAtPath,
   setValueAtPath,
 } from '@baserow/modules/core/utils/object'
@@ -34,12 +35,12 @@ const mutations = {
 
     setFormEntryAtPath(page, uniqueElementId, payload)
   },
-  REMOVE_FORM_DATA(state, { page, elementId }) {
-    page.formData = Object.fromEntries(
-      Object.entries(page.formData).filter(
-        ([key]) => key !== elementId.toString()
-      )
-    )
+  REMOVE_FORM_DATA(state, { page, uniqueElementId }) {
+    if (!page.formData) {
+      return
+    }
+
+    deleteValueAtPath(page.formData, uniqueElementId)
   },
   SET_ELEMENT_TOUCHED(state, { page, uniqueElementId, wasTouched }) {
     setFormEntryAtPath(page, `${uniqueElementId}.touched`, wasTouched)
@@ -50,8 +51,8 @@ const actions = {
   setFormData({ commit }, { page, uniqueElementId, payload }) {
     commit('SET_FORM_DATA', { page, uniqueElementId, payload })
   },
-  removeFormData({ commit }, { page, elementId }) {
-    commit('REMOVE_FORM_DATA', { page, elementId })
+  removeFormData({ commit }, { page, uniqueElementId }) {
+    commit('REMOVE_FORM_DATA', { page, uniqueElementId })
   },
   setElementTouched({ commit }, { page, uniqueElementId, wasTouched }) {
     commit('SET_ELEMENT_TOUCHED', { page, uniqueElementId, wasTouched })

--- a/web-frontend/modules/core/utils/object.js
+++ b/web-frontend/modules/core/utils/object.js
@@ -183,3 +183,34 @@ export function setValueAtPath(obj, path, value) {
     }
   }
 }
+
+/**
+ * Deeply deletes a value in an object (or array) from a dotted path string.
+ * Missing intermediate parts are ignored.
+ *
+ * @param {Object} obj - The object we want to update.
+ * @param {String} path - The path, delimited by periods, to the value.
+ */
+export function deleteValueAtPath(obj, path) {
+  const keys = path.split('.')
+  const lastKey = keys.pop()
+  let current = obj
+
+  for (const key of keys) {
+    if (current === null || typeof current !== 'object' || !(key in current)) {
+      return
+    }
+
+    current = current[key]
+  }
+
+  if (current === null || typeof current !== 'object') {
+    return
+  }
+
+  if (Array.isArray(current) && /^\d+$/.test(lastKey)) {
+    current.splice(Number(lastKey), 1)
+  } else {
+    delete current[lastKey]
+  }
+}

--- a/web-frontend/test/unit/builder/store/formData.spec.js
+++ b/web-frontend/test/unit/builder/store/formData.spec.js
@@ -1,0 +1,85 @@
+import formDataStore from '@baserow/modules/builder/store/formData'
+
+describe('formData store', () => {
+  test('removeFormData deletes a repeated form data entry by unique element id', () => {
+    const page = {}
+    const commit = (mutation, payload) => {
+      formDataStore.mutations[mutation](formDataStore.state, payload)
+    }
+
+    formDataStore.actions.setFormData(
+      { commit },
+      {
+        page,
+        uniqueElementId: '42.0',
+        payload: {
+          value: 'first',
+          elementId: 42,
+        },
+      }
+    )
+    formDataStore.actions.setFormData(
+      { commit },
+      {
+        page,
+        uniqueElementId: '42.1',
+        payload: {
+          value: 'second',
+          elementId: 42,
+        },
+      }
+    )
+
+    formDataStore.actions.removeFormData(
+      { commit },
+      {
+        page,
+        uniqueElementId: '42.0',
+      }
+    )
+
+    expect(page.formData).toStrictEqual({
+      42: [
+        {
+          value: 'second',
+          elementId: 42,
+        },
+      ],
+    })
+  })
+
+  test('removeFormData deletes all form data for an element', () => {
+    const page = {
+      formData: {
+        42: [
+          {
+            value: 'first',
+            elementId: 42,
+          },
+        ],
+        43: {
+          value: 'other',
+          elementId: 43,
+        },
+      },
+    }
+    const commit = (mutation, payload) => {
+      formDataStore.mutations[mutation](formDataStore.state, payload)
+    }
+
+    formDataStore.actions.removeFormData(
+      { commit },
+      {
+        page,
+        uniqueElementId: '42',
+      }
+    )
+
+    expect(page.formData).toStrictEqual({
+      43: {
+        value: 'other',
+        elementId: 43,
+      },
+    })
+  })
+})

--- a/web-frontend/test/unit/core/utils/object.spec.js
+++ b/web-frontend/test/unit/core/utils/object.spec.js
@@ -1,5 +1,6 @@
 import {
   clone,
+  deleteValueAtPath,
   isPromise,
   mappingToStringifiedJSONLines,
   getValueAtPath,
@@ -70,6 +71,41 @@ describe('test utils object', () => {
     // but it does. Unfortunately this is as close to a good promise detection
     // as we can get
     expect(isPromise({ then: () => null, catch: () => null })).toBeTruthy()
+  })
+
+  test('deleteValueAtPath deletes object properties', () => {
+    const obj = {
+      a: { b: { c: 123, d: 456 } },
+    }
+
+    deleteValueAtPath(obj, 'a.b.c')
+
+    expect(obj).toStrictEqual({
+      a: { b: { d: 456 } },
+    })
+  })
+
+  test('deleteValueAtPath removes array entries', () => {
+    const obj = {
+      list: [{ d: 456 }, { d: 789 }, { d: 111 }],
+    }
+
+    deleteValueAtPath(obj, 'list.1')
+
+    expect(obj.list).toStrictEqual([{ d: 456 }, { d: 111 }])
+  })
+
+  test('deleteValueAtPath ignores missing paths', () => {
+    const obj = {
+      a: { b: { c: 123 } },
+    }
+
+    deleteValueAtPath(obj, 'a.x.c')
+    deleteValueAtPath(obj, 'a.b.c.x')
+
+    expect(obj).toStrictEqual({
+      a: { b: { c: 123 } },
+    })
   })
 
   test.each([


### PR DESCRIPTION
### What is in this PR
Form container validation and submit-time touched only apply to form fields that are actually shown, so conditionally hidden fields no longer block submit when they never mount and have no formData entry. 

### How to test this PR
Form with field A and field B, B has a visibility condition so it starts hidden.
With B hidden, fill A, submit → should succeed.
Make B visible, leave B invalid if required → submit should fail as usual.

Fixes #5203 
Fixes #4794

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
