### PR TITLE
Fix workflow broken after node replace inside a container

### DIFF
--- a/backend/src/baserow/contrib/automation/nodes/models.py
+++ b/backend/src/baserow/contrib/automation/nodes/models.py
@@ -127,10 +127,12 @@ class AutomationNode(
         the current node instance.
         """
 
+        previous_positions = self.workflow.get_graph().get_previous_positions(self)
+        if previous_positions is None:
+            return []
+
         return [
-            position[0]
-            for position in self.workflow.get_graph().get_previous_positions(self)
-            if position[1] == "child"
+            position[0] for position in previous_positions if position[1] == "child"
         ]
 
     def get_next_nodes(

--- a/backend/src/baserow/contrib/automation/nodes/service.py
+++ b/backend/src/baserow/contrib/automation/nodes/service.py
@@ -418,6 +418,9 @@ class AutomationNodeService:
             workflow.simulate_until_node = None
             workflow.save(update_fields=["simulate_until_node"])
 
+        cache_key = WORKFLOW_DIRTY_CACHE_KEY.format(workflow.id)
+        global_cache.update(cache_key, lambda _: True)
+
         automation_node_deleted.send(
             self,
             workflow=workflow,

--- a/changelog/entries/unreleased/bug/fix_broken_workflow_after_node_replacement.json
+++ b/changelog/entries/unreleased/bug/fix_broken_workflow_after_node_replacement.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix broken workflow after node replacement",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-05-05"
+}

--- a/web-frontend/modules/automation/pages/automationWorkflow.vue
+++ b/web-frontend/modules/automation/pages/automationWorkflow.vue
@@ -88,10 +88,6 @@ const { data: pageData, error } = await useAsyncData(
         workflowId: workflowId.value,
       })
 
-      await $store.dispatch('automationHistory/fetchWorkflowHistory', {
-        workflowId: workflowId.value,
-      })
-
       await $store.dispatch('automationWorkflowNode/fetch', {
         workflow,
       })


### PR DESCRIPTION
### What is in this PR

Try to prevent the Sentry issue BASEROW-SAAS-BACKEND-KQ

This error is likely to happen when a user has just replaced a node that was a child of a container but I don't know the exact reproduction steps.

### How to test this PR

Although I'm not able to reproduce it, you can check that the history entries are not loaded anymore on the workflow page load which should prevent at least to have a broken workflow page.

Also, you can reproduce the missing invalidation:
On develop:
- Create a workflow
- Test it to create the TEST_CLONE
- Replace one node but don't do any other modification
- Re test the workflow
- Open the history: the history should contain the previous node for the last test entry. This shouldn't be the case with this PR.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
