### PR TITLE
fix: custom code editors first line issue

### DIFF
--- a/changelog/entries/unreleased/bug/5310_fix_custom_code_editors_when_deleting_the_first_line.json
+++ b/changelog/entries/unreleased/bug/5310_fix_custom_code_editors_when_deleting_the_first_line.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix custom code editors when deleting the first line",
+    "issue_origin": "github",
+    "issue_number": 5310,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-05"
+}

--- a/web-frontend/modules/core/assets/scss/components/code_editor.scss
+++ b/web-frontend/modules/core/assets/scss/components/code_editor.scss
@@ -16,4 +16,8 @@
     padding: 0;
     overflow-y: auto;
   }
+
+  &__code-wrapper {
+    margin: 2px 0;
+  }
 }

--- a/web-frontend/modules/core/components/CodeEditor.vue
+++ b/web-frontend/modules/core/components/CodeEditor.vue
@@ -8,8 +8,11 @@
 import { Editor, EditorContent } from '@tiptap/vue-3'
 
 import { Document } from '@tiptap/extension-document'
-import { Paragraph } from '@tiptap/extension-paragraph'
 import { Text } from '@tiptap/extension-text'
+
+const CodeEditorDocument = Document.extend({
+  content: 'codeBlock',
+})
 
 export default {
   name: 'CodeEditor',
@@ -36,13 +39,23 @@ export default {
   watch: {
     modelValue(newCode) {
       if (this.editor && newCode !== this.getCurrentCode()) {
-        this.editor.commands.setContent(this.generateCodeBlock(newCode))
+        this.editor.commands.setContent(
+          this.generateCodeBlock(newCode),
+          false,
+          {
+            preserveWhitespace: 'full',
+          }
+        )
       }
     },
     language() {
       if (this.editor) {
         this.editor.commands.setContent(
-          this.generateCodeBlock(this.getCurrentCode())
+          this.generateCodeBlock(this.getCurrentCode()),
+          false,
+          {
+            preserveWhitespace: 'full',
+          }
         )
       }
     },
@@ -60,17 +73,44 @@ export default {
     lowlight.register('javascript', javascript)
     lowlight.register('css', css)
 
+    const LockedCodeBlockLowlight = CodeBlockLowlight.extend({
+      addKeyboardShortcuts() {
+        const parentShortcuts = this.parent?.() || {}
+
+        return {
+          ...parentShortcuts,
+          Backspace: () => {
+            const { empty, $anchor } = this.editor.state.selection
+
+            if (!empty || $anchor.parent.type.name !== this.name) {
+              return false
+            }
+
+            if ($anchor.pos === 1 || !$anchor.parent.textContent.length) {
+              return true
+            }
+
+            return false
+          },
+        }
+      },
+    })
+
     this.editor = new Editor({
       extensions: [
-        Document,
-        Paragraph,
+        CodeEditorDocument,
         Text,
-        CodeBlockLowlight.configure({
+        LockedCodeBlockLowlight.configure({
           lowlight,
+          exitOnTripleEnter: false,
+          exitOnArrowDown: false,
+          HTMLAttributes: {
+            class: 'code-editor__code-wrapper',
+          },
         }),
       ],
       content: this.generateCodeBlock(this.modelValue),
-      onUpdate: ({ editor }) => {
+      onUpdate: () => {
         this.$emit('update:modelValue', this.getCurrentCode())
       },
     })
@@ -80,21 +120,21 @@ export default {
   },
   methods: {
     generateCodeBlock(code) {
-      return `<pre class="code-editor__code-wrapper"><code class="code-editor__code code-editor__code--language-${
-        this.language
-      }">${this.escapeHtml(code)}</code></pre>`
+      return {
+        type: 'doc',
+        content: [
+          {
+            type: 'codeBlock',
+            attrs: {
+              language: this.language,
+            },
+            content: code ? [{ type: 'text', text: code }] : [],
+          },
+        ],
+      }
     },
     getCurrentCode() {
-      const codeNode = this.editor?.getJSON()?.content?.[0]?.content?.[0]
-      return codeNode?.text || ''
-    },
-    escapeHtml(string) {
-      return string
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;')
+      return this.editor?.getText() || ''
     },
   },
 }


### PR DESCRIPTION
### What is in this PR

The current editor was adding an extra line at the begining of the text area that could be deleted and if so replacing the content of the editor with a paragraph instead of a codeBlock. This PR ensure the code block remains a code block forever.

### How to test this PR

To reproduce on develop:
- Write some CSS custom code for an application. The syntax highlighting should apply.
- Click on the first char and press `Del`. It should remove a hidden line and breaks the syntax highlighting. From now, the syntaywx highlighting is broken even if you try to modify the content.
- Reload the page to restore the content and now select the whole content, copy it and paste it in the same area. It should also break the syntax.
- Test with this branch, it should be solved.
- Check the community post for more details.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
