### PR TITLE
chore: Improve error message specificity and show Slack icon in Node History

### DIFF
--- a/changelog/entries/unreleased/refactor/added_the_slack_icon_to_node_history_entries.json
+++ b/changelog/entries/unreleased/refactor/added_the_slack_icon_to_node_history_entries.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Added the Slack icon to Node History entries.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-05-06"
+}

--- a/changelog/entries/unreleased/refactor/improved_the_frontend_error_message_to_be_more_specific.json
+++ b/changelog/entries/unreleased/refactor/improved_the_frontend_error_message_to_be_more_specific.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Improved the frontend error message to be more specific.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-06"
+}

--- a/web-frontend/modules/automation/components/workflow/sidePanels/NodeHistory.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/NodeHistory.vue
@@ -7,7 +7,8 @@
       <template #header="{ expanded }">
         <div class="node-history__header-row">
           <div class="node-history__header-icon">
-            <i :class="nodeIconClass"></i>
+            <i v-if="nodeIconClass" :class="nodeIconClass"></i>
+            <img v-else :alt="nodeType.name" :src="nodeType.image" />
           </div>
           <div class="node-history__header-info">
             <div>
@@ -100,7 +101,8 @@
 
     <div v-else class="node-history__header-row">
       <div class="node-history__header-icon">
-        <i :class="nodeIconClass"></i>
+        <i v-if="nodeIconClass" :class="nodeIconClass"></i>
+        <img v-else :alt="nodeType.name" :src="nodeType.image" />
       </div>
       <div class="node-history__header-info">
         <div

--- a/web-frontend/modules/core/plugins/clientHandler.js
+++ b/web-frontend/modules/core/plugins/clientHandler.js
@@ -278,7 +278,14 @@ export class ErrorHandler {
       return this.errorMap[this.code]
     }
 
-    if (this.detail && typeof this.detail === 'string') {
+    const status = this.response?.status || 500
+    if (
+      this.detail &&
+      typeof this.detail === 'string' &&
+      status >= 400 &&
+      status < 500 &&
+      this.code != 'ERROR_REQUEST_BODY_VALIDATION'
+    ) {
       return new ResponseErrorMessage(
         this.app.$i18n.t('clientHandler.notCompletedTitle'),
         this.detail

--- a/web-frontend/modules/core/plugins/clientHandler.js
+++ b/web-frontend/modules/core/plugins/clientHandler.js
@@ -278,6 +278,13 @@ export class ErrorHandler {
       return this.errorMap[this.code]
     }
 
+    if (this.detail && typeof this.detail === 'string') {
+      return new ResponseErrorMessage(
+        this.app.$i18n.t('clientHandler.notCompletedTitle'),
+        this.detail
+      )
+    }
+
     return this.genericDefaultError()
   }
 

--- a/web-frontend/test/unit/core/utils/errors.spec.js
+++ b/web-frontend/test/unit/core/utils/errors.spec.js
@@ -83,6 +83,27 @@ describe('test error handling', () => {
       }
     }
   )
+  test('a 400 response with a string detail and no matching error map entry shows the detail as the message', async () => {
+    try {
+      await errorInterceptorWithStubAppAndStore()({
+        response: {
+          data: {
+            error: 'noMatchingEntryInSpecificErrorMap',
+            detail: 'The `minute` value must be greater or equal to 2.',
+          },
+          status: 400,
+        },
+      })
+    } catch (error) {
+      const message = error.handler.getMessage('name', {
+        doesntMatch: new ResponseErrorMessage('title', 'message'),
+      })
+      expect(message.title).toBe('clientHandler.notCompletedTitle')
+      expect(message.message).toBe(
+        'The `minute` value must be greater or equal to 2.'
+      )
+    }
+  })
   test('an 429 response results in a too many requests error', async () => {
     try {
       await errorInterceptorWithStubAppAndStore()({


### PR DESCRIPTION
# What is in this PR
This PR introduces two small changes.

### 1. Improved Error Message
The error handling in the frontend has been improved to show a specific error when possible.
| Before | After |
| - | - |
| <img width="678" height="272" alt="image" src="https://github.com/user-attachments/assets/e4921752-7d6f-40b8-a5e0-643e90aeb1d7" /> | <img width="678" height="222" alt="image" src="https://github.com/user-attachments/assets/91d10731-344f-47b2-b3ad-3e2be88d0edf" /> |

### 2. Icon rendering in Node History
Currently, the Node History renders icons for all service types, with the exception of Slack. This PR fixes this by rendering the Slack icon using the image as a fallback (since we don't have an icon for it).
| Before | After |
| - | - |
| <img width="678" height="212" alt="image" src="https://github.com/user-attachments/assets/c64ae1f8-f722-44f7-a2a5-0aa16000cd08" /> | <img width="662" height="190" alt="image" src="https://github.com/user-attachments/assets/a9b9318f-c93d-4399-9139-ae18f9b5370d" /> |

# How to test this PR

### Test: Improved Error Message
To test the improved error message, you'll need to trigger a 400 status code on any backend service that returns a general error with this shape:
```
{
    "error": ...,
    "detail": ...
}
```

A quick way to test this is to use the Period Trigger node to trigger the error. First, update `base.py` and override this setting:
```
 INTEGRATIONS_PERIODIC_MINUTE_MIN = int(
-    os.getenv("BASEROW_INTEGRATIONS_PERIODIC_MINUTE_MIN") or 1
+    os.getenv("BASEROW_INTEGRATIONS_PERIODIC_MINUTE_MIN") or 2
 )
```

Then create a Periodic Trigger, and set its value to 1. In `develop`, you'll see the generic error and in this branch you'll see the specific error; see the screenshots above.

### Test: Node History's Slack Icon
In Automations, create a Slack node (you don't have to use a real integration) and test the workflow. In the history, you should see the icon (or more specifically, the service type's image) is now visible in this branch.

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered