### PR TITLE
fix: harden BaserowIndex evaluation against unaugmented args

### DIFF
--- a/backend/src/baserow/contrib/database/formula/ast/function_defs.py
+++ b/backend/src/baserow/contrib/database/formula/ast/function_defs.py
@@ -3107,8 +3107,12 @@ class BaserowIndex(BaserowFunctionDefinition):
         args: List["WrappedExpressionWithMetadata"],
         context: BaserowExpressionContext,
     ) -> "WrappedExpressionWithMetadata":
-        mode = _unwrap_literal_value(args[2].expression) or "text"
-        value_sql = _unwrap_literal_value(args[3].expression) or "{elem} ->> 'value'"
+        # Fall back to text defaults if args weren't augmented at type time.
+        mode = "text"
+        value_sql = "{elem} ->> 'value'"
+        if len(args) >= 4:
+            mode = _unwrap_literal_value(args[2].expression) or mode
+            value_sql = _unwrap_literal_value(args[3].expression) or value_sql
         safe_index = handle_arg_being_nan(
             args[1].expression,
             Value(None, output_field=fields.IntegerField()),

--- a/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
+++ b/backend/tests/baserow/contrib/database/formula/test_index_generalized.py
@@ -864,3 +864,27 @@ def test_index_nan_argument_returns_null(data_fixture):
     result = model.objects.get(id=row_a.id)
     assert getattr(result, nan_field.db_column) is None
     assert getattr(result, div_zero_field.db_column) is None
+
+
+def test_baserow_index_to_django_expression_handles_unaugmented_args():
+    """Regression test: https://github.com/baserow/baserow/issues/5320"""
+
+    from django.db.models import IntegerField, JSONField, Value
+
+    from baserow.contrib.database.formula.ast.function_defs import BaserowIndex
+    from baserow.contrib.database.formula.expression_generator.django_expressions import (
+        JSONBArrayGetElement,
+    )
+    from baserow.contrib.database.formula.expression_generator.generator import (
+        WrappedExpressionWithMetadata,
+    )
+
+    array_arg = WrappedExpressionWithMetadata(Value([], output_field=JSONField()))
+    index_arg = WrappedExpressionWithMetadata(Value(0, output_field=IntegerField()))
+
+    result = BaserowIndex().to_django_expression_given_args(
+        [array_arg, index_arg], context=None
+    )
+
+    assert isinstance(result, WrappedExpressionWithMetadata)
+    assert isinstance(result.expression, JSONBArrayGetElement)

--- a/changelog/entries/unreleased/bug/5320_fix_index_formula_indexerror_when_args_not_augmented.json
+++ b/changelog/entries/unreleased/bug/5320_fix_index_formula_indexerror_when_args_not_augmented.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixed index(), first() and last() formulas crashing on partial arguments.",
+  "issue_origin": "github",
+  "issue_number": 5320,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-05-06"
+}


### PR DESCRIPTION
## Summary

- `BaserowIndex.to_django_expression_given_args` assumed `type_function_given_valid_args` always ran first and augmented 2-arg `index()` / `first()` / `last()` calls into the 4-arg internal form. When the augmentation didn't run, args[2]/args[3] raised `IndexError: list index out of range`, 500ing several row endpoints and application-builder dispatches.
- Fall back to the generic text extraction defaults at evaluation time when fewer than four args are present, so the function degrades gracefully.
- Adds a regression test that calls the function with the un-augmented 2-arg form.

Fixes #5320 / Sentry `BASEROW-SAAS-BACKEND-GT`.

## Test plan

- [x] `just b test tests/baserow/contrib/database/formula/test_index_generalized.py` — 18 passed (incl. new regression)