### PR TITLE
fix: periodic trigger export with datetime

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -1317,6 +1317,48 @@ class CorePeriodicServiceType(TriggerServiceTypeMixin, CoreServiceType):
 
         return super().prepare_values(values, user, instance)
 
+    def serialize_property(
+        self,
+        service: CorePeriodicService,
+        prop_name: str,
+        files_zip=None,
+        storage=None,
+        cache=None,
+    ):
+        if prop_name == "next_run_at":
+            return (
+                service.next_run_at.isoformat()
+                if service.next_run_at is not None
+                else None
+            )
+
+        return super().serialize_property(
+            service, prop_name, files_zip=files_zip, storage=storage, cache=cache
+        )
+
+    def deserialize_property(
+        self,
+        prop_name: str,
+        value: Any,
+        id_mapping: Dict[str, Any],
+        files_zip=None,
+        storage=None,
+        cache=None,
+        **kwargs,
+    ):
+        if prop_name == "next_run_at" and value is not None:
+            return datetime.fromisoformat(value)
+
+        return super().deserialize_property(
+            prop_name,
+            value,
+            id_mapping,
+            files_zip=files_zip,
+            storage=storage,
+            cache=cache,
+            **kwargs,
+        )
+
     def can_immediately_be_tested(self, service):
         return True
 

--- a/backend/tests/baserow/contrib/integrations/core/test_core_periodic_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_core_periodic_service_type.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, call, patch
 
@@ -110,6 +111,21 @@ def test_periodic_trigger_node_creation_and_property_updates(data_fixture):
     assert updated_service_specific.hour == 14
     assert updated_service_specific.day_of_week == 2
     assert updated_service_specific.next_run_at is None
+
+
+@pytest.mark.django_db
+def test_periodic_service_export_serializes_next_run_at_as_iso(data_fixture):
+    service = data_fixture.create_core_periodic_service(
+        interval=PERIODIC_INTERVAL_MINUTE,
+        minute=15,
+        next_run_at=datetime(2025, 2, 15, 10, 30, 0, tzinfo=timezone.utc),
+    )
+
+    serialized = json.loads(
+        json.dumps(CorePeriodicServiceType().export_serialized(service))
+    )
+
+    assert serialized["next_run_at"] == "2025-02-15T10:30:00+00:00"
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/fix_export_workflow_with_periodic_triggers.json
+++ b/changelog/entries/unreleased/bug/fix_export_workflow_with_periodic_triggers.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix export workflow with periodic triggers",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-05-06"
+}

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
@@ -241,7 +241,7 @@ export default {
      */
     handleDateBlur(event) {
       this.updateDate(event.target.value)
-      this.$refs.dateContext.hide()
+      this.$refs.dateContext?.hide()
     },
     /**
      * Handle blur event on the time input field.


### PR DESCRIPTION
### What is in this PR

Somehow some periodic triggers have a `next_run_at` value set to a specific datetime. It should never happens but I guess it's related to the data migration that populated old services.

### How to test this PR

Reproduce on develop:
- Create a workflow with a periodic trigger.
- Using the django shell, set the `next_run_at` value to any date
- Try to export this workflow. It should fail to serialize the datetime
- Checkout this branch and it should work


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
