### PR TITLE
chore: add for-id to checkbox label and improve small screen support

### DIFF
--- a/changelog/entries/unreleased/bug/improve_column_element_and_data_picker_style_for_small_scree.json
+++ b/changelog/entries/unreleased/bug/improve_column_element_and_data_picker_style_for_small_scree.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Improve column element and data picker style for small screens",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-07"
+}

--- a/changelog/entries/unreleased/feature/allow_to_click_on_checkbox_label_to_check_them_for_more_brow.json
+++ b/changelog/entries/unreleased/feature/allow_to_click_on_checkbox_label_to_check_them_for_more_brow.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Allow to click on checkbox label to check them for more browsers",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-07"
+}

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABCheckbox.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABCheckbox.vue
@@ -1,6 +1,7 @@
 <template>
-  <div class="ab-checkbox" @click="toggle">
+  <div class="ab-checkbox">
     <input
+      :id="inputId"
       type="checkbox"
       :checked="modelValue"
       :required="required"
@@ -11,14 +12,17 @@
         'ab-checkbox--readonly': readOnly,
       }"
       :aria-disabled="disabled"
+      @change="onChange"
     />
-    <label v-if="hasSlot" class="ab-checkbox__label">
+    <label v-if="hasSlot" :for="inputId" class="ab-checkbox__label">
       <slot></slot>
     </label>
   </div>
 </template>
 
 <script>
+import { useId } from 'vue'
+
 export default {
   name: 'ABCheckbox',
   props: {
@@ -64,15 +68,23 @@ export default {
     },
   },
   emits: ['update:modelValue'],
+  setup() {
+    const uniqId = useId()
+
+    return { uniqId }
+  },
   computed: {
+    inputId() {
+      return `ab-checkbox-${this.uniqId}`
+    },
     hasSlot() {
       return !!this.$slots.default
     },
   },
   methods: {
-    toggle() {
+    onChange(event) {
       if (this.disabled || this.readOnly) return
-      this.$emit('update:modelValue', !this.modelValue)
+      this.$emit('update:modelValue', event.target.checked)
     },
   },
 }

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
@@ -6,7 +6,7 @@
     />
     <ABInput
       v-model="dateInputValue"
-      class="ab-datetime-picker__input"
+      class="ab-datetime-picker__input ab-datetime-picker__input--date"
       :placeholder="dateFormat"
       @focus="$refs.dateContext.toggle($refs.wrapper, 'bottom', 'left', 0)"
       @click="$refs.dateContext.show($refs.wrapper, 'bottom', 'left', 0)"
@@ -14,18 +14,18 @@
       @keydown.enter.prevent="$event.target.blur()"
       @blur="handleDateBlur($event)"
     />
-    <div ref="timeWrapper">
-      <ABInput
-        v-if="includeTime"
-        v-model="timeInputValue"
-        class="ab-datetime-picker__input"
-        :placeholder="timeFormat"
-        @focus="$refs.timeContext.toggle($refs.timeWrapper, 'bottom', 'left')"
-        @click="$refs.timeContext.show($refs.timeWrapper, 'bottom', 'left')"
-        @keydown.enter.prevent="$event.target.blur()"
-        @blur="handleTimeBlur($event)"
-      />
-    </div>
+    <ABInput
+      v-if="includeTime"
+      ref="timeWrapper"
+      v-model="timeInputValue"
+      class="ab-datetime-picker__input ab-datetime-picker__input--time"
+      :placeholder="timeFormat"
+      cclick="$refs.timeContext.show($refs.timeWrapper, 'bottom', 'left')"
+      @focus="$refs.timeContext.show($refs.timeWrapper, 'bottom', 'left')"
+      @keydown.enter.prevent="$event.target.blur()"
+      @blur="handleTimeBlur($event)"
+    />
+    <div class="flex-grow-1" />
     <i
       v-if="dateInputValue"
       class="ab-datetime-picker__clear button-icon__icon iconoir-cancel"

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABDateTimePicker.vue
@@ -1,7 +1,8 @@
 <template>
   <div ref="wrapper" class="ab-datetime-picker__wrapper">
-    <i
-      class="button-icon__icon iconoir-calendar"
+    <ABIcon
+      class="ab-datetime-picker__icon"
+      icon="iconoir-calendar"
       @click="$refs.dateContext.show($refs.wrapper, 'bottom', 'left', 0)"
     />
     <ABInput
@@ -20,15 +21,16 @@
       v-model="timeInputValue"
       class="ab-datetime-picker__input ab-datetime-picker__input--time"
       :placeholder="timeFormat"
-      cclick="$refs.timeContext.show($refs.timeWrapper, 'bottom', 'left')"
-      @focus="$refs.timeContext.show($refs.timeWrapper, 'bottom', 'left')"
+      @click="$refs.timeContext.show($refs.timeWrapper.$el, 'bottom', 'left')"
+      @focus="$refs.timeContext.show($refs.timeWrapper.$el, 'bottom', 'left')"
       @keydown.enter.prevent="$event.target.blur()"
       @blur="handleTimeBlur($event)"
     />
     <div class="flex-grow-1" />
-    <i
+    <ABIcon
       v-if="dateInputValue"
-      class="ab-datetime-picker__clear button-icon__icon iconoir-cancel"
+      class="ab-datetime-picker__icon"
+      icon="iconoir-cancel"
       @click="clearValue"
     />
     <Context

--- a/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
@@ -4,13 +4,13 @@
     :style="{
       '--space-between-columns': `${element.column_gap}px`,
       '--alignment': flexAlignment,
+      '--column-amount': columnAmount,
     }"
   >
     <div
       v-for="(childrenInColumn, columnIndex) in childrenElements"
       :key="columnIndex"
       class="column-element__column"
-      :style="{ '--column-width': `${columnWidth}%` }"
     >
       <template v-if="childrenInColumn.length > 0">
         <div
@@ -115,9 +115,6 @@ export default {
       } else {
         return this.element.column_amount
       }
-    },
-    columnWidth() {
-      return 100 / this.columnAmount - 0.00000000000001
     },
     childrenByColumnOrdered() {
       return _.groupBy(this.children, (child) => {

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
@@ -1,18 +1,19 @@
 .ab-datetime-picker__wrapper {
   display: flex;
+  justify-content: flex-start;
   align-items: center;
+  gap: var(--input-horizontal-padding, 12px);
   border: var(--input-border-size, 1px) solid var(--input-border-color, black);
   border-radius: var(--input-border-radius, 0);
   background-color: var(--input-background-color, $white);
   padding: var(--input-vertical-padding, 8px)
     var(--input-horizontal-padding, 12px);
+  overflow: hidden;
 }
 
-.ab-datetime-picker__clear {
+.ab-datetime-picker__icon.ab-icon {
   cursor: pointer;
   color: var(--input-text-color, $black);
-  flex-shrink: 0;
-  margin-left: auto;
 
   &:hover {
     opacity: 0.7;
@@ -20,10 +21,20 @@
 }
 
 .ab-datetime-picker__input {
+  flex: 0;
+
   &.ab-input {
     border: none;
-    padding: 0 var(--input-horizontal-padding, 12px);
-    width: 14ch; // 14 characters is enough to fit a date format ('YYYY-MM-DD')
+    width: auto;
+    padding: 0;
+  }
+
+  &--date.ab-input {
+    min-width: 11ch;
+  }
+
+  &--time.ab-input {
+    min-width: 5ch;
   }
 }
 

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_datetime_picker.scss
@@ -27,14 +27,19 @@
     border: none;
     width: auto;
     padding: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &--date.ab-input {
-    min-width: 11ch;
+    min-width: 5ch;
+    flex-basis: 11ch;
   }
 
   &--time.ab-input {
-    min-width: 5ch;
+    min-width: 2ch;
+    flex-basis: 5ch;
   }
 }
 

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
@@ -1,7 +1,7 @@
 .column-element {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(var(--column-amount), minmax(0, 1fr));
   width: 100%;
-  justify-content: space-between;
   gap: var(--space-between-columns);
   align-items: stretch;
 }
@@ -11,7 +11,7 @@
   display: flex;
   flex-direction: column;
   justify-content: var(--alignment);
-  width: var(--column-width);
+  min-width: 0;
 }
 
 .column-element__element {

--- a/web-frontend/modules/core/components/Checkbox.vue
+++ b/web-frontend/modules/core/components/Checkbox.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script>
-import { useId } from '#app'
+import { useId } from 'vue'
 
 export default {
   name: 'Checkbox',

--- a/web-frontend/modules/core/components/FormGroup.vue
+++ b/web-frontend/modules/core/components/FormGroup.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script setup>
-import { useId } from '#app'
+import { useId } from 'vue'
 
 // Props
 const props = defineProps({

--- a/web-frontend/package.json
+++ b/web-frontend/package.json
@@ -22,7 +22,7 @@
     "stylelint": "stylelint --cache --cache-location=.cache/stylelint **/*.scss ../premium/web-frontend/modules/**/*.scss ../enterprise/web-frontend/modules/**/*.scss",
     "stylelint:fix": "stylelint --cache --cache-location=.cache/stylelint --fix **/*.scss ../premium/web-frontend/modules/**/*.scss ../enterprise/web-frontend/modules/**/*.scss",
     "prettier": "prettier --check --log-level=warn --cache --cache-location=.cache/prettier . ../premium/web-frontend ../enterprise/web-frontend",
-    "prettier:fix": "prettier --write --log-level=warn --cache --cache-location=.cache/prettier . ../premium/web-frontend ../enterprise/web-frontend"
+    "prettier:fix": "prettier --write --log-level=warn . ../premium/web-frontend ../enterprise/web-frontend"
   },
   "resolutions": {
     "cipher-base": "^1.0.5",

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/ChoiceElement.spec.js.snap
@@ -108,10 +108,12 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
             <input
               aria-disabled="false"
               class="ab-checkbox__input"
+              id="ab-checkbox-v-0-0-1"
               type="checkbox"
             />
             <label
               class="ab-checkbox__label"
+              for="ab-checkbox-v-0-0-1"
             >
               
               First
@@ -124,10 +126,12 @@ exports[`ChoiceElement > as manual checkboxes 1`] = `
             <input
               aria-disabled="false"
               class="ab-checkbox__input"
+              id="ab-checkbox-v-0-0-2"
               type="checkbox"
             />
             <label
               class="ab-checkbox__label"
+              for="ab-checkbox-v-0-0-2"
             >
               
               Second

--- a/web-frontend/test/unit/builder/components/elements/components/__snapshots__/DateTimePickerElement.spec.js.snap
+++ b/web-frontend/test/unit/builder/components/elements/components/__snapshots__/DateTimePickerElement.spec.js.snap
@@ -26,17 +26,19 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="DD/MM/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <!--v-if-->
-            </div>
+            <!--v-if-->
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -80,17 +82,19 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="MM/DD/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <!--v-if-->
-            </div>
+            <!--v-if-->
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -134,17 +138,19 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="YYYY-MM-DD"
               type="text"
               value=""
             />
-            <div>
-              <!--v-if-->
-            </div>
+            <!--v-if-->
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -188,22 +194,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="DD/MM/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="HH:mm"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="HH:mm"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -247,22 +255,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="DD/MM/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="hh:mm A"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="hh:mm A"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -306,22 +316,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="MM/DD/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="HH:mm"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="HH:mm"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -365,22 +377,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="MM/DD/YYYY"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="hh:mm A"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="hh:mm A"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -424,22 +438,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="YYYY-MM-DD"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="HH:mm"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="HH:mm"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           
@@ -483,22 +499,24 @@ exports[`DateTimePickerElement > placeholder corresponds to date and time format
             class="ab-datetime-picker__wrapper"
           >
             <i
-              class="button-icon__icon iconoir-calendar"
+              class="ab-icon iconoir-calendar ab-datetime-picker__icon"
+              title=""
             />
             <input
-              class="ab-input ab-datetime-picker__input"
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--date"
               placeholder="YYYY-MM-DD"
               type="text"
               value=""
             />
-            <div>
-              <input
-                class="ab-input ab-datetime-picker__input"
-                placeholder="hh:mm A"
-                type="text"
-                value=""
-              />
-            </div>
+            <input
+              class="ab-input ab-datetime-picker__input ab-datetime-picker__input--time"
+              placeholder="hh:mm A"
+              type="text"
+              value=""
+            />
+            <div
+              class="flex-grow-1"
+            />
             <!--v-if-->
           </div>
           


### PR DESCRIPTION
### What is in this PR

- On some browsers (Ipad) clicking on the label of a checkbox in a choice option wasn't working.
- The column element style is broken with some screen resolutions depending on the content
- The date picker content is too wide for small screen if you have two side by side

### How to test this PR

On develop first:
- import this [application](https://github.com/user-attachments/files/27472823/test-5329.zip)
- Use a safari browser if you have one and click on the labels of the choice input. It might not work. Ideally you should test with an Ipad if you have one :D
- Resize the screen to see the column element overflowing the page and the date pickers use a lot of space for nothing
- Checkout this branch. everything should be better. ~You still have some resolution where the date pickers are not perfect but it supports now a wider range.~


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
