### PR TITLE
fix: bad aggregation serialization for multi valued fields

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_aggregations.py
+++ b/backend/src/baserow/contrib/database/fields/field_aggregations.py
@@ -53,6 +53,7 @@ class CountFieldAggregationType(FieldAggregationType):
     """
 
     type = "count"
+    result_type = "integer"
     raw_type = CountViewAggregationType
     compatible_field_types = raw_type.compatible_field_types
 
@@ -63,6 +64,7 @@ class EmptyCountFieldAggregationType(FieldAggregationType):
     """
 
     type = "empty_count"
+    result_type = "integer"
     raw_type = EmptyCountViewAggregationType
     compatible_field_types = raw_type.compatible_field_types
 
@@ -73,6 +75,7 @@ class NotEmptyCountFieldAggregationType(FieldAggregationType):
     """
 
     type = "not_empty_count"
+    result_type = "integer"
     raw_type = NotEmptyCountViewAggregationType
     compatible_field_types = raw_type.compatible_field_types
 
@@ -83,6 +86,7 @@ class CheckedFieldAggregationType(FieldAggregationType):
     """
 
     type = "checked_count"
+    result_type = "integer"
     raw_type = NotEmptyCountViewAggregationType
     compatible_field_types = [
         BooleanFieldType.type,
@@ -98,6 +102,7 @@ class NotCheckedFieldAggregationType(FieldAggregationType):
     """
 
     type = "not_checked_count"
+    result_type = "integer"
     raw_type = EmptyCountViewAggregationType
     compatible_field_types = [
         BooleanFieldType.type,
@@ -113,6 +118,7 @@ class EmptyPercentageFieldAggregationType(FieldAggregationType):
     """
 
     type = "empty_percentage"
+    result_type = "float"
     raw_type = EmptyCountViewAggregationType
     with_total = True
     compatible_field_types = [
@@ -150,6 +156,7 @@ class NotEmptyPercentageFieldAggregationType(FieldAggregationType):
     """
 
     type = "not_empty_percentage"
+    result_type = "float"
     raw_type = NotEmptyCountViewAggregationType
     with_total = True
     compatible_field_types = [
@@ -187,6 +194,7 @@ class CheckedPercentageFieldAggregationType(FieldAggregationType):
     """
 
     type = "checked_percentage"
+    result_type = "float"
     raw_type = NotEmptyCountViewAggregationType
     with_total = True
     compatible_field_types = [
@@ -203,6 +211,7 @@ class NotCheckedPercentageFieldAggregationType(FieldAggregationType):
     """
 
     type = "not_checked_percentage"
+    result_type = "float"
     raw_type = EmptyCountViewAggregationType
     with_total = True
     compatible_field_types = [
@@ -219,6 +228,7 @@ class UniqueCountFieldAggregationType(FieldAggregationType):
     """
 
     type = "unique_count"
+    result_type = "integer"
     raw_type = UniqueCountViewAggregationType
     compatible_field_types = raw_type.compatible_field_types
 

--- a/backend/src/baserow/contrib/database/fields/registries.py
+++ b/backend/src/baserow/contrib/database/fields/registries.py
@@ -74,7 +74,10 @@ from .exceptions import (
 )
 from .fields import DurationFieldUsingPostgresFormatting
 from .models import Field, FieldConstraint, LinkRowField
-from .utils import DeferredForeignKeyUpdater
+from .utils import (
+    DeferredForeignKeyUpdater,
+    guess_json_type_from_response_serializer_field,
+)
 
 if TYPE_CHECKING:
     from baserow.contrib.database.fields.dependencies.handler import FieldDependants
@@ -2394,10 +2397,14 @@ class FieldAggregationType(Instance):
     attributes.
     """
 
-    result_type = "string"
+    result_type = "field"
     """Informs features which use field aggregation types what the aggregation
-    result type be. At the moment the result is always a string, but in the future
-    if we generated an array for example, the result type would be 'array'."""
+    result type is.
+
+    The value is used as the single source of truth for both schema generation
+    and serializer selection. Use "field" to reuse the underlying field
+    serializer, or a primitive result type such as "integer" or "float".
+    """
 
     with_total = False
     """Determines if the result of the aggregation needs to
@@ -2513,6 +2520,35 @@ class FieldAggregationType(Instance):
                 return 0
             return (raw_aggregation_result / total_count) * 100
         return raw_aggregation_result
+
+    def get_result_schema(self, field: Field) -> Dict[str, Any]:
+        """
+        Returns the JSON schema fragment describing the aggregation result.
+        """
+
+        serializer_field = self.get_result_serializer_field(field)
+        return guess_json_type_from_response_serializer_field(serializer_field)
+
+    def get_result_serializer_field(self, field: Field):
+        """
+        Returns the DRF serializer field used to serialize the aggregation result.
+        """
+
+        if self.result_type == "field":
+            return field.get_type().get_serializer_field(field)
+        if self.result_type == "integer":
+            return serializers.IntegerField()
+        if self.result_type == "float":
+            return serializers.FloatField()
+        if self.result_type == "boolean":
+            return serializers.BooleanField()
+        if self.result_type == "string":
+            return serializers.CharField()
+
+        raise ValueError(
+            f"Unsupported aggregation result type '{self.result_type}' "
+            f"for field aggregation type '{self.type}'."
+        )
 
 
 class FieldAggregationTypeRegistry(Registry):

--- a/backend/src/baserow/contrib/database/fields/utils/__init__.py
+++ b/backend/src/baserow/contrib/database/fields/utils/__init__.py
@@ -3,6 +3,7 @@ from typing import Optional, Union
 
 from .deferred_field_importer import DeferredFieldImporter  # noqa: F401
 from .deferred_foreign_key_updater import DeferredForeignKeyUpdater  # noqa: F401
+from .schema import guess_json_type_from_response_serializer_field  # noqa: F401
 
 field_pattern = re.compile("^field_([0-9]+)$")
 

--- a/backend/src/baserow/contrib/database/fields/utils/schema.py
+++ b/backend/src/baserow/contrib/database/fields/utils/schema.py
@@ -1,0 +1,96 @@
+from typing import Any, Dict, Union
+
+from drf_spectacular.types import OPENAPI_TYPE_MAPPING
+from rest_framework.fields import (
+    BooleanField,
+    CharField,
+    ChoiceField,
+    DateField,
+    DateTimeField,
+    DecimalField,
+    Field,
+    FloatField,
+    IntegerField,
+    ListField,
+    SerializerMethodField,
+    TimeField,
+    UUIDField,
+)
+from rest_framework.serializers import ListSerializer, Serializer
+
+
+def guess_json_type_from_response_serializer_field(
+    serializer_field: Union[Field, Serializer],
+) -> Dict[str, Any]:
+    """
+    Responsible for taking a serializer field, and guessing what its JSON
+    type will be. If the field is a ListSerializer, and it has a child serializer,
+    we add the child's type as well.
+
+    :param serializer_field: The serializer field.
+    :return: A dictionary to add to our schema.
+    """
+
+    from baserow.contrib.database.api.fields.serializers import (
+        DurationFieldSerializer,
+    )
+
+    if isinstance(serializer_field, (UUIDField, CharField, DecimalField, FloatField)):
+        # DecimalField/FloatField values are returned as strings from the API.
+        base_type = "string"
+    elif isinstance(serializer_field, DateField):
+        return {"type": "string", "format": "date"}
+    elif isinstance(serializer_field, DateTimeField):
+        return {"type": "string", "format": "date-time"}
+    elif isinstance(serializer_field, (TimeField, DurationFieldSerializer)):
+        base_type = "string"
+    elif isinstance(serializer_field, ChoiceField):
+        base_type = "string"
+    elif isinstance(serializer_field, IntegerField):
+        base_type = "number"
+    elif isinstance(serializer_field, BooleanField):
+        base_type = "boolean"
+    elif isinstance(serializer_field, ListSerializer):
+        sub_type = guess_json_type_from_response_serializer_field(
+            serializer_field.child
+        )
+        return {"type": "array", "items": sub_type}
+    elif isinstance(serializer_field, ListField):
+        sub_type = guess_json_type_from_response_serializer_field(
+            serializer_field.child
+        )
+        return {"type": "array", "items": sub_type}
+    elif isinstance(serializer_field, SerializerMethodField):
+        # Try to guess the json type of SerializerMethodField based on the
+        # OpenAPI annotations.
+        #
+        # When a method serializer uses @extend_schema_field decorator it will
+        # include a dictionary called "_spectacular_annotation" that contains
+        # the type of the field to return.
+        #
+        # NOTE: This only works for primitive types (e.g, string, boolean, etc.)
+        # and not for composite ones (e.g, object, lists, etc.).
+        base_type = None
+        method = getattr(serializer_field.parent, serializer_field.method_name)
+        if hasattr(method, "_spectacular_annotation"):
+            field = method._spectacular_annotation.get("field")
+            mapping = OPENAPI_TYPE_MAPPING.get(field)
+            if isinstance(mapping, dict):
+                base_type = mapping.get("type", None)
+    elif issubclass(serializer_field.__class__, Serializer):
+        properties = {}
+        for name, child_serializer in serializer_field.fields.items():
+            guessed_type = guess_json_type_from_response_serializer_field(
+                child_serializer
+            )
+            if guessed_type["type"] is not None:
+                properties[name] = {
+                    "title": name,
+                    **guessed_type,
+                }
+
+        return {"type": "object", "properties": properties}
+    else:
+        base_type = None
+
+    return {"type": base_type}

--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -1239,7 +1239,7 @@ class LocalBaserowAggregateRowsUserServiceType(
             return {}
 
         # Pluck out the aggregation type which this service uses. We'll use its
-        # `result_type` to inform the schema what the expected `result` format is.
+        # declared result metadata to inform the schema and serialization.
         aggregation_type = field_aggregation_registry.get(service.aggregation_type)
 
         return {
@@ -1248,7 +1248,7 @@ class LocalBaserowAggregateRowsUserServiceType(
             "properties": {
                 "result": {
                     "title": f"{service.field.name} result",
-                    "type": aggregation_type.result_type,
+                    **aggregation_type.get_result_schema(service.field.specific),
                 }
             },
         }
@@ -1511,6 +1511,7 @@ class LocalBaserowAggregateRowsUserServiceType(
                 "data": {"result": result},
                 "baserow_table_model": model,
                 "field": field,
+                "service": service,
             }
         except DjangoFieldDoesNotExist as ex:
             raise ServiceImproperlyConfiguredDispatchException(
@@ -1534,16 +1535,14 @@ class LocalBaserowAggregateRowsUserServiceType(
         :return: A dictionary containing the aggregation result.
         """
 
-        # Use the field type's serializer field to ensure the aggregation result
-        # is serialized correctly. Some aggregations can return values which are not
-        # JSON serializable (e.g. Decimal), so we need to use the serializer field
-        # to convert them into a JSON serializable format.
-        result = (
-            data["field"]
-            .get_type()
-            .get_serializer_field(data["field"])
-            .to_representation(data["data"]["result"])
+        # Use the aggregation type's declared result metadata to serialize the
+        # aggregation output. This avoids reusing a list-like field serializer for
+        # count-like aggregations which return scalars.
+        aggregation_type = field_aggregation_registry.get(
+            data["service"].aggregation_type
         )
+        serializer_field = aggregation_type.get_result_serializer_field(data["field"])
+        result = serializer_field.to_representation(data["data"]["result"])
 
         return DispatchResult(data={"result": result})
 

--- a/backend/src/baserow/contrib/integrations/local_baserow/utils.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/utils.py
@@ -1,28 +1,15 @@
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union
 from urllib.parse import urlparse
 
 from django.contrib.auth.models import AbstractUser
 
-from drf_spectacular.types import OPENAPI_TYPE_MAPPING
 from loguru import logger
-from rest_framework.fields import (
-    BooleanField,
-    CharField,
-    ChoiceField,
-    DateField,
-    DateTimeField,
-    DecimalField,
-    Field,
-    FloatField,
-    IntegerField,
-    ListField,
-    SerializerMethodField,
-    TimeField,
-    UUIDField,
-)
-from rest_framework.serializers import ListSerializer, Serializer
+from rest_framework.fields import Field
+from rest_framework.serializers import Serializer
 
-from baserow.contrib.database.api.fields.serializers import DurationFieldSerializer
+from baserow.contrib.database.fields.utils import (
+    guess_json_type_from_response_serializer_field,
+)
 from baserow.contrib.integrations.local_baserow.models import LocalBaserowUpsertRow
 from baserow.core.formula.validator import (
     ensure_array,
@@ -40,82 +27,6 @@ from baserow.core.user_files.exceptions import (
     FileURLCouldNotBeReached,
 )
 from baserow.core.user_files.handler import UserFileHandler
-
-
-def guess_json_type_from_response_serializer_field(
-    serializer_field: Union[Field, Serializer],
-) -> Dict[str, Any]:
-    """
-    Responsible for taking a serializer field, and guessing what its JSON
-    type will be. If the field is a ListSerializer, and it has a child serializer,
-    we add the child's type as well.
-
-    :param serializer_field: The serializer field.
-    :return: A dictionary to add to our schema.
-    """
-
-    if isinstance(serializer_field, (UUIDField, CharField, DecimalField, FloatField)):
-        # DecimalField/FloatField values are returned as strings from the API.
-        base_type = "string"
-    elif isinstance(serializer_field, DateField):
-        return {"type": "string", "format": "date"}
-    elif isinstance(serializer_field, DateTimeField):
-        return {"type": "string", "format": "date-time"}
-    elif isinstance(serializer_field, (TimeField, DurationFieldSerializer)):
-        base_type = "string"
-    elif isinstance(serializer_field, ChoiceField):
-        base_type = "string"
-    elif isinstance(serializer_field, IntegerField):
-        base_type = "number"
-    elif isinstance(serializer_field, BooleanField):
-        base_type = "boolean"
-    elif isinstance(serializer_field, ListSerializer):
-        # ListSerializer.child is required, so add its subtype.
-        sub_type = guess_json_type_from_response_serializer_field(
-            serializer_field.child
-        )
-        return {"type": "array", "items": sub_type}
-    elif isinstance(serializer_field, ListField):
-        # ListField.child is required, so add its subtype.
-        sub_type = guess_json_type_from_response_serializer_field(
-            serializer_field.child
-        )
-        return {"type": "array", "items": sub_type}
-    elif isinstance(serializer_field, SerializerMethodField):
-        # Try to guess the json type of SerializerMethodField based on the
-        # OpenAPI annotations.
-        #
-        # When a method serializer uses @extend_schema_field decorator it will
-        # include a dictionary called "_spectacular_annotation" that contains
-        # the type of the field to return.
-        #
-        # NOTE: This only works for primitive types (e.g, string, boolean, etc.)
-        # and not for composite ones (e.g, object, lists, etc.).
-        base_type = None
-        method = getattr(serializer_field.parent, serializer_field.method_name)
-        if hasattr(method, "_spectacular_annotation"):
-            field = method._spectacular_annotation.get("field")
-            mapping = OPENAPI_TYPE_MAPPING.get(field)
-            if isinstance(mapping, dict):
-                base_type = mapping.get("type", None)
-
-    elif issubclass(serializer_field.__class__, Serializer):
-        properties = {}
-        for name, child_serializer in serializer_field.fields.items():
-            guessed_type = guess_json_type_from_response_serializer_field(
-                child_serializer
-            )
-            if guessed_type["type"] is not None:
-                properties[name] = {
-                    "title": name,
-                    **guessed_type,
-                }
-
-        return {"type": "object", "properties": properties}
-    else:
-        base_type = None
-
-    return {"type": base_type}
 
 
 def _handle_file(file_obj: dict, user: AbstractUser) -> dict:

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_aggregate_rows_service_type.py
@@ -50,6 +50,32 @@ def test_local_baserow_aggregate_rows_service_generate_schema(data_fixture):
     assert service_type.generate_schema(Mock(aggregation_type="")) is None
 
 
+@pytest.mark.django_db
+def test_local_baserow_aggregate_rows_service_generate_schema_for_count_result(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_multiple_select_field(table=table)
+    service = data_fixture.create_local_baserow_aggregate_rows_service(
+        table_id=table.id,
+        field_id=field.id,
+        aggregation_type="unique_count",
+    )
+    service_type = service_type_registry.get("local_baserow_aggregate_rows")
+
+    assert service_type.generate_schema(service) == {
+        "title": f"Aggregation{service.id}Schema",
+        "type": "object",
+        "properties": {
+            "result": {
+                "title": f"{field.name} result",
+                "type": "number",
+            },
+        },
+    }
+
+
 def test_local_baserow_aggregate_rows_resolve_service_formulas():
     service_type = service_type_registry.get("local_baserow_aggregate_rows")
     with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
@@ -286,6 +312,33 @@ def test_local_baserow_aggregate_rows_dispatch_data_with_view(data_fixture):
     assert service_type.dispatch_transform(result) == DispatchResult(
         data={"result": "20"}, status=200, output_uid=""
     )
+
+
+@pytest.mark.django_db
+def test_local_baserow_aggregate_rows_dispatch_transform_with_scalar_result_for_list_field(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    dashboard = page.builder
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_multiple_select_field(table=table)
+    integration = data_fixture.create_local_baserow_integration(
+        application=dashboard, user=user
+    )
+    service_type = service_type_registry.get("local_baserow_aggregate_rows")
+    service = data_fixture.create_local_baserow_aggregate_rows_service(
+        integration=integration,
+        table=table,
+        field=field,
+        aggregation_type="unique_count",
+    )
+
+    result = service_type.dispatch_transform(
+        {"field": field, "service": service, "data": {"result": 2}}
+    )
+
+    assert result == DispatchResult(data={"result": 2}, status=200, output_uid="")
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/fix_error_when_sumarizing_any_array_shaped_field.json
+++ b/changelog/entries/unreleased/bug/fix_error_when_sumarizing_any_array_shaped_field.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Fix error when sumarizing any array shaped field",
+    "message": "Fix error when summarizing any array shaped field",
     "issue_origin": "github",
     "issue_number": null,
     "domain": "dashboard",

--- a/changelog/entries/unreleased/bug/fix_error_when_sumarizing_any_array_shaped_field.json
+++ b/changelog/entries/unreleased/bug/fix_error_when_sumarizing_any_array_shaped_field.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix error when sumarizing any array shaped field",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "dashboard",
+    "bullet_points": [],
+    "created_at": "2026-05-07"
+}


### PR DESCRIPTION
### What is in this PR

Fix the sentry bug https://baserow-eu.sentry.io/issues/100773725

This PR introduces the aggregation result type to define the serializer that should be used to serialize the result value. Previously we were always using the field serializer but it doesn't work when the aggregation type has nothing to do with the value like the `Count` aggregation for a multiselect field. The count is an integer while the field is a array of object. That's why it was failing (a lot) in sentry.

### How to test this PR

Reproduce on develop:
- create a dashboard with a summary widget
- Configure this summary for a table with a multi valued field like multi select, link row, ...
- Select "count" as aggregation value
- It should immediatly try to get the value and trigger the error in the backend
- Checkout this branch and see how it perfectly working.
- Check it still working well (better) for an application (We had the same issue I believe)

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
