### PR TITLE
Add search support to Kanban view

### DIFF
--- a/premium/backend/src/baserow_premium/api/views/kanban/views.py
+++ b/premium/backend/src/baserow_premium/api/views/kanban/views.py
@@ -4,13 +4,19 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from baserow.api.decorators import allowed_includes, map_exceptions
+from baserow.api.decorators import (
+    allowed_includes,
+    map_exceptions,
+    validate_query_parameters,
+)
 from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.schemas import get_error_schema
+from baserow.api.search.serializers import SearchQueryParamSerializer
 from baserow.contrib.database.api.constants import (
     ADHOC_FILTERS_API_PARAMS,
     ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
     LIMIT_LINKED_ITEMS_API_PARAM,
+    SEARCH_MODE_API_PARAM,
 )
 from baserow.contrib.database.api.fields.errors import (
     ERROR_FIELD_DOES_NOT_EXIST,
@@ -119,6 +125,15 @@ class KanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            OpenApiParameter(
+                name="search",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                description="If provided only rows with data that matches the search "
+                "query are going to be returned.",
+                required=False,
+            ),
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
             LIMIT_LINKED_ITEMS_API_PARAM,
         ],
@@ -162,7 +177,8 @@ class KanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options", "row_metadata")
-    def get(self, request, view_id, field_options, row_metadata):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, view_id, field_options, row_metadata, query_params):
         """Responds with the rows grouped by the view's select option field value."""
 
         adhoc_filters = AdHocFilters.from_request(request)
@@ -220,6 +236,8 @@ class KanbanViewView(APIView):
             option_settings=included_select_options,
             default_limit=default_limit,
             default_offset=default_offset,
+            search=query_params.get("search"),
+            search_mode=query_params.get("search_mode"),
             model=model,
         )
 
@@ -302,6 +320,15 @@ class PublicKanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            OpenApiParameter(
+                name="search",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                description="If provided only rows with data that matches the search "
+                "query are going to be returned.",
+                required=False,
+            ),
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS,
             LIMIT_LINKED_ITEMS_API_PARAM,
         ],
@@ -346,7 +373,8 @@ class PublicKanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options")
-    def get(self, request, slug: str, field_options: bool):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, slug: str, field_options: bool, query_params):
         """
         Lists all the rows of a kanban view that is publicly shared. The rows are
         grouped by the view's single select field options.
@@ -383,6 +411,8 @@ class PublicKanbanViewView(APIView):
             publicly_visible_field_options,
         ) = ViewHandler().get_public_rows_queryset_and_field_ids(
             view,
+            search=query_params.get("search"),
+            search_mode=query_params.get("search_mode"),
             adhoc_filters=adhoc_filters,
             table_model=model,
             view_type=view_type,

--- a/premium/backend/src/baserow_premium/views/handler.py
+++ b/premium/backend/src/baserow_premium/views/handler.py
@@ -35,6 +35,8 @@ def get_rows_grouped_by_single_select_field(
     option_settings: Dict[str, Dict[str, int]] = None,
     default_limit: int = 40,
     default_offset: int = 0,
+    search: Optional[str] = None,
+    search_mode: Optional[str] = None,
     adhoc_filters: Optional[AdHocFilters] = None,
     model: Optional[GeneratedTableModel] = None,
     base_queryset: Optional[QuerySet] = None,
@@ -67,6 +69,8 @@ def get_rows_grouped_by_single_select_field(
         specific settings for that field have been provided.
     :param default_offset: The default offset that applies to all options if no
         specific settings for that field have been provided.
+    :param search: An optional search term to apply before grouping rows.
+    :param search_mode: The type of search to perform if a search term is provided.
     :param adhoc_filters: The optional ad hoc filters if they should be used
         instead of view filters.
     :param model: Additionally, an existing model can be provided so that it doesn't
@@ -87,6 +91,9 @@ def get_rows_grouped_by_single_select_field(
 
     if base_queryset is None:
         base_queryset = model.objects.all().enhance_by_fields().order_by("order", "id")
+
+    if search is not None:
+        base_queryset = base_queryset.search_all_fields(search, search_mode=search_mode)
 
     if adhoc_filters is None:
         adhoc_filters = AdHocFilters()

--- a/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
@@ -245,6 +245,105 @@ def test_list_all_rows(api_client, premium_data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_search_kanban_rows(api_client, premium_data_fixture):
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    single_select_field = premium_data_fixture.create_single_select_field(table=table)
+    option_a = premium_data_fixture.create_select_option(
+        field=single_select_field, value="A", color="blue"
+    )
+    option_b = premium_data_fixture.create_select_option(
+        field=single_select_field, value="B", color="red"
+    )
+    kanban = premium_data_fixture.create_kanban_view(
+        table=table, single_select_field=single_select_field
+    )
+
+    model = table.get_model()
+    row_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "Call client",
+            f"field_{single_select_field.id}_id": option_a.id,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Internal planning",
+            f"field_{single_select_field.id}_id": option_a.id,
+        }
+    )
+    row_b = model.objects.create(
+        **{
+            f"field_{text_field.id}": "Client follow up",
+            f"field_{single_select_field.id}_id": option_b.id,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Archive notes",
+            f"field_{single_select_field.id}_id": None,
+        }
+    )
+
+    url = reverse("api:database:views:kanban:list", kwargs={"view_id": kanban.id})
+    response = api_client.get(
+        f"{url}?search=client", **{"HTTP_AUTHORIZATION": f"JWT {token}"}
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["rows"]["null"]["count"] == 0
+    assert response_json["rows"][str(option_a.id)]["count"] == 1
+    assert response_json["rows"][str(option_a.id)]["results"][0]["id"] == row_a.id
+    assert response_json["rows"][str(option_b.id)]["count"] == 1
+    assert response_json["rows"][str(option_b.id)]["results"][0]["id"] == row_b.id
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_search_kanban_with_empty_term(api_client, premium_data_fixture):
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    single_select_field = premium_data_fixture.create_single_select_field(table=table)
+    option_a = premium_data_fixture.create_select_option(
+        field=single_select_field, value="A", color="blue"
+    )
+    kanban = premium_data_fixture.create_kanban_view(
+        table=table, single_select_field=single_select_field
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Call client",
+            f"field_{single_select_field.id}_id": option_a.id,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Internal planning",
+            f"field_{single_select_field.id}_id": None,
+        }
+    )
+
+    url = reverse("api:database:views:kanban:list", kwargs={"view_id": kanban.id})
+    response = api_client.get(
+        f"{url}?search=", **{"HTTP_AUTHORIZATION": f"JWT {token}"}
+    )
+
+    assert response.status_code == HTTP_200_OK
+    total_results = sum(stack["count"] for stack in response.json()["rows"].values())
+    assert total_results == 2
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_list_with_specific_select_options(api_client, premium_data_fixture):
     user, token = premium_data_fixture.create_user_and_token(
         has_active_premium_license=True
@@ -2142,6 +2241,67 @@ def test_list_public_rows_valid_select_option_parameter(
             },
         },
     }
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_search_public_kanban_rows(api_client, premium_data_fixture):
+    user, token = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+
+    kanban_view = premium_data_fixture.create_kanban_view(
+        table=table,
+        user=user,
+        public=True,
+    )
+    single_select = kanban_view.single_select_field
+    option_a = premium_data_fixture.create_select_option(
+        field=single_select, value="A", color="blue"
+    )
+    option_b = premium_data_fixture.create_select_option(
+        field=single_select, value="B", color="red"
+    )
+
+    row_1 = RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{text_field.id}": "Client call",
+            f"field_{single_select.id}": option_a.id,
+        },
+    )
+    RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{text_field.id}": "Internal planning",
+            f"field_{single_select.id}": option_a.id,
+        },
+    )
+    row_3 = RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{text_field.id}": "Client follow up",
+            f"field_{single_select.id}": option_b.id,
+        },
+    )
+
+    response = api_client.get(
+        reverse(
+            "api:database:views:kanban:public_rows", kwargs={"slug": kanban_view.slug}
+        )
+        + "?search=client"
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["rows"]["null"]["count"] == 0
+    assert response_json["rows"][str(option_a.id)]["count"] == 1
+    assert response_json["rows"][str(option_a.id)]["results"][0]["id"] == row_1.id
+    assert response_json["rows"][str(option_b.id)]["count"] == 1
+    assert response_json["rows"][str(option_b.id)]["results"][0]["id"] == row_3.id
 
 
 @pytest.mark.django_db

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanView.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanView.vue
@@ -146,8 +146,8 @@
         (fieldCreated($event), (showHiddenFieldsInRowModal = true))
       "
       @field-created-callback-done="afterFieldCreatedUpdateFieldOptions"
-      @navigate-previous="$emit('navigate-previous', $event)"
-      @navigate-next="$emit('navigate-next', $event)"
+      @navigate-previous="$emit('navigate-previous', $event, activeSearchTerm)"
+      @navigate-next="$emit('navigate-next', $event, activeSearchTerm)"
       @refresh-row="refreshRow"
     ></RowEditModal>
     <Context
@@ -297,6 +297,11 @@ export default {
     fieldOptions() {
       return this.$store.getters[
         `${this.storePrefix}view/kanban/getAllFieldOptions`
+      ]
+    },
+    activeSearchTerm() {
+      return this.$store.getters[
+        `${this.storePrefix}view/kanban/getActiveSearchTerm`
       ]
     },
   },

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
@@ -80,6 +80,18 @@
         @update-cover-image-field="updateCoverImageField"
       ></ViewFieldsContext>
     </li>
+    <li
+      v-if="singleSelectFieldId !== -1"
+      class="header__filter-item header__filter-item--full-width"
+    >
+      <ViewSearch
+        :view="view"
+        :fields="fields"
+        :store-prefix="storePrefix"
+        :always-hide-rows-not-matching-search="true"
+        @refresh="$emit('refresh', $event)"
+      ></ViewSearch>
+    </li>
   </ul>
 </template>
 
@@ -88,13 +100,14 @@ import { mapState, mapGetters } from 'vuex'
 
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import ViewFieldsContext from '@baserow/modules/database/components/view/ViewFieldsContext'
+import ViewSearch from '@baserow/modules/database/components/view/ViewSearch'
 import KanbanViewStackedBy from '@baserow_premium/components/views/kanban/KanbanViewStackedBy'
 import kanbanViewHelper from '@baserow_premium/mixins/kanbanViewHelper'
 
 export default {
   name: 'KanbanViewHeader',
   emits: ['refresh'],
-  components: { KanbanViewStackedBy, ViewFieldsContext },
+  components: { KanbanViewStackedBy, ViewFieldsContext, ViewSearch },
   mixins: [kanbanViewHelper],
   props: {
     database: {

--- a/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
@@ -17,6 +17,8 @@ export default (client) => {
       publicUrl = false,
       publicAuthToken = null,
       filters = {},
+      search = '',
+      searchMode = '',
       limitLinkedItems = null,
     }) {
       const include = []
@@ -44,6 +46,13 @@ export default (client) => {
           params.append(key, value)
         })
       })
+
+      if (search) {
+        params.append('search', search)
+        if (searchMode) {
+          params.append('search_mode', searchMode)
+        }
+      }
 
       selectOptions.forEach((selectOption) => {
         let value = selectOption.id.toString()

--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -4,11 +4,13 @@ import { GroupTaskQueue } from '@baserow/modules/core/utils/queue'
 import ViewService from '@baserow/modules/database/services/view'
 import KanbanService from '@baserow_premium/services/views/kanban'
 import {
+  calculateSingleRowSearchMatches,
   extractRowMetadata,
   getFilters,
   getRowSortFunction,
   matchSearchFilters,
 } from '@baserow/modules/database/utils/view'
+import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 import RowService from '@baserow/modules/database/services/row'
 import FieldService from '@baserow/modules/database/services/field'
 import { SingleSelectFieldType } from '@baserow/modules/database/fieldTypes'
@@ -54,6 +56,11 @@ export const state = () => ({
   draggingOriginalBefore: null,
   // If true, ad hoc filtering is used instead of persistent one
   adhocFiltering: false,
+  // A user provided optional search term which can be used to filter down rows.
+  activeSearchTerm: '',
+  // If true then the activeSearchTerm will be sent to the server to filter rows
+  // entirely out.
+  hideRowsNotMatchingSearch: true,
   // Indicates whether row(s) are currently being created.
   creating: false,
 })
@@ -64,6 +71,12 @@ export const mutations = {
     state.singleSelectFieldId = -1
     state.stacks = {}
     state.fieldOptions = {}
+    state.activeSearchTerm = ''
+    state.hideRowsNotMatchingSearch = true
+  },
+  SET_SEARCH(state, { activeSearchTerm, hideRowsNotMatchingSearch }) {
+    state.activeSearchTerm = activeSearchTerm.trim()
+    state.hideRowsNotMatchingSearch = hideRowsNotMatchingSearch
   },
   SET_LAST_KANBAN_ID(state, kanbanId) {
     state.lastKanbanId = kanbanId
@@ -227,9 +240,9 @@ export const actions = {
       includeFieldOptions = true,
     }
   ) {
+    const { $client, $config } = this
     commit('SET_ADHOC_FILTERING', adhocFiltering)
     commit('SET_LAST_KANBAN_ID', kanbanId)
-    const { $client } = this
     const view = rootGetters['view/get'](kanbanId)
     const { data } = await KanbanService($client).fetchRows({
       kanbanId,
@@ -240,6 +253,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       filters: getFilters(view, adhocFiltering),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
     // because that probably means the user switched to another view or table, and
@@ -265,7 +280,7 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { selectOptionId }
   ) {
-    const { $client } = this
+    const { $client, $config } = this
     const kanbanId = getters.getLastKanbanId
     const stack = getters.getStack(selectOptionId)
     const view = rootGetters['view/get'](kanbanId)
@@ -284,6 +299,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       filters: getFilters(view, getters.getAdhocFiltering),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
     // because that probably means the user switched to another view or table, and
@@ -563,11 +580,12 @@ export const actions = {
    * Check if the provided row matches the provided view filters.
    */
   rowMatchesFilters(context, { view, fields, row, overrides = {} }) {
+    const { getters } = context
     const values = JSON.parse(JSON.stringify(row))
     Object.assign(values, overrides)
 
     // The value is always valid if the filters are disabled.
-    return view.filters_disabled
+    const matchesViewFilters = view.filters_disabled
       ? true
       : matchSearchFilters(
           this.$registry,
@@ -577,6 +595,30 @@ export const actions = {
           fields,
           values
         )
+
+    if (!matchesViewFilters) {
+      return false
+    }
+
+    if (!getters.getActiveSearchTerm) {
+      return true
+    }
+
+    return calculateSingleRowSearchMatches(
+      row,
+      getters.getActiveSearchTerm,
+      getters.isHidingRowsNotMatchingSearch,
+      fields,
+      this.$registry,
+      getDefaultSearchModeFromEnv(this.$config),
+      overrides
+    ).matchSearch
+  },
+  updateSearch(
+    { commit },
+    { activeSearchTerm, hideRowsNotMatchingSearch = true }
+  ) {
+    commit('SET_SEARCH', { activeSearchTerm, hideRowsNotMatchingSearch })
   },
   /**
    * Can be called when a row in the table has been updated. This action will make sure
@@ -1099,6 +1141,15 @@ export const actions = {
 }
 
 export const getters = {
+  getServerSearchTerm(state) {
+    return state.hideRowsNotMatchingSearch ? state.activeSearchTerm : false
+  },
+  getActiveSearchTerm(state) {
+    return state.activeSearchTerm
+  },
+  isHidingRowsNotMatchingSearch(state) {
+    return state.hideRowsNotMatchingSearch
+  },
   getLastKanbanId(state) {
     return state.lastKanbanId
   },


### PR DESCRIPTION
﻿## Summary
- add `search` and `search_mode` query params to Kanban row listing endpoints
- apply the search term before grouping rows into Kanban stacks, including public Kanban views
- add the shared ViewSearch control to the Kanban header
- pass search params from the Kanban frontend store/service for initial loads and pagination
- add backend coverage for private, public, and empty-search Kanban cases

Fixes #768

## Verification
- `python -m ruff check --config backend/pyproject.toml premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py`
- `python -m ruff format --config backend/pyproject.toml --check premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py`
- `npx --yes prettier@3.7.4 --check premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanView.vue premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue premium/web-frontend/modules/baserow_premium/services/views/kanban.js premium/web-frontend/modules/baserow_premium/store/view/kanban.js`
- `python -m py_compile premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py`

Note: I attempted the focused pytest selection locally, but this fresh isolated checkout does not have the backend Django test dependencies installed, so pytest stopped at `ModuleNotFoundError: No module named 'django'` before running the tests.
