### PR TITLE
Handle Azure SAML metadata RoleDescriptor elements

### DIFF
--- a/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
+++ b/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
@@ -1,7 +1,9 @@
 import io
+from xml.etree.ElementTree import ParseError, tostring
 
 from django.db.models import QuerySet
 
+from defusedxml import ElementTree
 from rest_framework import serializers
 
 from baserow_enterprise.sso.saml.exceptions import SamlProviderForDomainAlreadyExists
@@ -28,6 +30,7 @@ def validate_saml_metadata(value):
     from saml2.xml.schema import XMLSchemaError
     from saml2.xml.schema import validate as validate_saml_metadata_schema
 
+    value = remove_role_descriptors_from_saml_metadata(value)
     metadata = io.StringIO(value)
     try:
         validate_saml_metadata_schema(metadata)
@@ -37,3 +40,21 @@ def validate_saml_metadata(value):
         )
 
     return value
+
+
+def remove_role_descriptors_from_saml_metadata(value):
+    try:
+        root = ElementTree.fromstring(value)
+    except ParseError:
+        return value
+
+    role_descriptors = root.findall(
+        "{urn:oasis:names:tc:SAML:2.0:metadata}RoleDescriptor"
+    )
+    if not role_descriptors:
+        return value
+
+    for role_descriptor in role_descriptors:
+        root.remove(role_descriptor)
+
+    return tostring(root, encoding="unicode")

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py
@@ -234,6 +234,49 @@ def test_admin_can_create_saml_provider_with_an_enterprise_license(
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_admin_can_create_saml_provider_with_azure_role_descriptor_metadata(
+    api_client, data_fixture, enterprise_data_fixture
+):
+    data_fixture.create_password_provider()
+
+    domain = "test.it"
+    metadata = enterprise_data_fixture.get_test_saml_idp_metadata()
+    metadata_with_role_descriptor = metadata.replace(
+        "</md:EntityDescriptor>",
+        """
+        <md:RoleDescriptor
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:type="fed:ApplicationServiceType"
+            protocolSupportEnumeration="http://docs.oasis-open.org/wsfed/federation/200706"
+            xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706">
+            <md:KeyDescriptor use="signing"/>
+        </md:RoleDescriptor>
+        </md:EntityDescriptor>
+        """,
+    )
+
+    _, token = enterprise_data_fixture.create_enterprise_admin_user_and_token()
+
+    response = api_client.post(
+        reverse("api:enterprise:admin:auth_provider:list"),
+        {
+            "type": SamlAuthProviderType.type,
+            "domain": domain,
+            "metadata": metadata_with_role_descriptor,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["domain"] == domain
+    assert "RoleDescriptor" not in response_json["metadata"]
+    assert "IDPSSODescriptor" in response_json["metadata"]
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_admin_cannot_update_saml_provider_without_an_enterprise_license(
     api_client, data_fixture, enterprise_data_fixture
 ):

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py
@@ -1,0 +1,38 @@
+import pytest
+from rest_framework import serializers
+
+from baserow_enterprise.api.sso.saml.validators import validate_saml_metadata
+from baserow_enterprise_tests.fixtures.sso.saml.saml import load_test_idp_metadata
+
+
+def test_validate_saml_metadata_preserves_valid_metadata_without_role_descriptor():
+    metadata = load_test_idp_metadata()
+
+    assert validate_saml_metadata(metadata) == metadata
+
+
+def test_validate_saml_metadata_accepts_azure_metadata_with_role_descriptor():
+    metadata = load_test_idp_metadata()
+    azure_role_descriptor = """
+    <md:RoleDescriptor
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:type="fed:ApplicationServiceType"
+        protocolSupportEnumeration="http://docs.oasis-open.org/wsfed/federation/200706"
+        xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706">
+        <md:KeyDescriptor use="signing"/>
+    </md:RoleDescriptor>
+    """
+    metadata_with_role_descriptor = metadata.replace(
+        "</md:EntityDescriptor>",
+        f"{azure_role_descriptor}</md:EntityDescriptor>",
+    )
+
+    validated_metadata = validate_saml_metadata(metadata_with_role_descriptor)
+
+    assert "RoleDescriptor" not in validated_metadata
+    assert "IDPSSODescriptor" in validated_metadata
+
+
+def test_validate_saml_metadata_still_rejects_invalid_metadata():
+    with pytest.raises(serializers.ValidationError):
+        validate_saml_metadata("invalid_metadata")


### PR DESCRIPTION
## What

Fixes #1673.

Azure federation metadata can include SAML `md:RoleDescriptor` entries for WS-Federation application service data. Baserow currently validates the whole uploaded metadata document against the PySAML2 metadata schema, so those Azure-specific role descriptors make SAML auth provider creation fail.

This PR removes top-level SAML metadata `RoleDescriptor` elements before schema validation. Normal metadata without those elements is returned unchanged, and invalid metadata still fails with the existing validation error.

## Validation

Ran locally:

```bash
BASEROW_TESTS_SETUP_DB_FIXTURE=off PYTHONPATH="backend/src:premium/backend/src:enterprise/backend/src:backend/tests:premium/backend/tests:enterprise/backend/tests" UV_PROJECT_ENVIRONMENT=../.venv uv run --active --project backend pytest -c backend/pytest.ini enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py

PYTHONPATH="backend/src:premium/backend/src:enterprise/backend/src:backend/tests:premium/backend/tests:enterprise/backend/tests" UV_PROJECT_ENVIRONMENT=../.venv uv run --active --project backend ruff check --config backend/pyproject.toml enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py

PYTHONPATH="backend/src:premium/backend/src:enterprise/backend/src:backend/tests:premium/backend/tests:enterprise/backend/tests" UV_PROJECT_ENVIRONMENT=../.venv uv run --active --project backend ruff format --config backend/pyproject.toml --check enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py
```

The database-backed API test was added but not run locally because Docker is not running on my machine, so the local Postgres service could not be started.
