### PR TITLE
Add search support to Kanban view

### DIFF
--- a/premium/backend/src/baserow_premium/api/views/kanban/views.py
+++ b/premium/backend/src/baserow_premium/api/views/kanban/views.py
@@ -4,13 +4,20 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from baserow.api.decorators import allowed_includes, map_exceptions
+from baserow.api.decorators import (
+    allowed_includes,
+    map_exceptions,
+    validate_query_parameters,
+)
 from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.schemas import get_error_schema
+from baserow.api.search.serializers import SearchQueryParamSerializer
 from baserow.contrib.database.api.constants import (
     ADHOC_FILTERS_API_PARAMS,
     ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
     LIMIT_LINKED_ITEMS_API_PARAM,
+    SEARCH_MODE_API_PARAM,
+    SEARCH_VALUE_API_PARAM,
 )
 from baserow.contrib.database.api.fields.errors import (
     ERROR_FIELD_DOES_NOT_EXIST,
@@ -119,6 +126,8 @@ class KanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            SEARCH_VALUE_API_PARAM,
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
             LIMIT_LINKED_ITEMS_API_PARAM,
         ],
@@ -162,10 +171,13 @@ class KanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options", "row_metadata")
-    def get(self, request, view_id, field_options, row_metadata):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, view_id, field_options, row_metadata, query_params):
         """Responds with the rows grouped by the view's select option field value."""
 
         adhoc_filters = AdHocFilters.from_request(request)
+        search = query_params.get("search")
+        search_mode = query_params.get("search_mode")
 
         view_handler = ViewHandler()
         view = view_handler.get_view_as_user(request.user, view_id, KanbanView)
@@ -201,6 +213,13 @@ class KanbanViewView(APIView):
 
         model = view.table.get_model()
         hidden_field_ids = get_hidden_field_ids_for_view_user(request.user, view)
+        only_search_by_field_ids = None
+        if hidden_field_ids:
+            only_search_by_field_ids = [
+                field_id
+                for field_id in model._field_objects.keys()
+                if field_id not in hidden_field_ids
+            ]
 
         limit_linked_items = parse_limit_linked_items_params(request)
         serializer_extra_kwargs = {"limit_linked_items": limit_linked_items}
@@ -220,6 +239,9 @@ class KanbanViewView(APIView):
             option_settings=included_select_options,
             default_limit=default_limit,
             default_offset=default_offset,
+            search=search,
+            search_mode=search_mode,
+            only_search_by_field_ids=only_search_by_field_ids,
             model=model,
         )
 
@@ -302,6 +324,8 @@ class PublicKanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            SEARCH_VALUE_API_PARAM,
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS,
             LIMIT_LINKED_ITEMS_API_PARAM,
         ],
@@ -346,13 +370,16 @@ class PublicKanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options")
-    def get(self, request, slug: str, field_options: bool):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, slug: str, field_options: bool, query_params):
         """
         Lists all the rows of a kanban view that is publicly shared. The rows are
         grouped by the view's single select field options.
         """
 
         adhoc_filters = AdHocFilters.from_request(request)
+        search = query_params.get("search")
+        search_mode = query_params.get("search_mode")
 
         view_handler = ViewHandler()
         view = view_handler.get_public_view_by_slug(
@@ -383,6 +410,8 @@ class PublicKanbanViewView(APIView):
             publicly_visible_field_options,
         ) = ViewHandler().get_public_rows_queryset_and_field_ids(
             view,
+            search=search,
+            search_mode=search_mode,
             adhoc_filters=adhoc_filters,
             table_model=model,
             view_type=view_type,

--- a/premium/backend/src/baserow_premium/views/handler.py
+++ b/premium/backend/src/baserow_premium/views/handler.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth.models import AbstractUser
@@ -35,6 +35,9 @@ def get_rows_grouped_by_single_select_field(
     option_settings: Dict[str, Dict[str, int]] = None,
     default_limit: int = 40,
     default_offset: int = 0,
+    search: Optional[str] = None,
+    search_mode: Optional[str] = None,
+    only_search_by_field_ids: Optional[Iterable[int]] = None,
     adhoc_filters: Optional[AdHocFilters] = None,
     model: Optional[GeneratedTableModel] = None,
     base_queryset: Optional[QuerySet] = None,
@@ -67,6 +70,9 @@ def get_rows_grouped_by_single_select_field(
         specific settings for that field have been provided.
     :param default_offset: The default offset that applies to all options if no
         specific settings for that field have been provided.
+    :param search: A search term to apply to the resulting queryset.
+    :param search_mode: The type of search to perform if a search term is provided.
+    :param only_search_by_field_ids: Optional field ids to restrict searching to.
     :param adhoc_filters: The optional ad hoc filters if they should be used
         instead of view filters.
     :param model: Additionally, an existing model can be provided so that it doesn't
@@ -87,6 +93,11 @@ def get_rows_grouped_by_single_select_field(
 
     if base_queryset is None:
         base_queryset = model.objects.all().enhance_by_fields().order_by("order", "id")
+
+    if search is not None:
+        base_queryset = base_queryset.search_all_fields(
+            search, only_search_by_field_ids, search_mode=search_mode
+        )
 
     if adhoc_filters is None:
         adhoc_filters = AdHocFilters()

--- a/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
@@ -245,6 +245,67 @@ def test_list_all_rows(api_client, premium_data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_list_rows_with_search(api_client, premium_data_fixture):
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    single_select_field = premium_data_fixture.create_single_select_field(table=table)
+    option_a = premium_data_fixture.create_select_option(
+        field=single_select_field, value="A", color="blue"
+    )
+    option_b = premium_data_fixture.create_select_option(
+        field=single_select_field, value="B", color="red"
+    )
+    kanban = premium_data_fixture.create_kanban_view(
+        table=table, single_select_field=single_select_field
+    )
+
+    model = table.get_model()
+    row_none = model.objects.create(
+        **{
+            f"field_{text_field.id}": "Needle row none",
+            f"field_{single_select_field.id}_id": None,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Other row none",
+            f"field_{single_select_field.id}_id": None,
+        }
+    )
+    row_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "Needle row A",
+            f"field_{single_select_field.id}_id": option_a.id,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "Other row B",
+            f"field_{single_select_field.id}_id": option_b.id,
+        }
+    )
+
+    url = reverse("api:database:views:kanban:list", kwargs={"view_id": kanban.id})
+    response = api_client.get(
+        f"{url}?search=Needle&search_mode=compat",
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["rows"]["null"]["count"] == 1
+    assert response_json["rows"]["null"]["results"][0]["id"] == row_none.id
+    assert response_json["rows"][str(option_a.id)]["count"] == 1
+    assert response_json["rows"][str(option_a.id)]["results"][0]["id"] == row_a.id
+    assert response_json["rows"][str(option_b.id)]["count"] == 0
+    assert response_json["rows"][str(option_b.id)]["results"] == []
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_list_with_specific_select_options(api_client, premium_data_fixture):
     user, token = premium_data_fixture.create_user_and_token(
         has_active_premium_license=True
@@ -1872,6 +1933,72 @@ def test_list_public_rows_doesnt_show_hidden_columns(api_client, premium_data_fi
             },
         },
     }
+
+
+@pytest.mark.django_db
+def test_list_public_rows_searches_only_visible_columns(
+    api_client, premium_data_fixture
+):
+    user, token = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+
+    kanban_view = premium_data_fixture.create_kanban_view(
+        table=table,
+        user=user,
+        public=True,
+    )
+
+    public_field = premium_data_fixture.create_text_field(table=table, name="public")
+    hidden_field = premium_data_fixture.create_text_field(table=table, name="hidden")
+
+    premium_data_fixture.create_kanban_view_field_option(
+        kanban_view, public_field, hidden=False
+    )
+    premium_data_fixture.create_kanban_view_field_option(
+        kanban_view, hidden_field, hidden=True
+    )
+
+    row_1 = RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{public_field.id}": "visible-match",
+            f"field_{hidden_field.id}": "hidden-other",
+        },
+    )
+    RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{public_field.id}": "visible-other",
+            f"field_{hidden_field.id}": "hidden-target",
+        },
+    )
+
+    url = reverse(
+        "api:database:views:kanban:public_rows", kwargs={"slug": kanban_view.slug}
+    )
+    response = api_client.get(f"{url}?search=hidden-target&search_mode=compat")
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json == {
+        "rows": {
+            "null": {
+                "count": 0,
+                "results": [],
+            }
+        },
+    }
+
+    response = api_client.get(f"{url}?search=visible-match&search_mode=compat")
+
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json["rows"]["null"]["count"] == 1
+    assert response_json["rows"]["null"]["results"][0]["id"] == row_1.id
+    assert f"field_{public_field.id}" in response_json["rows"]["null"]["results"][0]
+    assert f"field_{hidden_field.id}" not in response_json["rows"]["null"]["results"][0]
 
 
 @pytest.mark.django_db

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
@@ -80,21 +80,34 @@
         @update-cover-image-field="updateCoverImageField"
       ></ViewFieldsContext>
     </li>
+    <li
+      v-if="singleSelectFieldId !== -1"
+      class="header__filter-item header__filter-item--full-width"
+    >
+      <ViewSearch
+        :view="view"
+        :fields="fields"
+        :store-prefix="storePrefix"
+        :always-hide-rows-not-matching-search="true"
+        @refresh="$emit('refresh', $event)"
+      ></ViewSearch>
+    </li>
   </ul>
 </template>
 
 <script>
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import ViewFieldsContext from '@baserow/modules/database/components/view/ViewFieldsContext'
+import ViewSearch from '@baserow/modules/database/components/view/ViewSearch'
 import KanbanViewStackedBy from '@baserow_premium/components/views/kanban/KanbanViewStackedBy'
 import kanbanViewHelper from '@baserow_premium/mixins/kanbanViewHelper'
 
 export default {
   name: 'KanbanViewHeader',
   emits: ['refresh'],
-  components: { KanbanViewStackedBy, ViewFieldsContext },
+  components: { KanbanViewStackedBy, ViewFieldsContext, ViewSearch },
   mixins: [kanbanViewHelper],
   props: {
     database: {

--- a/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
@@ -13,6 +13,8 @@ export default (client) => {
       signal = null,
       includeFieldOptions = false,
       includeRowMetadata = true,
+      search = '',
+      searchMode = '',
       selectOptions = [],
       publicUrl = false,
       publicAuthToken = null,
@@ -37,6 +39,13 @@ export default (client) => {
 
       if (include.length > 0) {
         params.append('include', include.join(','))
+      }
+
+      if (search) {
+        params.append('search', search)
+        if (searchMode) {
+          params.append('search_mode', searchMode)
+        }
       }
 
       Object.keys(filters).forEach((key) => {

--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -4,11 +4,13 @@ import { GroupTaskQueue } from '@baserow/modules/core/utils/queue'
 import ViewService from '@baserow/modules/database/services/view'
 import KanbanService from '@baserow_premium/services/views/kanban'
 import {
+  calculateSingleRowSearchMatches,
   extractRowMetadata,
   getFilters,
   getRowSortFunction,
   matchSearchFilters,
 } from '@baserow/modules/database/utils/view'
+import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 import RowService from '@baserow/modules/database/services/row'
 import FieldService from '@baserow/modules/database/services/field'
 import { SingleSelectFieldType } from '@baserow/modules/database/fieldTypes'
@@ -26,6 +28,8 @@ export function populateRow(row, metadata = {}, fullyLoaded = true) {
     dragging: false,
     fetching: false,
     fullyLoaded,
+    matchSearch: true,
+    fieldSearchMatches: [],
   }
   return row
 }
@@ -54,6 +58,7 @@ export const state = () => ({
   draggingOriginalBefore: null,
   // If true, ad hoc filtering is used instead of persistent one
   adhocFiltering: false,
+  activeSearchTerm: '',
   // Indicates whether row(s) are currently being created.
   creating: false,
 })
@@ -64,6 +69,14 @@ export const mutations = {
     state.singleSelectFieldId = -1
     state.stacks = {}
     state.fieldOptions = {}
+    state.activeSearchTerm = ''
+  },
+  SET_SEARCH(state, { activeSearchTerm }) {
+    state.activeSearchTerm = activeSearchTerm.trim()
+  },
+  SET_ROW_SEARCH_MATCHES(state, { row, matchSearch, fieldSearchMatches }) {
+    row._.matchSearch = matchSearch
+    row._.fieldSearchMatches = fieldSearchMatches
   },
   SET_LAST_KANBAN_ID(state, kanbanId) {
     state.lastKanbanId = kanbanId
@@ -229,7 +242,7 @@ export const actions = {
   ) {
     commit('SET_ADHOC_FILTERING', adhocFiltering)
     commit('SET_LAST_KANBAN_ID', kanbanId)
-    const { $client } = this
+    const { $client, $config } = this
     const view = rootGetters['view/get'](kanbanId)
     const { data } = await KanbanService($client).fetchRows({
       kanbanId,
@@ -240,6 +253,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       filters: getFilters(view, adhocFiltering),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
     // because that probably means the user switched to another view or table, and
@@ -265,7 +280,7 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { selectOptionId }
   ) {
-    const { $client } = this
+    const { $client, $config } = this
     const kanbanId = getters.getLastKanbanId
     const stack = getters.getStack(selectOptionId)
     const view = rootGetters['view/get'](kanbanId)
@@ -284,6 +299,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       filters: getFilters(view, getters.getAdhocFiltering),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
     // because that probably means the user switched to another view or table, and
@@ -563,20 +580,39 @@ export const actions = {
    * Check if the provided row matches the provided view filters.
    */
   rowMatchesFilters(context, { view, fields, row, overrides = {} }) {
+    const { $config, $registry } = this
     const values = JSON.parse(JSON.stringify(row))
     Object.assign(values, overrides)
 
     // The value is always valid if the filters are disabled.
-    return view.filters_disabled
+    const matchesFilters = view.filters_disabled
       ? true
       : matchSearchFilters(
-          this.$registry,
+          $registry,
           view.filter_type,
           view.filters,
           view.filter_groups,
           fields,
           values
         )
+
+    if (!matchesFilters) {
+      return false
+    }
+
+    if (context.getters.getActiveSearchTerm) {
+      return calculateSingleRowSearchMatches(
+        values,
+        context.getters.getActiveSearchTerm,
+        context.getters.isHidingRowsNotMatchingSearch,
+        fields,
+        $registry,
+        getDefaultSearchModeFromEnv($config),
+        overrides
+      ).matchSearch
+    }
+
+    return true
   },
   /**
    * Can be called when a row in the table has been updated. This action will make sure
@@ -1096,9 +1132,55 @@ export const actions = {
       commit('UPDATE_ROW_METADATA', { row, rowMetadataType, updateFunction })
     }
   },
+  updateSearch(
+    { commit, dispatch, getters, state },
+    {
+      fields,
+      activeSearchTerm = state.activeSearchTerm,
+      refreshMatchesOnClient = true,
+    }
+  ) {
+    commit('SET_SEARCH', { activeSearchTerm })
+    if (refreshMatchesOnClient) {
+      getters.getAllRows.forEach((row) =>
+        dispatch('updateSearchMatchesForRow', {
+          row,
+          fields,
+          forced: true,
+        })
+      )
+    }
+  },
+  updateSearchMatchesForRow(
+    { commit, getters },
+    { row, fields = null, overrides, forced = false }
+  ) {
+    const { $config, $registry } = this
+    if (getters.getActiveSearchTerm || forced) {
+      const rowSearchMatches = calculateSingleRowSearchMatches(
+        row,
+        getters.getActiveSearchTerm,
+        getters.isHidingRowsNotMatchingSearch,
+        fields,
+        $registry,
+        getDefaultSearchModeFromEnv($config),
+        overrides
+      )
+      commit('SET_ROW_SEARCH_MATCHES', rowSearchMatches)
+    }
+  },
 }
 
 export const getters = {
+  getServerSearchTerm(state) {
+    return state.activeSearchTerm
+  },
+  getActiveSearchTerm(state) {
+    return state.activeSearchTerm
+  },
+  isHidingRowsNotMatchingSearch() {
+    return true
+  },
   getLastKanbanId(state) {
     return state.lastKanbanId
   },

--- a/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
@@ -22,6 +22,19 @@ describe('Kanban view store', () => {
     testApp.afterEach()
   })
 
+  test('updateSearch', async () => {
+    await store.dispatch('kanban/updateSearch', {
+      fields: [],
+      activeSearchTerm: '  test  ',
+      refreshMatchesOnClient: false,
+    })
+
+    expect(store.state.kanban.activeSearchTerm).toBe('test')
+    expect(store.getters['kanban/getActiveSearchTerm']).toBe('test')
+    expect(store.getters['kanban/getServerSearchTerm']).toBe('test')
+    expect(store.getters['kanban/isHidingRowsNotMatchingSearch']).toBe(true)
+  })
+
   test('createdNewRow', async () => {
     const stacks = {}
     stacks.null = {


### PR DESCRIPTION
## What
- Adds the standard view search control to Kanban views.
- Sends `search` and `search_mode` through the Kanban row service and API.
- Filters grouped Kanban rows server-side while keeping public-view search restricted to visible fields.
- Adds backend and frontend coverage for the new behavior.

Closes #768

## Verification
- `ruff check --config backend/pyproject.toml premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py`
- `ruff format --config backend/pyproject.toml --check premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py`
- `node --check premium/web-frontend/modules/baserow_premium/services/views/kanban.js`
- `node --check premium/web-frontend/modules/baserow_premium/store/view/kanban.js`
- `node --check premium/web-frontend/test/unit/premium/store/view/kanban.spec.js`
- `prettier --check` on touched frontend files
- `python -m py_compile` on touched backend files
- `EXTRA_VITEST_PARAMS="../premium/web-frontend/test/unit/premium/store/view/kanban.spec.js --run" yarn test:premium`

Full backend pytest was not run locally because the local isolated environment does not have the project database services available.