### PR TITLE
feat: Add clear button to the view search

### DIFF
--- a/changelog/entries/unreleased/feature/2753_clear_button_for_view_search.json
+++ b/changelog/entries/unreleased/feature/2753_clear_button_for_view_search.json
@@ -3,7 +3,7 @@
   "message": "Add clear button to the view search",
   "issue_origin": "github",
   "issue_number": 2753,
-  "domain": "builder",
+  "domain": "database",
   "bullet_points": [],
   "created_at": "2026-05-11"
 }

--- a/changelog/entries/unreleased/feature/2753_clear_button_for_view_search.json
+++ b/changelog/entries/unreleased/feature/2753_clear_button_for_view_search.json
@@ -1,0 +1,9 @@
+{
+  "type": "feature",
+  "message": "Add clear button to the view search",
+  "issue_origin": "github",
+  "issue_number": 2753,
+  "domain": "builder",
+  "bullet_points": [],
+  "created_at": "2026-05-11"
+}

--- a/web-frontend/modules/core/assets/scss/components/form_input.scss
+++ b/web-frontend/modules/core/assets/scss/components/form_input.scss
@@ -100,6 +100,10 @@
     padding-right: 8px;
   }
 
+  .form-input--can-clear & {
+    padding-right: 26px;
+  }
+
   .form-input--disabled & {
     cursor: not-allowed;
     background-color: $palette-neutral-100;
@@ -178,6 +182,20 @@
     ):not(.form-input--no-border)
     & {
     color: $palette-blue-500;
+  }
+}
+
+.form-input__clear {
+  color: $palette-neutral-900;
+  font-size: 14px;
+  line-height: 20px;
+  margin-top: -10px;
+
+  @include absolute(50%, 8px, 0, auto);
+
+  &:hover {
+    text-decoration: none;
+    color: $palette-neutral-1200;
   }
 }
 

--- a/web-frontend/modules/core/assets/scss/components/header.scss
+++ b/web-frontend/modules/core/assets/scss/components/header.scss
@@ -238,6 +238,7 @@
 }
 
 .header__search {
+  position: relative;
   margin-left: auto;
   flex-direction: row-reverse;
   display: flex;
@@ -248,12 +249,24 @@
     @extend %ellipsis;
 
     display: inline-block;
+
+    &.active {
+      padding-right: 26px;
+    }
   }
 }
 
-.header__filter-clear {
+.header__search-form {
+  position: relative;
+}
+
+.header__search-clear {
   color: $palette-neutral-900;
   font-size: 14px;
+  line-height: 20px;
+  margin-top: -10px;
+
+  @include absolute(50%, 8px, 0, auto);
 
   &:hover {
     text-decoration: none;

--- a/web-frontend/modules/core/assets/scss/components/header.scss
+++ b/web-frontend/modules/core/assets/scss/components/header.scss
@@ -251,6 +251,16 @@
   }
 }
 
+.header__filter-clear {
+  color: $palette-neutral-900;
+  font-size: 14px;
+
+  &:hover {
+    text-decoration: none;
+    color: $palette-neutral-1200;
+  }
+}
+
 .header__search-icon {
   color: $color-neutral-900;
   font-size: 16px;

--- a/web-frontend/modules/core/components/FormInput.vue
+++ b/web-frontend/modules/core/components/FormInput.vue
@@ -13,6 +13,7 @@
       'form-input--xlarge': size === 'xlarge',
       'form-input--suffix': hasSuffixSlot,
       'form-input--no-controls': removeNumberInputControls,
+      'form-input--can-clear': canClear,
     }"
     @click="focusOnClick && focus()"
   >
@@ -27,7 +28,9 @@
         :id="forInput"
         ref="input"
         class="form-input__input"
-        :class="{ 'form-input__input--text-invisible': textInvisible }"
+        :class="{
+          'form-input__input--text-invisible': textInvisible,
+        }"
         :value="fromValue(innerValue)"
         :disabled="disabled"
         :type="type"
@@ -52,6 +55,14 @@
         class="form-input__icon form-input__icon-right"
         :class="iconRight"
       />
+      <a
+        v-if="canClear"
+        v-show="fromValue(innerValue) !== ''"
+        class="form-input__clear"
+        @click="updateValue('')"
+      >
+        <i class="iconoir-cancel"></i>
+      </a>
     </div>
 
     <div v-if="hasSuffixSlot" class="form-input__suffix">
@@ -95,6 +106,7 @@ const props = defineProps({
   step: { type: Number, default: -1 },
   focusOnClick: { type: Boolean, default: true },
   textInvisible: Boolean,
+  canClear: { type: Boolean, default: false },
 })
 
 const emit = defineEmits([

--- a/web-frontend/modules/database/components/view/ViewSearch.vue
+++ b/web-frontend/modules/database/components/view/ViewSearch.vue
@@ -10,6 +10,13 @@
     >
       <i class="header__search-icon iconoir-search"></i>
       {{ headerSearchTerm }}
+      <a
+        v-show="headerSearchTerm.length > 0"
+        class="header__filter-clear"
+        @click.stop="clear"
+      >
+        <i class="iconoir-cancel"></i>
+      </a>
     </a>
     <ViewSearchContext
       ref="context"
@@ -94,6 +101,14 @@ export default {
       event.preventDefault()
       this.$bus.$emit('close-modals')
       this.$refs.contextLink.click()
+    },
+    clear() {
+      const ref = this.$refs.context
+      const context = ref.getRootContext()
+      if (this.$refs.context.getRootContext().open) {
+        context.hide()
+      }
+      ref.setActiveSearchTerm('')
     },
   },
 }

--- a/web-frontend/modules/database/components/view/ViewSearch.vue
+++ b/web-frontend/modules/database/components/view/ViewSearch.vue
@@ -10,13 +10,14 @@
     >
       <i class="header__search-icon iconoir-search"></i>
       {{ headerSearchTerm }}
-      <a
-        v-show="headerSearchTerm.length > 0"
-        class="header__filter-clear"
-        @click.stop="clear"
-      >
-        <i class="iconoir-cancel"></i>
-      </a>
+    </a>
+    <a
+      v-show="headerSearchTerm.length > 0"
+      class="header__search-clear"
+      :aria-label="$t('viewSearch.clearSearch')"
+      @click.stop.prevent="clear"
+    >
+      <i class="iconoir-cancel"></i>
     </a>
     <ViewSearchContext
       ref="context"
@@ -105,7 +106,7 @@ export default {
     clear() {
       const ref = this.$refs.context
       const context = ref.getRootContext()
-      if (this.$refs.context.getRootContext().open) {
+      if (context.open) {
         context.hide()
       }
       ref.setActiveSearchTerm('')

--- a/web-frontend/modules/database/components/view/ViewSearchContext.vue
+++ b/web-frontend/modules/database/components/view/ViewSearchContext.vue
@@ -79,6 +79,11 @@ export default {
         this.$refs.activeSearchTermInput.focus()
       })
     },
+    setActiveSearchTerm(value) {
+      this.activeSearchTerm = value
+      this.$emit('search-changed', this.activeSearchTerm)
+      this.search(true)
+    },
     searchIfChanged() {
       this.$emit('search-changed', this.activeSearchTerm)
       if (
@@ -93,7 +98,7 @@ export default {
       this.lastSearch = this.activeSearchTerm
       this.lastHide = this.hideRowsNotMatchingSearch
     },
-    search() {
+    search(immediate = false) {
       if (this.readOnly) {
         this.$emit('refresh', { activeSearchTerm: this.activeSearchTerm })
         return
@@ -104,14 +109,22 @@ export default {
       // When the user toggles from hiding rows to not hiding rows we still
       // need to refresh as we need to fetch the un-searched rows from the server first.
       if (this.hideRowsNotMatchingSearch || this.lastHide) {
-        // noinspection JSValidateTypes
-        this.debouncedServerSearchRefresh()
+        if (immediate) {
+          this.serverSearchRefresh()
+        } else {
+          // noinspection JSValidateTypes
+          this.debouncedServerSearchRefresh()
+        }
       } else {
-        // noinspection JSValidateTypes
-        this.debouncedClientSideSearchRefresh()
+        if (immediate) {
+          this.clientSideSearchRefresh()
+        } else {
+          // noinspection JSValidateTypes
+          this.debouncedClientSideSearchRefresh()
+        }
       }
     },
-    debouncedServerSearchRefresh: debounce(async function () {
+    async serverSearchRefresh() {
       await this.$store.dispatch(
         `${this.storePrefix}view/${this.view.type}/updateSearch`,
         {
@@ -127,10 +140,8 @@ export default {
         callback: this.finishedLoading,
         activeSearchTerm: this.activeSearchTerm,
       })
-    }, 400),
-    // Debounce even the client side only refreshes as otherwise spamming the keyboard
-    // can cause many refreshes to queue up quickly bogging down the UI.
-    debouncedClientSideSearchRefresh: debounce(async function () {
+    },
+    async clientSideSearchRefresh() {
       await this.$store.dispatch(
         `${this.storePrefix}view/${this.view.type}/updateSearch`,
         {
@@ -141,6 +152,14 @@ export default {
         }
       )
       this.finishedLoading()
+    },
+    debouncedServerSearchRefresh: debounce(function () {
+      return this.serverSearchRefresh()
+    }, 400),
+    // Debounce even the client side only refreshes as otherwise spamming the keyboard
+    // can cause many refreshes to queue up quickly bogging down the UI.
+    debouncedClientSideSearchRefresh: debounce(function () {
+      return this.clientSideSearchRefresh()
     }, 10),
     finishedLoading() {
       this.loading = false

--- a/web-frontend/modules/database/components/view/ViewSearchContext.vue
+++ b/web-frontend/modules/database/components/view/ViewSearchContext.vue
@@ -7,15 +7,18 @@
     @shown="focus"
   >
     <form class="context__form" @submit.prevent="searchIfChanged">
-      <FormInput
-        ref="activeSearchTermInput"
-        v-model="activeSearchTerm"
-        size="large"
-        icon-left="iconoir-search"
-        :placeholder="$t('viewSearchContext.searchInRows')"
-        class="margin-bottom-2"
-        @keyup="searchIfChanged"
-      ></FormInput>
+      <div class="header__search-form">
+        <FormInput
+          ref="activeSearchTermInput"
+          v-model="activeSearchTerm"
+          size="large"
+          icon-left="iconoir-search"
+          :placeholder="$t('viewSearchContext.searchInRows')"
+          class="margin-bottom-2"
+          :can-clear="true"
+          @keyup="searchIfChanged"
+        ></FormInput>
+      </div>
       <div
         v-if="!alwaysHideRowsNotMatchingSearch"
         class="control control--align-right margin-bottom-0"

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -508,6 +508,9 @@
     "syntax": "Syntax",
     "examples": "Examples"
   },
+  "viewSearch": {
+    "clearSearch": "Clear search"
+  },
   "viewSearchContext": {
     "searchInRows": "Search in all rows",
     "hideNotMatching": "hide not matching rows"

--- a/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
+++ b/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
@@ -9,6 +9,7 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
         <div class="form-input form-input--icon-left form-input--large"><i class="form-input__icon form-input__icon-left iconoir-search"></i>
           <div class="form-input__wrapper"><input class="form-input__input" type="text" min="false" max="false" step="false" placeholder="crudTableSearch.search" autocomplete="" value="">
             <!--v-if-->
+            <!--v-if-->
           </div>
           <!--v-if-->
         </div>
@@ -154,6 +155,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
       <form>
         <div class="form-input form-input--icon-left form-input--large"><i class="form-input__icon form-input__icon-left iconoir-search"></i>
           <div class="form-input__wrapper"><input class="form-input__input" type="text" min="false" max="false" step="false" placeholder="crudTableSearch.search" autocomplete="" value="">
+            <!--v-if-->
             <!--v-if-->
           </div>
           <!--v-if-->

--- a/web-frontend/test/unit/database/__snapshots__/publicView.spec.js.snap
+++ b/web-frontend/test/unit/database/__snapshots__/publicView.spec.js.snap
@@ -311,7 +311,15 @@ exports[`Public View Page Tests > Can see a publicly shared grid view 1`] = `
                 <i
                   class="header__search-icon iconoir-search"
                 />
-                 
+                  
+                <a
+                  class="header__filter-clear"
+                  style="display: none;"
+                >
+                  <i
+                    class="iconoir-cancel"
+                  />
+                </a>
               </a>
             </div>
           </li>

--- a/web-frontend/test/unit/database/__snapshots__/publicView.spec.js.snap
+++ b/web-frontend/test/unit/database/__snapshots__/publicView.spec.js.snap
@@ -311,15 +311,16 @@ exports[`Public View Page Tests > Can see a publicly shared grid view 1`] = `
                 <i
                   class="header__search-icon iconoir-search"
                 />
-                  
-                <a
-                  class="header__filter-clear"
-                  style="display: none;"
-                >
-                  <i
-                    class="iconoir-cancel"
-                  />
-                </a>
+                 
+              </a>
+              <a
+                aria-label="viewSearch.clearSearch"
+                class="header__search-clear"
+                style="display: none;"
+              >
+                <i
+                  class="iconoir-cancel"
+                />
               </a>
             </div>
           </li>

--- a/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
+++ b/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
@@ -68,7 +68,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           </div>
         </li>
         <li class="header__filter-item header__filter-item--full-width">
-          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a></div>
+          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> <a class="header__filter-clear" style="display: none;"><i class="iconoir-cancel"></i></a></a></div>
         </li>
       </ul>
     </header>
@@ -289,7 +289,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           </div>
         </li>
         <li class="header__filter-item header__filter-item--full-width">
-          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a></div>
+          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> <a class="header__filter-clear" style="display: none;"><i class="iconoir-cancel"></i></a></a></div>
         </li>
       </ul>
     </header>

--- a/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
+++ b/web-frontend/test/unit/database/__snapshots__/table.spec.js.snap
@@ -68,7 +68,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           </div>
         </li>
         <li class="header__filter-item header__filter-item--full-width">
-          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> <a class="header__filter-clear" style="display: none;"><i class="iconoir-cancel"></i></a></a></div>
+          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a><a class="header__search-clear" aria-label="viewSearch.clearSearch" style="display: none;"><i class="iconoir-cancel"></i></a></div>
         </li>
       </ul>
     </header>
@@ -289,7 +289,7 @@ exports[`Table Component Tests > Adding a row to a table increases the row count
           </div>
         </li>
         <li class="header__filter-item header__filter-item--full-width">
-          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> <a class="header__filter-clear" style="display: none;"><i class="iconoir-cancel"></i></a></a></div>
+          <div class="header__search"><a class="header__filter-link"><i class="header__search-icon iconoir-search"></i> </a><a class="header__search-clear" aria-label="viewSearch.clearSearch" style="display: none;"><i class="iconoir-cancel"></i></a></div>
         </li>
       </ul>
     </header>

--- a/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
+++ b/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
@@ -559,6 +559,7 @@ exports[`ViewFilterForm match snapshots > Full view filter component 1`] = `
                   value="test"
                 />
                 <!--v-if-->
+                <!--v-if-->
               </div>
               <!--v-if-->
             </div>


### PR DESCRIPTION
### What is in this PR

Added button to clear the view search.

https://github.com/user-attachments/assets/4e76fd91-238d-43af-aa83-f2ebc79f26ea

### How to test this PR

- Create a grid view.
- Search for something.
- Click on the `X` next to the search term.
- Observe that the search is cleared.
- If the search context is open, then it should be hidden if the `X` is clicked.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered

Closes #2753 