### PR TITLE
Add sorting support to calendar views

### DIFF
--- a/changelog/entries/unreleased/feature/1729_add_sorting_support_to_calendar_views.json
+++ b/changelog/entries/unreleased/feature/1729_add_sorting_support_to_calendar_views.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add support for sorting rows in calendar views.",
+    "issue_origin": "github",
+    "issue_number": 1729,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-05-12"
+}

--- a/premium/backend/src/baserow_premium/views/handler.py
+++ b/premium/backend/src/baserow_premium/views/handler.py
@@ -237,6 +237,8 @@ def get_rows_grouped_by_date_field(
         )
     if search is not None:
         base_queryset = base_queryset.search_all_fields(search, search_mode=search_mode)
+    if view.viewsort_set.exists():
+        base_queryset = ViewHandler().apply_sorting(view, base_queryset)
 
     # Check if the view ownership type is enforcing the filters to be applied. If
     # so, then regardless of what argument is provided, the filters are applied to

--- a/premium/backend/tests/baserow_premium_tests/views/test_calendar_view_type.py
+++ b/premium/backend/tests/baserow_premium_tests/views/test_calendar_view_type.py
@@ -671,6 +671,62 @@ def test_calendar_timezone_test_cases(
     assert dict(grouped_rows) == test_case["expected_result"]
 
 
+@pytest.mark.django_db
+@pytest.mark.view_calendar
+def test_get_rows_grouped_by_date_field_applies_sortings_within_date_buckets(
+    premium_data_fixture,
+):
+    user = premium_data_fixture.create_user()
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    date_field = premium_data_fixture.create_date_field(table=table)
+    calendar_view = premium_data_fixture.create_calendar_view(
+        table=table, date_field=date_field
+    )
+    premium_data_fixture.create_view_sort(
+        view=calendar_view, field=text_field, order="ASC"
+    )
+
+    model = table.get_model()
+    row_b_day_1 = model.objects.create(
+        **{
+            f"field_{text_field.id}": "B",
+            f"field_{date_field.id}": date(2023, 1, 10),
+        }
+    )
+    row_a_day_1 = model.objects.create(
+        **{
+            f"field_{text_field.id}": "A",
+            f"field_{date_field.id}": date(2023, 1, 10),
+        }
+    )
+    row_c_day_2 = model.objects.create(
+        **{
+            f"field_{text_field.id}": "C",
+            f"field_{date_field.id}": date(2023, 1, 11),
+        }
+    )
+    row_a_day_2 = model.objects.create(
+        **{
+            f"field_{text_field.id}": "A",
+            f"field_{date_field.id}": date(2023, 1, 11),
+        }
+    )
+
+    grouped_rows = get_rows_grouped_by_date_field(
+        user,
+        calendar_view,
+        date_field,
+        from_timestamp=datetime(2023, 1, 10, 0, 0, 0, 0),
+        to_timestamp=datetime(2023, 1, 11, 0, 0, 0, 0),
+        user_timezone="UTC",
+        model=model,
+    )
+
+    assert grouped_rows["2023-01-10"]["results"] == [row_a_day_1, row_b_day_1]
+    assert grouped_rows["2023-01-11"]["results"] == [row_a_day_2, row_c_day_2]
+
+
 @pytest.mark.view_calendar
 def test_to_midnight():
     assert to_midnight(datetime(2023, 1, 9, 23, 0, 0, 0)) == datetime(

--- a/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
@@ -54,6 +54,19 @@ export function populateDateStack(stack, data) {
 
 const updateRowQueue = new GroupTaskQueue()
 
+function getCalendarRowSortings(view, dateFieldId) {
+  return view.sortings?.length
+    ? view.sortings
+    : [
+        {
+          field: dateFieldId,
+          value: 'ASC',
+          order: 'ASC',
+          type: DEFAULT_SORT_TYPE_KEY,
+        },
+      ]
+}
+
 export const state = () => ({
   loading: false,
   loadingRows: false,
@@ -606,14 +619,7 @@ export const actions = {
     if (stack === undefined) {
       return
     }
-    const sortings = [
-      {
-        field: dateFieldId,
-        value: 'ASC',
-        order: 'ASC',
-        type: DEFAULT_SORT_TYPE_KEY,
-      },
-    ]
+    const sortings = getCalendarRowSortings(view, dateFieldId)
     const sortedRows = clone(stack.results)
     sortedRows.push(row)
     sortedRows.sort(getRowSortFunction($registry, sortings, fields))
@@ -764,14 +770,7 @@ export const actions = {
       }
       newStackResults.push(newRow)
       newStackCount++
-      const sortings = [
-        {
-          field: dateFieldId,
-          value: 'ASC',
-          order: 'ASC',
-          type: DEFAULT_SORT_TYPE_KEY,
-        },
-      ]
+      const sortings = getCalendarRowSortings(view, dateFieldId)
       newStackResults.sort(getRowSortFunction($registry, sortings, fields))
       newIndex = newStackResults.findIndex((r) => r.id === newRow.id)
       const newIsLast = newIndex === newStackResults.length - 1

--- a/premium/web-frontend/modules/baserow_premium/viewTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/viewTypes.js
@@ -307,7 +307,7 @@ export class CalendarViewType extends PremiumViewType {
   }
 
   canSort() {
-    return false
+    return true
   }
 
   canShare() {

--- a/premium/web-frontend/test/fixtures/calendar.js
+++ b/premium/web-frontend/test/fixtures/calendar.js
@@ -48,7 +48,7 @@ export function createCalendarView(
         colorClass: 'color-success',
         name: 'Calendar',
         canFilter: true,
-        canSort: false,
+        canSort: true,
         canShare: true,
         canGroupBy: false,
       },

--- a/premium/web-frontend/test/unit/premium/store/view/calendar.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/calendar.spec.js
@@ -128,6 +128,10 @@ describe('Calendar view store', () => {
     filters: [],
     filters_disabled: true,
   }
+  const viewWithTextSort = {
+    ...view,
+    sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+  }
 
   beforeEach(() => {
     testApp = new TestApp()
@@ -318,6 +322,59 @@ describe('Calendar view store', () => {
           expect(resultStack.results[1].id).toBe(3)
           expect(resultStack.results[2].id).toBe(10)
           expect(resultStack.results[3].id).toBe(11)
+        })
+
+        test('new rows use view sortings within the same date', async () => {
+          const dateStacks = {}
+          dateStacks['2023-01-01'] = {
+            count: 2,
+            results: [
+              {
+                id: 10,
+                order: '10.00',
+                field_1: 'B',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 11,
+                order: '11.00',
+                field_1: 'D',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+            ],
+          }
+
+          const state = Object.assign(calendarStore.state(), {
+            dateFieldId: 2,
+            dateStacks,
+          })
+          store.replaceState({ ...store.state, calendar: state })
+
+          await store.dispatch('calendar/createdNewRow', {
+            view: viewWithTextSort,
+            values: {
+              id: 1,
+              order: '1.00',
+              field_1: 'A',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            fields,
+          })
+          await store.dispatch('calendar/createdNewRow', {
+            view: viewWithTextSort,
+            values: {
+              id: 12,
+              order: '12.00',
+              field_1: 'C',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            fields,
+          })
+
+          const resultStack = store.state.calendar.dateStacks['2023-01-01']
+          expect(resultStack.results.map(({ id }) => id)).toStrictEqual([
+            1, 10, 12, 11,
+          ])
         })
 
         test('new rows added across dates', async () => {
@@ -886,6 +943,61 @@ describe('Calendar view store', () => {
           expect(resultStack.results[0].id).toBe(100)
           expect(resultStack.results[1].id).toBe(22)
           expect(resultStack.results[2].id).toBe(10)
+        })
+
+        test('updated rows use view sortings within the same date', async () => {
+          const dateStacks = {}
+          dateStacks['2023-01-01'] = {
+            count: 3,
+            results: [
+              {
+                id: 10,
+                order: '10.00',
+                field_1: 'A',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 11,
+                order: '11.00',
+                field_1: 'B',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 12,
+                order: '12.00',
+                field_1: 'D',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+            ],
+          }
+
+          const state = Object.assign(calendarStore.state(), {
+            dateFieldId: 2,
+            dateStacks,
+          })
+          store.replaceState({ ...store.state, calendar: state })
+
+          await store.dispatch('calendar/updatedExistingRow', {
+            view: viewWithTextSort,
+            row: {
+              id: 12,
+              order: '12.00',
+              field_1: 'D',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            values: {
+              id: 12,
+              order: '12.00',
+              field_1: 'AA',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            fields,
+          })
+
+          const resultStack = store.state.calendar.dateStacks['2023-01-01']
+          expect(resultStack.results.map(({ id }) => id)).toStrictEqual([
+            10, 12, 11,
+          ])
         })
 
         test('moving rows across dates', async () => {


### PR DESCRIPTION
## Summary
- enable the sort menu for calendar views
- apply view sortings to calendar rows returned within each day bucket
- keep the existing date/order/id fallback for calendar views without sortings
- use the configured view sortings when locally inserting or updating calendar rows in the frontend

Closes #1729

## Tests
- `NODE_OPTIONS="--max-old-space-size=8192" ./node_modules/.bin/vitest --run ../premium/web-frontend/test/unit/premium/store/view/calendar.spec.js --config ../premium/web-frontend/vitest.config.ts`
- `PYTHONPATH="..." DJANGO_SETTINGS_MODULE=baserow.config.settings.test DATABASE_HOST=127.0.0.1 DATABASE_PORT=55432 DATABASE_USER=baserow DATABASE_PASSWORD=baserow DATABASE_NAME=baserow uv run --active pytest -c pytest.ini ../premium/backend/tests/baserow_premium_tests/views/test_calendar_view_type.py`
- `uv run --active ruff check --config pyproject.toml ../premium/backend/src/baserow_premium/views/handler.py ../premium/backend/tests/baserow_premium_tests/views/test_calendar_view_type.py`
- `uv run --active ruff format --config pyproject.toml --check ../premium/backend/src/baserow_premium/views/handler.py ../premium/backend/tests/baserow_premium_tests/views/test_calendar_view_type.py`
- `web-frontend/node_modules/.bin/eslint premium/web-frontend/modules/baserow_premium/store/view/calendar.js premium/web-frontend/modules/baserow_premium/viewTypes.js premium/web-frontend/test/fixtures/calendar.js premium/web-frontend/test/unit/premium/store/view/calendar.spec.js`
- `./node_modules/.bin/prettier --check ../premium/web-frontend/modules/baserow_premium/store/view/calendar.js ../premium/web-frontend/modules/baserow_premium/viewTypes.js ../premium/web-frontend/test/fixtures/calendar.js ../premium/web-frontend/test/unit/premium/store/view/calendar.spec.js`
- `git diff --check`
