### PR TITLE
Accept Azure AD SAML metadata RoleDescriptor nodes

### DIFF
--- a/changelog/entries/unreleased/bug/1673_accept_azure_ad_saml_metadata_role_descriptors.json
+++ b/changelog/entries/unreleased/bug/1673_accept_azure_ad_saml_metadata_role_descriptors.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Accept Azure AD SAML metadata containing unsupported RoleDescriptor nodes.",
+    "issue_origin": "github",
+    "issue_number": 1673,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-05-12"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
+++ b/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
@@ -2,10 +2,14 @@ import io
 
 from django.db.models import QuerySet
 
+from defusedxml import ElementTree
 from rest_framework import serializers
 
 from baserow_enterprise.sso.saml.exceptions import SamlProviderForDomainAlreadyExists
 from baserow_enterprise.sso.saml.models import SamlAuthProviderModel
+
+SAML_METADATA_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:metadata"
+ROLE_DESCRIPTOR_TAG = f"{{{SAML_METADATA_NAMESPACE}}}RoleDescriptor"
 
 
 def validate_unique_saml_domain(
@@ -28,6 +32,7 @@ def validate_saml_metadata(value):
     from saml2.xml.schema import XMLSchemaError
     from saml2.xml.schema import validate as validate_saml_metadata_schema
 
+    value = remove_saml_metadata_role_descriptors(value)
     metadata = io.StringIO(value)
     try:
         validate_saml_metadata_schema(metadata)
@@ -37,3 +42,28 @@ def validate_saml_metadata(value):
         )
 
     return value
+
+
+def remove_saml_metadata_role_descriptors(value):
+    try:
+        root = ElementTree.fromstring(value)
+    except ElementTree.ParseError:
+        return value
+
+    removed = False
+    for parent in root.iter():
+        for child in list(parent):
+            if child.tag == ROLE_DESCRIPTOR_TAG:
+                parent.remove(child)
+                removed = True
+
+    if not removed:
+        return value
+
+    return ElementTree.tostring(root, encoding="unicode")
+
+
+class SamlMetadataField(serializers.CharField):
+    def to_internal_value(self, data):
+        value = super().to_internal_value(data)
+        return validate_saml_metadata(value)

--- a/enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py
+++ b/enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py
@@ -14,7 +14,7 @@ from baserow_enterprise.api.sso.saml.errors import (
     ERROR_SAML_PROVIDER_FOR_DOMAIN_ALREADY_EXISTS,
 )
 from baserow_enterprise.api.sso.saml.validators import (
-    validate_saml_metadata,
+    SamlMetadataField,
     validate_unique_saml_domain,
 )
 from baserow_enterprise.api.sso.utils import (
@@ -54,8 +54,7 @@ class SamlAuthProviderTypeMixin:
     ]
 
     saml_serializer_field_overrides = {
-        "metadata": serializers.CharField(
-            validators=[validate_saml_metadata],
+        "metadata": SamlMetadataField(
             required=True,
             help_text="The SAML metadata XML provided by the IdP.",
         ),

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from baserow_enterprise.api.sso.saml.validators import SamlMetadataField
+
+
+def test_saml_metadata_field_removes_azure_ad_role_descriptors():
+    metadata_path = Path(__file__).parents[2] / Path(
+        "fixtures/sso/saml/idp_test_metadata.xml"
+    )
+    metadata = metadata_path.read_text()
+    role_descriptor = (
+        '<RoleDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" '
+        'protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" />'
+    )
+    metadata = metadata.replace(
+        "<IDPSSODescriptor", f"{role_descriptor}<IDPSSODescriptor", 1
+    )
+
+    normalized_metadata = SamlMetadataField().run_validation(metadata)
+
+    assert "RoleDescriptor" not in normalized_metadata


### PR DESCRIPTION
## Summary
- normalize SAML metadata by removing unsupported metadata `RoleDescriptor` nodes before schema validation
- use a dedicated SAML metadata serializer field so normalized metadata is stored and reused by SAML client setup
- keep the existing XML schema validation error for malformed metadata

Closes #1673

Note: the linked issue mentions that the Azure AD SSO docs may need a follow-up update because users no longer need to manually remove these nodes.

## Tests
- `PYTHONPATH="..." DJANGO_SETTINGS_MODULE=baserow.config.settings.test DATABASE_HOST=127.0.0.1 DATABASE_PORT=55432 DATABASE_USER=baserow DATABASE_PASSWORD=baserow DATABASE_NAME=baserow uv run --active pytest -c pytest.ini ../enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py`
- `PYTHONPATH="..." DJANGO_SETTINGS_MODULE=baserow.config.settings.test DATABASE_HOST=127.0.0.1 DATABASE_PORT=55432 DATABASE_USER=baserow DATABASE_PASSWORD=baserow DATABASE_NAME=baserow uv run --active pytest -c pytest.ini ../enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py::test_admin_can_create_saml_provider_with_an_enterprise_license ../enterprise/backend/tests/baserow_enterprise_tests/api/admin/auth_provider/test_admin_auth_provider_views.py::test_admin_can_update_saml_provider_with_an_enterprise_license`
- `uv run --active ruff check --config pyproject.toml ../enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py ../enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py ../enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py`
- `uv run --active ruff format --config pyproject.toml --check ../enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py ../enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py ../enterprise/backend/tests/baserow_enterprise_tests/api/sso/test_saml_validators.py`
- `git diff --check`

## Not run
- Broader SAML login/ACS tests: local environment is missing `xmlsec1`, so those fail before exercising this change with `saml2.sigver.SigverError: Cannot find ['xmlsec1']`.
