### PR TITLE
fix: missing data source content for shared elements

### DIFF
--- a/changelog/entries/unreleased/bug/fix_missing_data_source_content_in_collection_element_in_pag.json
+++ b/changelog/entries/unreleased/bug/fix_missing_data_source_content_in_collection_element_in_pag.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix missing data source content in collection element in page headers or footers",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-12"
+}

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -904,9 +904,14 @@ export class ElementType extends Registerable {
       recordIndexPath = [0],
     } = applicationContext
 
+    const elementPage =
+      element.page_id === page.id
+        ? page
+        : this.app.$store.getters['page/getById'](builder, element.page_id)
+
     const collectionAncestry = this.getCollectionAncestry({
       element,
-      page,
+      page: elementPage,
       allowSameElement,
     })
 


### PR DESCRIPTION
### What is in this PR

Data source content weren't available for shared elements inside a repeat.

### How to test this PR

On develop:
- Create a page with a shared list data source
- Use this data source in a repeat element
- Add a header to show one field of the data source
- On develop you should see the iterations but the content is empty. With this branch it should work as expected.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
