### PR TITLE
bug: check permissions for collection element during dispatch

### DIFF
--- a/backend/src/baserow/contrib/builder/api/data_providers/serializers.py
+++ b/backend/src/baserow/contrib/builder/api/data_providers/serializers.py
@@ -2,7 +2,13 @@ import pytz
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from baserow.contrib.builder.data_sources.exceptions import (
+    DataSourceRefinementForbidden,
+)
+from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
 from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.service import ElementService
+from baserow.core.exceptions import PermissionException
 
 IANA_TIMEZONES = [(tz, tz) for tz in pytz.all_timezones]
 
@@ -27,6 +33,15 @@ class DispatchDataSourceDataSourceContextSerializer(serializers.Serializer):
         page = self.context.get("page")
         element = data.get("element")
         if element:
+            user = self.context.get("user")
+            if user is not None:
+                try:
+                    data["element"] = ElementService().get_element(user, element.id)
+                except (ElementDoesNotExist, PermissionException):
+                    raise DataSourceRefinementForbidden(
+                        "The data source is not available for the dispatched element."
+                    ) from None
+
             if (
                 element.page_id != page.id
                 and element.page.builder.shared_page.id != page.id

--- a/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
+++ b/backend/src/baserow/contrib/builder/data_sources/builder_dispatch_context.py
@@ -104,7 +104,14 @@ class BuilderDispatchContext(DispatchContext):
 
         serializer = DynamicMetadataSerializer(
             data=getattr(self.request, "data", {}).get("metadata", {}),
-            context={"page": self.page},
+            context={
+                "page": self.page,
+                "user": getattr(
+                    self.request,
+                    "user_source_user",
+                    getattr(self.request, "user", None),
+                ),
+            },
         )
         serializer.is_valid(raise_exception=True)
 

--- a/backend/src/baserow/contrib/builder/elements/permission_manager.py
+++ b/backend/src/baserow/contrib/builder/elements/permission_manager.py
@@ -2,7 +2,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
 from django.db.models import Q, QuerySet
 
-from baserow.contrib.builder.elements.operations import ListElementsPageOperationType
+from baserow.contrib.builder.elements.operations import (
+    ListElementsPageOperationType,
+    ReadElementOperationType,
+)
 from baserow.contrib.builder.pages.models import Page
 from baserow.contrib.builder.workflow_actions.operations import (
     DispatchBuilderWorkflowActionOperationType,
@@ -70,6 +73,53 @@ class ElementVisibilityPermissionManager(PermissionManagerType):
         # Return False by default for safety
         return False
 
+    def actor_can_view_page(self, actor, page):
+        """
+        Return True if the actor is allowed to view the page.
+        """
+
+        if isinstance(actor, User):
+            return True
+
+        if page.visibility != Page.VISIBILITY_TYPES.LOGGED_IN:
+            return True
+
+        if not getattr(actor, "is_authenticated", False):
+            return False
+
+        if page.role_type == Page.ROLE_TYPES.ALLOW_ALL:
+            return True
+        elif page.role_type == Page.ROLE_TYPES.ALLOW_ALL_EXCEPT:
+            return actor.role not in page.roles
+        elif page.role_type == Page.ROLE_TYPES.DISALLOW_ALL_EXCEPT:
+            return actor.role in page.roles
+
+        return False
+
+    def actor_can_view_element(self, actor, element):
+        """
+        Return True if the actor is allowed to view the element, taking element
+        and page visibility and role settings into account.
+        """
+
+        if not self.actor_can_view_page(actor, element.page):
+            return False
+
+        current_element = element
+        while current_element is not None:
+            if getattr(actor, "is_authenticated", False):
+                if current_element.visibility == Element.VISIBILITY_TYPES.NOT_LOGGED:
+                    return False
+
+                if not self.auth_user_can_view_element(actor, current_element):
+                    return False
+            elif current_element.visibility == Element.VISIBILITY_TYPES.LOGGED_IN:
+                return False
+
+            current_element = current_element.parent_element
+
+        return True
+
     def check_multiple_permissions(
         self,
         checks,
@@ -85,22 +135,10 @@ class ElementVisibilityPermissionManager(PermissionManagerType):
 
         for check in checks:
             if check.operation_name == DispatchBuilderWorkflowActionOperationType.type:
-                if getattr(check.actor, "is_authenticated", False):
-                    if (
-                        check.context.element.visibility
-                        == Element.VISIBILITY_TYPES.NOT_LOGGED
-                    ):
-                        result[check] = False
-                    elif not self.auth_user_can_view_element(
-                        check.actor, check.context.element
-                    ):
-                        result[check] = False
-                else:
-                    if (
-                        check.context.element.visibility
-                        == Element.VISIBILITY_TYPES.LOGGED_IN
-                    ):
-                        result[check] = False
+                if not self.actor_can_view_element(check.actor, check.context.element):
+                    result[check] = False
+            elif check.operation_name == ReadElementOperationType.type:
+                result[check] = self.actor_can_view_element(check.actor, check.context)
 
         return result
 

--- a/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
+++ b/backend/tests/baserow/contrib/builder/api/domains/test_domain_public_views.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import ANY, MagicMock, patch
 
 from django.test.utils import override_settings
@@ -1063,6 +1064,96 @@ def test_public_dispatch_data_source_view_returns_some_fields(
                 fields[0].name: "Gobi Manchurian",
             },
         ],
+    }
+
+
+@pytest.mark.django_db
+def test_public_dispatch_data_source_cannot_use_hidden_element_refinements(
+    api_client, data_fixture
+):
+    user = data_fixture.create_user()
+    builder_from = data_fixture.create_builder_application(user=user)
+    builder = data_fixture.create_builder_application(workspace=None)
+    data_fixture.create_builder_custom_domain(
+        builder=builder_from, published_to=builder
+    )
+    public_page = data_fixture.create_builder_page(builder=builder)
+    hidden_page = data_fixture.create_builder_page(
+        builder=builder, visibility=Page.VISIBILITY_TYPES.LOGGED_IN
+    )
+    integration = data_fixture.create_local_baserow_integration(
+        application=builder, authorized_user=user, name="test"
+    )
+    table, _, _ = data_fixture.build_table(
+        user=user,
+        columns=[
+            ("Name", "text"),
+            ("SSN", "text"),
+        ],
+        rows=[
+            ["Peter", "111"],
+            ["Afonso", "222"],
+        ],
+    )
+    public_field = table.field_set.get(name="Name")
+    private_field = table.field_set.get(name="SSN")
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user,
+        page=builder.shared_page,
+        integration=integration,
+        table=table,
+    )
+
+    visible_element = data_fixture.create_builder_table_element(
+        page=public_page,
+        data_source=data_source,
+        fields=[
+            {
+                "name": "Name",
+                "type": "text",
+                "config": {"value": f"get('current_record.{public_field.db_column}')"},
+            },
+        ],
+    )
+    visible_element.property_options.create(
+        schema_property=private_field.db_column, filterable=False
+    )
+
+    hidden_element = data_fixture.create_builder_table_element(
+        page=hidden_page,
+        data_source=data_source,
+        visibility=Element.VISIBILITY_TYPES.LOGGED_IN,
+    )
+    hidden_element.property_options.create(
+        schema_property=private_field.db_column, filterable=True
+    )
+
+    advanced_filters = {
+        "filter_type": "AND",
+        "filters": [
+            {
+                "field": private_field.id,
+                "type": "equal",
+                "value": "222",
+            }
+        ],
+    }
+    url = reverse(
+        "api:builder:domains:public_dispatch",
+        kwargs={"data_source_id": data_source.id},
+    )
+
+    response = api_client.post(
+        f"{url}?filters={json.dumps(advanced_filters)}",
+        {"metadata": {"data_source": {"element": hidden_element.id}}},
+        format="json",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json() == {
+        "error": "ERROR_DATA_SOURCE_REFINEMENT_FORBIDDEN",
+        "detail": "Data source filter, search and/or sort fields error: "
+        "The data source is not available for the dispatched element.",
     }
 
 

--- a/backend/tests/baserow/contrib/builder/elements/test_element_permission_manager.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_permission_manager.py
@@ -3,7 +3,10 @@ from django.contrib.auth.models import AnonymousUser
 import pytest
 
 from baserow.contrib.builder.elements.models import Element
-from baserow.contrib.builder.elements.operations import ListElementsPageOperationType
+from baserow.contrib.builder.elements.operations import (
+    ListElementsPageOperationType,
+    ReadElementOperationType,
+)
 from baserow.contrib.builder.elements.permission_manager import (
     ElementVisibilityPermissionManager,
 )
@@ -253,6 +256,82 @@ def test_element_visibility_permission_manager_filter_queryset(
             for wa in all_was_for_anonymous
         ]
     )
+
+
+@pytest.mark.django_db
+def test_element_visibility_permission_manager_read_element_permission(
+    data_fixture,
+    stub_user_source_registry,
+):
+    user = data_fixture.create_user(username="Auth user")
+    builder = data_fixture.create_builder_application(user=user)
+    builder_to = data_fixture.create_builder_application(workspace=None)
+    data_fixture.create_builder_custom_domain(builder=builder, published_to=builder_to)
+    public_page = data_fixture.create_builder_page(builder=builder_to)
+    logged_in_page = data_fixture.create_builder_page(
+        builder=builder_to, visibility=Page.VISIBILITY_TYPES.LOGGED_IN
+    )
+    public_user_source = data_fixture.create_user_source_with_first_type(
+        application=builder_to
+    )
+    public_user_source_user = UserSourceUser(
+        public_user_source, None, 1, "US public", "e@ma.il"
+    )
+
+    element_all = data_fixture.create_builder_button_element(
+        page=public_page, visibility=Element.VISIBILITY_TYPES.ALL
+    )
+    element_logged_in = data_fixture.create_builder_button_element(
+        page=public_page, visibility=Element.VISIBILITY_TYPES.LOGGED_IN
+    )
+    element_not_logged = data_fixture.create_builder_button_element(
+        page=public_page, visibility=Element.VISIBILITY_TYPES.NOT_LOGGED
+    )
+    element_on_logged_in_page = data_fixture.create_builder_button_element(
+        page=logged_in_page, visibility=Element.VISIBILITY_TYPES.ALL
+    )
+
+    checks = [
+        PermissionCheck(
+            public_user_source_user, ReadElementOperationType.type, element_all
+        ),
+        PermissionCheck(
+            public_user_source_user, ReadElementOperationType.type, element_logged_in
+        ),
+        PermissionCheck(
+            public_user_source_user, ReadElementOperationType.type, element_not_logged
+        ),
+        PermissionCheck(
+            public_user_source_user,
+            ReadElementOperationType.type,
+            element_on_logged_in_page,
+        ),
+        PermissionCheck(AnonymousUser(), ReadElementOperationType.type, element_all),
+        PermissionCheck(
+            AnonymousUser(), ReadElementOperationType.type, element_logged_in
+        ),
+        PermissionCheck(
+            AnonymousUser(), ReadElementOperationType.type, element_not_logged
+        ),
+        PermissionCheck(
+            AnonymousUser(), ReadElementOperationType.type, element_on_logged_in_page
+        ),
+    ]
+
+    result = ElementVisibilityPermissionManager().check_multiple_permissions(
+        checks, builder.workspace
+    )
+
+    assert [result.get(check, None) for check in checks] == [
+        True,
+        True,
+        False,
+        True,
+        True,
+        False,
+        True,
+        False,
+    ]
 
 
 @pytest.fixture(autouse=True)

--- a/changelog/entries/unreleased/bug/check_permission_on_the_element_provided_during_a_collection.json
+++ b/changelog/entries/unreleased/bug/check_permission_on_the_element_provided_during_a_collection.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Check permission on the element provided during a collection element data source dispatch",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-12"
+}


### PR DESCRIPTION
### What is in this PR

Fix missing permission check on element provided during the dispatch of a collection element data source.

### How to test this PR

1. Publish a builder with a shared-page list-rows data source over a table containing:
      - a public field, e.g. Name
      - a sensitive field, e.g. SSN
2. On a public page, add a visible collection element using that shared-page data source:
      - expose/use Name
      - leave SSN not filterable
3. On a hidden page, e.g. LOGGED_IN or role-restricted, add another collection element using the same shared-page data source:
      - mark SSN as filterable
4. As an anonymous public visitor, call the public single data-source dispatch endpoint with an ad hoc filter on SSN, but pass the hidden element ID in metadata:

```sh
export DATA_SOURCE_ID='<data_source_id>'
export SSN_FIELD_ID='<ssn_field_id>'
export HIDDEN_ELEMENT_ID='<hidden_element_id>'

curl -i -X POST \
"http://localhost:8000/api/builder/domains/published/data-source/$DATA_SOURCE_ID/dispatch/?filters={\"filter_type\":\"AND\",\"filters\":[{\"field\":$SSN_FIELD_ID,\"type\":\"equal\",\"value
\":\"222\"}]}" \
-H 'Content-Type: application/json' \
--data "{\"metadata\":{\"data_source\":{\"element\":$HIDDEN_ELEMENT_ID}}}"
```

  Expected behaviour on develop: the request returns 200 OK and public row data matching the hidden SSN predicate.

  Expected on this branch: the request is rejected with ERROR_DATA_SOURCE_REFINEMENT_FORBIDDEN, because the public visitor cannot view the supplied hidden element.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
