### PR TITLE
chore: map InvalidRuntimeFormula error

### DIFF
--- a/backend/src/baserow/contrib/builder/api/elements/errors.py
+++ b/backend/src/baserow/contrib/builder/api/elements/errors.py
@@ -29,3 +29,9 @@ ERROR_ELEMENT_MOVE_NOT_ALLOWED = (
     HTTP_400_BAD_REQUEST,
     "The move destination is not allowed for this element.",
 )
+
+ERROR_ELEMENT_INVALID_FORMULA = (
+    "ERROR_ELEMENT_INVALID_FORMULA",
+    HTTP_400_BAD_REQUEST,
+    "Error with element formula: {e}.",
+)

--- a/backend/src/baserow/contrib/builder/api/elements/views.py
+++ b/backend/src/baserow/contrib/builder/api/elements/views.py
@@ -26,6 +26,7 @@ from baserow.contrib.builder.api.data_sources.errors import (
 )
 from baserow.contrib.builder.api.elements.errors import (
     ERROR_ELEMENT_DOES_NOT_EXIST,
+    ERROR_ELEMENT_INVALID_FORMULA,
     ERROR_ELEMENT_MOVE_NOT_ALLOWED,
     ERROR_ELEMENT_NOT_IN_SAME_PAGE,
     ERROR_ELEMENT_PROPERTY_OPTIONS_NOT_UNIQUE,
@@ -56,6 +57,7 @@ from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.pages.exceptions import PageDoesNotExist, PageNotInBuilder
 from baserow.contrib.builder.pages.handler import PageHandler
+from baserow.core.formula.exceptions import InvalidRuntimeFormula
 
 
 class ElementsView(APIView):
@@ -138,6 +140,7 @@ class ElementsView(APIView):
             ),
             400: get_error_schema(
                 [
+                    "ERROR_ELEMENT_INVALID_FORMULA",
                     "ERROR_REQUEST_BODY_VALIDATION",
                 ]
             ),
@@ -151,6 +154,7 @@ class ElementsView(APIView):
             ElementDoesNotExist: ERROR_ELEMENT_DOES_NOT_EXIST,
             ElementNotInSamePage: ERROR_ELEMENT_NOT_IN_SAME_PAGE,
             ElementTypeDeactivated: ERROR_ELEMENT_TYPE_DEACTIVATED,
+            InvalidRuntimeFormula: ERROR_ELEMENT_INVALID_FORMULA,
         }
     )
     @validate_body_custom_fields(
@@ -202,6 +206,7 @@ class ElementView(APIView):
             ),
             400: get_error_schema(
                 [
+                    "ERROR_ELEMENT_INVALID_FORMULA",
                     "ERROR_REQUEST_BODY_VALIDATION",
                 ]
             ),
@@ -218,6 +223,7 @@ class ElementView(APIView):
             ElementDoesNotExist: ERROR_ELEMENT_DOES_NOT_EXIST,
             DataSourceDoesNotExist: ERROR_DATA_SOURCE_DOES_NOT_EXIST,
             CollectionElementPropertyOptionsNotUnique: ERROR_ELEMENT_PROPERTY_OPTIONS_NOT_UNIQUE,
+            InvalidRuntimeFormula: ERROR_ELEMENT_INVALID_FORMULA,
         }
     )
     @require_request_data_type(dict)

--- a/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
@@ -191,6 +191,25 @@ def test_create_element_bad_request_for_formula(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_create_element_bad_request_for_invalid_runtime_formula(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+
+    url = reverse("api:builder:element:list", kwargs={"page_id": page.id})
+    response = api_client.post(
+        url,
+        {"type": "heading", "value": "unsupported_function()"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_ELEMENT_INVALID_FORMULA"
+
+
+@pytest.mark.django_db
 def test_create_element_permission_denied(
     api_client, data_fixture, stub_check_permissions
 ):
@@ -287,6 +306,26 @@ def test_updating_element_with_invalid_formula_arguments_throws_error(
             ]
         },
     }
+
+
+@pytest.mark.django_db
+def test_update_element_bad_request_for_invalid_runtime_formula(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_heading_element(page=page)
+
+    url = reverse("api:builder:element:item", kwargs={"element_id": element.id})
+    response = api_client.patch(
+        url,
+        {"value": "unsupported_function()"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_ELEMENT_INVALID_FORMULA"
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/add_proper_error_when_an_invalidformulaerror_is_raised.json
+++ b/changelog/entries/unreleased/bug/add_proper_error_when_an_invalidformulaerror_is_raised.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Add proper error when an InvalidFormulaError is raised",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-05-12"
+}


### PR DESCRIPTION
### What is in this PR

Silent sentry issues about invalid function formulas

### How to test this PR

On develop:
- use these curl commands to trigger the 500 error:
```
export JWT_TOKEN=<your_jwt_access_token>
export PAGE_ID=<builder_page_id>

curl -i -X POST "http://localhost:8000/api/builder/page/$PAGE_ID/elements/" \
  -H "Authorization: JWT $JWT_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "type": "heading",
    "value": "unsupported_function()"
  }'
```
For the patch:

```
export ELEMENT_ID=<existing_heading_element_id>

curl -i -X PATCH "http://localhost:8000/api/builder/element/$ELEMENT_ID/" \
  -H "Authorization: JWT $JWT_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "value": "unsupported_function()"
  }'
```

To generate a token: 

```
curl -s -X POST "http://localhost:8000/api/user/token-auth/" \
  -H "Content-Type: application/json" \
  -d '{"email":"you@example.com","password":"your-password"}'
```

On this branch it should be 400 errors.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
