### PR TITLE
Fix sentry error BASEROW-SAAS-BACKEND-5

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_cache.py
+++ b/backend/src/baserow/contrib/database/fields/field_cache.py
@@ -53,6 +53,18 @@ class FieldCache:
             self.cache_model_fields(model)
         return self._model_cache[table_id]
 
+    def uncache_table(self, table):
+        table_id = table.id
+        self._model_cache.pop(table_id, None)
+        self._cached_field_by_name_per_table.pop(table_id, None)
+
+    def refresh_table_model(self, table):
+        self.uncache_table(table)
+        table.refresh_from_db(fields=["version"])
+        model = table.get_model(use_cache=False)
+        self.cache_model(model)
+        return model
+
     def uncache_field(self, field):
         return self._cached_field_by_name_per_table[field.table_id].pop(
             field.name, None

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -5779,12 +5779,34 @@ class FormulaFieldType(FormulaFieldTypeArrayFilterSupport, ReadOnlyFieldType):
         field_cache: "FieldCache",
         via_path_to_starting_table: Optional[List[LinkRowField]],
     ):
-        update_statement = (
-            FormulaHandler.baserow_expression_to_update_django_expression(
-                field.cached_typed_internal_expression,
-                field_cache.get_model(field.table),
+        if field.cached_formula_type.is_invalid():
+            return
+
+        try:
+            update_statement = (
+                FormulaHandler.baserow_expression_to_update_django_expression(
+                    field.cached_typed_internal_expression,
+                    field_cache.get_model(field.table),
+                    raise_exceptions=True,
+                )
             )
-        )
+        except Exception:
+            # If we get an error it's probably because we are using a stale cache and
+            # one of the field type used in this formula was changed
+            # let's try again after refreshing the field cache for this table
+            # Prevents the sentry issue BASEROW-SAAS-BACKEND-5
+            field_cache.refresh_table_model(field.table)
+            field.refresh_from_db()
+            field.clear_cached_properties()
+            if field.cached_formula_type.is_invalid():
+                return
+            update_statement = (
+                FormulaHandler.baserow_expression_to_update_django_expression(
+                    field.cached_typed_internal_expression,
+                    field_cache.get_model(field.table),
+                )
+            )
+
         update_collector.add_field_with_pending_update_statement(
             field,
             update_statement,

--- a/backend/src/baserow/contrib/database/formula/expression_generator/generator.py
+++ b/backend/src/baserow/contrib/database/formula/expression_generator/generator.py
@@ -40,8 +40,11 @@ from baserow.core.formula.parser.exceptions import MaximumFormulaSizeError
 def baserow_expression_to_update_django_expression(
     baserow_expression: BaserowExpression[BaserowFormulaType],
     model: Type[Model],
+    raise_exceptions: bool = False,
 ):
-    return _baserow_expression_to_django_expression(baserow_expression, model, None)
+    return _baserow_expression_to_django_expression(
+        baserow_expression, model, None, raise_exceptions=raise_exceptions
+    )
 
 
 def baserow_expression_to_single_row_update_django_expression(
@@ -67,6 +70,7 @@ def _baserow_expression_to_django_expression(
     model: Type[Model],
     model_instance: Optional[Model],
     insert=False,
+    raise_exceptions: bool = False,
 ) -> Expression:
     """
     Takes a BaserowExpression and converts it to a Django Expression which calculates
@@ -113,6 +117,8 @@ def _baserow_expression_to_django_expression(
     except RecursionError:
         raise MaximumFormulaSizeError()
     except Exception as e:
+        if raise_exceptions:
+            raise
         formula_exception_handler(e)
         return Value(None)
 

--- a/backend/src/baserow/contrib/database/formula/handler.py
+++ b/backend/src/baserow/contrib/database/formula/handler.py
@@ -104,7 +104,10 @@ class FormulaHandler(metaclass=baserow_trace_methods(tracer)):
 
     @classmethod
     def baserow_expression_to_update_django_expression(
-        cls, expression: BaserowExpression, model: Type[Model]
+        cls,
+        expression: BaserowExpression,
+        model: Type[Model],
+        raise_exceptions: bool = False,
     ) -> Expression:
         """
         Converts the provided baserow expression to a django expression that can be
@@ -118,7 +121,9 @@ class FormulaHandler(metaclass=baserow_trace_methods(tracer)):
         :return: A Django Expression for use in an update statement.
         """
 
-        return baserow_expression_to_update_django_expression(expression, model)
+        return baserow_expression_to_update_django_expression(
+            expression, model, raise_exceptions=raise_exceptions
+        )
 
     @classmethod
     def baserow_expression_to_row_update_django_expression(


### PR DESCRIPTION
### What is in this PR

Fix the sentry issue BASEROW-SAAS-BACKEND-5.

The issue is caused by a race in `run_periodic_fields_updates`.

The periodic formula update task selects fields that are valid at the start of the task and builds/reuses a `FieldCache` containing generated table models. If a referenced formula field is changed while the task is running, the task can resume with stale cached model/type information. In that state, a dependent formula can still be processed using the old typed expression, even though the referenced field has since changed type or become invalid.

This produced a split-brain state where Baserow’s formula expression still treated the referenced field as a valid boolean condition for `if(...)`, but Django’s generated expression no longer exposed it as a boolean condition. When `BaserowIf` built a Django `When(condition=...)`, Django rejected the stale expression with:

```text
TypeError: When() supports a Q object, a boolean expression, or lookups as a condition.
```

The fix makes the periodic update path resilient to this race by retrying expression generation after refreshing only the affected table’s cached model/field metadata. If the refreshed formula field is now invalid, the task skips updating it instead of trying to apply a stale update expression.

### How to test this PR

First try to reproduce it on develop:
- Create a table with a Boolean field named 'Test' and a formula field with the following formula: `if(Field('Test'), now(), today())`
- Now apply that patch to the code [add_delay.patch](https://github.com/user-attachments/files/27708819/add_delay.patch) it adds a delay of 30s to reproduce the delay in production.
- in a django shell execute:
```
from baserow.contrib.database.fields.tasks import run_periodic_fields_updates
run_periodic_fields_updates.delay()
```
- And quickly, before the 30s finish change the type of the 'Test' field to `Number`
- Wait for the completion of the task -> it should trigger the error.

Now try to reproduce it with this branch -> it should just ignore the update without error.


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
