### PR TITLE
fix: KeyError: None in get_date_time_format for date-only formula fields

### DIFF
--- a/backend/src/baserow/contrib/database/formula/types/formula_types.py
+++ b/backend/src/baserow/contrib/database/formula/types/formula_types.py
@@ -875,6 +875,14 @@ class BaserowFormulaDateType(
         "date_force_timezone",
     ]
     nullable_option_fields = ["date_force_timezone"]
+    # Only `date_force_timezone` is semantically nullable; others have defaults
+    # applied by `construct_type_from_formula_field` for legacy/corrupt rows.
+    non_nullable_option_defaults = {
+        "date_format": "ISO",
+        "date_include_time": False,
+        "date_time_format": "24",
+        "date_show_tzinfo": False,
+    }
     can_represent_date = True
     can_order_by_in_array = True
     can_group_by = True
@@ -896,6 +904,16 @@ class BaserowFormulaDateType(
         self.date_time_format = date_time_format
         self.date_show_tzinfo = date_show_tzinfo
         self.date_force_timezone = date_force_timezone
+
+    @classmethod
+    def construct_type_from_formula_field(cls, formula_field):
+        kwargs = {}
+        for field_name in cls.all_fields():
+            value = getattr(formula_field, field_name)
+            if value is None and field_name in cls.non_nullable_option_defaults:
+                value = cls.non_nullable_option_defaults[field_name]
+            kwargs[field_name] = value
+        return cls(**kwargs)
 
     @property
     def array_index_sql(self) -> str:

--- a/backend/tests/baserow/contrib/database/field/test_date_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_date_field_type.py
@@ -8,9 +8,12 @@ from pytest_unordered import unordered
 
 from baserow.contrib.database.fields.field_types import DateFieldType
 from baserow.contrib.database.fields.handler import FieldHandler
-from baserow.contrib.database.fields.models import DateField, TextField
+from baserow.contrib.database.fields.models import DateField, FormulaField, TextField
 from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.fields.utils import DeferredForeignKeyUpdater
+from baserow.contrib.database.formula.types.formula_types import (
+    BaserowFormulaDateType,
+)
 from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.views.handler import ViewHandler
 from baserow.core.psycopg import is_psycopg3
@@ -840,3 +843,54 @@ def test_datetime_field_overflow(on_db_connection, data_fixture):
     assert len(out) == 1
 
     assert getattr(out[0], date_field.db_column, None) is None
+
+
+def test_baserow_formula_date_type_normalizes_null_non_nullable_options():
+    # `FormulaField` allows every date option to be NULL. When existing rows
+    # violate invariants, `construct_type_from_formula_field` normalizes NULLs
+    # to prevent downstream crashes.
+    corrupt = FormulaField(
+        formula="TODAY()",
+        formula_type="date",
+        date_format=None,
+        date_include_time=None,
+        date_time_format=None,
+        date_show_tzinfo=None,
+        date_force_timezone=None,
+        version=0,
+        requires_refresh_after_insert=False,
+        nullable=True,
+    )
+
+    formula_type = BaserowFormulaDateType.construct_type_from_formula_field(corrupt)
+
+    assert formula_type.date_format == "ISO"
+    assert formula_type.date_include_time is False
+    assert formula_type.date_time_format == "24"
+    assert formula_type.date_show_tzinfo is False
+    assert formula_type.date_force_timezone is None
+
+
+def test_baserow_formula_date_type_preserves_user_set_options():
+    formula_field = FormulaField(
+        formula="TODAY()",
+        formula_type="date",
+        date_format="EU",
+        date_include_time=True,
+        date_time_format="12",
+        date_show_tzinfo=True,
+        date_force_timezone="Europe/Amsterdam",
+        version=0,
+        requires_refresh_after_insert=False,
+        nullable=True,
+    )
+
+    formula_type = BaserowFormulaDateType.construct_type_from_formula_field(
+        formula_field
+    )
+
+    assert formula_type.date_format == "EU"
+    assert formula_type.date_include_time is True
+    assert formula_type.date_time_format == "12"
+    assert formula_type.date_show_tzinfo is True
+    assert formula_type.date_force_timezone == "Europe/Amsterdam"

--- a/changelog/entries/unreleased/bug/fixes_search_index_updates_failing_for_tables_with_dateonly_.json
+++ b/changelog/entries/unreleased/bug/fixes_search_index_updates_failing_for_tables_with_dateonly_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes search index updates failing for tables with date-only formula fields",
+    "issue_origin": "github",
+    "issue_number": 5363,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-05-13"
+}


### PR DESCRIPTION
## Summary

- Fixes recurring `KeyError: None` crashing `update_search_data` for tables containing date-typed formula fields whose row stored `date_time_format=NULL`.
- Enforces the formula-type's own invariant (`BaserowFormulaDateType.nullable_option_fields = ["date_force_timezone"]`) at the type-construction boundary, instead of defending each downstream consumer.

## Root cause

`FormulaField` allows every date option to be `NULL` because the same row can morph between formula types — the schema can't constrain fields that are only meaningful for some types. The formula-type layer, however, declares that only `date_force_timezone` is semantically nullable for a date formula. Once a row reaches the state `(formula_type='date', date_time_format=NULL)` — historically via the DRF-auto-generated `ChoiceField(allow_null=True)` accepting `null`, template imports, or older code paths — `_has_user_defined_values` short-circuits and preserves it across every subsequent recalculation:

```python
if field.id and formula_type == self.type:
    return True   # skips overwrite, keeps existing values whatever they are
```

`cached_formula_type` then materializes a `BaserowFormulaDateType` carrying that `None`, and `DateFieldType.get_search_expression` calls `get_psql_format()` → `get_date_time_format()` → `DATE_TIME_FORMAT[None]` → `KeyError: None`.

Sentry: https://baserow-eu.sentry.io/issues/BASEROW-SAAS-BACKEND-FF/ (723 occurrences)

## Fix

Override `BaserowFormulaDateType.construct_type_from_formula_field` to substitute the documented defaults when a non-nullable option is `None` on the row (`date_format="ISO"`, `date_include_time=False`, `date_time_format="24"`, `date_show_tzinfo=False`). The fix lives at the boundary where corrupt rows enter the formula-type layer, so every downstream consumer (`get_search_expression`, `get_search_expression_in_array`, `get_export_value`, `contains_query`, `get_alter_column_*`) keeps its existing non-defensive shape.

## Potential follow-ups (not in this PR)

1. One-shot data migration to backfill `NULL` values on existing rows where `formula_type='date'` or `array_formula_type='date'`? 
2. API-layer validation rejecting `null` for non-nullable date options when the resolved formula type is `date`.
3. Apply the same `non_nullable_option_defaults` pattern to other formula types with `user_overridable_formatting_option_fields` (number, duration, …) — same shape of bug is latent there.

## Test plan

- [x] New unit tests assert `construct_type_from_formula_field` normalizes a corrupt row and preserves a user-set row
- [x] `just b test tests/baserow/contrib/database/field/test_date_field_type.py` — 12 passed
- [x] `just b test tests/baserow/contrib/database/field/test_formula_field_type.py` — 54 passed
- [x] `just b test tests/baserow/contrib/database/search/test_search_indexing.py` — 17 passed

Closes #5363