### PR TITLE
Fix snapshot ordering for multi-slot container elements

### DIFF
--- a/backend/src/baserow/contrib/builder/application_types.py
+++ b/backend/src/baserow/contrib/builder/application_types.py
@@ -615,11 +615,12 @@ class BuilderApplicationType(ApplicationType):
                 for slot in sorted(
                     by_slot, key=lambda s: min(e.order for e in by_slot[s])
                 ):
-                    ordered.extend(
-                        sorted(by_slot[slot], key=lambda e: (e.order, e.id))
-                    )
+                    ordered.extend(sorted(by_slot[slot], key=lambda e: (e.order, e.id)))
                 return [
-                    {"type": element.get_type().type, "children": build_tree(element.id)}
+                    {
+                        "type": element.get_type().type,
+                        "children": build_tree(element.id),
+                    }
                     for element in ordered
                 ]
 

--- a/backend/src/baserow/contrib/builder/application_types.py
+++ b/backend/src/baserow/contrib/builder/application_types.py
@@ -586,24 +586,41 @@ class BuilderApplicationType(ApplicationType):
         keyed by page name. Used by snapshot tests to detect element-hierarchy
         regressions across template changes.
 
+        Children are grouped by slot (place_in_container) and slots are ordered by
+        the minimum ``order`` value among their members, so the output is stable
+        regardless of cross-slot insertion history.
+
         :param builder: The builder application instance to serialize.
         :return: A dict mapping page names to their element-tree representation.
         """
+        from collections import defaultdict
+
         from baserow.contrib.builder.elements.handler import ElementHandler
         from baserow.contrib.builder.pages.handler import PageHandler
 
         result = {}
         for page in PageHandler().get_pages(builder):
             elements = list(ElementHandler().get_elements(page))
-            # Elements are already ordered by (order, id) via Element.Meta.ordering.
+
             by_parent: dict[int | None, list] = {}
             for el in elements:
                 by_parent.setdefault(el.parent_element_id, []).append(el)
 
             def build_tree(parent_id):
+                children = by_parent.get(parent_id, [])
+                by_slot: dict[str, list] = defaultdict(list)
+                for el in children:
+                    by_slot[el.place_in_container or ""].append(el)
+                ordered = []
+                for slot in sorted(
+                    by_slot, key=lambda s: min(e.order for e in by_slot[s])
+                ):
+                    ordered.extend(
+                        sorted(by_slot[slot], key=lambda e: (e.order, e.id))
+                    )
                 return [
-                    {"type": el.get_type().type, "children": build_tree(el.id)}
-                    for el in by_parent.get(parent_id, [])
+                    {"type": element.get_type().type, "children": build_tree(element.id)}
+                    for element in ordered
                 ]
 
             result[page.name] = build_tree(None)

--- a/backend/tests/baserow/core/templates/__snapshots__/ab-testing.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab-testing.ambr
@@ -55,77 +55,77 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_agency_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_agency_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_baserow_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_baserow_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_coral_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_coral_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_corporate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_corporate_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_eclipse_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_eclipse_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_education_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_education_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_finance_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_finance_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_forest_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_forest_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_healthcare_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_healthcare_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_ivory_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_ivory_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_lavender_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_lavender_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_legal_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_legal_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_luxury_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_luxury_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_midnight_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_midnight_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_mint_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_mint_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_neon_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_neon_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_ocean_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_ocean_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_realestate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_realestate_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_slate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_slate_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_startup_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_startup_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_sunset_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_sunset_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_tech_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_tech_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_terracotta_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_terracotta_theme.ambr
@@ -172,6 +172,11 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -189,11 +194,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -429,37 +429,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
                       'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
                     }),
                     dict({
                       'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/action-plan-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/action-plan-management.ambr
@@ -305,6 +305,41 @@
             }),
             dict({
               'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+              ]),
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
               ]),
               'type': 'text',
             }),
@@ -332,41 +367,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -461,12 +461,12 @@
             dict({
               'children': list([
               ]),
-              'type': 'iframe',
+              'type': 'text',
             }),
             dict({
               'children': list([
               ]),
-              'type': 'text',
+              'type': 'iframe',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/asset-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/asset-management.ambr
@@ -112,11 +112,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'text',
             }),
             dict({
@@ -143,6 +138,11 @@
                 }),
               ]),
               'type': 'form_container',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -321,6 +321,36 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
             }),
             dict({
@@ -337,36 +367,6 @@
               'children': list([
               ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -501,36 +501,6 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'datetime_picker',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
               ]),
               'type': 'link',
             }),
@@ -563,6 +533,36 @@
               'children': list([
               ]),
               'type': 'text',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'datetime_picker',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',
@@ -632,31 +632,6 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'datetime_picker',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
               ]),
               'type': 'link',
             }),
@@ -679,6 +654,31 @@
               'children': list([
               ]),
               'type': 'text',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'datetime_picker',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/brand-assets-manager.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/brand-assets-manager.ambr
@@ -17,6 +17,31 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -29,31 +54,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/business-goal-tracker-okrs.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/business-goal-tracker-okrs.ambr
@@ -18,47 +18,47 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -189,17 +189,22 @@
             dict({
               'children': list([
               ]),
+              'type': 'input_text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'input_text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'button',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'input_text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'input_text',
             }),
             dict({
               'children': list([
@@ -210,11 +215,6 @@
               'children': list([
               ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'button',
             }),
             dict({
               'children': list([
@@ -310,17 +310,17 @@
             dict({
               'children': list([
               ]),
+              'type': 'button',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'button',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/campaign-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/campaign-management.ambr
@@ -17,6 +17,61 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -64,61 +119,6 @@
                 }),
               ]),
               'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/car-dealership-inventory.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/car-dealership-inventory.ambr
@@ -192,6 +192,96 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'heading',
             }),
             dict({
@@ -242,31 +332,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
             }),
             dict({
@@ -278,11 +343,6 @@
               'children': list([
               ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -327,67 +387,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -530,6 +530,91 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -542,91 +627,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -648,42 +648,42 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -981,37 +981,37 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',
@@ -1359,7 +1359,42 @@
                 dict({
                   'children': list([
                   ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
                   'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
                 }),
                 dict({
                   'children': list([
@@ -1370,41 +1405,6 @@
                   'children': list([
                   ]),
                   'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/commercial-property-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/commercial-property-management.ambr
@@ -18,11 +18,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'text',
             }),
             dict({
@@ -54,6 +49,11 @@
                 }),
               ]),
               'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'image',
             }),
           ]),
           'type': 'column',
@@ -206,37 +206,37 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -307,12 +307,12 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'button',
+                  'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'link',
+                  'type': 'button',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/compliance-assessment-builder.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/compliance-assessment-builder.ambr
@@ -54,11 +54,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -66,6 +61,11 @@
                 }),
               ]),
               'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -280,12 +280,12 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'link',
+                  'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
+                  'type': 'link',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/electronic-health-record.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/electronic-health-record.ambr
@@ -204,17 +204,17 @@
             dict({
               'children': list([
               ]),
-              'type': 'table',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
               'type': 'button',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'table',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/esg-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/esg-management.ambr
@@ -63,6 +63,31 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
             }),
             dict({
@@ -73,32 +98,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -808,6 +808,36 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'iframe',
             }),
             dict({
@@ -823,37 +853,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -910,12 +910,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
+              'type': 'text',
             }),
             dict({
               'children': list([
@@ -930,12 +925,17 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
+              'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
               'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -1309,17 +1309,17 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/formulas.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/formulas.ambr
@@ -23,12 +23,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
+              'type': 'text',
             }),
             dict({
               'children': list([
@@ -37,13 +32,58 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
               ]),
-              'type': 'repeat',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -58,57 +98,17 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
+              'type': 'heading',
             }),
             dict({
               'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
+              'type': 'repeat',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/incident-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/incident-management.ambr
@@ -196,56 +196,6 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'datetime_picker',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'checkbox',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'checkbox',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
               ]),
               'type': 'text',
             }),
@@ -293,6 +243,56 @@
                 }),
               ]),
               'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'datetime_picker',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'checkbox',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'checkbox',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',
@@ -359,12 +359,12 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
+              'type': 'table',
             }),
             dict({
               'children': list([
               ]),
-              'type': 'table',
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -552,21 +552,6 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'choice',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'record_selector',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
               ]),
               'type': 'link',
             }),
@@ -604,6 +589,21 @@
                 }),
               ]),
               'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'choice',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'record_selector',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/lead-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/lead-management.ambr
@@ -75,21 +75,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
             }),
             dict({
@@ -130,7 +115,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
+              'type': 'link',
             }),
             dict({
               'children': list([
@@ -141,6 +126,21 @@
               'children': list([
               ]),
               'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/lightweight-crm.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/lightweight-crm.ambr
@@ -202,7 +202,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
+              'type': 'link',
             }),
             dict({
               'children': list([
@@ -217,7 +217,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'link',
+              'type': 'text',
             }),
             dict({
               'children': list([
@@ -294,37 +294,37 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'button',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',
@@ -879,37 +879,37 @@
             dict({
               'children': list([
               ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',
@@ -986,11 +986,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'input_text',
             }),
             dict({
@@ -1007,6 +1002,11 @@
               'children': list([
               ]),
               'type': 'button',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'image',
             }),
           ]),
           'type': 'column',
@@ -1195,12 +1195,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'image',
+              'type': 'link',
             }),
             dict({
               'children': list([
@@ -1215,12 +1210,17 @@
             dict({
               'children': list([
               ]),
-              'type': 'link',
+              'type': 'image',
             }),
             dict({
               'children': list([
               ]),
               'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'image',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/objectives-key-results.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/objectives-key-results.ambr
@@ -91,6 +91,16 @@
                 }),
                 dict({
                   'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
                     dict({
                       'children': list([
                       ]),
@@ -113,16 +123,6 @@
                     }),
                   ]),
                   'type': 'form_container',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/online-freelancer-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/online-freelancer-management.ambr
@@ -298,12 +298,12 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'button',
+                  'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'link',
+                  'type': 'button',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/order-kiosk.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/order-kiosk.ambr
@@ -95,27 +95,27 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -181,12 +181,17 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'image',
+                  'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'heading',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
                 }),
                 dict({
                   'children': list([
@@ -206,12 +211,7 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
+                  'type': 'image',
                 }),
                 dict({
                   'children': list([
@@ -271,27 +271,27 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -375,27 +375,27 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'image',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/policy-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/policy-management.ambr
@@ -333,22 +333,22 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -517,22 +517,22 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/purchase-order-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/purchase-order-management.ambr
@@ -139,16 +139,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'table',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -161,6 +151,16 @@
                 }),
               ]),
               'type': 'form_container',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'table',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/risk-assessment-and-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/risk-assessment-and-management.ambr
@@ -268,6 +268,21 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -275,21 +290,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -357,6 +357,21 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -374,21 +389,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -592,12 +592,12 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
+              'type': 'table',
             }),
             dict({
               'children': list([
               ]),
-              'type': 'table',
+              'type': 'heading',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/sales-pipeline-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/sales-pipeline-management.ambr
@@ -48,37 +48,37 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/santa-logistics.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/santa-logistics.ambr
@@ -42,6 +42,91 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'iframe',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -154,91 +239,6 @@
                 }),
               ]),
               'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'iframe',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/standard-operating-procedures.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/standard-operating-procedures.ambr
@@ -20,12 +20,12 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'link',
+                  'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
+                  'type': 'link',
                 }),
               ]),
               'type': 'column',
@@ -150,6 +150,21 @@
                 }),
                 dict({
                   'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
                     dict({
                       'children': list([
                       ]),
@@ -167,21 +182,6 @@
                     }),
                   ]),
                   'type': 'form_container',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
                 }),
               ]),
               'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/supply-chain-procurement-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/supply-chain-procurement-management.ambr
@@ -263,6 +263,41 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'link',
             }),
             dict({
@@ -273,42 +308,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -496,6 +496,56 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'heading',
             }),
             dict({
@@ -557,56 +607,6 @@
               'children': list([
               ]),
               'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',
@@ -807,6 +807,46 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'heading',
             }),
             dict({
@@ -837,31 +877,6 @@
             dict({
               'children': list([
               ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
               'type': 'link',
             }),
             dict({
@@ -873,21 +888,6 @@
               'children': list([
               ]),
               'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
             }),
           ]),
           'type': 'column',

--- a/backend/tests/baserow/core/templates/__snapshots__/task-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/task-management.ambr
@@ -331,72 +331,72 @@
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
               'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
             dict({
               'children': list([
@@ -456,7 +456,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
+              'type': 'table',
             }),
             dict({
               'children': list([
@@ -471,7 +471,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'table',
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -619,21 +619,6 @@
                 }),
                 dict({
                   'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
                     dict({
                       'children': list([
                       ]),
@@ -645,22 +630,37 @@
                 dict({
                   'children': list([
                   ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
                   'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
                 }),
               ]),
               'type': 'column',
@@ -949,7 +949,52 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
             }),
             dict({
               'children': list([
@@ -965,6 +1010,61 @@
               'children': list([
               ]),
               'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -983,36 +1083,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -1020,76 +1090,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
             }),
           ]),
           'type': 'column',
@@ -1213,6 +1213,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
                   'type': 'link',
                 }),
                 dict({
@@ -1223,12 +1238,7 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
+                  'type': 'link',
                 }),
                 dict({
                   'children': list([
@@ -1244,16 +1254,6 @@
                     }),
                   ]),
                   'type': 'repeat',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
                 }),
               ]),
               'type': 'column',
@@ -1276,7 +1276,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'heading',
+              'type': 'table',
             }),
             dict({
               'children': list([
@@ -1291,7 +1291,7 @@
             dict({
               'children': list([
               ]),
-              'type': 'table',
+              'type': 'heading',
             }),
             dict({
               'children': list([

--- a/backend/tests/baserow/core/templates/__snapshots__/work-management-platform.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/work-management-platform.ambr
@@ -17,11 +17,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                     dict({
@@ -39,6 +34,11 @@
                 }),
               ]),
               'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -121,56 +121,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -234,6 +184,56 @@
               ]),
               'type': 'form_container',
             }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'repeat',
+            }),
           ]),
           'type': 'column',
         }),
@@ -273,11 +273,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -285,6 +280,11 @@
                 }),
               ]),
               'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -308,11 +308,6 @@
             }),
             dict({
               'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -320,6 +315,11 @@
                 }),
               ]),
               'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'heading',
             }),
             dict({
               'children': list([
@@ -417,8 +417,93 @@
             }),
             dict({
               'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
               ]),
               'type': 'text',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'link',
+                }),
+              ]),
+              'type': 'repeat',
             }),
             dict({
               'children': list([
@@ -444,91 +529,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
             }),
           ]),
           'type': 'column',
@@ -564,21 +564,6 @@
             }),
             dict({
               'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_file',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
               ]),
               'type': 'table',
             }),
@@ -591,6 +576,21 @@
               'children': list([
               ]),
               'type': 'table',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_file',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',
@@ -613,121 +613,6 @@
               'children': list([
               ]),
               'type': 'link',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'input_text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
             }),
             dict({
               'children': list([
@@ -771,6 +656,26 @@
                   ]),
                   'type': 'simple_container',
                 }),
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
               ]),
               'type': 'simple_container',
             }),
@@ -798,6 +703,101 @@
                 }),
               ]),
               'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'text',
+                    }),
+                  ]),
+                  'type': 'simple_container',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'input_text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'text',
+                }),
+              ]),
+              'type': 'form_container',
             }),
           ]),
           'type': 'column',
@@ -872,6 +872,56 @@
               'children': list([
                 dict({
                   'children': list([
+                  ]),
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                  ]),
+                  'type': 'repeat',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                  ]),
+                  'type': 'repeat',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'type': 'link',
+                    }),
+                  ]),
+                  'type': 'repeat',
+                }),
+              ]),
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
                     dict({
                       'children': list([
                         dict({
@@ -942,56 +992,6 @@
                 }),
               ]),
               'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                  ]),
-                  'type': 'repeat',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                  ]),
-                  'type': 'repeat',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                  ]),
-                  'type': 'repeat',
-                }),
-              ]),
-              'type': 'simple_container',
             }),
             dict({
               'children': list([
@@ -1358,6 +1358,61 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -1436,61 +1491,6 @@
               ]),
               'type': 'simple_container',
             }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
           ]),
           'type': 'column',
         }),
@@ -1560,6 +1560,16 @@
             }),
             dict({
               'children': list([
+              ]),
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'type': 'table',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
@@ -1572,16 +1582,6 @@
                 }),
               ]),
               'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'table',
             }),
           ]),
           'type': 'column',
@@ -1804,12 +1804,12 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'image',
+                  'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
+                  'type': 'image',
                 }),
               ]),
               'type': 'column',


### PR DESCRIPTION
#### Problem

`serialize_for_regression_testing` sorted all children of a parent element by `(order, id)` globally, which made snapshots sensitive to insertion history rather than visual structure.

Consider a two-column layout where a user adds elements in this order:

1. text_A → column 0
2. text_B → column 1
3. text_C → column 0
  
The old snapshot would record `[text_A, text_B, text_C`: the raw DB insertion order, interleaving columns. A different template author who added `text_A, text_C` to column 0 first, then `text_B` to column 1, would produce `[text_A, text_C, text_B]` for the identical visual result — a different snapshot for the same page.

#### Fix

Children are now grouped by slot (`place_in_container`), slots are ordered by the earliest-created element in each slot, and within each slot elements are sorted by creation order. The above example always produces `[text_A, text_C, text_B]` — all column-0 elements first, then column-1 — regardless of when `text_B` was inserted.

This is a better invariant for regression testing: it reflects the visual hierarchy the user sees, not an artifact of edit history.

#### Impact
  
156 template snapshots regenerated; 50 updated with the new stable ordering.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
