### PR TITLE
docs: systems overview, architectural patterns, and core technical guides

### DIFF
--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1,73 +1,221 @@
-# Debugging Tools
+# Debugging
 
-Baserow development dependencies include some useful tools for debugging that you can use.
+A practical reference for the day-to-day "something's wrong, where do I
+look" question. Three sections: **tools available**, **Baserow-specific
+debugging recipes**, and **gotchas**.
 
-## snoop
+## Tools available
 
-[snoop](https://github.com/alexmojaki/snoop) is a powerful set of Python debugging tools.
+### snoop — automatic Python tracing
 
-### Automatic tracing
-
-One of the common things to do is to use the `@snoop` decorator or the `snoop` context manager to trace the execution of a piece of Python code and show how variable values change over time:
+[snoop](https://github.com/alexmojaki/snoop) traces a piece of code and
+shows how variables change over time. Available globally — no import
+needed.
 
 ```python
 @snoop
-def test():
+def my_function():
     for i in range(5):
-        a = i*2
+        a = i * 2
 
-# or
-
+# Or as a context manager
 with snoop:
-    for i in range(5):
-        a = i*2
+    for row in rows:
+        do_something(row)
 ```
 
-The depth can be controlled with `depth` parameter, e.g. `@snoop(depth=2)` for tracing functions that go deep.
+Useful kwargs:
 
-Objects and dictionaries can be expanded automatically to show all their items or attributes using the `watch_explode` parameter taking a list of watched variable names:
+- `@snoop(depth=2)` — also traces functions called from the traced
+  function (default depth is 1).
+- `@snoop(watch_explode=['my_dict'])` — expands dicts/objects to show
+  every key/attribute.
+
+Pretty-print a variable manually with `pp(x)`. Most useful when you
+already know roughly where the bug is and want a frame-by-frame view of a
+short stretch of code.
+
+### `django-extensions` — Django power tools
+
+Available inside the backend container:
+
+- `django-admin shell_plus` — interactive shell with Baserow models
+  auto-imported. Faster than typing `from baserow... import` for ten
+  minutes.
+- `django-admin show_urls` — lists every registered URL. Use it when
+  you can't find the view that handles a particular endpoint.
+- `django-admin runserver_plus` — runserver with Werkzeug debugger
+  attached.
+- `django-admin graph_models` — generates a Graphviz ER diagram of the
+  models in an app. Worth running once when learning a new area.
+
+### `django-silk` — request and query profiler
+
+Once Baserow is up in debug mode, browse to
+http://localhost:8000/silk/. Every request is logged with its full query
+list and timings. Indispensable for spotting N+1s in real flows —
+particularly the dashboard views that fan out across the model graph.
+
+### Flower — Celery monitor
+
+http://localhost:5555/. Real-time view of Celery workers and tasks.
+Use it when you suspect a job is failing silently, getting retried too
+much, or stuck.
+
+### `ipdb` / breakpoints
+
+`breakpoint()` works as expected. In a container, attach with
+`docker attach <container>` first, then `breakpoint()` drops you into
+`ipdb`.
+
+### OTEL traces in dev
+
+If OTEL is configured in dev (see
+[Monitoring Baserow](../installation/monitoring.md)), span data flows to
+your local backend and is queryable. Most local devs skip this — the same
+data is available locally via `django-silk`, and the loguru logs are
+easier to grep.
+
+## Baserow-specific debugging recipes
+
+### "Why is this field acting weird?"
+
+Most field-behaviour mysteries trace to one of three things: the
+`FieldType`, the dynamic model cache, or the field-dependency graph.
 
 ```python
-@snoop(watch_explode=['d'])
-def test():
-    d = {'key1': 0, 'key2': 1}
-    for i in range(5):
-        d["key1"] += 1
+# In shell_plus
+table = Table.objects.get(pk=...)
+model = table.get_model()
+
+# Inspect every field on the model
+model.info()  # rich-printed table; dev-only
+
+# Find the field type
+field = Field.objects.get(pk=...).specific
+field_type = field_type_registry.get_by_model(field)
+print(type(field), type(field_type))
+
+# Force a cache miss and rebuild
+from baserow.contrib.database.table.cache import invalidate_table_in_model_cache
+invalidate_table_in_model_cache(table.id)
+model = table.get_model()
 ```
 
-### Pretty printing
+If the field's value looks right in the DB but wrong via the model, the
+generated model is likely stale. Verify with `Table.version` — every
+field change should bump it.
 
-Besides automatic tracing, variables can be pretty printed manually with `pp` function:
+### "Why didn't I get a realtime update?"
 
-```python
-d = {'key1': 0, 'key2': 1}
-pp(d)
-```
+Walk the chain:
 
-Note that `import snoop` or `from snoop import pp` is not necessary as snoop is installed and available automatically.
+1. Did the **handler emit the signal**? Add `breakpoint()` after the
+   handler mutates state, check `dir(baserow.contrib.database.rows.signals)`
+   for the expected signal, and confirm it's being sent.
+2. Did a **ws receiver fire**? `baserow.ws.*` has receivers; add a log
+   statement at the entry point or set `BASEROW_BACKEND_LOG_LEVEL=DEBUG`.
+3. Did the **message reach the right page**? Each ws page has a
+   `page_registry` entry that decides who subscribes. Mismatched page
+   ids = no broadcast.
+4. Did the **frontend handler run**? In the browser, the Vuex store
+   action that processes the ws message logs in dev. Confirm the
+   message type matches a registered realtime handler.
 
-## django-extensions
+See [websockets guide](../technical/websockets.md) for the full path.
 
-[django-extensions](https://github.com/django-extensions/django-extensions) is available to provide a variety of features like a shell with auto-imported Django models or a command to list all registered urls.
+### "Why is this query slow?"
 
-You can use django-extensions commands inside backend docker containers:
+1. Hit the endpoint with `django-silk` on. Read the query list.
+2. If query count grows with the page size → N+1. Find where the loop
+   touches an FK or reverse-FK. Fix per [queries](../patterns/queries.md).
+3. If query count is small but one query is slow → either a missing
+   index (check `EXPLAIN ANALYZE` via raw SQL) or a poorly-bounded
+   queryset (look for `.filter(...)` without an index-backed column).
+4. If it's a search query → check the TSV column has been built;
+   `SearchHandler` may be lagging.
 
-* `django-admin shell_plus` starts an interactive Python shell with loaded Django contexts and imported models.
-* `django-admin show_urls` lists all registered urls in the Baserow. 
+### "Why did my migration fail in CI but pass locally?"
 
-## django-silk
+- Local DB is smaller; you may have skipped batching that prod-scale needs.
+- Your local DB might be missing a constraint that prod has (e.g. a
+  unique index added in a later migration).
+- You forgot `atomic = False` on a `CREATE INDEX CONCURRENTLY` migration.
+- You imported a model directly instead of using `apps.get_model()`.
 
-[django-silk](https://github.com/jazzband/django-silk) is a live profiling and inspection tool for executed requests and database queries.
+See migration conventions in [creating features](../patterns/creating-features.md).
 
-The interface can be accessed at http://localhost:8000/silk/ after Baserow is started in the debug mode. Every request is logged and can be analyzed, including the list of performed database queries.
+### "Why is undo not undoing this thing?"
 
-django-silk can be also configured and used for profiling using the Python's built-in profiler, see the official documentation for details.
+Check whether the operation goes through an `ActionType`. If it doesn't —
+i.e. the handler is called directly without an action wrapper — there's
+nothing to undo. Add the action or use a different code path. See
+[action system](../technical/action-system.md).
 
-## flower
+If the operation *is* an action but undo doesn't work:
 
-[Flower](https://flower.readthedocs.io/en/latest/) is an open source web application for
-monitoring and managing Celery clusters. It provides real-time information about the
-status of Celery workers and tasks.
+1. Check the action ran with the right `scope()`. Undo is scope-filtered.
+2. Check `Params` round-trips through JSON cleanly. A non-JSON-safe value
+   in `Params` will cause silent breakage on undo.
+3. Check there are no exceptions during undo — they're logged but the
+   action row is still marked undone-with-error.
 
-The interface can be accessed at http://localhost:5555/ after the Baserow development
-environment has started.
+### "Why is the test passing but production failing?"
+
+The most common culprit in Baserow tests:
+
+- **Cache differences.** Tests use an in-memory cache; prod uses Redis.
+  An invalidation race that always wins in memory may lose in prod.
+- **Transaction isolation.** Tests typically run each test in a
+  transaction that's rolled back. `on_commit` callbacks never fire by
+  default. Wrap with `TestCase.captureOnCommitCallbacks(execute=True)` if
+  you need them.
+- **Search index not built.** Tests skip the async search reindex unless
+  you flush Celery synchronously.
+- **Different ordering.** Production traffic interleaves; tests run
+  sequentially. Race conditions hide in tests.
+
+### "I want to see every SQL query"
+
+Set `BASEROW_BACKEND_DATABASE_LOG_LEVEL=DEBUG` (default is `ERROR` so DB
+logs stay quiet). Each query appears in the loguru log with its timing.
+Useful for short snippets; for full request analysis use `django-silk`.
+
+### "I want to see what an OTEL trace would look like"
+
+Add `add_baserow_trace_attrs(name="value", ...)` in the code path of
+interest, then load the page locally and check the OTEL exporter output
+(or run the Honeycomb URL if you have access). See
+[observability](../patterns/observability.md).
+
+## Gotchas
+
+- **`Table.get_model()` returns a fresh class each time.** Don't `is`-compare
+  generated model classes. See [dynamic models](../technical/dynamic-models.md).
+- **Lenient field-type conversion silently nulls unconvertible values.**
+  If data disappeared after a field type change with no error, this is why.
+  See [field system](../patterns/field-system.md).
+- **`on_commit` doesn't fire inside `TestCase`** unless you opt in.
+- **Signals can fail silently.** A raise in one receiver doesn't stop
+  the others, but it also doesn't surface to the caller. Always log
+  exceptions in receivers.
+- **Soft-deleted (trashed) rows are filtered by the default manager.**
+  Use `Model.trash` (manager) to see them. They're not gone; they're
+  hidden.
+- **The local cache is per-request.** Anything you cache via `local_cache`
+  is lost the moment the request ends. Don't use it for cross-request
+  state; it'll look like the cache "doesn't work".
+- **Cachalot must be opt-in for user tables.** A query that "should be
+  cached" but isn't is probably outside the `cachalot_enabled()` context.
+  See [caching](../technical/caching.md).
+- **Action signals fire on undo/redo too.** If you have a receiver that
+  reacts to `action_done`, it fires three times during a do/undo/redo
+  sequence. Filter by `action_command_type`.
+
+## Related
+
+- [Observability](../patterns/observability.md) — logging and OTEL.
+- [Queries](../patterns/queries.md) — N+1 and ORM tips.
+- [Architectural patterns](../patterns/architecture.md) — where to suspect
+  the bug is.
+- [Running tests](running-tests.md), [running the dev env locally](running-the-dev-env-locally.md).

--- a/docs/development/directory-structure.md
+++ b/docs/development/directory-structure.md
@@ -1,13 +1,65 @@
 # Directory structure
 
-One of the things you will notice it that all the files and directories are in the
-same repository. This makes it easier to setup a demo and development environment and
-all the changes can be put in a single merge request.
+Everything ships from a single repository. This makes it easier to set up a demo or
+development environment and to land cross-cutting changes in one pull request.
 
-In the root you will find three folders `backend`, `docs` and `web-frontend`. You will
-also notice some files that are related to the whole project like an editor config
-file, continuous integration config, changelog, docker-compose yaml files and a readme.
-In the following topics we will zoom in on the directories.
+## Top-level layout
+
+| Folder | What lives here |
+|---|---|
+| `backend` | Python/Django backend for core + contrib. |
+| `web-frontend` | Nuxt/Vue frontend for core + contrib. |
+| `premium` | Plugin containing premium-licensed features (backend + web-frontend). |
+| `enterprise` | Plugin containing enterprise-licensed features (backend + web-frontend). |
+| `integrations` | External integrations (currently Zapier; automation integrations will land here). |
+| `e2e-tests` | Playwright end-to-end tests. The only place where we use TypeScript today. |
+| `deploy` | One sub-folder per deployment target (all-in-one image, Heroku, Cloudron, …). |
+| `docs` | Developer documentation that gets published to baserow.io/docs. |
+| `changelog` | Source for the changelog generator used when opening a pull request. |
+| `config` | Per-IDE starter configurations. |
+| `formula` | Formula language grammar/parser source. |
+| `embeddings` | Embeddings/AI server source. |
+| `tests` | Repository-wide test helpers. |
+
+Top-level files include the editor config, CI config, the root `justfile`,
+`docker-compose.*.yml` files, `CHANGELOG.md`, `README.md`, and `LICENSE`.
+
+## core and contrib
+
+Inside `backend/src/baserow/` (and analogously in `web-frontend/modules/`) the code
+is split into two layers:
+
+- **core** — the framework: users, workspaces, applications, undo/redo,
+  notifications, trash, search, permissions, jobs, telemetry, and every base
+  class/registry that other code extends.
+- **contrib** — concrete Baserow application types built on top of core. Today
+  contrib contains `database`, `builder`, `automation`, `dashboard`, and
+  `integrations`. The Automation Builder application will also live here.
+
+Import rule: **contrib can import from core, core must never import from contrib.**
+Core code should know nothing about specific application types. The same rule
+applies between core/contrib and `premium`/`enterprise`: the plugins import from
+core and contrib, never the other way around.
+
+Note that Baserow application types are not Django apps. A single Django app can
+host multiple Baserow application types, and one Baserow application type may span
+multiple Django apps.
+
+## api vs business logic
+
+Inside both core and contrib we separate the HTTP-facing layer from the business
+logic:
+
+- `api/` — DRF urls, views, serializers and exception mappings.
+- everything else — handlers, services, actions, registries, models.
+
+The api layer can (and should) import from the business logic. The business logic
+must not import from the api layer. The reason is straightforward: handlers must be
+callable from the shell, management commands, Celery tasks and tests without going
+through HTTP.
+
+For the layered shape of a typical request, see
+[Architectural patterns](../patterns/architecture.md).
 
 ## backend
 
@@ -42,13 +94,13 @@ The src directory contains the full source code of the Baserow backend module.
    specific environments. It also contains the root url config that includes the api
    under the namespace `api`. There is
    also a wsgi.py file which can be used to expose the applications.
-* `contrib`: contains extra apps that can be installed. For now it only contains the
-  backend part of the database plugin. This app is installed by default, but it is
-  optional.
-* `core`: is a required app that is installed by default. It contains some abstract
-  concepts that are reused throughout the backend. It also contains the code for the
-  workspace and application concepts that are at the core of Baserow. Of course there are
-  also helper classes, functions, and decorators that can be reused.
+* `contrib`: contains the Baserow application types built on top of `core`. Today
+  it holds `database`, `builder`, `automation`, `dashboard` and `integrations`.
+  Each application type has its own handlers, registries, models, api and
+  migrations.
+* `core`: the framework. Contains users, workspaces, applications, undo/redo,
+  notifications, trash, search, permissions, jobs, telemetry and every base class
+  and registry that contrib code extends. `core` must not import from `contrib`.
 * `manage.py`: the Django manage.py file to execute management commands.
 
 ### tests

--- a/docs/development/engineering-workflow.md
+++ b/docs/development/engineering-workflow.md
@@ -1,0 +1,121 @@
+# Engineering workflow
+
+How we work day to day: issues → branches → pull requests → review → merge. This
+is the rule of thumb; specific exceptions (security fixes, enterprise release
+windows, hotfixes) have their own runbooks.
+
+## Issues
+
+We use [GitHub Issues](https://github.com/baserow/baserow/issues). New issues are
+opened through one of two templates from the
+[New issue page](https://github.com/baserow/baserow/issues/new/choose):
+
+- **🪲 Bug Report** (`.github/ISSUE_TEMPLATE/bug.yml`) — auto-applies the
+  `bug 🪲` and `needs feedback ⚠️` labels.
+- **💡 Feature Request** (`.github/ISSUE_TEMPLATE/feature_request.yml`) —
+  auto-applies the `feature request 💡` and `needs feedback ⚠️` labels.
+
+Blank issues are disabled by default; vague ideas go to the
+[community forum](https://community.baserow.io/) first.
+
+There is no "maintenance" template — refactors, dependency upgrades and pure tech
+debt are typically tracked directly in pull requests rather than as separate
+issues.
+
+### Labels worth knowing
+
+**Domain labels** identify which team's expertise is needed. Exactly one is
+usually applied:
+
+- `database 🗄️` — database module.
+- `application 📱` — application builder.
+- `automation 🤖` — automations.
+- `dashboard 📈` — dashboards.
+- `core 🔩` — only core code; no contrib expertise required.
+- `devops 👨‍🔧` — infra, CI, deployment, install methods.
+- `integration 🔗` — Zapier and other external integrations.
+
+**Type labels** are mostly auto-applied by the issue templates:
+
+- `bug 🪲` — bugs.
+- `feature request 💡` — feature requests.
+- `AI` — AI-related code.
+
+**Triage / lifecycle labels:**
+
+- `needs feedback ⚠️` — applied automatically; means a maintainer hasn't
+  reviewed it yet.
+- `up-next` — triaged and prioritized; safe to pick from when starting new work.
+- `good first issue` — simple starting issues. Note: the label is sparsely
+  maintained, so prefer `up-next` + domain + recency when looking for work.
+- `needs ux design 🎨` — blocked on UI/UX design.
+- `external contribution` — opened by a community contributor.
+- `gitlab issue` — migrated from the old GitLab tracker; ignore for new triage.
+
+**Priority labels:** `p0` (high) → `p3` (lowest).
+
+**Size label:** `size:xl` — represents over 10 days of work; issues with this
+label must be split into smaller tasks.
+
+**Bot-managed labels** (auto-applied by dependabot etc.): `dependencies`,
+`python`, `python:uv`, `javascript`.
+
+## Branches
+
+Branch off `develop` unless instructed otherwise. Suggested patterns, matching
+existing branch names in the repo:
+
+- `fix/<issue-number>-short-description` — bug fixes.
+- `feature/<short-description>` or `feat/<short-description>` — features.
+- `chore/<short-description>` — maintenance / chore.
+- `docs/<short-description>` — documentation.
+
+## Pull request workflow
+
+1. **Open the PR in draft.** This signals "work in progress; CI is welcome to run
+   but don't review yet". Use the
+   [PR template](https://github.com/baserow/baserow/blob/master/.github/PULL_REQUEST_TEMPLATE.md).
+2. **Mark ready for review** when it's genuinely ready. Either request a reviewer
+   directly or drop a message in the review channel asking for one.
+3. **Reviewers always start a formal review** rather than leaving loose comments.
+   A formal review communicates intent (approve / request changes) and groups
+   feedback.
+4. **Working through feedback?** Put the PR back into draft state while you do
+   the work, then re-mark as ready when you've addressed the comments and
+   re-request a review.
+5. **Merge** once approvals are in and CI is green.
+
+## What the PR template asks for
+
+The repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) is the canonical
+list. The items worth remembering:
+
+- A short summary of what the PR does.
+- A short test plan a reviewer can follow.
+- A changelog entry added under `changelog/entries/unreleased` using
+  `changelog/src/changelog.py`.
+- Premium / enterprise code separated into the right folder (`premium/` or
+  `enterprise/` — never in `core` or `contrib`).
+- Tested in latest Chrome and Firefox for frontend changes.
+- Documentation updated when behaviour or surface area changes.
+- API docs (redoc + the custom token-API docs page in
+  `web-frontend/modules/database/pages/APIDocsDatabase.vue`) updated for REST
+  API changes.
+- Performance check for tables at 100k+ rows / 100+ fields when relevant.
+- Security impact considered.
+
+## Useful GitHub queries
+
+- [Pull requests sorted by latest activity](https://github.com/baserow/baserow/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc)
+- [Pull requests waiting on my review](https://github.com/baserow/baserow/pulls/review-requested/%40me)
+- [Pull requests I authored](https://github.com/baserow/baserow/pulls/%40me)
+- [Issues in `database 🗄️` labeled `up-next`](https://github.com/baserow/baserow/issues?q=is%3Aopen+is%3Aissue+label%3A%22database+%F0%9F%97%84%EF%B8%8F%22+label%3Aup-next)
+
+## Related
+
+- [Code quality](code-quality.md) — formatting, linting and quality bar.
+- [Running tests](running-tests.md) — how to run the backend test suite.
+- [E2E testing](e2e-testing.md) — when and how to add Playwright tests.
+- [CI/CD](ci-cd.md) — what runs on every PR.
+- [CONTRIBUTING.md](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md)
+  — repo-wide contribution standards.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,22 +75,70 @@ Baserow provides various APIs detailed below:
 
 ## Technical Overviews
 
+**Start here when ramping up:**
+
 * [Introduction](technical/introduction.md): An introduction to some important technical
   concepts in Baserow.
-* [Database plugin](technical/database-plugin.md) An introduction to the database plugin
-  which is installed by default.
+* [Systems overview](technical/systems-overview.md): A high-level map of the major
+  subsystems in Baserow.
+* [Architectural patterns](patterns/architecture.md): The view → service → action →
+  handler → ORM shape that almost every feature follows, plus the realtime path.
+* [Registries](patterns/registries.md): The extension pattern used by nearly every
+  subsystem.
+* [Features and interactions](technical/features-and-interactions.md): Catalogue of
+  features and the interaction map of where they couple non-trivially.
+
+**Database plugin:**
+
+* [Database plugin](technical/database-plugin.md): Architecture entry point for the
+  database contrib application.
+* [Dynamic models](technical/dynamic-models.md): How `Table.get_model()` builds Django
+  models at runtime, and where the caches are.
+* [Field system](patterns/field-system.md): The `FieldHandler` / `FieldType` /
+  `field_type_registry` architecture.
 * [Formula Technical Guide](technical/formula-technical-guide.md): A more technical
   guide about formulas aimed at developers who want to understand and work with
   internals of Baserow formulas.
+
+**Core systems:**
+
+* [Action system](technical/action-system.md): `ActionType` / `Action` / `ActionHandler`
+  and how operations get audited and made undoable.
 * [Undo Redo Technical Guide](technical/undo-redo-guide.md): How Baserow implements undo
   redo technically.
 * [Permissions handling Guide](technical/permissions-guide.md): How Baserow implements
   permission checking technically.
+* [Trash system](technical/trash-system.md): Soft-delete, retention, restore.
+* [Notification system](technical/notification-system.md): In-product notifications and
+  email delivery.
+* [Serialization system](technical/serialization-system.md): Export / import / snapshots
+  / templates / duplication.
+* [Caching](technical/caching.md): The map of all caches and what invalidates them.
+* [WebSockets guide](technical/websockets.md): How Baserow pushes realtime updates to
+  the frontend.
+* [Workspace search](technical/workspace-search.md): How table search is implemented.
+* [PostgreSQL locks](technical/postgresql-locks.md): Lock conventions used in the
+  backend.
+
+**Patterns for everyday development:**
+
+* [Creating a feature](patterns/creating-features.md): How to add a view, action,
+  handler, model — plus zero-downtime migration conventions.
+* [Query patterns](patterns/queries.md): `select_related`, `prefetch_related`,
+  `specific_iterator`, bulk writes, N+1 avoidance.
+* [Observability](patterns/observability.md): Logging, OTEL tracing, and how
+  to verify assumptions in production.
+* [Jobs pattern](patterns/jobs.md), [forms pattern](patterns/forms.md),
+  [emails pattern](patterns/emails.md), [date and time](patterns/date-and-time.md),
+  [row history from action](patterns/row_history_from_action.md),
+  [loading animations](patterns/loading-animations.md).
 
 ## Development
 
 Everything related to contributing and developing for Baserow.
 
+* [Engineering workflow](./development/engineering-workflow.md): How we move from
+  issue to merged pull request — labels, templates, draft PRs, review flow.
 * [Development environment](./development/development-environment.md): More detailed
   information on baserow's local development environment.
 * [Running the Dev Environment](development/running-the-dev-environment.md): A

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,6 +85,8 @@ Baserow provides various APIs detailed below:
   handler → ORM shape that almost every feature follows, plus the realtime path.
 * [Registries](patterns/registries.md): The extension pattern used by nearly every
   subsystem.
+* [Baserow vs Django](patterns/baserow-vs-django.md): How Baserow overloads Django
+  terminology (field, table, model, application) and what each word means.
 * [Features and interactions](technical/features-and-interactions.md): Catalogue of
   features and the interaction map of where they couple non-trivially.
 
@@ -114,6 +116,8 @@ Baserow provides various APIs detailed below:
 * [Serialization system](technical/serialization-system.md): Export / import / snapshots
   / templates / duplication.
 * [Caching](technical/caching.md): The map of all caches and what invalidates them.
+* [Editions and licensing](technical/editions-and-licensing.md): Core / contrib /
+  premium / enterprise boundaries, the `LicenseHandler` API, SaaS context.
 * [WebSockets guide](technical/websockets.md): How Baserow pushes realtime updates to
   the frontend.
 * [Workspace search](technical/workspace-search.md): How table search is implemented.

--- a/docs/patterns/architecture.md
+++ b/docs/patterns/architecture.md
@@ -1,0 +1,201 @@
+# Architectural patterns
+
+This page describes the layered shape that the backend and frontend both follow.
+Almost every feature in Baserow is built out of these same pieces — once you can
+trace a request through them end to end, you can read most of the codebase.
+
+For the inventory of which subsystems exist, see
+[Systems overview](../technical/systems-overview.md). For how those subsystems make
+themselves pluggable, see [Registries](registries.md).
+
+## Backend layers
+
+```
+                 ┌──────────┐
+HTTP request ──▶ │  View    │  api / urls / serializers — deserialise, validate,
+                 └────┬─────┘  call the right service or action, return response.
+                      │
+                 ┌────▼─────┐
+                 │ Service  │  Optional. Permission checks, efficient fetch, glue
+                 └────┬─────┘  between view and (action OR handler).
+                      │
+                 ┌────▼─────┐
+                 │  Action  │  Optional. Records an Action row for audit + undo/redo.
+                 └────┬─────┘  Wraps a handler call; not every operation is an action.
+                      │
+                 ┌────▼─────┐
+                 │ Handler  │  Business logic across multiple models. Emits signals.
+                 └────┬─────┘
+                      │
+                 ┌────▼─────┐
+                 │   ORM    │  Django models.
+                 └────┬─────┘
+                      │
+                 ┌────▼─────┐
+                 │    DB    │  PostgreSQL.
+                 └──────────┘
+
+                 Handler ──signals──▶ Receivers ──websocket──▶ frontend
+                 Handler ──long-task──▶ Celery worker
+```
+
+### View
+
+Lives under `backend/src/baserow/.../api/`. Responsibilities:
+
+- Deserialise the request with a DRF serializer.
+- Map domain exceptions to HTTP responses (`map_exceptions`).
+- Delegate to a service or, if there is no service, directly to an action or handler.
+- Serialise the result for the response.
+
+Views must not contain business logic. The rule of thumb: a view should read like a
+sentence. If you can't summarise it in one, push the work down.
+
+### Service
+
+A relatively newer layer; the rollout is incremental, so coverage is uneven. New
+code should default to a service; direct view→handler is fine for trivial reads
+but is considered legacy for anything more involved.
+
+Create a service when the operation needs any of:
+
+- **Permission checks** via `CoreHandler.check_permissions()`.
+- **Optimised fetching** — loading just enough data for this operation rather than
+  pulling in everything a generic handler method would.
+- **Composing multiple handler calls** when the view-level operation crosses
+  domains.
+
+Services live next to handlers in the domain folder, typically as `service.py`.
+Examples to copy from: `baserow.core.service`,
+`baserow.core.notifications.service`, `baserow.contrib.database.table.service`,
+`baserow.contrib.database.views.service`,
+`baserow.contrib.automation.nodes.service`. (Note that
+`baserow.core.services` is a separate concept — it's the dispatch system for
+the builder application's data sources, not the architectural service layer
+discussed here.)
+
+Rule of thumb: if you're tempted to put permission-checking logic directly in a
+view, you want a service instead.
+
+### Action
+
+An `ActionType` describes a state change worth recording. It writes a row to the
+`Action` table (audit log) and, if undoable, exposes `undo()` / `redo()` methods.
+Not every operation is an action — GET requests, idempotent queries, and pure read
+flows skip straight to a handler.
+
+The terminology to keep straight:
+
+- **`ActionType`** — the *kind* of action, registered in `action_type_registry`. It
+  defines `do()`, `undo()`, `redo()` and the params it accepts.
+- **`Action`** — a Django model row recording that one specific occurrence of an
+  `ActionType` happened, with its params, scope, user, and timestamp. This is what
+  populates the audit log.
+- **`ActionHandler`** — the orchestrator. It's what views/services call. It looks up
+  the `ActionType`, runs `do()` inside a transaction, writes the `Action` row,
+  emits the `action_done` signal, and handles undo/redo lookup.
+
+A typical `ActionType.do()` does three things: validate inputs, call into a handler
+to do the work, and return a structure rich enough to undo. See
+`baserow/contrib/database/rows/actions.py` for representative examples and
+[Undo/redo guide](../technical/undo-redo-guide.md) for the model.
+
+### Handler
+
+A handler is a class encapsulating business logic that spans multiple models — the
+seam between the ORM and the action/service layer. Examples: `TableHandler`,
+`FieldHandler`, `RowHandler`, `ViewHandler`, `CoreHandler`. Handlers are where the
+real work happens: cross-model queries, transactional writes, emitting signals,
+scheduling Celery tasks.
+
+A handler method should be callable from a shell, a management command, or a test
+without going through HTTP. If you can't, the layering is wrong.
+
+### Signals
+
+After a handler mutates state it emits Django signals (e.g. `rows_created`,
+`field_updated`, `table_created`). Receivers in `baserow.ws.*`, `baserow.core.search`,
+`baserow.core.notifications`, and the formula/field-dependency code react to those
+signals. Signals are how a single write fans out to "send websocket update",
+"reindex search", "recompute dependent formulas", "send notification", without each
+handler having to know about all of those concerns.
+
+Concrete example — what happens after `RowHandler.create_row()`:
+
+1. The row is inserted via the dynamic model's ORM.
+2. The handler emits `rows_created`.
+3. A receiver in `baserow.ws.*` translates that into a websocket message addressed to
+   subscribers of the table's page.
+4. The search code reindexes the affected TSV columns.
+5. The formula/field-dependency code recomputes any fields that depend on the new
+   row.
+6. The notification code may emit a "row mention" notification if a mention was added.
+
+### Celery
+
+Long-running work moves to Celery: large imports, exports, snapshots, duplications,
+search reindex backfills, periodic trash cleanup. The
+[Job system](../technical/systems-overview.md#job-system) is the user-facing wrapper
+around this: a `JobType` represents one kind of long operation with progress,
+cancellation and realtime updates. Internal periodic tasks (cron-style) are
+registered with the Celery beat scheduler.
+
+A handler that needs background work either schedules a Celery task directly (for
+internal housekeeping) or creates a Job (for user-visible long operations).
+
+## Frontend layers
+
+```
+            ┌────────────┐
+User UI ──▶ │ Components │  Presentation, Vue templates and behaviour.
+            └─────┬──────┘
+                  │ dispatch
+            ┌─────▼──────┐
+            │ Vuex Store │  Application state.
+            └─────┬──────┘
+                  │
+            ┌─────▼──────┐
+            │  Service   │  HTTP calls to the backend REST API (axios).
+            └─────┬──────┘
+                  │ XHR
+                  ▼
+                Backend
+
+            Backend ──websocket──▶ Realtime handlers ──▶ Store
+            Backend ──websocket──▶ Notification handlers ──▶ Notification store
+```
+
+### Components
+
+Vue components own presentation and local UI behaviour only. They dispatch actions
+to the store; they should not call services directly.
+
+### Vuex store
+
+Contains application state. Components subscribe to it; actions and mutations update
+it. The store is also the destination for realtime updates pushed from the backend.
+
+### Service
+
+The frontend "service" is just the typed wrapper around `axios` that hits the REST
+API. It returns plain data; it does not own state. Store actions call services.
+
+### Realtime handlers
+
+For each websocket message type the backend emits, the frontend has a handler that
+applies the change to the store. The pattern is symmetrical with the backend: the
+backend signals → ws receivers → message; the frontend receives the message →
+realtime handler → store update → reactive re-render.
+
+### Notification handlers
+
+Notification messages are a special kind of websocket message that also land in the
+notification store, drive the unread counter, and surface in the notification panel.
+
+## Reading a feature end to end
+
+Picking any feature and tracing it through these layers — view → service → action →
+handler → signal → ws receiver → frontend handler → store → component — is the
+single most useful exercise for ramping up. Pick a small one (`row update` is a
+good first walk-through; `field create` is the next step up; `field type
+conversion` is the level after that).

--- a/docs/patterns/baserow-vs-django.md
+++ b/docs/patterns/baserow-vs-django.md
@@ -1,0 +1,135 @@
+# Baserow vs Django — same words, different meanings
+
+A senior Django developer can read most of the Baserow codebase fluently from
+day one. The trap is the words we share. Baserow overloads several Django
+terms — **field**, **table**, **model**, **application**, **migration** — to
+mean Baserow-specific things that are *related to* but *not the same as*
+their Django counterparts.
+
+This page resolves the ambiguity. If you only read one pattern doc before
+diving in, read this one.
+
+## The big four overloads
+
+| Word | Django meaning | Baserow meaning |
+|---|---|---|
+| **Field** | A column on a Django model (`models.CharField`, etc.). | A user-defined column on a user-defined table. Backed by a row in the `Field` table (or one of its polymorphic subclasses like `TextField`, `LinkRowField`). Mapped to a Django field through `FieldType.get_model_field()` at model generation time. |
+| **Table** | A SQL table that corresponds to a Django model. | A user-defined logical table (`Table` row), backed by a real SQL table (`database_table_{id}`) and a dynamically generated Django model. |
+| **Model** | A Python class subclassing `django.db.models.Model`. | Same — but **the Django model for a user table doesn't exist in the source code**. It's generated at runtime by `Table.get_model()`. |
+| **Application** | A Django app (directory with `apps.py`, `models.py`, etc.). | A Baserow application *type* (e.g. a database, a builder app, an automation, a dashboard). A Baserow application is a row in `Application` (polymorphic), not a Django app. Baserow application types are not Django apps. |
+
+Once you have those mappings, most things make sense.
+
+## The full glossary
+
+**Django field** = Python descriptor on a Django model. Lives in code.
+
+**Baserow field** = column on a user table. Lives as data in the `Field`
+table (or a polymorphic subclass). Has a corresponding `FieldType`
+implementation that knows how to translate it into a Django field at model
+generation time. See [field system](field-system.md).
+
+**Django model** = Python class. Hand-written.
+
+**Baserow model** = generated Python class for a user table. Built at
+runtime from `Field` rows. See [dynamic models](../technical/dynamic-models.md).
+
+**Django table** = SQL table backing a Django model. Comes from a migration.
+
+**Baserow table** = (a) the `Table` row representing a user's logical table,
+*and* (b) the real PostgreSQL table named `database_table_{id}` that holds
+the user's row data. These are two different things; both are referred to
+as "the table" in conversation. Context disambiguates — when in doubt, ask.
+
+**Django migration** = a file that alters the schema declaratively. Tracked
+in `django_migrations`.
+
+**Baserow migration** = same, but you have an additional category: user-table
+schema changes happen at runtime via the schema editor when a user adds /
+removes / converts a field. They are *not* Django migrations and *not* tracked
+in `django_migrations`. They alter the `database_table_{id}` tables directly.
+
+**Django app** = a Python package with `apps.py` declaring a Django
+`AppConfig`. Has its own `models.py`, `migrations/`, etc.
+
+**Baserow application** = a row in the `Application` table representing a
+user-facing app (database, builder, automation, dashboard, integrations).
+*Each Baserow application is an instance of an application type, registered
+in `application_type_registry`.* Baserow application types are not Django
+apps. A single Django app (`baserow.contrib.database`) implements one
+Baserow application type (`database`). But the mapping isn't necessarily 1:1.
+
+**Django signal** = `django.dispatch.Signal`. Standard Django.
+
+**Baserow signal** = same — but the codebase is structured around emitting
+them from handlers and dispatching to receivers in `baserow.ws.*`, search,
+notifications, etc. See [architectural patterns](architecture.md).
+
+**Django registry** = the global `apps` registry, plus `ContentType`.
+
+**Baserow registry** = an extension-point pattern used pervasively. A
+collection of polymorphic implementations keyed by a string `type`. See
+[registries](registries.md).
+
+**View** in Django = a request handler. In Baserow = (a) a user-defined
+presentation of a table (grid view, kanban view) *and* (b) a DRF view
+class. Context disambiguates; the user-facing "view" is what people usually
+mean.
+
+**Permission** in Django = an entry in `auth_permission`. In Baserow =
+something granted via the permission system (`PermissionManagerType` in
+`permission_manager_type_registry`, RBAC in enterprise). Baserow's
+permission model is its own thing; `django.contrib.auth.Permission` is
+barely used.
+
+## Three things a Django developer expects but doesn't find
+
+1. **`class Customers(models.Model)` for a user table.** Doesn't exist.
+   `Table.get_model()` generates the class at runtime from the `Field` rows.
+   See [dynamic models](../technical/dynamic-models.md).
+
+2. **Migrations for user tables.** They live outside Django's migration
+   system. When a user adds a field, `FieldHandler.create_field()` calls
+   `schema_editor.add_field()` to alter the `database_table_{id}` table
+   directly. There's no migration file.
+
+3. **`ContentType` for user tables.** A user-table model doesn't have a
+   `ContentType` entry. The Baserow `Field` model and `Application` model
+   *do* use Django's `ContentType` framework for their own polymorphism, but
+   user tables don't. The polymorphism is implemented separately via
+   `GeneratedTableModel`.
+
+## Three things a Django developer doesn't expect but finds
+
+1. **Polymorphic models with `.specific`.** `Application`, `Field`, `View`,
+   and a few others use Django's content-type framework to store multiple
+   subclasses behind one parent table. `app.specific` returns the concrete
+   subclass instance. See [queries](queries.md) for the `specific_iterator`
+   pattern.
+
+2. **A "handler" layer between view and ORM.** Django convention puts
+   business logic on managers or model methods. Baserow puts it in
+   handlers (`TableHandler`, `FieldHandler`, `RowHandler`, `CoreHandler`,
+   …). The view delegates to a service or directly to the handler. See
+   [architectural patterns](architecture.md).
+
+3. **An action layer between service and handler.** State changes that
+   should be auditable or undoable run through an `ActionType` instead of
+   straight to a handler. See [action system](../technical/action-system.md).
+
+## The mental model in one sentence
+
+> A user table in Baserow is data that *describes* a Django model — at
+> request time, that data is turned into a real Django model via
+> `Table.get_model()`, and from there it behaves like any other ORM model
+> for the duration of the request.
+
+Hold that, and the rest of the architecture stops feeling weird.
+
+## Related
+
+- [Systems overview](../technical/systems-overview.md).
+- [Architectural patterns](architecture.md).
+- [Registries](registries.md).
+- [Field system](field-system.md).
+- [Dynamic models](../technical/dynamic-models.md).

--- a/docs/patterns/creating-features.md
+++ b/docs/patterns/creating-features.md
@@ -1,0 +1,268 @@
+# Creating a feature
+
+The practical how-to. When you sit down to add a new endpoint, action,
+handler, or model in Baserow, this is the order to do things in and the
+files you'll touch.
+
+Read [Architectural patterns](architecture.md), [Registries](registries.md)
+and [Queries](queries.md) first if you haven't.
+
+## The shape of a typical feature
+
+Most user-visible features in Baserow split into these layers, in this order:
+
+1. **Model** — the persisted state.
+2. **Migration** — getting that state into the database safely.
+3. **Handler** — the business logic.
+4. **Action** — if it's a state change worth recording / undoing.
+5. **Service** — permissions, fetch optimisation, composition.
+6. **View** — DRF view, URL, serializer, error mapping.
+7. **Tests** — unit + API + occasionally e2e.
+8. **Changelog entry.**
+
+If your feature is read-only there is no action; if it's trivial there may be
+no service. Everything else is almost always present.
+
+## Adding a model
+
+Where it goes:
+
+- **Core concept** (workspace, user, application, notification): under
+  `backend/src/baserow/core/<area>/models.py`.
+- **Database application concept** (table, field, view, row metadata,
+  webhook): `backend/src/baserow/contrib/database/<area>/models.py`.
+- **Premium / enterprise** feature: under the matching plugin directory.
+
+Conventions:
+
+- Inherit from `CreatedAndUpdatedOnMixin` if you want `created_on` /
+  `updated_on` columns (most models do).
+- Inherit from `HierarchicalModelMixin` and implement `get_parent()` if your
+  model fits into the hierarchy (almost everything does — workspace →
+  application → table → field/view/row, etc.). This is what lets generic
+  permission checks walk the tree.
+- Add `Meta.ordering` if the natural sort isn't insertion order.
+- Add indexes for any query path that filters by columns other than primary
+  key in production traffic.
+
+If the model is **trashable**, inherit from `TrashableModelMixin` and register
+a `TrashableItemType` for it (see [trash system](../technical/trash-system.md)).
+
+## Writing a migration (zero-downtime)
+
+Baserow is deployed without downtime, so migrations need to coexist with old
+code reading and writing the same tables. Follow these patterns.
+
+### Nullable-then-backfill-then-NOT-NULL
+
+For a new non-nullable column on a non-trivial table, split into three
+migrations (or three operations in one migration):
+
+1. `AddField(name="x", null=True, default=None)`.
+2. `RunPython(populate_x, reverse_populate_x)` to backfill.
+3. `AlterField(name="x", null=False)`.
+
+Worked example: `baserow/contrib/database/migrations/0053_add_and_move_public_flags.py`
+uses temp fields (`public_temp`, `slug_temp`), backfills with
+`bulk_update(batch_size=...)`, then renames back.
+
+### Backfill in batches
+
+`RunPython` migrations must batch and commit periodically on large tables.
+Don't load millions of rows into memory.
+
+```python
+def populate_x(apps, schema_editor):
+    Model = apps.get_model("app", "Model")
+    for chunk in chunked_iterator(Model.objects.all(), chunk_size=1000):
+        Model.objects.bulk_update(
+            [update_one(obj) for obj in chunk], ["x"], batch_size=100
+        )
+```
+
+A real example with explicit batching and atomic-per-chunk semantics:
+`baserow/core/migrations/0081_usersource_uid.py` (single-pass, but the
+pattern is the same) and
+`baserow/contrib/database/migrations/0081_batch_webhooks.py` (multi-chunk).
+
+### `atomic = False` for index operations
+
+PostgreSQL's `CREATE INDEX CONCURRENTLY` doesn't run in a transaction. To use
+it, set `atomic = False` on the migration class and use `RunSQL` with
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS ...`.
+
+Worked example: `baserow/core/migrations/0113_alter_notification_options_and_more.py`.
+
+### Use `apps.get_model()` in `RunPython`
+
+Never `from app.models import Model` inside a migration function — at the
+point your migration runs, the schema may not match the current model code.
+Use `apps.get_model("app", "Model")`.
+
+### Reversibility
+
+Every `RunPython` and `RunSQL` should pass a `reverse_code` / `reverse_sql`,
+even if it's a no-op. Without one, the migration cannot be rolled back, which
+makes incident response much harder.
+
+### Check before commit
+
+- Did you add a NOT NULL with no default on a large table? (Wrong.)
+- Did you create an index without `CONCURRENTLY` on a large table? (Wrong.)
+- Did you put a `RunPython` that scans millions of rows in a single
+  transaction? (Wrong.)
+- Did you import models directly? (Wrong.)
+
+The full migration checklist is in
+[Migration conventions in the queries doc](queries.md). When in doubt, ask
+in review.
+
+## Writing a handler
+
+Where it goes:
+
+- Core handler: `baserow/core/handler.py` or domain-specific
+  `baserow/core/<area>/handler.py`.
+- Database handler: `baserow/contrib/database/<area>/handler.py`.
+
+A handler is a class with classmethods (or a singleton with instance methods —
+both styles exist). The single most important property: a handler method must
+be callable **without HTTP context**. From a shell, a management command, a
+Celery task, a test. If you find yourself reaching for request/response data
+inside a handler, you want a service.
+
+What a handler typically does:
+
+1. Validates inputs that can't be checked at the API layer (cross-model
+   invariants, business rules).
+2. Loads required state, often inside `transaction.atomic()`.
+3. Mutates state.
+4. Emits signals.
+
+What a handler should *not* do:
+
+- HTTP serialisation. That's the view.
+- Permission checks. That belongs in the service (or the action's `do()` if
+  there's no service yet).
+- Build error responses. Raise domain exceptions; let the view map them.
+
+See [queries](queries.md) for ORM patterns inside a handler.
+
+## Writing an action
+
+If your operation should be in the audit log or undoable, wrap it in an
+`ActionType`. The full how-to is in
+[action-system](../technical/action-system.md); the short version:
+
+1. Subclass `ActionType` (non-undoable) or `UndoableActionType`.
+2. Define a `type: str` and a `Params` dataclass capturing everything you
+   need to undo.
+3. Implement `do()` to call your handler and `register_action(...)`.
+4. For undoable: implement `undo()` and `redo()`.
+5. Implement `scope()` to return the right `ActionScopeStr` for undo scoping.
+6. Register in `apps.py`.
+
+Service-or-view code then calls `MyActionType.do(user, ...)` instead of the
+handler directly.
+
+## Writing a service
+
+Where it goes: next to the handler. Either `service.py` / `services.py`
+(single class) or a `services/` package (multiple). Both patterns exist.
+
+The decision rule: create a service for new code unless the endpoint is a
+trivial read with no permission nuance. Direct view-to-handler is acceptable
+for simple GETs and considered legacy for everything else.
+
+A typical service method does:
+
+1. `CoreHandler().check_permissions(user, operation, workspace=...,
+   context=...)`.
+2. Loads only what's needed for this operation, with the right
+   `select_related` / `prefetch_related`.
+3. Delegates to an action (state change) or handler (read).
+4. Returns plain data the view can serialise.
+
+The view becomes a one-liner: deserialise input, call the service, serialise
+output.
+
+## Writing a view
+
+Where it goes:
+
+- `backend/src/baserow/<area>/api/<resource>/views.py` (DRF view).
+- `backend/src/baserow/<area>/api/<resource>/serializers.py`.
+- `backend/src/baserow/<area>/api/<resource>/urls.py`.
+- `backend/src/baserow/<area>/api/<resource>/errors.py` for the exception
+  mapping.
+
+Conventions:
+
+- Use DRF `APIView` or `GenericAPIView` subclasses.
+- Use `map_exceptions` to translate domain exceptions to HTTP responses.
+- Document with `extend_schema` decorators so the OpenAPI / redoc page picks
+  up the endpoint.
+- Validate the request body via a serializer — never reach into
+  `request.data` directly.
+- Do not call handlers directly if a service exists.
+
+The custom token API for database tokens has a separate documentation page in
+`web-frontend/modules/database/pages/APIDocsDatabase.vue` — if your endpoint
+is accessible by API token, update that too.
+
+## Writing tests
+
+Conventions in this codebase:
+
+- **Unit tests** for handlers and services live in
+  `backend/tests/baserow/.../test_<module>.py`, mirroring the source layout.
+- **API tests** for views live alongside the unit tests with `test_<area>_views.py`
+  filenames; they use `APIClient`.
+- **`data_fixture`** is the test fixture that creates DB objects efficiently.
+  Use `data_fixture.create_text_field(...)`, `data_fixture.create_row_for_many_to_many_field(...)`,
+  etc. Search existing tests for examples.
+- **Query-count tests** for hot paths. See [queries](queries.md).
+- **Snapshot / serialisation round-trip tests** for any new field type or
+  view type. See [serialization](../technical/serialization-system.md).
+
+## Wiring it up
+
+Once your model, handler, action, service and view exist, the loose ends:
+
+- **Register everything in `apps.py`** — actions, field types, view types,
+  trash item types, notification types, scopes — they all register in
+  `ready()`. Forgetting this is the #1 way new features don't work in
+  production but pass tests.
+- **Add a changelog entry** in `changelog/entries/unreleased/` using
+  `changelog/src/changelog.py`. The PR template will remind you.
+- **Update docs** if your feature has a user-facing surface.
+- **Premium/enterprise**: code lives under `premium/` or `enterprise/`. Core
+  code must not import from these directories.
+- **Realtime updates** — if the change should propagate to other clients,
+  make sure your handler emits a signal and there's a receiver in `ws/` that
+  translates it. The action system handles this for actions automatically via
+  `action_done`.
+
+## Checklist before opening the PR
+
+- [ ] Handler is callable without HTTP context.
+- [ ] View has no business logic.
+- [ ] Permission check happens (in service or action).
+- [ ] State change is an action if it should be auditable or undoable.
+- [ ] Signal emitted for any change other clients should see.
+- [ ] N+1 audited; query-count test added for hot paths.
+- [ ] Migration follows zero-downtime conventions; reversible.
+- [ ] All new types registered in `apps.py`.
+- [ ] Serialisation `export_serialized` / `import_serialized` implemented for
+      any new persisted concept.
+- [ ] Changelog entry added.
+- [ ] Tests cover the happy path + 1-2 edge cases.
+- [ ] Docs updated if user-facing.
+
+## Related
+
+- [Architectural patterns](architecture.md).
+- [Registries](registries.md).
+- [Queries](queries.md).
+- [Action system](../technical/action-system.md).
+- [Engineering workflow](../development/engineering-workflow.md).

--- a/docs/patterns/field-system.md
+++ b/docs/patterns/field-system.md
@@ -1,0 +1,246 @@
+# Field system
+
+The field system is the engine behind every column in every user table. If
+you're working anywhere in the database module, you'll spend most of your
+time here. This page is the architectural overview; [the
+field-type plugin guide](../plugins/field-type.md) is the practical "how to
+register a new type" companion.
+
+For the broader request flow and the registry pattern itself, read
+[Architectural patterns](architecture.md) and [Registries](registries.md)
+first.
+
+## Three things, three roles
+
+| Component | Lives in | What it owns |
+|---|---|---|
+| **`FieldHandler`** | `baserow.contrib.database.fields.handler` | Orchestration. The create/update/convert/delete entry points. Triggers side effects. |
+| **`FieldType` subclasses** | `baserow.contrib.database.fields.field_types` + plugins | Per-type behaviour: storage shape, validation, search representation, dependency contract, conversion hooks. |
+| **`Field` model + subclasses** | `baserow.contrib.database.fields.models` | The Django models. Polymorphic — every `FieldType` has its own model subclass (e.g. `TextField`, `LinkRowField`). |
+
+Plus the registries:
+
+- **`field_type_registry`** — string `type` → `FieldType` instance.
+- **`field_converter_registry`** — supplies `FieldConverter`s for non-trivial
+  type-to-type conversions.
+
+The `FieldHandler` is the orchestrator; `FieldType` subclasses are the
+customisation points; the registries are the plugin surface.
+
+## The polymorphic `Field` model
+
+Every `FieldType` has its own model subclass. There's a base `Field` table and
+each subclass adds columns via Django's content-type framework. When you query
+`Field.objects.filter(...)` you get base `Field` instances; calling `.specific`
+on a base instance returns the concrete subclass instance.
+
+This matters for queries — see [queries](queries.md) for the `specific()` /
+`specific_iterator` patterns.
+
+## Lifecycle — create
+
+`FieldHandler.create_field(user, table, type_name, **kwargs)`:
+
+1. Permission check via `CoreHandler`.
+2. Validate (no duplicate primary, unique name within the table, etc.).
+3. Resolve the `FieldType` from `field_type_registry`.
+4. Extract allowed values from kwargs via the type's `allowed_fields`.
+5. `field_type.prepare_values(field_values, user)` — normalise inputs.
+6. `field_type.before_create(table, primary, field_values, last_order, user,
+   kwargs)` — type-specific setup; returns a `before` token reused later.
+7. Save the new `Field` row to the DB.
+8. Create any `FieldConstraint`s.
+9. Rebuild the field dependency graph via
+   `FieldDependencyHandler.rebuild_or_raise_if_user_doesnt_have_permissions_after()`.
+10. `schema_editor.add_field()` — alter the underlying user table to add the
+    new column.
+11. `field_type.after_create(...)` — post-save setup (e.g. building the M2M
+    join table for link-row fields).
+12. `field_type.init_field_data(...)` if `init_field_data=True` — populate
+    initial values (e.g. autonumber sequence reset).
+13. Update existing dependents via `_update_dependencies_of_field_created()`.
+14. Schedule a search reindex for the new column:
+    `SearchHandler.schedule_update_search_data(table, fields=[instance])`.
+15. Emit `field_created` signal.
+
+Steps 5-12 are the FieldType's hooks; steps 1-4 and 13-15 are the handler's
+own work. Side effects fan out from there via signals (see
+[architecture](architecture.md)).
+
+## Lifecycle — update
+
+`FieldHandler.update_field(user, field, new_type_name=None, **kwargs)`:
+
+The interesting variable is whether the type changes.
+
+**Same type:**
+
+1. Resolve types (`from_field_type == to_field_type`).
+2. `to_field_type.prepare_values(...)` and `to_field_type.before_update(...)`.
+3. Handle constraints, save the `Field` row.
+4. Decide if search needs reindex:
+   `from_field_type.should_update_search_data(old_field, field_values)`.
+5. `to_field_type.after_update(...)` — post-save fix-ups.
+6. Update dependents via `_update_dependencies_of_field_updated()`.
+7. Schedule search reindex if needed; emit `field_updated`.
+
+**Type change:**
+
+1. Resolve types (`from_field_type ≠ to_field_type`).
+2. `ViewHandler().before_field_type_change(field)` — invalidate view filters
+   and sortings that depended on the old type.
+3. `from_field_type.get_dependants_which_will_break_when_field_type_changes(...)`
+   — identify dependents that need fixing up after.
+4. `field.change_polymorphic_type_to(new_model_class)` — swap the subclass row.
+5. **Conversion** — see next section.
+6. `to_field_type.after_update(...)`.
+7. Cascade updates to broken dependents via
+   `dependant_field_type.field_dependency_updated(...)`.
+8. Apply collected updates via the `update_collector`.
+9. Schedule search reindex; emit `field_updated` with `field_type_changed=True`.
+
+## Lifecycle — convert (the interesting one)
+
+When a field's type changes, the existing column data must convert from one
+representation to another. Baserow has two paths:
+
+### Custom converter (preserves data)
+
+`field_converter_registry.find_applicable_converter(from_model, old_field,
+field)` returns the first registered `FieldConverter` whose `is_applicable()`
+returns `True`. If found, its `alter_field()` owns the schema change and the
+data migration.
+
+Real examples:
+
+- **`TextFieldToMultipleSelectFieldConverter`** — splits the comma-separated
+  text values into individual select options, creating the options as needed.
+- **`MultipleSelectFieldToSingleSelectFieldConverter`** — picks the first
+  option per row, sets the rest to NULL.
+- **`LinkRowFieldConverter`** — drops and recreates the M2M table.
+- **`RecreateFieldConverter`** — generic fallback. Drops the old column and
+  creates the new one. **Data is lost.**
+
+### Lenient schema editor (data loss possible)
+
+If no converter applies, `lenient_schema_editor()` does the conversion:
+
+1. `from_field_type.get_alter_column_prepare_old_value()` — pre-process old
+   data (e.g. trim whitespace before parsing).
+2. PostgreSQL `ALTER COLUMN` with `USING` clause that attempts to cast.
+3. `to_field_type.get_alter_column_prepare_new_value()` — post-process the
+   converted value.
+4. **Any value that fails to cast is silently set to NULL.** There is no
+   per-value error report.
+
+**Rule of thumb:** if a conversion needs to preserve data and would otherwise
+fail or null out, register a `FieldConverter`. Don't hope the lenient path
+handles it gracefully.
+
+## Lifecycle — delete
+
+`FieldHandler.delete_field(user, field, delete_strategy=DeleteFieldStrategyEnum.TRASH)`:
+
+1. Permission check; refuse to delete primary fields unless overridden.
+2. Identify dependents via `FieldDependencyHandler`.
+3. `FieldDependencyHandler.break_dependencies_delete_dependants(field)` —
+   delete edges; formulas/lookups that referenced this field error out.
+4. Emit `before_field_deleted`.
+5. Apply the delete strategy:
+   - **`TRASH`** (default) — `TrashHandler.trash(...)`. Cascade-trash related
+     fields via `field_type.get_other_fields_to_trash_restore_always_together(field)`.
+   - **`DELETE_OBJECT`** — immediate hard delete; no recovery.
+   - **`PERMANENTLY_DELETE`** — through the trash system but bypassing the
+     retention window.
+6. Cascade updates to dependents via `field_dependency_deleted()`.
+7. Emit `field_deleted` with the list of fields that were updated as a result.
+
+See [trash system](../technical/trash-system.md) for the broader trash flow.
+
+## Search reindex contract
+
+Field types control how their data ends up in search. Two methods on
+`FieldType`:
+
+- **`get_search_expression(field, queryset) -> Expression`** — returns a
+  Django ORM expression that casts the field's value to `CharField` for
+  inclusion in the table's TSV column. Default: `Cast(field.db_column,
+  output_field=CharField())`. Override for non-trivial types (e.g.
+  `LinkRowFieldType` joins to the related row's primary value).
+- **`is_searchable(field) -> bool`** — whether to include this field in search
+  at all. Defaults to `True`; computed/read-only fields may return `False`.
+
+Critical to understand: **there is one TSV column per table, not per field.**
+Every searchable field's expression is concatenated into it. Reindex is
+asynchronous (`SearchHandler.schedule_update_search_data` queues a Celery task
+on transaction commit), so search data can lag behind writes briefly.
+
+See [workspace search guide](../technical/workspace-search.md) for the
+indexing path.
+
+## Dependency contract
+
+Formulas, lookups and rollups depend on other fields' values. When the source
+changes, the dependent must recompute. `FieldDependencyHandler` tracks the
+graph.
+
+Field types participate via:
+
+- **`get_field_dependencies(field, field_cache) -> FieldDependencies`** —
+  declares the fields this type depends on. Computed dynamically from the
+  field's definition (formula expression, lookup target, rollup target).
+- **`field_dependency_created(field, created_field, update_collector, ...)`**
+  — called when a new field is added that this field now depends on.
+- **`field_dependency_updated(field, updated_field, old_field,
+  update_collector, ...)`** — called when a dependency changes.
+- **`field_dependency_deleted(field, deleted_field, update_collector, ...)`**
+  — called when a dependency goes away.
+
+The `update_collector` is a queue. Hooks add updates to it; after all hooks
+have fired, the handler applies the queued updates in dependency order. This
+prevents circular update storms.
+
+## Representative field types
+
+| Type | File | Why it's interesting to study |
+|---|---|---|
+| `TextFieldType` | `field_types.py` | Baseline; minimal hooks. |
+| `NumberFieldType` | `field_types.py` | Demonstrates `allowed_fields` extending the base model. |
+| `LinkRowFieldType` | `field_types.py` | Manages M2M tables; uses `before_create`/`after_create`/`before_schema_change`; cascade-deletes via `get_other_fields_to_trash_restore_always_together`. |
+| `FormulaFieldType` | `field_types.py` | Polymorphic — wraps a dynamic type based on formula result. Implements `field_dependency_updated` for recompute. Search expression delegates to the resolved type. |
+
+Read these in roughly that order to build a model of how complexity scales.
+
+## Surprises for new developers
+
+1. **The `Field` model is polymorphic.** Every type has its own subclass. To
+   access type-specific columns from a base `Field`, you need `.specific`.
+   When iterating many fields, use `specific_iterator()` to avoid N+1.
+2. **FieldType hooks aren't just for validation.** `after_create()` creates
+   M2M tables. `before_field_type_change()` cleans up view filter state. Not
+   implementing a hook silently skips required behaviour.
+3. **Dependencies are recomputed, not stored as schema.** Editing a formula
+   string rediscovers its dependencies on save. Bugs in
+   `get_field_dependencies` cause hard-to-diagnose stale data.
+4. **The lenient schema editor silently NULLs unconvertible values.** If you
+   add a new type pair conversion and don't write a `FieldConverter`, data
+   loss is the default behaviour. There is no error.
+5. **Search reindex is async on commit.** Search may lag a moment behind
+   recent writes. Code that needs synchronous search after a write should
+   flush explicitly.
+6. **Deleting a field can cascade silently.** `LinkRowFieldType`'s
+   `get_other_fields_to_trash_restore_always_together` trashes the
+   backreference field on the other side. Don't be surprised when "deleting
+   one field" trashes two trash entries.
+
+## Related
+
+- [Plugin guide: field types](../plugins/field-type.md) — registration
+  mechanics for new types.
+- [Plugin guide: field converters](../plugins/field-converter.md) —
+  registration for new type conversions.
+- [Dynamic models](../technical/dynamic-models.md) — how field changes
+  invalidate the generated model cache.
+- [Workspace search](../technical/workspace-search.md).
+- [Undo/redo guide](../technical/undo-redo-guide.md) — actions wrap most
+  field-handler operations.

--- a/docs/patterns/observability.md
+++ b/docs/patterns/observability.md
@@ -1,0 +1,236 @@
+# Observability — logging, tracing, verifying in prod
+
+Three things this page covers:
+
+1. **Logging** — what to log, what not to log, conventions.
+2. **OpenTelemetry tracing** — how Baserow instruments code, and how to add
+   instrumentation that matters.
+3. **Verifying assumptions in production** — how to answer "is what I think
+   is happening actually happening?" using the data we already collect.
+
+Production traces land in Honeycomb. See also
+[Metrics and logs](../development/metrics-and-logs.md) and
+[Monitoring Baserow](../installation/monitoring.md).
+
+## Logging
+
+We use [loguru](https://github.com/Delgan/loguru). Import the logger directly
+from any module:
+
+```python
+from loguru import logger
+
+logger.info("imported {count} rows", count=len(rows))
+logger.warning("unexpected state: {state}", state=state)
+logger.exception("import failed for table {table_id}", table_id=table.id)
+```
+
+Conventions:
+
+- **Use keyword placeholders, not f-strings.** Loguru extracts the kwargs as
+  structured fields, which makes the logs queryable. f-strings flatten
+  everything into a single rendered message and lose the structure.
+- **`logger.exception(...)` from inside `except:`.** It captures the
+  traceback. Don't `logger.error(str(exc))` — you lose the stack.
+- **Levels.** `debug` for verbose internals, `info` for noteworthy normal
+  state, `warning` for unexpected-but-not-broken, `error` for handled but
+  serious, `exception` for unhandled-in-this-frame errors.
+- **Default backend log level is `INFO`** (`BASEROW_BACKEND_LOG_LEVEL`).
+  Don't ship `info` logs that fire many times per request.
+
+### What to log
+
+- **Boundaries that produce side effects:** outbound webhooks, email sends,
+  external API calls, Celery task starts and finishes.
+- **Branch points an operator would need to debug an incident:** "fell back
+  to lenient schema conversion for field X", "search index rebuild started
+  for workspace Y".
+- **Unhandled or recovered errors** with the relevant ids and context.
+- **Long-running steps** with timing — log the start *and* the finish so you
+  can compute durations from log timestamps.
+
+### What not to log
+
+- **PII.** Email addresses, names, row values, formula content. If you have
+  to log them, log the id and let the operator look it up.
+- **Per-row chatter in loops.** Move the log outside the loop and aggregate.
+- **Secrets, tokens, credentials.** Ever.
+- **Things you can already see in OTEL traces.** Span attributes are
+  queryable; don't double-log.
+
+## OpenTelemetry tracing
+
+OTEL is the primary way we understand production behaviour. A trace per
+request, with spans for handler methods, Celery tasks, outbound HTTP, DB
+queries, and explicit user code.
+
+### Auto-tracing handler classes
+
+Most handler classes are auto-traced via the `baserow_trace_methods`
+metaclass:
+
+```python
+from opentelemetry import trace
+from baserow.core.telemetry.utils import baserow_trace_methods
+
+tracer = trace.get_tracer(__name__)
+
+class RowHandler(metaclass=baserow_trace_methods(tracer)):
+    def create_row(self, user, table, values):
+        ...
+```
+
+Every method on the class automatically becomes a span. Optionally restrict
+to specific methods (`only=["do", "undo", "redo"]`) — the `ActionType` base
+class uses this to trace only the public methods.
+
+### Tracing one function
+
+For a single function (Celery task, helper) use the decorator:
+
+```python
+from baserow.core.telemetry.utils import baserow_trace
+
+@baserow_trace(tracer)
+def update_search_data(table_id):
+    ...
+```
+
+### Adding attributes
+
+Spans become useful when they carry context. Add attributes to the current
+span via `add_baserow_trace_attrs(...)`:
+
+```python
+from baserow.core.telemetry.utils import add_baserow_trace_attrs
+
+add_baserow_trace_attrs(table_id=table.id, row_count=len(rows))
+```
+
+Attributes are namespaced under the `baserow.` prefix automatically. Real
+example:
+`baserow/contrib/database/fields/tasks.py:96`
+(`add_baserow_trace_attrs(update_now=update_now, workspace_id=workspace.id)`).
+
+### User context in spans
+
+`setup_user_in_baggage_and_spans(user, request)` (in
+`baserow.core.telemetry.utils`) attaches the user id and session id to the
+current span *and* propagates them as OTEL baggage so downstream spans (e.g.
+inside a Celery task spawned from this request) inherit the same fields.
+The `BaserowOTELMiddleware` wires this up for HTTP requests; you only need
+to call it directly in Celery tasks that need user context.
+
+### What to instrument
+
+- **Anything that crosses a layer boundary** worth tracking duration on
+  (view → service → handler → ORM).
+- **Anything where the time spent answers "where did the request go?"** A
+  span around a single line that does work is almost always useless; a span
+  around a method that calls into other handlers is almost always useful.
+- **Things you'd want to alert on** — slow handler calls, search index
+  rebuilds, formula recomputes.
+
+### What NOT to instrument
+
+- **Trivial pure functions.** Span overhead exceeds the work.
+- **Tight loops.** One span per iteration overwhelms the trace.
+- **Code already covered by the metaclass.** Don't double-wrap.
+
+### Suppressing instrumentation
+
+If a function shouldn't generate spans (e.g. periodic health checks that
+would dwarf real traffic), wrap it in `@disable_instrumentation`:
+
+```python
+from baserow.core.telemetry.utils import disable_instrumentation
+
+@disable_instrumentation
+def health_check_loop():
+    ...
+```
+
+## Verifying assumptions in production
+
+The point of all the above is that you can answer questions like "is my
+change actually doing what I think it is?" without redeploying with extra
+logging.
+
+### Pattern 1 — "How often is this code path hit?"
+
+Find the span in Honeycomb. Count by attribute. If your branch instruments
+its choice as a span attribute (`add_baserow_trace_attrs(branch="fast")`),
+you can group and compare.
+
+If the code path isn't traced, add a span attribute on the relevant handler
+method *before* deploying the change you want to measure. Then in the next
+release you can compare.
+
+### Pattern 2 — "How long does this thing take?"
+
+Honeycomb gives you duration percentiles on any span name. If a method
+matters enough to keep an eye on, put it on a handler class (covered by the
+metaclass) or wrap it in `@baserow_trace`.
+
+### Pattern 3 — "Did this user actually do X?"
+
+`setup_user_in_baggage_and_spans` puts `user.id` on the span and propagates
+it via baggage. You can filter by `user.id == ?` in Honeycomb and see every
+trace the user touched, across HTTP and Celery boundaries.
+
+For finer state — "what params did they pass" — use span attributes, not
+logs. Logs are best for narrative; spans are best for aggregation.
+
+### Pattern 4 — "What happens after my change deploys?"
+
+Before deploying:
+
+1. Add one or two span attributes that distinguish the new path from the
+   old (e.g. `add_baserow_trace_attrs(strategy="v2")`).
+2. Identify the metric that should move (latency, count, error rate).
+3. Pick the Honeycomb query in advance.
+
+After deploying, run the query. The strongest "I verified this in prod" you
+can give in a PR review is a Honeycomb link.
+
+### Pattern 5 — "Was it really an N+1?"
+
+Honeycomb shows the number of DB spans inside each parent span. If the
+count grows with the page size of the affected listing, it's N+1. Add a
+query-count test (see [queries](queries.md#cheat-sheet-—-writing-a-new-handler-method))
+to lock in the fix.
+
+## Configuration knobs
+
+Relevant environment variables:
+
+- `BASEROW_BACKEND_LOG_LEVEL` — overall backend log level. Default `INFO`.
+- `BASEROW_BACKEND_DATABASE_LOG_LEVEL` — Django DB queries. Default `ERROR`
+  (set to `DEBUG` locally to see every query).
+- `BASEROW_DJANGO_REQUEST_LOG_LEVEL` — request log level. Default `ERROR`.
+- OTEL exporter settings — see
+  [Monitoring Baserow](../installation/monitoring.md).
+
+## Gotchas
+
+- **f-string vs keyword logging.** `logger.info(f"id={x}")` works but loses
+  the structured field. `logger.info("id={id}", id=x)` keeps it queryable.
+  Use the second form.
+- **Double-tracing.** Handler classes are already traced via the metaclass.
+  Adding `@baserow_trace` on individual methods is redundant and clutters
+  traces.
+- **PII in span attributes.** Same rule as logs: ids only, no values.
+- **`logger.exception` outside `except`.** Use `logger.error` if you don't
+  have a live exception — `.exception()` will log "NoneType: None" if there's
+  no traceback available.
+- **Span attributes are sampled.** High-cardinality attributes (one unique
+  value per request) survive; the volume of traffic decides what makes it to
+  Honeycomb. Don't put debugging data behind a "set a low-frequency
+  attribute" trick — sampling will swallow it.
+
+## Related
+
+- [Metrics and logs](../development/metrics-and-logs.md).
+- [Monitoring Baserow](../installation/monitoring.md).
+- [Queries](queries.md) — for the N+1 query-count test pattern.
+- `baserow.core.telemetry.utils` — the source of the helpers used here.

--- a/docs/patterns/queries.md
+++ b/docs/patterns/queries.md
@@ -1,0 +1,232 @@
+# Query patterns
+
+This page collects the ORM idioms you'll need when writing handlers and
+services in Baserow. The goal is to make N+1 the exception and to surface the
+patterns the codebase actually uses, with concrete locations to read for
+context.
+
+Rules of thumb up front:
+
+- For foreign keys you'll dereference: **`select_related`**.
+- For reverse foreign keys or many-to-many: **`prefetch_related`**, with a
+  `Prefetch()` object if the prefetched set needs filtering or extra joins.
+- For polymorphic base models (`Application`, `Field`, etc.): **`specific()`**
+  or **`specific_iterator()`** to fetch concrete subclass instances without
+  N+1.
+- For ≥10 writes: **`bulk_create` / `bulk_update`** with a `batch_size`.
+- Don't trust correctness by inspection — add query-count tests on hot paths.
+
+## The most important rule: never query inside a loop
+
+If you remember nothing else from this page, remember this. The single most
+common performance bug in this codebase — and most Django codebases — is a
+loop that issues one query per iteration. At one hundred rows it's invisible.
+At a hundred thousand it's a production incident.
+
+Before writing `for x in something:`, ask: *does the body do any of these
+forbidden things?*
+
+- `.get(...)`, `.filter(...)`, `.first()` against the ORM.
+- Touching a foreign key or reverse-FK attribute that wasn't prefetched
+  (this issues a query lazily).
+- Calling `.specific` (one query per content type if not batched).
+- `.save()` (one INSERT or UPDATE per call).
+
+If yes, restructure as one of:
+
+1. **Prefetch outside the loop.** `select_related` for FKs you'll dereference,
+   `prefetch_related` (with a `Prefetch()` object when you need filtering or
+   nested optimisation) for reverse FKs and M2Ms. The loop body should never
+   issue follow-up queries.
+2. **Iterator for one-shot reads.** When you'll touch each row exactly once
+   and the result set is large, `.iterator(chunk_size=N)` streams rows from
+   the database instead of loading them all into memory. Combine with
+   `.only(...)` to trim columns. Real example:
+   `baserow/contrib/database/table/handler.py:208`
+   (`table_qs.only("id").iterator(1000)`).
+3. **Bulk writes.** Collect everything to insert or update in a list and call
+   `Model.objects.bulk_create(objs, batch_size=100)` or
+   `Model.objects.bulk_update(objs, ["col"], batch_size=100)` after the
+   loop. Never `.save()` in a loop.
+4. **Chunked bulk writes for very large arrays.** `baserow.core.utils.grouper`
+   (`from baserow.core.utils import grouper`) splits an iterable into
+   chunks of N items. Use it when the input list is too large to bulk-write
+   in a single call (memory, lock duration). The migration in
+   `baserow/contrib/database/migrations/0081_batch_webhooks.py` shows this
+   in anger: `grouper(...)` plus `bulk_create(batch_size=100)`.
+5. **Drop to SQL or a CTE.** When the work is fundamentally set-based —
+   updating one column based on another across millions of rows, computing
+   aggregates the ORM can't express efficiently — write the query. Use
+   `connection.cursor()` or a `RawSQL` / `RunSQL` in a migration. CTEs (via
+   `django-cte` or hand-rolled `WITH ... AS (...)`) handle the "update X
+   from a derived set" shape without a Python loop at all. This is a
+   precision tool: it skips signals, cachalot invalidation, and search
+   reindex, so use it deliberately.
+
+`groupby` from `itertools` (or `django.db.models` aggregation) is the right
+tool when you want to roll up data; `grouper` is for batching writes. Don't
+confuse them.
+
+## `select_related` — single-query FK joins
+
+Use when you'll access an FK attribute on each row in the result.
+
+Real examples:
+
+- `baserow/core/handler.py:171` — fetching `Settings` with a related
+  co-branding logo image (`select_related("co_branding_logo")`) avoids a
+  follow-up query on access.
+- `baserow/core/handler.py:600-602` — `WorkspaceUser` with chained
+  `select_related("user", "user__profile")`. One query, two joined tables.
+
+Don't chain deeper than 2-3 levels — Postgres is happy, but the SQL gets
+unwieldy and the result rows get wide.
+
+## `prefetch_related` — reverse FK and M2M
+
+Use when each result needs a collection.
+
+Simple cases:
+
+- `baserow/core/handler.py:564` — `prefetch_related("workspaceuser_set",
+  "template_set")` batches two reverse-FK queries for workspace listings.
+- `baserow/contrib/database/application_types.py:90` —
+  `prefetch_related("field_set")` on a database application, used during
+  serialisation.
+
+With a custom queryset via `Prefetch()`:
+
+```python
+from django.db.models import Prefetch
+
+workspaceusers_with_user_and_profile = (
+    WorkspaceUser.objects.select_related("user", "user__profile")
+)
+workspaces = Workspace.objects.prefetch_related(
+    Prefetch("workspaceuser_set", queryset=workspaceusers_with_user_and_profile),
+)
+```
+
+The above pattern lives in `baserow/core/handler.py:606-609`. The
+`Prefetch()` object lets you chain further optimisations into the prefetched
+relation — without it, the prefetch fetches all columns naively.
+
+A more advanced shape that filters fields and adds annotations is in
+`baserow/contrib/database/search_types.py:274`.
+
+## `specific()` and `specific_iterator()` — polymorphic models
+
+Baserow uses Django's content-type framework to make `Application`, `Field`,
+and several other models polymorphic. Querying the base model returns base
+instances; you usually want the concrete subclass.
+
+For a single instance: `application.specific` resolves to a `Database` (or
+whatever concrete type).
+
+For many instances: never call `.specific` in a loop — that's N queries.
+Instead use `specific_iterator()` (`baserow/core/db.py:118-149`), which
+groups by content type and fetches each subclass in a single query per type.
+
+Example call sites:
+
+- `baserow/core/service.py:137-143` — `get_application` uses
+  `specific_iterator()` with the `per_content_type_queryset_hook` parameter
+  to attach prefetches per subclass.
+- `enterprise/.../restricted_view/fields/signals.py:31-34` — a more elaborate
+  example where each subclass gets a different prefetch.
+
+If you find yourself doing `for x in qs: x.specific.something`, replace with
+`for x in specific_iterator(qs): x.something`.
+
+## Column trimming — `only`, `defer`, `values_list`
+
+When you don't need full rows:
+
+- **`.only("id")`** — load only specific columns, paired with `.iterator()`
+  for streaming large querysets.
+  `baserow/contrib/database/table/handler.py:208`:
+  `table_qs.only("id").iterator(1000)` for bulk table processing.
+- **`.defer("password")`** — exclude one or more columns from the load.
+  `baserow/api/authentication.py:36-38` uses this to keep passwords out of
+  the user cache.
+- **`.values_list("name", flat=True)`** — return tuples / scalars, not
+  models. `baserow/core/handler.py:1458` for bulk name-only lookups.
+
+These matter most when:
+
+- You're iterating thousands of rows for a backfill or migration.
+- You're caching, and the cached payload size matters.
+- You want to avoid loading rarely-accessed binary blobs.
+
+## Bulk writes
+
+For ≥10 writes, never loop `.save()`.
+
+- **`bulk_create(batch_size=100)`** — `baserow/core/apps.py:618-621` registers
+  all operation types in one go (`ignore_conflicts=True` skips duplicates).
+- **`bulk_update(objs, ["field"], batch_size=100)`** —
+  `baserow/core/handler.py:1795` updates the `order` field for many imported
+  applications at once.
+- **`update_or_create(defaults={...}, ...)`** — idempotent upsert.
+  `baserow/core/handler.py:1133-1140` for workspace invitations.
+
+Choose `batch_size` so each batch fits in a reasonable query (100-500 is
+usually right). Larger batches reduce round-trips but increase memory and
+lock duration.
+
+## Pessimistic locking — `select_for_update`
+
+When the next operation depends on the row's current value and concurrent
+mutation is possible (rename, delete, transfer), lock the row:
+
+```python
+workspace = (
+    Workspace.objects
+    .select_for_update(of=("self",))
+    .get(pk=workspace_id)
+)
+```
+
+`baserow/core/handler.py:531` (`get_workspace_for_update`) is the canonical
+example. Always pair with `transaction.atomic()`. See
+[postgresql-locks.md](../technical/postgresql-locks.md) for the broader lock
+strategy.
+
+## N+1 hotspots — fix and guard
+
+When fixing an N+1, add a query-count test as the regression guard. The
+enterprise tests in
+`enterprise/backend/tests/.../data_scanner/test_data_scanner_views.py:141-145`
+show the pattern: `@override_settings(DEBUG=True)` plus
+`assert len(connection.queries) <= N`. The assertion fails if the count grows
+with dataset size — exactly what an N+1 would do.
+
+Comments in the codebase calling out N+1 fixes are searchable; look for
+`# N+1` or commit messages mentioning N+1.
+
+## Cheat sheet — writing a new handler method
+
+1. **No queries inside loops.** Prefetch, iterate, bulk-write — see the
+   first section of this page.
+2. **Identify every FK you'll dereference.** Add `select_related` for them.
+3. **Identify every collection you'll iterate.** Add `prefetch_related` (or
+   a `Prefetch()` object if you need further optimisation).
+4. **If the model is polymorphic (`Application`, `Field`, etc.) and you'll
+   call `.specific`,** use `specific_iterator` instead of a loop.
+5. **Trim columns** if you're processing thousands of rows or caching.
+6. **Bulk-write** anything ≥ 10 mutations. Use `grouper` to chunk very large
+   batches.
+7. **Lock** rows you'll update if concurrent mutation is possible.
+8. **Add a query-count test** on the hot path you cared enough to optimise.
+9. **Drop to raw SQL or a CTE** for set-based work the ORM can't express
+   efficiently — but accept that signals, cachalot, and search reindex won't
+   fire.
+
+## Related
+
+- [Architectural patterns](architecture.md) — where handlers fit.
+- [Creating features](creating-features.md) — the broader how-to for writing a
+  view + action + handler + model.
+- [PostgreSQL locks](../technical/postgresql-locks.md).
+- [Caching](../technical/caching.md) — `cachalot` enablement for user-table
+  queries.

--- a/docs/patterns/registries.md
+++ b/docs/patterns/registries.md
@@ -1,0 +1,168 @@
+# Registries
+
+Registries are the single most common pattern in the Baserow codebase. Fields,
+views, view filters, applications, actions, jobs, formulas, permission managers,
+trash items, notification types, integrations, and webhook events are all built on
+them. If you understand registries, you understand the shape of most of the code.
+
+## What a registry is
+
+A registry is a collection of all the concrete implementations of a base class,
+keyed by a unique string `type`. We use registries to:
+
+- Look up an implementation given a type string (e.g. "what's the field type for
+  `text`?").
+- Iterate over all implementations (e.g. "give me every sortable field type").
+- Provide an extension point so plugins (including premium and enterprise) can add
+  new implementations without modifying core code.
+
+## A simplified example
+
+The real codebase wraps registries in helper classes (see below), but the underlying
+idea is just a dictionary of instances:
+
+```python
+import abc
+
+# 1. The base class — defines the interface every concrete type must implement.
+class FieldType(abc.ABC):
+    type: str
+    is_sortable: bool = False
+
+    @abc.abstractmethod
+    def prepare_value_for_db(self, value): ...
+
+# 2. Two concrete implementations, each with a unique `type`.
+class TextFieldType(FieldType):
+    type = "text"
+    is_sortable = True
+
+    def prepare_value_for_db(self, value):
+        if not isinstance(value, str):
+            raise ValueError()
+        return value
+
+class NumberFieldType(FieldType):
+    type = "number"
+    is_sortable = True
+
+    def prepare_value_for_db(self, value):
+        if not isinstance(value, int):
+            raise ValueError()
+        return value
+
+# 3. The "registry" — in real code this is wrapped in a Registry class, but it is
+#    fundamentally a dict of instances keyed by `type`.
+field_type_registry = {
+    TextFieldType.type: TextFieldType(),
+    NumberFieldType.type: NumberFieldType(),
+}
+
+# 4. Two common usages: look up by type, and filter across all types.
+def validate_new_cell_value(field_type: str, cell_value):
+    return field_type_registry[field_type].prepare_value_for_db(cell_value)
+
+def get_all_sortable_field_types():
+    return [ft for ft in field_type_registry.values() if ft.is_sortable]
+```
+
+The concrete instances are stateless singletons. They behave like plain functions
+grouped onto a class — having them as instances rather than module-level functions
+is what lets us iterate, filter and look them up uniformly.
+
+## The real implementation
+
+The base classes and registry helpers live in
+`backend/src/baserow/core/registry.py`:
+
+- `Instance` — the abstract base every registered class extends. Owns the `type`
+  property and lifecycle hooks (`after_register`, `before_unregister`).
+- `Registry` — the dict wrapper. Provides `register`, `unregister`, `get`,
+  `get_all`, and dispatches the lifecycle hooks.
+- Several mixins (`ModelInstanceMixin`, `CustomFieldsInstanceMixin`,
+  `APIUrlsInstanceMixin`, `MapAPIExceptionsInstanceMixin`, …) add common behaviour
+  for registries whose entries need a related Django model, custom serializer
+  fields, extra API URLs, or exception mapping.
+
+A real registry looks like:
+
+```python
+from baserow.core.registry import Registry, ModelInstanceMixin, Instance
+
+class FieldType(ModelInstanceMixin, Instance):
+    ...
+
+class FieldTypeRegistry(Registry):
+    name = "field"
+
+field_type_registry = FieldTypeRegistry()
+```
+
+Registration happens at app-ready time, typically from each app's `apps.py`:
+
+```python
+def ready(self):
+    from .registries import field_type_registry
+    from .field_types import TextFieldType, NumberFieldType
+
+    field_type_registry.register(TextFieldType())
+    field_type_registry.register(NumberFieldType())
+```
+
+## A non-exhaustive tour of the registries
+
+In `baserow/core/`:
+
+- `registries.py` — `application_type_registry`, `plugin_registry`,
+  `permission_manager_type_registry`, `object_scope_type_registry`,
+  `operation_type_registry`, `email_context_registry`,
+  `subject_type_registry`, `auth_provider_type_registry`.
+- `action/registries.py` — `action_type_registry`, `action_scope_registry`.
+- `jobs/registries.py` — `job_type_registry`.
+- `notifications/registries.py` — `notification_type_registry`.
+- `trash/registries.py` — `trash_item_type_registry`.
+- `search/registries.py`, `services/registries.py`,
+  `integrations/registries.py`, `user_sources/registries.py`,
+  `formula/registries.py`, `mcp/registries.py`, `captcha/registries.py`,
+  `workflow_actions/registries.py`, …
+
+In `baserow/contrib/database/`:
+
+- `fields/registries.py` — `field_type_registry`,
+  `field_converter_registry`, `field_aggregation_registry`.
+- `views/registries.py` — `view_type_registry`, `view_filter_type_registry`,
+  `view_aggregation_type_registry`, `decorator_value_provider_type_registry`, …
+- `webhooks/registries.py`, `data_sync/registries.py`,
+  `export/registries.py`, `airtable/registries.py`, …
+
+This list is not exhaustive — search the codebase for `registries.py` files to find
+the full set; there are several more in `core/services/`, `core/integrations/`,
+`core/formula/`, `core/workflow_actions/`, `core/captcha/`, `core/user_sources/`,
+and elsewhere.
+
+In `baserow/ws/` and `baserow/api/`:
+
+- `ws/registries.py` — `page_registry` for the websocket subscription model.
+- `api/registries.py` — `api_exception_registry` for exception serialisation.
+
+## Adding a new type
+
+The most common reason to touch a registry is to register a new type from a plugin
+or feature. The plugin guides cover the per-registry detail:
+
+- [Create application type](../plugins/application-type.md)
+- [Create field type](../plugins/field-type.md)
+- [Create view type](../plugins/view-type.md)
+- [Create view filter type](../plugins/view-filter-type.md)
+- [Create field converter](../plugins/field-converter.md)
+
+The pattern is always the same: subclass the base, give it a unique `type` string,
+implement the abstract methods, register the instance from `apps.py` `ready()`.
+
+## When to use a registry yourself
+
+If you find yourself writing `if field_type == "text": ... elif field_type ==
+"number": ...` in business logic, that branching belongs on the field type
+subclass, not at the call site. The registry exists so that adding a new field type
+is a single new class plus a registration — not a sweep through every `if/elif` in
+the codebase.

--- a/docs/technical/action-system.md
+++ b/docs/technical/action-system.md
@@ -1,0 +1,166 @@
+# Action system
+
+The action system is the event-based backbone of state changes in Baserow. Any user
+operation that mutates state — creating a row, renaming a table, deleting a view,
+importing data — goes through it. The system gives you three things essentially for
+free once an operation is modelled as an action:
+
+1. An audit row in the `Action` table, so we know who did what and when.
+2. Undo/redo support, for operations that opt into it.
+3. A consistent signal (`action_done`) that other subsystems can listen to.
+
+If you've read [the architectural patterns](../patterns/architecture.md), this is
+the layer between **service** and **handler** in the backend flow.
+
+## The three types you keep straight
+
+| Concept | Lives in | What it is |
+|---|---|---|
+| **`ActionType`** | `baserow.core.action.registries` (and per-domain `actions.py` files) | The *kind* of action. Defines `do()`, parameters, scope, and (if undoable) `undo()`/`redo()`. Registered in `action_type_registry`. |
+| **`Action`** | `baserow.core.action.models` | A Django model row: one specific occurrence of an `ActionType` happening, with its params, scope, user, session, timestamps. This populates the audit log. |
+| **`ActionHandler`** | `baserow.core.action.handler` | The orchestrator. Drives `undo()` and `redo()` for a user across the latest action(s) within a set of scopes. |
+
+A common confusion early on: `ActionType.do()` is what runs the operation, but
+it's not what views call directly. Views/services call **`ActionType.do()` itself**
+(the class method); inside `do()`, the implementation calls `cls.register_action()`
+to record the `Action` row, then delegates to a handler for the actual mutation.
+
+Read `baserow/contrib/database/rows/actions.py` for canonical examples.
+
+## Shape of an `ActionType`
+
+A representative `ActionType` defines:
+
+- A `type: str` identifier (registered in `action_type_registry`).
+- A nested `Params` dataclass holding everything needed to undo or redo the change
+  later. Stored as JSON in the `Action.params` column.
+- `do(cls, ...)` — performs the operation, calls `register_action(...)` to record
+  it, returns the result (often the created/updated object). The arguments are
+  domain-specific (typically `user`, the relevant resources, and the change being
+  made).
+- `scope(cls, ...)` — returns an `ActionScopeStr` (e.g. for table 42, "table42").
+  Scopes control which actions the user sees when they hit undo — undo is
+  scoped, not global.
+- Optional: `params_to_serializable()` / `serialized_to_params()` hooks if the
+  `Params` dataclass needs special handling round-tripping through JSON.
+
+Undoable types also implement:
+
+- `undo(cls, user, params, action_being_undone)` — reverses the change.
+- `redo(cls, user, params, action_being_redone)` — re-applies the change.
+
+The base classes are in `baserow.core.action.registries`:
+
+- `ActionType` — non-undoable.
+- `UndoableActionType` — undoable. Inherits the `UndoableActionTypeMixin`.
+
+## Scopes
+
+Every action is recorded with a scope. Scopes are how undo/redo is partitioned:
+when a user presses undo, the frontend tells the backend which scopes the user is
+currently "in" (the table they're looking at, the workspace, etc.), and
+`ActionHandler.undo()` only considers actions in those scopes.
+
+Scope types are registered in `action_scope_registry` (see `ActionScopeType` in
+`baserow/core/action/registries.py`). Each scope type implements `value()` to
+build an `ActionScopeStr` from runtime context.
+
+## Undo and redo
+
+`ActionHandler.undo()` and `ActionHandler.redo()` walk the latest action(s) for a
+user, in the given scopes, in the given client session, and call the type's
+`undo()` / `redo()`. A few non-obvious behaviours:
+
+- **Per-session.** Undo stacks are per browser session (via the untrusted client
+  session id), not global per user. Opening another tab gives you another stack.
+- **Action groups.** Operations that semantically belong together (e.g. creating
+  several fields in one go) write multiple `Action` rows that share an
+  `action_group` UUID. Undo treats the whole group as one step; `redo` too.
+  See `get_client_undo_redo_action_group_id`.
+- **Atomic.** Group undo runs inside a `transaction.atomic()`. If one action in
+  the group fails, all of them get their `error` recorded and `undone_at` set,
+  and the user sees the failure on the next attempt.
+- **Lock conflicts.** `select_for_update(of=("self",))` is used when picking the
+  latest action; a `LockConflict` is raised if another undo/redo is already in
+  flight for the same row.
+- **`web_socket_id` clearing.** Before running undo/redo, the handler clears the
+  user's `web_socket_id` so that the realtime events triggered by the undo are
+  also broadcast back to the user who triggered the undo — they want to see the
+  state change.
+
+## When to make something an action
+
+Yes:
+
+- Any state-changing operation a user can do that we want in the audit log.
+- Any state-changing operation where undo makes sense from the user's
+  perspective.
+
+No:
+
+- GET / read endpoints.
+- Internal housekeeping (periodic cleanup, background reindex, signal handlers).
+- Operations triggered by another action (e.g. signal receivers that update
+  search). The originating action covers them.
+
+If you're unsure, make it an action. The cost is small and you get the audit log
+for free.
+
+## Anatomy of a typical action implementation
+
+A simplified shape (read the real ones in `baserow/contrib/database/rows/actions.py`):
+
+```python
+from baserow.core.action.registries import UndoableActionType
+
+class CreateRowActionType(UndoableActionType):
+    type = "create_row"
+
+    @dataclasses.dataclass
+    class Params:
+        table_id: int
+        row_id: int
+        row_values: dict
+
+    @classmethod
+    def do(cls, user, table, values):
+        row = RowHandler().create_row(user, table, values)
+        cls.register_action(
+            user=user,
+            params=cls.Params(table.id, row.id, values),
+            scope=cls.scope(table.id),
+            workspace=table.database.workspace,
+        )
+        return row
+
+    @classmethod
+    def scope(cls, table_id):
+        return TableActionScopeType.value(table_id)
+
+    @classmethod
+    def undo(cls, user, params, action):
+        RowHandler().delete_row_by_id(user, params.row_id, params.table_id)
+
+    @classmethod
+    def redo(cls, user, params, action):
+        RowHandler().create_row(user, ..., params.row_values)
+```
+
+The real handlers do more: they return data rich enough to rebuild deleted state
+on undo, they pass `send_realtime_update=False` to skip ws events for the actual
+mutation (the action signal carries them instead), and they update `params` on
+the action row if state shifts during undo.
+
+## The `action_done` signal
+
+When `do()`, `undo()`, or `redo()` finishes, `ActionType.send_action_done_signal()`
+fires `action_done`. Receivers — primarily `baserow.ws.*` — translate it into
+realtime websocket messages addressed at the right table/page subscribers. This
+is how undo "shows up" in other tabs.
+
+## Related
+
+- [Undo/redo guide](undo-redo-guide.md) — the deeper undo-specific notes.
+- [Architectural patterns](../patterns/architecture.md) — where actions fit in the
+  request flow.
+- [Systems overview](systems-overview.md#action-system).

--- a/docs/technical/caching.md
+++ b/docs/technical/caching.md
@@ -1,0 +1,218 @@
+# Caching
+
+Baserow caches at several levels: per-request in-process, distributed Redis,
+ORM-level (cachalot), and ad-hoc `lru_cache`/`cached_property` decorators in
+hot paths. This page is the map. If you're touching anything performance-
+sensitive, know the layer you're in and what invalidates it.
+
+## At a glance
+
+| Layer | Backend | Scope | TTL | Invalidation |
+|---|---|---|---|---|
+| `local_cache` | `asgiref.Local` (in-process) | One request / task | Auto, on exit | Auto via `LocalCacheMiddleware`; explicit `.delete(key)` |
+| `global_cache` | Django cache (Redis) | Cross-request | Per call; defaults short | Versioned counter; `.invalidate()` |
+| `generated_models` cache | Dedicated Django cache (Redis) | Cross-request | None | `Table.version` UUID change |
+| `cachalot` | Redis (separate config) | Cross-request | None | Auto on ORM write |
+| User & Settings cache | Django cache | Cross-request | `BASEROW_CACHE_TTL_SECONDS` | `post_save` signals |
+| Job progress cache | Django cache (Redis) | Cross-request | While job runs | On job completion |
+| `lru_cache` / `cached_property` | In-process | Worker lifetime / object lifetime | None | Worker restart / object disposal |
+
+The two you should know cold: **`local_cache`** (request-scoped) and
+**`global_cache`** (Redis, versioned). Most of the rest are special-purpose.
+
+## Framework-layer caches
+
+### `local_cache` — per-request in-process
+
+`baserow.core.cache.local_cache`. Backed by `asgiref.local.Local`, so it's
+thread- and async-safe.
+
+```python
+from baserow.core.cache import local_cache
+
+value = local_cache.get(
+    f"workspace_user_{workspace.id}_{user.id}",
+    default=lambda: fetch_workspace_user(workspace, user),
+)
+```
+
+`LocalCacheMiddleware` (and analogous wrappers for Celery tasks and async
+contexts) clears the cache at the boundary so values never leak across
+requests.
+
+Use it for **anything you'd look up twice in the same request**: permission
+checks, role assignments, repeated workspace lookups, dynamic model lookups,
+etc. It's strictly free — no Redis round-trip — so the bar for using it is
+low.
+
+The `delete(key)` method supports `*` wildcards for invalidating families
+(e.g. `local_cache.delete("role_assignments_*")`).
+
+### `global_cache` — versioned Redis cache
+
+`baserow.core.cache.global_cache`. Wraps the Django cache backend
+(`django.core.cache.cache`) with two patterns:
+
+1. **Versioned keys.** Each cached entry carries a version number; calling
+   `.invalidate(key)` increments that counter so all readers atomically see a
+   miss without you having to know every key that should be flushed.
+2. **Distributed locks.** When a cache miss occurs, the populator runs under a
+   short-lived Redis lock to prevent thundering-herd recompute.
+
+```python
+data = global_cache.get(
+    "expensive_thing",
+    default=lambda: compute_expensive_thing(),
+    timeout=300,
+    invalidate_key="expensive_thing_family",
+)
+
+global_cache.invalidate("expensive_thing_family")
+```
+
+Use it for **expensive cross-request computations** with clear invalidation
+points: rendered settings, user metadata, derived structures recomputed
+periodically.
+
+### Django cache backends overview
+
+`baserow.config.settings.base` defines several Django cache "names":
+
+- `default` — main Redis cache. Used by `global_cache`, sessions, etc.
+- `generated_models` — separate cache for `Table.get_model()` `field_attrs`
+  (see [dynamic models](dynamic-models.md)).
+- `cachalot` — separate Redis instance for ORM-level cachalot.
+
+Splitting caches by name keeps flushes targeted: clearing `cachalot` doesn't
+clear `default`.
+
+## Application-layer caches
+
+### Generated model `field_attrs` cache
+
+Covered in detail in [dynamic models](dynamic-models.md). Two-layer
+(`local_cache` + `generated_models` Redis cache), versioned by
+`Table.version` UUID, invalidated by every field change.
+
+### cachalot — ORM query cache for user tables
+
+`baserow.cachalot_patch.py`. cachalot caches Django ORM query results in
+Redis, with automatic invalidation on writes to the relevant tables. Baserow
+applies it selectively to the dynamic user tables (`db_table_*`,
+`link_row_*`, `multiple_*`):
+
+```python
+from baserow.cachalot_patch import cachalot_enabled
+
+with cachalot_enabled():
+    rows = model.objects.filter(...).all()  # cached
+```
+
+Globally enabled via the `CACHALOT_ENABLED` env var; per-call via the context
+manager.
+
+The big benefit is for repeated reads of the same user-table query in a
+session. The big risk is correctness: any code path that writes to those
+tables outside the ORM (raw SQL, signals from non-ORM sources) won't trigger
+cachalot's invalidation hooks, and you'll see stale reads. If you're not sure,
+don't enable cachalot for your query.
+
+### User & Settings caches
+
+`baserow.core.user.cache` and the singleton `Settings` cache. Cache full User
+ORM objects (with `UserProfile` preloaded) and the global `Settings` row.
+
+TTL controlled by `BASEROW_CACHE_TTL_SECONDS` (env). Default `0` in dev (off);
+production sets a small TTL.
+
+Invalidated by `post_save` signal handlers on `User`, `UserProfile` and
+`Settings`. There's an explicit `invalidate_cached_user(user_id)` helper for
+flows that need it.
+
+### Job progress cache
+
+`baserow.core.jobs.cache`. Holds `progress_percentage` and `state` for
+in-flight `Job` rows. Necessary because DB transaction isolation otherwise
+hides progress updates from other workers and the API. The job model uses
+`.get_from_cached_value_or_from_self()` to prefer the cache when available
+and fall back to the DB row.
+
+### Role assignment cache (enterprise)
+
+`enterprise/backend/.../role/handler.py`. Caches role lookups and role
+assignments per actor/scope using `local_cache`. Decorator
+`@clear_roles_from_local_cache()` clears the cache after role mutations.
+
+Per-class in-memory cache for `Role` objects (used at module level — these
+are essentially immutable for the worker's lifetime).
+
+### Registry lookups
+
+`baserow.core.registry`. Several registry methods are wrapped in
+`@lru_cache`, e.g. `get_for_class()` for content-type-keyed lookups. These
+are unbounded process-level caches; registry contents don't change at
+runtime, so the cache is essentially permanent.
+
+### Search index existence
+
+`baserow.contrib.database.search.handler._workspace_search_table_exists` is
+wrapped in `@lru_cache(maxsize=1024)`. Cached for the worker's lifetime.
+Acceptable because workspace search tables are created once and effectively
+never dropped during a workspace's lifetime.
+
+### `cached_property` and friends
+
+Used liberally on models and request-scoped objects:
+
+- `Field.get_field_objects()`.
+- `FieldRule.filter_type()`.
+- `Page.get_theme()`.
+- Builder `*DispatchContext` properties.
+
+These cache for the lifetime of the object instance and need no explicit
+invalidation — discarding the instance discards the cache.
+
+## Minor / specialised caches
+
+- **Celery singleton locks** (`baserow.celery_singleton_backend`) — Redis-
+  backed locks preventing duplicate task runs.
+- **Auto-index lock flags** for search auto-indexing.
+
+## Things every dev should know
+
+1. **`local_cache` is essentially free; use it.** If you're looking up the
+   same thing twice in a request (permissions, workspace membership, dynamic
+   model), wrap it.
+2. **Versioned caches don't need surgical invalidation.** When you change
+   something cached by `global_cache` or the `generated_models` cache, you
+   roll the version once and every reader sees a miss on next access.
+   You do not need to know every key in the family.
+3. **cachalot is opt-in for user tables.** Don't sprinkle it; correctness
+   bugs from missed invalidation are nasty.
+4. **`BASEROW_VERSION` is part of several cache keys.** A Baserow upgrade
+   gives you a free flush. You can rely on this for cross-release schema
+   changes that didn't get an explicit invalidation.
+5. **`lru_cache` lives until the worker restarts.** Don't use it for anything
+   that changes at runtime. Don't use it on functions with `self`, ever
+   (silent memory leaks).
+
+## Common mistakes
+
+1. **Forgetting that `local_cache` is per-request.** If you cache a value at
+   module import time using `local_cache`, you're not caching anything —
+   it'll be empty on the first request that hits the code.
+2. **Leaking context across cache keys.** Don't cache user-scoped data under
+   a workspace-only key; it'll cross-leak between users sharing a workspace.
+   Always include the smallest identifier that defines the answer (`user_id`,
+   not just `workspace_id`).
+3. **Relying on TTL as the invalidation strategy.** TTL is a safety net.
+   Mutations should explicitly invalidate. Otherwise you race with the TTL
+   and users see stale data unpredictably.
+
+## Related
+
+- [Dynamic models](dynamic-models.md) — the most prominent application of the
+  generated-models cache.
+- [Workspace search guide](workspace-search.md) — search index `lru_cache`.
+- [Architectural patterns](../patterns/architecture.md) — where caching fits
+  relative to handlers and services.

--- a/docs/technical/database-plugin.md
+++ b/docs/technical/database-plugin.md
@@ -1,108 +1,135 @@
 # Database plugin
 
-The database plugin is installed by default in every copy of Baserow. Without it you 
-can't really do anything with the application. In short this is the plugin that allows
-creating a database with a spreadsheet-like interface. You will notice that everything
-has been built around this concept.
+The database plugin is the Baserow application type that gives users tables,
+fields, views, formulas, search, and everything spreadsheet-like. It is one of
+several application types in Baserow (`builder`, `automation`, `dashboard`,
+`integrations` are the others) and lives in
+`backend/src/baserow/contrib/database/`.
 
-## Tables
+This page is the entry into the database-specific architecture. If you're new
+to the codebase, start with the [systems overview](systems-overview.md), then
+[architectural patterns](../patterns/architecture.md), then
+[registries](../patterns/registries.md), and only then this page.
 
-Each database application can have multiple tables and a table is exactly what you
-might suspect. It contains rows and columns, but in Baserow the columns are called fields. 
-Every table has its own schema representation in the PostgreSQL database.
+## What it contains
 
-There is a `baserow.contrib.database.table.handler.TableHandler` handler class that has
-all kinds of methods related to creating, modifying, and deleting tables. Another nice
-thing is that a Django model of the table can easily be generated. Let's say you have 
-the following table with id `id` and you want select all the data.
+A database application owns:
 
-| Model name | Brand | Price |
-|------------|-------|-------|
-| 3 Series   | BTW   | 30000 |
-| A4         | Audi  | 25000 |
-| Model 3    | Tesla | 50000 |
+- **Tables** — each user table is backed by its own PostgreSQL table and a
+  Django model generated at runtime. See
+  [dynamic models](dynamic-models.md).
+- **Fields** — the columns of a table. Each field type
+  (`text`, `number`, `link_row`, `formula`, …) is a registered `FieldType`.
+  See [field system](../patterns/field-system.md) and
+  [Create field type](../plugins/field-type.md).
+- **Views** — alternative presentations of the same data (grid, gallery,
+  kanban, calendar, …). Each view type is a registered `ViewType`. See
+  [Create view type](../plugins/view-type.md).
+- **Rows** — the actual data, accessed through the dynamically generated model
+  of each table.
+- **Webhooks** — outbound HTTP callbacks fired when table state changes.
+- **Data sync** — periodic sync from external sources (Airtable, ICS, JSON,
+  …) into a table.
+- **Imports / exports** — bulk row import from CSV/JSON/XML/Excel; exports to
+  the same formats. See
+  [systems overview — table/view import/export](systems-overview.md#table--view-import--export-system).
+- **Search** — TSV-backed full-text search per table. See
+  [workspace search](workspace-search.md).
+- **Formulas** — a typed formula language with cross-field dependency
+  tracking. See [formula technical guide](formula-technical-guide.md).
 
-```python
-from baserow.contrib.database.table.models import Table
+## Working with tables programmatically
 
-cars_table = Table.objects.get(pk=ID_REFERENCED_TABLE_ABOVE)
-# If you set the attribute_names to True the attribute name is going to be the field 
-# name provided by the user instead of field_{id}
-cars_model = cars_table.get_model(attribute_names=True)
-
-for car in cars_model.objects.all():
-    print(car.id, car.model_name, car.price)
-
-# Results in:
-# 1 3 series 30000
-# 2 A4 30000
-# 2 Model 3 30000
-```
-
-## Fields
-
-A field is actually a column definition of a table. It accepts only a certain data type 
-for its cell values. A field can, for example, be a number field that accepts two
-placements after the comma. If a new field is added to a table it is also added as
-column to the table  representation in the database. The column name in the database
-will be field_{id}. The fields can be created, modified and deleted via the 
-`baserow.contrib.database.fields.handler.FieldHandler` and via the REST API. Several 
-field types have been included by default.
-
-> Field types can be added via plugins. More about that on the 
-> [field type plugin page](../plugins/field-type.md).
-
-* `text`: Single line text.
-* `long_text`: Multi line text.
-* `number`: A number that can optionally be negative and optionally be a decimal.
-* `boolean`: Just holds true or false.
-* `date`: A date field in EU, ISO or USA format that can optionally include time am/pm 
-  format.
-
-## Views
-
-Views define how the table data is displayed to the user. By default the `grid` view 
-type is included, which displays the data in a spreadsheet-like interface. Multiple
-views can be added to each table and each view has its own settings. If you, for
-example, have two grid views, A and B, of the same table of data, and you change the
-width of a column in grid A, then it only changes for grid A and not for grid B. The
-views can be created, modified and deleted via the 
-`baserow.contrib.database.views.handler.ViewHandler` and via the REST API.
-
-> View types can be added via plugins. More about that on the 
-> [view type plugin page](../plugins/view-type.md).
-
-### Rows
-
-Rows are the table data. The values that are accepted depend on the fields of the 
-table. The data is stored in the representation table in the database. In the example 
-below we will insert a single row of data in a table we have just created via the 
-python shell. The same result could be achieved via the REST API.
+Every operation has a handler entry point. Examples:
 
 ```python
-from django.contrib.auth import get_user_model 
-from baserow.contrib.database.table.models import Table
+from baserow.contrib.database.table.handler import TableHandler
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.rows.handler import RowHandler
 
-User = get_user_model()
-user = User.objects.get(pk=1)
-table = Table.objects.get(pk=10)
+# Create a table
+table = TableHandler().create_table(user, database, name="Customers")
 
-name = FieldHandler().create_field(user, table, 'text', name='Name')
-price = FieldHandler().create_field(user, table, 'number', name='Price')
-row = RowHandler().create_row(user, table, {
-    f'field_{name.id}': 'Smartphone',
-    f'field_{price.id}': 300
-})
+# Add fields
+name_field = FieldHandler().create_field(
+    user, table, "text", name="Name", primary=True,
+)
+revenue_field = FieldHandler().create_field(
+    user, table, "number", name="Revenue",
+)
 
+# Insert a row using the dynamically generated model
 model = table.get_model()
-rows = model.objects.all()
+row = RowHandler().create_row(
+    user, table,
+    {f"field_{name_field.id}": "Acme", f"field_{revenue_field.id}": 100000},
+)
 
-print(rows[0].name)
-print(rows[0].price)
-
-# Which will result in:
-# Smartphone
-# 300
+# Query the rows
+for row in model.objects.all():
+    print(row.id, getattr(row, f"field_{name_field.id}"))
 ```
+
+The same operations can run through the REST API. Handlers are the canonical
+business logic; the API is a serialisation layer over them. See
+[architectural patterns](../patterns/architecture.md).
+
+## Module layout
+
+`backend/src/baserow/contrib/database/`:
+
+| Subfolder | What's there |
+|---|---|
+| `api/` | DRF views, serializers, URLs, exception mappings. |
+| `table/` | `TableHandler`, `Table` model, dynamic model generation, table cache. |
+| `fields/` | `FieldHandler`, every built-in `FieldType`, field converters, dependency tracking. |
+| `views/` | `ViewHandler`, every built-in `ViewType` (grid, gallery, kanban, calendar, form), view filters, sortings, decorations, group bys. |
+| `rows/` | `RowHandler`, row signals, row history. |
+| `webhooks/` | Outbound webhook delivery. |
+| `data_sync/` | Periodic sync from external data sources. |
+| `file_import/` | CSV / JSON / XML / Excel importers. |
+| `export/` | Row data exporters. |
+| `formula/` | Formula parser, type system, function registry, AST. |
+| `search/` | TSV-based search indexing. |
+| `airtable/` | Airtable importer. |
+| `data_providers/` | Pluggable data-provider hooks used by formulas. |
+| `field_rules/` | Computed field-rule infrastructure. |
+| `migrations/` | Django migrations for the contrib.database app. |
+| `apps.py` | Application registration — every type, handler, signal connects here. |
+
+Mirror layout in `web-frontend/modules/database/` for the frontend
+counterpart: components, services, stores, realtime handlers, and the Nuxt
+modules that wire them up.
+
+## Cross-cutting concerns
+
+Many subsystems hook into database operations through signals (see
+[architectural patterns](../patterns/architecture.md)):
+
+- The search system reindexes affected rows on writes.
+- The websocket layer broadcasts changes to subscribed clients.
+- The formula / field-dependency system recomputes derived values.
+- The notification system emits user mentions and collaborator events.
+- The trash system intercepts deletions for soft-delete + retention.
+
+If you change how a handler writes data, audit the receivers in `baserow.ws.*`,
+`baserow.contrib.database.search`, the dependency code in
+`baserow.contrib.database.fields.dependencies`, and the notification handlers.
+
+## See also
+
+- [Systems overview](systems-overview.md) — the map of subsystems.
+- [Architectural patterns](../patterns/architecture.md) — request flow shape.
+- [Registries](../patterns/registries.md) — the extension pattern.
+- [Field system](../patterns/field-system.md) — the central architectural
+  concept of the database plugin.
+- [Dynamic models](dynamic-models.md) — how `Table.get_model()` works.
+- [Formula technical guide](formula-technical-guide.md).
+- [Workspace search guide](workspace-search.md).
+- [Undo/redo guide](undo-redo-guide.md).
+- [Permissions guide](permissions-guide.md).
+- [Action system](action-system.md).
+- [Trash system](trash-system.md).
+- [Notification system](notification-system.md).
+- [Serialization system](serialization-system.md).
+- [Plugin guides for the database](../plugins/introduction.md).

--- a/docs/technical/dynamic-models.md
+++ b/docs/technical/dynamic-models.md
@@ -1,0 +1,210 @@
+# Dynamic table models
+
+User tables in Baserow are real PostgreSQL tables with real Django models — but
+the Django model classes are **generated at runtime** from the table's field
+definitions. There is no `class Customers(models.Model)` in the codebase for a
+user's "Customers" table. Instead, `Table.get_model()` builds a fresh model
+class on demand, and that class is what every query against user data goes
+through.
+
+This page explains how that works, where the caches are, what invalidates them,
+and the surprises new developers regularly run into.
+
+Read [Systems overview](systems-overview.md) and
+[Architectural patterns](../patterns/architecture.md) first.
+
+## Entry point
+
+```python
+from baserow.contrib.database.table.models import Table
+
+table = Table.objects.get(pk=table_id)
+model = table.get_model()  # → a subclass of GeneratedTableModel
+
+# Now use it like any Django model
+for row in model.objects.all():
+    print(row.id, row.field_1234)
+
+# Or with human-readable attribute names
+model_with_names = table.get_model(attribute_names=True)
+for row in model_with_names.objects.all():
+    print(row.name, row.revenue)
+```
+
+`Table.get_model()` lives in
+`baserow.contrib.database.table.models` and wraps the real generation function
+`Table._get_model()`. Its useful kwargs:
+
+| kwarg | What it does |
+|---|---|
+| `attribute_names=True` | Use the field's user-given name (`name`, `revenue`) for model attributes instead of `field_1234`. Disables the Redis cache. |
+| `field_ids=[...]` | Restrict the generated model to only these fields. Performance shortcut. |
+| `field_names=[...]` | Same but by name. |
+| `add_dependencies=True` (default) | When restricting fields, automatically include fields the requested ones depend on (e.g. formula sources). |
+| `use_cache=True` (default) | Use the cached `field_attrs` if present. |
+| `manytomany_models={}` | Internal — shared dict for resolving link-row M2Ms across nested calls. |
+| `app_label=...` | Internal — override the model's app label, used to make circular link-rows safe. |
+
+## How a model is built
+
+`_get_model()` does roughly the following:
+
+1. Fetch all `Field` rows for the table — including **trashed fields** so the
+   generated model still knows about the columns that exist in the database
+   (NOT NULL constraints would break on restore otherwise). Trashed fields are
+   filtered out of `_field_objects` and stored in `_trashed_field_objects`.
+2. For each field, call `field_type.get_model_field(field, **kwargs)` to get
+   the appropriate Django model field (e.g. `models.CharField`,
+   `models.DecimalField`).
+3. Assemble an `attrs` dict — Django field attributes, plus `_field_objects`,
+   plus `Meta` with `db_table = "database_table_{table_id}"` and
+   `app_label`/`managed` settings.
+4. Build the class with `type(name, bases, attrs)`, where `bases` is
+   `(GeneratedTableModel, TrashableModelMixin, CreatedAndUpdatedOnMixin,
+   models.Model)`.
+5. Call `_after_model_generation()` so field types can do post-class
+   setup — most notably `LinkRowFieldType.after_model_generation` adds the
+   ManyToMany field via `contribute_to_class` (see "Gotchas" below).
+
+The result is a Django model class indistinguishable from a hand-written one
+for ORM purposes.
+
+## `GeneratedTableModel` — the base class
+
+Every generated model inherits from `GeneratedTableModel`
+(`baserow.contrib.database.table.models`). It is the safe `isinstance` check
+for "is this a user-table model" and provides shortcuts useful when you have
+the model class but not the fields:
+
+- `get_field_objects()` — list of `_field_objects` entries.
+- `get_field_object_by_id(field_id)`.
+- `get_fields()`, `get_primary_field()`, `get_searchable_fields()`.
+- `get_primary_field_value()` — for rendering a row's display label.
+- `info()` — rich-formatted debug table of fields (dev-only).
+
+It also mixes in `HierarchicalModelMixin` which provides `get_parent()` (the
+`Table`) and `get_root()` (the workspace).
+
+## Caching
+
+There are **two layers**, both of which `get_model()` consults.
+
+### Layer 1 — per-request local cache
+
+`baserow.core.cache.local_cache` (built on `asgiref.local.Local`, so it's safe
+across both threads and async tasks). Keyed by
+`database_table_model_{table_id}`. Scope: the duration of a single HTTP request
+or background task.
+
+Hit only when the kwargs are at their defaults (i.e. no `field_ids`,
+`field_names`, `attribute_names`, etc.). The check is
+`are_kwargs_default(...)`.
+
+This cache is cleared by the `LocalCacheMiddleware` at the boundary of every
+request.
+
+### Layer 2 — distributed Redis cache (versioned)
+
+The dedicated `generated_models` cache backend (Redis in production).
+Key: `full_table_model_{table_id}_{BASEROW_VERSION}`.
+
+This cache **does not store the model class itself** — dynamically generated
+Python classes can't be safely round-tripped through a cache. It stores the
+precomputed `field_attrs` dict that the generator uses to assemble the model.
+The model class is rebuilt from those attrs on a cache hit, which is much
+faster than re-querying all the fields and calling each
+`field_type.get_model_field()`.
+
+Stored shape: `{"field_attrs": {...}, "version": table.version}`.
+
+The cache is invalidated by **version mismatch**: every `Table` row has a
+`version: str` UUID column; when something changes that affects the model,
+`invalidate_table_in_model_cache(table_id)` rolls the UUID, so the cache lookup
+finds a stale `version` and discards the entry.
+
+Invalidation happens in:
+
+- `Field` model save / delete (via the `invalidate_table_model_cache` method on
+  the FieldHandler).
+- `FieldHandler.update_field()`.
+- `FieldHandler.move_field_between_tables()` — invalidates both tables.
+- Table post-delete signal.
+- Search index initialise/update.
+
+Also, the cache key includes `BASEROW_VERSION` — so every Baserow upgrade is a
+full cache flush for free.
+
+## What forces a fresh model build
+
+In day-to-day code, anything that mutates a table's schema:
+
+- A field added, updated (including type conversion), deleted, restored.
+- A field moved between tables.
+- The table itself being deleted (cache invalidated then dropped).
+
+Restores and undo/redo go through the same mutation paths, so they invalidate
+correctly.
+
+If you're writing code that *directly* manipulates `Field` rows outside the
+`FieldHandler` (rare — usually a migration or a data-fix script), call
+`invalidate_table_in_model_cache(table_id)` yourself.
+
+## Gotchas
+
+### 1. The class object is not stable across calls
+
+```python
+m1 = table.get_model()
+m2 = table.get_model()
+assert m1 is m2  # ❌ NOT guaranteed
+```
+
+Every call returns a *fresh* Python class object, even on a cache hit (the
+class is rebuilt from cached `field_attrs`). The class **name** is stable
+(`Table42Model`) but identity is not. Use `isinstance(row, GeneratedTableModel)`,
+or compare by `table_id`, not by class identity.
+
+### 2. `LinkRowFieldType.get_model_field()` returns `None`
+
+This is intentional. The M2M field for a link row can't be added during the
+initial `type(...)` call because it might reference the same model
+(self-link) or a not-yet-built model. The field type's
+`after_model_generation()` hook attaches it via `contribute_to_class()` after
+the class exists. If you debug into model generation and see a "missing"
+link-row attribute, that's why.
+
+### 3. Trashed fields are columns, not attributes
+
+The PostgreSQL column for a trashed field is still there (to support restore).
+The generated model knows about it via `_trashed_field_objects` but doesn't
+expose it as an attribute. If you query the underlying table directly with
+raw SQL, you'll see columns the ORM model doesn't mention.
+
+### 4. `attribute_names=True` disables the Redis cache
+
+Because the attribute names are derived from current field names (which can
+change), the cached attrs would go stale. Use `attribute_names=True` only for
+human-readable code paths (exports, formula rendering, snapshots), not for
+hot-path queries.
+
+### 5. `add_dependencies=True` may include more fields than you asked for
+
+If you call `table.get_model(field_ids=[10])` and field 10 is a formula that
+references field 7, the generated model will include both fields 10 and 7. To
+disable this transitively-include behaviour, pass `add_dependencies=False`.
+
+### 6. Circular link rows need consistent `app_label`
+
+If you generate two mutually-linked models in the same call chain, both must
+share the same `app_label` so Django's pending-operations resolver pairs them
+up. The generator manages this for you via the shared `manytomany_models`
+dict; if you ever bypass that path, you'll see "pending operations" exceptions.
+
+## Where to read next
+
+- [Field system](../patterns/field-system.md) — the FieldType ↔ FieldHandler
+  contract that drives model generation.
+- [Caching](caching.md) — the broader cache architecture this slot fits into.
+- `baserow.contrib.database.table.models` — the source.
+- `baserow.contrib.database.table.cache` — the Redis cache helpers.
+- `baserow.core.cache` — `local_cache` and the cache primitives.

--- a/docs/technical/editions-and-licensing.md
+++ b/docs/technical/editions-and-licensing.md
@@ -1,0 +1,196 @@
+# Editions and licensing
+
+Baserow ships in three editions. They share most of the code but differ in
+what's enabled at runtime. This page covers:
+
+1. The boundaries between core, premium, and enterprise — what goes where
+   and why.
+2. The licensing mechanism — how the code knows whether a feature is
+   active.
+3. The SaaS context — how baserow.io differs from a self-hosted install.
+
+## Editions
+
+| Edition | Folder | License | Contents |
+|---|---|---|---|
+| **Core** | `backend/`, `web-frontend/` | Open-source (MIT) | Everything everyone gets: users, workspaces, the database application type with all built-in field/view types, the builder app, automations, dashboards, integrations. The framework. |
+| **Premium** | `premium/` | Baserow Premium Edition License | Self-hostable but licensed features: personal views, row comments, AI fields, advanced exports, etc. |
+| **Enterprise** | `enterprise/` | Baserow Enterprise Edition License | RBAC, SSO/SAML, audit logs, advanced admin, restricted views, data scanner, etc. |
+
+Premium and enterprise are themselves Baserow plugins — they register types
+into the same registries the core code uses. There is no special code path
+that "is premium" or "is enterprise" beyond a licence check at the feature
+boundaries.
+
+## Boundary rules
+
+**The single most important architectural rule in the project:**
+
+```
+core   ──> can be imported from anywhere
+contrib ──> may import from core, never the other way
+premium ──> may import from core and contrib, never the other way
+enterprise ──> may import from core, contrib, and premium, never the other way
+```
+
+In particular:
+
+- **Core code must never import from contrib, premium, or enterprise.** Core
+  should be agnostic about which application types or licensed features
+  exist. The way features extend core is by *registering into core's
+  registries* from their own `apps.py` `ready()` methods.
+- **Contrib must never import from premium or enterprise.** Same reason.
+- **Premium and enterprise extend the platform**, they don't modify it. If
+  you need to change core behaviour to make a premium feature work, you
+  refactor core to provide a registration point — you don't reach into
+  premium from core.
+
+Why it matters: a Baserow user who self-hosts core-only must be able to run
+without `premium/` or `enterprise/` on disk at all. The licence model also
+depends on it — a premium feature can't run if `premium/` isn't installed.
+
+## Where things go
+
+The rule of thumb when you're adding a new feature:
+
+- **Touches everyone:** core or contrib.
+- **Touches paid plans on self-hosted *and* on SaaS:** premium.
+- **Touches paid plans only on SaaS or enterprise self-hosted:** enterprise.
+- **Touches the database application type:** `contrib/database` (for free) or
+  `premium`/`enterprise` (for paid).
+- **Touches the builder, automations, dashboards, integrations:** the
+  corresponding `contrib/<area>` folder.
+
+When in doubt, ask. Putting a feature in the wrong folder is hard to undo
+because users get used to having it available on their plan.
+
+## The licensing mechanism
+
+The licence system lives in `premium/backend/src/baserow_premium/license/`.
+This is deliberately not in core — core knows nothing about licensing. Code
+that needs to gate behaviour on a feature flag imports the `LicenseHandler`
+from premium.
+
+### Models
+
+- **`License`** (`baserow_premium.license.models.License`) — one row per
+  installed licence. Holds the encoded licence token; decoding gives the
+  product code, valid-from / valid-to dates, granted features, and seat
+  count.
+- **`LicenseUser`** — many-to-many between `License` and `User` for
+  per-seat licences.
+
+### `LicenseType` — the registry
+
+Each kind of licence is a `LicenseType` registered in `license_type_registry`
+(also in premium). Today there are two:
+
+- `PremiumLicenseType` (`baserow_premium.license.license_types`).
+- `EnterpriseLicenseType` (`baserow_enterprise.license_types`).
+
+A `LicenseType` defines which features it grants, the product code stored on
+the licence, and behaviour like seat assignment rules.
+
+### `LicenseHandler` — the API
+
+`baserow_premium.license.handler.LicenseHandler` is the entry point for
+checking features. Three patterns of use:
+
+```python
+from baserow_premium.license.handler import LicenseHandler
+from baserow_premium.license.features import PREMIUM
+
+# Instance-wide check (no workspace context).
+if LicenseHandler.instance_has_feature(PREMIUM):
+    ...
+
+# Workspace-scoped check.
+if LicenseHandler.workspace_has_feature(SOME_FEATURE, workspace):
+    ...
+
+# User-scoped check inside a workspace.
+if LicenseHandler.user_has_feature(SOME_FEATURE, user, workspace):
+    ...
+
+# Raising variant — recommended in handlers/services so failure
+# turns into a clean HTTP response via the exception mapping.
+LicenseHandler.raise_if_user_doesnt_have_feature(SOME_FEATURE, user, workspace)
+```
+
+The handler delegates to a "license plugin" abstraction so the implementation
+can vary between standard self-hosted, SaaS, and test environments. The
+default plugin lives in premium; SaaS overrides it with its own variant.
+
+### Feature constants
+
+Each plugin keeps its feature flag constants in a `features.py`:
+
+- `premium/backend/src/baserow_premium/license/features.py` — `PREMIUM`,
+  `AI`, `PERSONAL_VIEWS`, `EXPORT_GROUP`, ...
+- `enterprise/backend/src/baserow_enterprise/features.py` — `RBAC`,
+  `SSO`, `AUDIT_LOG`, ...
+
+Use these constants by import. Don't pass raw strings.
+
+### Failing closed
+
+`LicenseHandler.raise_if_*` raise `FeaturesNotAvailableError`, which the API
+exception mapping translates to a clear "feature not available" response.
+This is the right behaviour for new feature checks — fail closed, not open.
+
+A handler that needs to gate behaviour on a feature looks like:
+
+```python
+class MyHandler:
+    def my_method(self, user, workspace):
+        LicenseHandler.raise_if_user_doesnt_have_feature(
+            SOME_FEATURE, user, workspace,
+        )
+        # ... the actual work
+```
+
+## SaaS context — baserow.io
+
+The hosted product (baserow.io) is a different deployment of the same
+codebase, plus a private repository (`baserow-saas`) that overrides some
+behaviour:
+
+- **Trials and billing.** SaaS users land on a trial; expiry transitions are
+  handled by SaaS-only code. The free / paid plan distinction in SaaS is
+  enforced through the same `LicenseHandler` API, but with the SaaS
+  licence plugin doing the actual lookup against subscription state instead
+  of installed licences.
+- **Account-management UI.** Self-hosted admins manage licences in their
+  admin panel; SaaS users manage their plan through Stripe-driven flows in
+  `baserow-saas`.
+- **Marketing pages.** baserow.io serves marketing content. Self-hosted
+  doesn't.
+
+Most code paths run identically in both environments. When SaaS-specific
+behaviour is needed in shared code, register a hook in core and let SaaS
+implement it — same pattern as premium/enterprise vs core.
+
+## Common mistakes
+
+- **Importing `LicenseHandler` from core.** Don't. Core code must not depend
+  on premium. Instead, refactor: expose a hook in core, register the
+  feature-gated behaviour from premium.
+- **Hard-coding feature strings.** Use the constants in `features.py`. Strings
+  drift; constants don't.
+- **Checking the license inside a tight loop.** The check is cheap but
+  non-zero. Cache the result for the request via `local_cache` (see
+  [caching](caching.md)).
+- **Forgetting that premium / enterprise files don't exist in core-only
+  installs.** Conditional imports must be defensive; do not assume
+  `baserow_premium` is importable from a core code path.
+- **Putting a paid feature in the wrong tier.** Premium vs enterprise is a
+  product decision, not an engineering one. Check with PM before deciding.
+
+## Related
+
+- [Systems overview — license/feature/pricing system](systems-overview.md#license--feature--pricing-system).
+- [Directory structure](../development/directory-structure.md) — the boundary
+  rules in the broader codebase layout.
+- [Architectural patterns](../patterns/architecture.md) — where the licence
+  check belongs in a request (in the service or at the start of the action,
+  not in the view).

--- a/docs/technical/features-and-interactions.md
+++ b/docs/technical/features-and-interactions.md
@@ -1,0 +1,174 @@
+# Features and interactions
+
+A catalogue of the major user-facing features of the database plugin, plus a
+map of which features interact in non-trivial ways. The interaction map is
+the more valuable half — it's where most bugs and design questions live.
+
+For the *implementation* of each feature, follow the links to the relevant
+technical or plugin guide.
+
+## Feature catalogue
+
+### Tables and rows
+
+- **Tables** — the spreadsheet-like unit of structured data. Backed by a
+  dynamically generated Django model. See
+  [dynamic models](dynamic-models.md).
+- **Rows** — the records inside a table. Soft-deletion via the
+  [trash system](trash-system.md); history via the
+  [row history pattern](../patterns/row_history_from_action.md).
+
+### Fields
+
+Built-in field types and what's notable about them:
+
+| Type | Notes |
+|---|---|
+| `text`, `long_text`, `email`, `phone_number`, `url` | Basic scalar text. |
+| `number` | Decimal places + prefix/suffix formatting. |
+| `boolean` | True / false. |
+| `date`, `last_modified`, `created_on`, `last_modified_by`, `created_by` | Time + metadata fields. |
+| `single_select`, `multiple_select` | User-defined option sets. |
+| `link_row` | M2M between tables; powers lookups, rollups and counts. |
+| `formula` | Polymorphic: result type derived from the formula expression. See [formula](formula-technical-guide.md). |
+| `lookup` | Pulls a value from a linked row. Implemented as a constrained formula. |
+| `rollup` | Aggregates linked rows (sum, count, max, …). |
+| `count` | Counts linked rows. |
+| `multiple_collaborator` | Multiple users from the workspace. |
+| `file`, `password`, `rating`, `duration`, `autonumber`, `uuid`, `ai`, `rich_text` | Special-purpose. |
+
+See [field system](../patterns/field-system.md) and
+[plugin: field-type](../plugins/field-type.md).
+
+### Views
+
+Built-in view types:
+
+| Type | Notable |
+|---|---|
+| `grid` | Spreadsheet-style. Supports filtering, sorting, grouping, search, decorations. |
+| `gallery` | Card layout. |
+| `kanban` | Board grouped by a single-select field. |
+| `calendar` | Time-based layout on a date field. |
+| `form` | Public input form generating rows. |
+| `timeline` | Date-range layout. |
+
+View modifiers, applied to most view types:
+
+- **Filtering** — boolean conditions over fields, combined as a tree.
+- **Sorting** — ordered list of field-direction pairs.
+- **Grouping** — applies on grid view today; group-by hooks exist for others.
+- **Search** — full-text TSV search across the table.
+- **Decorations** — visual annotations conditional on row state.
+
+### Cross-cutting features
+
+- **Comments / row activity** — per-row commentary and history.
+- **Webhooks** — fire HTTP requests on row events.
+- **Data sync** — periodic pull from Airtable / ICS / JSON / etc.
+- **Imports / exports** — CSV / JSON / XML / Excel.
+- **Snapshots** — point-in-time application copies. Serialization-backed.
+- **Templates** — pre-built applications. Serialization-backed.
+- **API tokens** — long-lived credentials with per-resource scopes.
+- **Realtime updates** — every state change pushed to subscribed clients.
+- **Undo / redo** — through the action system.
+- **Notifications** — events users opted into seeing.
+- **Search** — workspace-scoped full-text search.
+- **Trash** — soft-delete + retention for almost everything.
+- **Permissions** — RBAC (enterprise), public sharing, personal views
+  (premium).
+
+## Interaction map
+
+The interesting question for a new developer isn't "what features exist" —
+it's "which features lie about being independent." This table marks the
+pairs that *don't* compose cleanly and where you need to think carefully.
+
+Legend: ✔ = simple, ⚠ = non-trivial, watch out, 🛑 = known landmine.
+
+| → \ ↓ | Field type | View modifier | Realtime | Trash | Undo | Snapshot/export | Search | Notifications | Webhooks |
+|---|---|---|---|---|---|---|---|---|---|
+| **Field type** | — | ⚠ | ✔ | ⚠ | ⚠ | ⚠ | ⚠ | ✔ | ⚠ |
+| **View modifier** | ⚠ | — | ✔ | ⚠ | ⚠ | ⚠ | ⚠ | ✔ | ✔ |
+| **Realtime** | ✔ | ✔ | — | ✔ | ✔ | ✔ | ✔ | ✔ | ✔ |
+| **Trash** | ⚠ | ⚠ | ✔ | — | ⚠ | ⚠ | ⚠ | ✔ | ✔ |
+| **Undo/redo** | ⚠ | ⚠ | ✔ | ⚠ | — | ✔ | ✔ | ✔ | ✔ |
+| **Snapshot/export** | ⚠ | ⚠ | ✔ | ⚠ | ✔ | — | ⚠ | ✔ | ✔ |
+| **Search** | ⚠ | ⚠ | ✔ | ⚠ | ✔ | ⚠ | — | ✔ | ✔ |
+| **Formula** | 🛑 | ⚠ | ✔ | ⚠ | ⚠ | ⚠ | ⚠ | ✔ | ⚠ |
+| **Link rows** | 🛑 | 🛑 | ⚠ | 🛑 | ⚠ | 🛑 | ⚠ | ✔ | ⚠ |
+| **Permissions** | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ | ⚠ |
+
+### Specifics worth knowing
+
+- **Field type × view modifier** — Filters and sorts depend on the field
+  type's capabilities. Changing a field's type calls
+  `ViewHandler.before_field_type_change(field)` to invalidate filters/sorts
+  that referenced behaviour the new type doesn't support.
+- **Field type × search** — Every searchable field type provides a
+  `get_search_expression`. Changing a field's type, or changing values,
+  schedules a TSV reindex.
+- **Field type × dynamic model** — Every field change (create / update /
+  delete / type conversion) bumps `Table.version` and invalidates the
+  generated model cache. See [dynamic models](dynamic-models.md).
+- **Formula × link row** — The most complex interaction in Baserow. Lookups
+  and rollups are formulas over a link-row field; the dependency graph keeps
+  values current as either side changes. Bugs in this corner are common
+  enough that #5184 (link-row group-by crash) is on the bug queue. See
+  [formula technical guide](formula-technical-guide.md) and
+  [field system: dependency contract](../patterns/field-system.md#dependency-contract).
+- **Formula × field deletion** — Deleting a field that a formula depends on
+  breaks the formula. The dependency system reports the break to the
+  affected dependents via `field_dependency_deleted`.
+- **Link row × trash** — Deleting a linked row removes M2M rows, but the
+  link-row field's backref is cascade-trashed via
+  `get_other_fields_to_trash_restore_always_together`. Restoring the field
+  restores both ends.
+- **Link row × group-by** — Grouping by a link-row field when rows have many
+  linked items has surfaced as a crash (#5184). The combination is fragile.
+- **Trash × cascading** — Trashing a parent doesn't iterate children; the
+  `TrashEntry` is linked via cascading FK so permanent deletion of a parent
+  takes its children with it. Restoring a child whose parent is still trashed
+  raises `CannotRestoreChildBeforeParent`. See
+  [trash system](trash-system.md).
+- **Trash × search** — Each `TrashableItemType`'s `permanently_delete_item()`
+  is responsible for tearing down the search index entries. New trashable
+  types must wire this up.
+- **Undo/redo × every action** — Most state changes flow through an
+  `ActionType`. Undoable types implement `undo()` / `redo()`. Anything that
+  bypasses the action system won't appear in the undo stack — common source
+  of "but I did Ctrl+Z" support tickets.
+- **Snapshot/export × everything** — Snapshots and templates are
+  serialise-and-deserialise of the entire application. Any feature whose
+  state isn't covered by `export_serialized` / `import_serialized` is lost
+  in snapshots. See [serialization system](serialization-system.md).
+- **Realtime × every state change** — Handlers emit signals; receivers
+  translate to ws messages. A new feature whose handler doesn't emit signals
+  appears to work but doesn't update other clients in real time. Check
+  `baserow.ws.*` receivers for what's covered.
+- **Permissions × everything** — Permission checks live in services (or
+  actions when there's no service). Adding a new endpoint without a
+  permission check is the most common security regression. RBAC in
+  enterprise extends but doesn't replace the base permission model.
+
+## Reading order for a new developer
+
+The most efficient sequence to internalise this map:
+
+1. Read this page top-to-bottom to know what exists.
+2. [Dynamic models](dynamic-models.md) — the universal substrate.
+3. [Field system](../patterns/field-system.md) — the central interaction
+   hub.
+4. [Action system](action-system.md) — the auditing/undo backbone.
+5. [Architectural patterns](../patterns/architecture.md) — how the layers
+   compose.
+6. [Workspace search](workspace-search.md), [trash](trash-system.md),
+   [serialization](serialization-system.md) — supporting systems.
+7. [Formula](formula-technical-guide.md) — left for last because it pulls
+   in everything else.
+
+## Related
+
+- [Systems overview](systems-overview.md).
+- [Database plugin](database-plugin.md).
+- The plugin guides under [`docs/plugins/`](../plugins/introduction.md).

--- a/docs/technical/introduction.md
+++ b/docs/technical/introduction.md
@@ -1,5 +1,11 @@
 # Baserow Technical Introduction
 
+> **New to the codebase?** Start with [Systems overview](systems-overview.md) for
+> the map of major subsystems, then [Architectural patterns](../patterns/architecture.md)
+> for the layered shape of a request, then [Registries](../patterns/registries.md) for
+> the pattern most of the code uses. The deeper per-system guides (undo/redo,
+> permissions, websockets, workspace search, …) are linked from the systems overview.
+
 ## Architecture
 
 Baserow consists of two main components:

--- a/docs/technical/notification-system.md
+++ b/docs/technical/notification-system.md
@@ -1,0 +1,152 @@
+# Notification system
+
+Notifications are the in-product way Baserow tells a user something happened
+that they care about: a collaborator was added to a row, a form was submitted,
+a webhook was deactivated, an automation workflow failed. Each notification can
+also be sent by email (instantly, daily, or weekly digest) depending on the
+user's preferences and the notification type's configuration.
+
+Entry point: `baserow.core.notifications.handler.NotificationHandler`.
+
+## Data model
+
+Two models in `baserow.core.notifications.models`:
+
+- **`Notification`** — one row per notification *event*. Holds the type, the
+  workspace, the params data (JSON), broadcast flag, and creation/scheduling
+  metadata.
+- **`NotificationRecipient`** — many-to-many between `Notification` and `User`.
+  Holds per-user state: `read`, `email_scheduled`, `queued`, and (for broadcast
+  notifications) the marker that this specific user has seen it.
+
+The model split exists because some notifications target many users (workspace
+admins, all workspace members, a broadcast to every user) and we want one
+`Notification` row + one recipient row per user rather than duplicating data.
+
+## `NotificationType` — the registry
+
+Each notification kind is a `NotificationType` subclass registered in
+`notification_type_registry` (see `baserow/core/notifications/registries.py`).
+The type owns:
+
+- **Recipient resolution** — given the params, which users should receive this?
+- **Formatting** — what does the title/body look like in the UI?
+- **Email integration** — does this type emit emails too, and what does the
+  email look like? (`EmailNotificationTypeMixin`.)
+- **Web frontend URL** (optional) — a deep link the user clicks to take action.
+
+Built-in registrations (non-exhaustive):
+
+| Type | Registered in |
+|---|---|
+| `WorkspaceInvitationCreatedNotificationType`, `WorkspaceInvitationAcceptedNotificationType`, `WorkspaceInvitationRejectedNotificationType`, `BaserowVersionUpgradeNotificationType` | `baserow.core.apps` |
+| `CollaboratorAddedToRowNotificationType`, `UserMentionInRichTextFieldNotificationType`, `FormSubmittedNotificationType`, `WebhookDeactivatedNotificationType`, `WebhookPayloadTooLargeNotificationType` | `baserow.contrib.database.apps` |
+| `WorkflowDisabledNotificationType` | `baserow.contrib.automation.apps` |
+
+Premium/enterprise plugins register their own types in their respective `apps.py`.
+
+## Creating a notification
+
+A typical call from a handler looks like:
+
+```python
+NotificationHandler.create_direct_notification_for_users(
+    notification_type=CollaboratorAddedToRowNotificationType.type,
+    recipients=[user_a, user_b],
+    data={"row_id": row.id, "field_id": field.id},
+    sender=requesting_user,
+    workspace=table.database.workspace,
+)
+```
+
+`NotificationHandler` also has helpers for **broadcast** notifications
+(`create_broadcast_notification`) where the notification is created once and
+every user can see it until they've marked it read, and for **workspace-wide**
+notifications (`create_workspace_notification`) that target all users in a
+workspace.
+
+Three signals fire from the handler:
+
+- `notification_created` — receivers in `baserow.ws.*` translate this into a
+  realtime push to connected clients.
+- `notification_marked_as_read` — pushes a marker so the unread counter updates
+  in the user's UI.
+- `all_notifications_cleared` / `all_notifications_marked_as_read` — bulk
+  variants.
+
+## Reading and marking read
+
+The frontend fetches notifications via the notifications API, displays them in
+the panel, and tracks unread count by querying `NotificationRecipient` filtered
+by `read=False` for the current user. Marking read flips `read=True` and emits
+the corresponding signal.
+
+## Email delivery
+
+`EmailNotificationTypeMixin` is the opt-in. A type that inherits from it must
+implement:
+
+- `get_notification_title_for_email(notification, context)` — the email subject.
+- `get_notification_description_for_email(notification, context)` — the body.
+- Optionally set `has_web_frontend_route = True` to make the email clickable.
+
+Users choose their email cadence (instant, daily digest, weekly digest, or
+never) in their profile.
+
+Three Celery beat schedules in `baserow.config.settings.base` drive delivery:
+
+| Cadence | Env crontab var | Default |
+|---|---|---|
+| Instant | `BASEROW_EMAIL_NOTIFICATIONS_INSTANT_CRONTAB` | `* * * * *` (every minute) |
+| Daily | `BASEROW_EMAIL_NOTIFICATIONS_DAILY_HOUR_OF_DAY` | hour `0` |
+| Weekly | `BASEROW_EMAIL_NOTIFICATIONS_WEEKLY_*` | configurable |
+
+Per-task batch caps (`BASEROW_EMAIL_NOTIFICATIONS_LIMIT_INSTANT/_DAILY/_WEEKLY`,
+defaults 50 / 1000 / 5000) prevent runaway email blasts and split work across
+multiple task runs.
+
+The send path is `send_queued_notifications_to_users` in
+`baserow.core.notifications.tasks`. It pulls users with scheduled+unread+queued
+notifications and renders a `NotificationsSummaryEmail` (defined in
+`baserow.core.emails`) per user.
+
+`EMAIL_NOTIFICATIONS_ENABLED` (env `BASEROW_EMAIL_NOTIFICATIONS_ENABLED`, default
+true) is the global kill switch. Set to false to disable all email sending.
+
+## Adding a new notification type
+
+1. Subclass `NotificationType` (and `EmailNotificationTypeMixin` if you want
+   emails). Add `CliNotificationTypeMixin` if you want a `manage.py` command to
+   create one for testing.
+2. Define the `type` string and any params your formatting needs.
+3. Implement `get_notification_title_for_email` / `get_notification_description_for_email`
+   if applicable.
+4. Register the type from the relevant `apps.py` `ready()` method.
+5. Add the API serializer if the params surface in the API response.
+6. Wire the trigger — typically a signal receiver or a call from a handler that
+   creates the notification.
+
+## Gotchas
+
+- **`create_direct_notification_for_users` vs `create_broadcast_notification`.**
+  Direct creates one `Notification` and one `NotificationRecipient` per user
+  (you can mark per-user state). Broadcast creates one `Notification` with no
+  per-user rows — users get a "seen" recipient row the first time they mark it
+  read.
+- **The signal-versus-handler split.** Notifications are often emitted from
+  signal receivers, not from the handler that did the work, because the
+  notification depends on context that's only available after the action is
+  complete. Look at `baserow.contrib.database.collaborator_field` for a
+  representative example.
+- **Email send is async.** Sending an email is a Celery task triggered by beat,
+  not by the request that created the notification. A user that creates a
+  notification and then immediately checks their inbox will not see it yet.
+- **Workspace inference.** Many types require the workspace to scope visibility
+  and email routing. If you write a new type and forget the `workspace`
+  parameter, the notification will be created but won't be discoverable by
+  workspace-scoped queries.
+
+## Related
+
+- [Systems overview — Notification system](systems-overview.md#notification-system).
+- [Email pattern](../patterns/emails.md) — how email rendering works generally.

--- a/docs/technical/serialization-system.md
+++ b/docs/technical/serialization-system.md
@@ -1,0 +1,184 @@
+# Serialization system
+
+The serialization system is the mechanism Baserow uses to convert applications,
+tables, views, fields, rows and a lot of other state into a portable
+JSON-and-ZIP representation, and back again.
+
+It is what powers, behind the scenes:
+
+- **Templates** — the catalog of pre-built applications shipped with Baserow is
+  just a set of serialized applications imported on first run.
+- **Workspace export / import** — exporting a workspace to share or back up,
+  and re-importing it elsewhere.
+- **Snapshots** — taking a point-in-time copy of an application and restoring
+  it later. Snapshots are stored as serialized data.
+- **Duplication** — the "duplicate database" / "duplicate table" / "duplicate
+  view" operations are implemented as in-memory `export_serialized` →
+  `import_serialized` round trips.
+- **AI / agent context** in some flows — the same serialized representation is
+  used as canonical input to LLM-driven actions.
+
+Because so many features funnel through this system, it has strong implications
+when you change a model or registry: if you don't update the
+`export_serialized` / `import_serialized` paths, **template loading,
+duplication and snapshots silently break**.
+
+## The pattern
+
+Every registry whose entries own user-visible state implements two methods on
+its `Instance` base class:
+
+- `export_serialized(instance, ...)` — return a JSON-serialisable dict
+  describing the instance.
+- `import_serialized(parent, serialized_values, id_mapping, ...)` — given the
+  dict, recreate the instance under a new parent, populating an `id_mapping`
+  dict from old ids → new ids so downstream cross-references can be rewritten.
+
+Registries that participate include `application_type_registry`,
+`field_type_registry`, `view_type_registry`, `view_filter_type_registry`,
+`view_decoration_type_registry`, `formula_function_type_registry`,
+`webhook_event_type_registry`, and several more in `core` and `contrib`.
+
+The base classes live in `baserow/core/registries.py` (`ApplicationType`) and
+in each app's `registries.py` (e.g. `FieldType.export_serialized`,
+`ViewType.export_serialized`).
+
+## Shape of the export
+
+The application-level export, for a `database` application, looks roughly like:
+
+```jsonc
+{
+  "id": 42,
+  "name": "My database",
+  "order": 1,
+  "type": "database",
+  "tables": [
+    {
+      "id": 100,
+      "name": "Customers",
+      "order": 1,
+      "fields": [
+        {"id": 1000, "type": "text", "name": "Name", "order": 1, ...},
+        {"id": 1001, "type": "number", "name": "Revenue", "order": 2, ...}
+      ],
+      "views": [
+        {
+          "id": 2000,
+          "type": "grid",
+          "name": "All",
+          "filters": [...],
+          "sortings": [...],
+          "decorations": [...]
+        }
+      ],
+      "rows": [
+        {"id": 1, "field_1000": "Acme", "field_1001": "1000.0", ...}
+      ]
+    }
+  ]
+}
+```
+
+Files (uploads, exports) referenced by serialized rows are written into a
+companion `ExportZipFile` and referenced by relative path. The pair (JSON +
+ZIP) is what gets stored / transmitted.
+
+## `id_mapping`
+
+The most important parameter in the import path. When importing a serialized
+application into a workspace, every primary key gets remapped to a new one (so
+that templates can be imported many times into the same workspace without
+collision). `id_mapping` is the dictionary that records "old id 1000 became new
+id 5042" so that when a row arrives whose `field_1000` value is set, the
+importer can find the corresponding new field.
+
+Conventionally, `id_mapping` has typed keys like
+`"database_fields"`, `"database_views"`, `"database_view_filters"`,
+`"database_rows"`, etc., each pointing at a `{old_id: new_id}` dict.
+
+If you add a new type, give it its own key so other types' importers can rely
+on it.
+
+## `SerializationProcessor`
+
+A separate registry (`serialization_processor_registry`) lets you piggyback
+extra data onto the serialized structure without modifying the core types.
+This is how the search system, formulas, and other cross-cutting concerns
+serialise their auxiliary state. Each processor implements
+`export_serialized` and `import_serialized` that take a `serialized_structure`
+dict and return / receive the same dict possibly with extra keys.
+
+This is how core stays decoupled from concerns that span the system, e.g.
+search indexes don't appear on field types' own export but get attached
+through a processor.
+
+## Round trips: duplicate, snapshot, restore
+
+These three operations all use the same shape:
+
+1. `application_type.export_serialized(application, config, files_zip)`
+   produces the serialised dict (and an in-memory zip).
+2. (Optional) persist to storage — snapshots store both; duplications keep
+   the data in memory.
+3. `application_type.import_serialized(workspace, serialized, config,
+   id_mapping, files_zip)` produces a new application in the target workspace.
+
+The `ImportExportConfig` (`baserow.core.import_export.handler`) controls
+flags: whether to include row data, whether to remap permissions, whether the
+files are external or internal, etc.
+
+## Templates
+
+Templates are JSON+ZIP files committed under
+`backend/templates/`. On first run (or on `loaddata` calls), each template is
+imported into a special templates workspace. When a user "installs a
+template", that workspace's application is duplicated into theirs — again,
+via the same `export_serialized` / `import_serialized` round trip.
+
+## Adding a new type — serialisation checklist
+
+When you add a new `FieldType`, `ViewType`, registered registry entry, or any
+new model that participates in user-visible state, the serialisation work is
+the easy thing to forget. Run this checklist:
+
+1. Override `export_serialized()` to include every persisted attribute the type
+   cares about (and recursively serialise sub-objects — e.g. a view's filters).
+2. Override `import_serialized()` to:
+   - Build the new instance under the supplied parent.
+   - Use `id_mapping` to translate any cross-references in the serialised
+     dict.
+   - Add `{old_id: new_id}` to the right `id_mapping` bucket so other types
+     can reference the new id.
+3. Round-trip test: write a fixture, export it, import into a fresh workspace,
+   compare. There's `baserow.test_utils` plumbing for this — search existing
+   field type tests for `export_serialized` to find patterns.
+4. If your type involves user-uploaded files, pass them through the
+   `files_zip` parameter and reference them by archive path in the JSON.
+5. If your data needs a side-channel that doesn't fit on the type itself,
+   register a `SerializationProcessor`.
+
+## Gotchas
+
+- **JSON-serialisable.** Values must round-trip through `json.dumps`. Date
+  objects, decimals, sets — all must be converted to a JSON-safe form on
+  export and restored on import.
+- **`extract_allowed` and `CoreExportSerializedStructure`.** When the
+  `ApplicationType` builds the core "shell" of the export, only a fixed list
+  of fields (`["id", "name", "order", "type", "snapshot_from"]`) is
+  guaranteed; everything else has to come from your subclass.
+- **Order matters for fields and views.** Importers re-sort by `order` after
+  insertion; don't rely on the source ordering being preserved if `order` is
+  stale.
+- **Row imports are by far the heaviest path.** For large applications the
+  importer batches rows and uses `bulk_create` (see [queries](../patterns/queries.md))
+  to keep performance acceptable.
+- **Backwards-compatibility.** Old templates and snapshots must still import
+  on a new Baserow version. If you change a field type's export shape, you
+  need a migration path in `import_serialized` that handles both old and new
+  formats.
+
+## Related
+
+- [Systems overview — Serialization system](systems-overview.md#serialization-system).
+- [Snapshots — runbook stub](../runbooks/back-up-and-restore-baserow.md).

--- a/docs/technical/systems-overview.md
+++ b/docs/technical/systems-overview.md
@@ -1,0 +1,176 @@
+# Systems overview
+
+This is the high-level map of the major subsystems that make up Baserow. It is the
+recommended starting point before diving into any individual technical guide.
+
+Each system below has a one-paragraph description and, where one exists, a pointer to
+the deeper guide. Some systems are well documented; others currently live only in the
+code. Open follow-ups to fill the gaps are tracked separately.
+
+For the architectural pattern that ties these systems together (view → service →
+action → handler → ORM, plus signals and realtime), see
+[Architectural patterns](../patterns/architecture.md). For the registry pattern that
+nearly every system uses to make itself extensible, see
+[Registries](../patterns/registries.md).
+
+## Generated model / user table system
+
+Each user-created table is backed by its own PostgreSQL table and a dynamically
+generated Django model. `Table.get_model()` builds the model class on demand from the
+table's field definitions, which lets us reuse Django ORM and migrations to manage
+user data. Field serialisations are cached through the Django cache backend (Redis in
+production, in-memory in tests) to avoid regenerating them on every request. The
+relevant entry points are `baserow.contrib.database.table.handler.TableHandler` and
+`Table.get_model()`.
+
+## Field system
+
+Fields are the column definitions of user tables. Each field type (`text`, `number`,
+`link_row`, `formula`, …) is a subclass of `FieldType` registered in
+`field_type_registry`, and it owns the rules for storage, validation, search
+representation, formula compatibility, import/export, and converters when a field
+changes type. `FieldHandler` is the orchestration layer that creates, updates, deletes
+and converts fields, coordinating side effects across dependent systems (dynamic model
+regeneration, search reindex, formula recomputation, dependency graph updates).
+
+See also: [Create database table field](../plugins/field-type.md),
+[Field converters](../plugins/field-converter.md).
+
+## Serialization system
+
+Allows exporting Baserow applications to and from JSON / ZIP. It powers templates,
+workspace export/import, snapshots, and the in-memory "duplicate" flow (every
+duplication is just a serialize-then-deserialize round trip). Each registry that owns
+user-visible types implements `export_serialized` / `import_serialized` on its
+instances. See `baserow.core.export_serialized` and the per-app
+`export_serialized.py` modules.
+
+## Action system
+
+The event-based backbone of user-driven changes. Every state-changing user operation
+goes through an `ActionType` so it can be audited and, where applicable, undone or
+redone. `ActionHandler.do()` runs the action and writes an `Action` model row to the
+audit log. Actions live in `actions.py` modules per domain
+(e.g. `baserow/contrib/database/rows/actions.py`). The registry and base classes are
+in `baserow.core.action.registries`.
+
+See also: [Undo/redo guide](undo-redo-guide.md).
+
+## Permissions system
+
+A flexible system used for RBAC, personal/restricted views, and staff/admin-only
+features. `CoreHandler.check_permissions()` is the single entry point; the actual
+check is delegated to the registered `PermissionManagerType` chain
+(`permission_manager_type_registry`). Some managers live in core; RBAC and several
+others live in `enterprise/`.
+
+See also: [Permissions guide](permissions-guide.md).
+
+## Realtime system
+
+Sends realtime updates to clients over Django Channels websockets when state changes.
+Backend handlers emit Django signals; receivers in `baserow.ws.*` translate those
+signals into messages addressed to relevant page/table subscribers. The frontend has
+matching realtime handlers that update the Vuex store, which causes components to
+re-render without a page refresh.
+
+See also: [WebSockets guide](websockets.md),
+[WebSocket API](../apis/web-socket-api.md).
+
+## Trash system
+
+Provides soft-deletion and restore for almost every user-visible entity (workspace,
+application, table, field, row, view). Deletions move objects to the trash; after the
+retention window (`HOURS_UNTIL_TRASH_PERMANENTLY_DELETED`, default 72) a periodic
+Celery task permanently removes them. Each trashable type registers a
+`TrashableItemType` in `trash_item_type_registry` describing how to trash, restore and
+permanently delete its instances. Entry point: `baserow.core.trash.handler.TrashHandler`.
+
+## Search system
+
+Maintains per-column TSV (PostgreSQL full-text search) representations so that
+searching across user tables is fast even on large datasets. Field types decide how
+their values get serialized into the TSV column; field updates, row writes and field
+type conversions all trigger reindex paths. See
+`baserow.contrib.database.search` and `baserow.core.search.registries`.
+
+See also: [Workspace search guide](workspace-search.md).
+
+## Notification system
+
+Sends in-product notifications (and, where configured, emails) to users when
+something happens that they care about: a row mention, a collaborator assignment,
+a job completion, etc. Each notification kind is a `NotificationType` registered in
+`notification_type_registry`, which owns the formatting, recipient resolution, and
+delivery channels. Entry point:
+`baserow.core.notifications.handler.NotificationHandler`.
+
+## Table / view import / export system
+
+Allows bulk-importing data into tables from CSV/JSON/XML/Excel and exporting tables or
+views to a file. Importers and exporters are types registered in their respective
+registries; long imports are executed as jobs (see [Job system](#job-system)) with
+progress reporting and cancellation. See `baserow.contrib.database.file_import` and
+`baserow.contrib.database.export`.
+
+## Formula system
+
+Lets users define formulas that compute cell values from other fields, and recompute
+those values when their dependencies change. The formula language has its own parser,
+type system, function registry, and an execution path that compiles formulas down to
+Django expressions for evaluation at the database level. This is the most complex
+system in the codebase; defer the deep dive until the rest of the map is in place.
+
+See also: [Formula technical guide](formula-technical-guide.md),
+[Understanding Baserow formulas](../tutorials/understanding-baserow-formulas.md).
+
+## Field dependency system
+
+Tracks which fields depend on which other fields (primarily because of formulas, link
+rows, lookups and rollups). When a field value or field definition changes, the
+dependency graph is used to decide what else has to be recomputed or reindexed. See
+`baserow.contrib.database.fields.dependencies` and
+`FieldDependencyHandler`.
+
+## License / feature / pricing system
+
+Gates premium and enterprise features behind license checks. Code that runs only
+under a license lives under `premium/` or `enterprise/`; the core has no direct
+knowledge of either. Feature checks go through `LicenseHandler` and the feature
+registry. Avoid coupling core or contrib code to license state — use the registered
+hooks instead.
+
+## Telemetry / logs / metrics
+
+Sends traces, logs and metrics via OpenTelemetry. Tracing is wired through
+`baserow.core.telemetry` and applied broadly via the `baserow_trace_methods`
+decorator on handlers and action types. Production traces are shipped to Honeycomb.
+
+See also: [Metrics and logs](../development/metrics-and-logs.md),
+[Monitoring Baserow](../installation/monitoring.md).
+
+## Plugin system
+
+External code can extend Baserow by registering new application types, field types,
+view types, filters, formula functions, etc. into the same registries the built-in
+code uses. The premium and enterprise editions are themselves plugins, which is the
+mechanism that keeps the licensing boundary clean.
+
+See also: [Plugin basics](../plugins/introduction.md).
+
+## Job system
+
+Moves costly user-triggered operations (duplications, exports, large imports,
+snapshots) to a Celery worker so the request thread stays responsive. Each job kind
+is a `JobType` in `job_type_registry`; jobs report progress, can be cancelled, and
+can broadcast realtime updates as they advance.
+
+See also: [Jobs pattern](../patterns/jobs.md).
+
+## Where this fits
+
+If you are new to Baserow, read this page first, then
+[Architectural patterns](../patterns/architecture.md) and
+[Registries](../patterns/registries.md). After that, the deeper per-system guides
+(undo/redo, permissions, websockets, workspace search, jobs) can be read in any
+order driven by whatever you happen to be working on.

--- a/docs/technical/trash-system.md
+++ b/docs/technical/trash-system.md
@@ -1,0 +1,127 @@
+# Trash system
+
+Baserow soft-deletes almost everything user-visible. Deleting a row, a view, a
+field, a table, an application or even a workspace doesn't immediately destroy
+it — it goes into the trash. A user with access can restore it, or empty the
+trash to delete it for good. After a configurable retention window a periodic
+Celery task permanently deletes everything older than the limit.
+
+This page describes the moving parts. Entry point:
+`baserow.core.trash.handler.TrashHandler`.
+
+## The two data structures
+
+- **`TrashEntry`** (`baserow.core.models.TrashEntry`) — one row per trashed item.
+  Records the type, item id, parent ids (if relevant), the user who trashed it,
+  the workspace/application, when it was trashed, and a marker for items already
+  permanently deleted. Trash entries can also link to parent entries via a
+  cascading foreign key so that permanent deletion of a parent (e.g. an
+  application) propagates to its descendants (tables, fields, rows).
+
+- **The trashable model itself.** Trashable models inherit from
+  `TrashableModelMixin`, which adds a `trashed: bool` column and a custom
+  `trash` manager that returns trashed instances (the default manager filters
+  them out). Restoring a row is just setting `trashed = False`.
+
+## `TrashableItemType` — the registry
+
+For each trashable Django model there's a `TrashableItemType` subclass registered
+in `trash_item_type_registry`. The registry is the extension point: to make a new
+model trashable, register a `TrashableItemType` for it.
+
+The base class (see `baserow/core/trash/registries.py`) requires implementations
+to provide:
+
+- `model_class` — the Django model.
+- `permanently_delete_item(trashed_item, lookup_cache)` — actually delete the row
+  (and any related state — files, search index entries, etc.) when the retention
+  window expires.
+- `restore(trashed_item, trash_entry)` — flip `trashed = False`, save, and emit
+  any realtime signals so other clients see the restore.
+- `get_parent(trashed_item)` — return the parent item if one exists (used to
+  link trash entries hierarchically so parent deletion cascades).
+- `get_name(trashed_item)` / `get_names(trashed_item)` — the human-readable
+  label shown in the trash modal.
+- `requires_parent_id: bool` — `True` if a parent id is required to look up this
+  type (e.g. a row needs its table id).
+
+Built-in registrations (non-exhaustive, see each app's `apps.py`):
+
+| Type | Where registered |
+|---|---|
+| `WorkspaceTrashableItemType`, `ApplicationTrashableItemType` | `baserow.core.apps` |
+| `TableTrashableItemType`, `FieldTrashableItemType`, `RowTrashableItemType`, `RowsTrashableItemType` (bulk), `ViewTrashableItemType` | `baserow.contrib.database.apps` |
+| `WidgetTrashableItemType` | `baserow.contrib.dashboard.apps` |
+| `AutomationTrashableItemType`, `AutomationWorkflowTrashableItemType`, `AutomationNodeTrashableItemType` | `baserow.contrib.automation.apps` |
+| `DomainTrashableItemType` | `baserow.contrib.builder.apps` |
+
+## Trashing flow
+
+`TrashHandler.trash(requesting_user, workspace, application, trash_item, ...)`:
+
+1. Look up whether the parent already has a trash entry. If yes, link the new
+   entry to it via a cascading FK so they share fate at permanent-deletion time.
+2. Set `trash_item.trashed = True` and save.
+3. Create the `TrashEntry`.
+4. Emit signals so the ws layer can broadcast the deletion to other clients.
+
+There is also `permanently_delete(...)` for items that bypass the retention
+window (rare; mostly used for cleanup of unrecoverable state).
+
+## Restore flow
+
+`TrashHandler.restore(requesting_user, trash_entry_id)`:
+
+1. Refuse to restore a child whose parent is still trashed (raises
+   `CannotRestoreChildBeforeParent`). The user has to restore the parent first.
+2. Call the type's `restore()` which flips `trashed = False` and saves.
+3. Delete the `TrashEntry` (the item is alive again).
+4. Emit signals.
+
+## Permanent deletion
+
+A periodic Celery task in `baserow.core.trash.tasks` walks `TrashEntry` rows
+older than the retention window, looks up each type, and calls
+`permanently_delete_item()`. This is where files get removed, search index
+entries are cleaned up, and the actual SQL `DELETE` runs.
+
+Two relevant signals fire around this:
+
+- `before_permanently_deleted` — last chance to capture state.
+- `permanently_deleted` — fired after the row is gone.
+
+### Retention window
+
+Default **72 hours** (`HOURS_UNTIL_TRASH_PERMANENTLY_DELETED`, set in
+`baserow.config.settings.base`, derived from env var of the same name, default
+`24 * 3`). Set to a different number of hours to lengthen or shorten.
+
+## Trash listings
+
+The trash modal in the UI is backed by API endpoints that list `TrashEntry` rows
+in scope, grouped by parent. Type-specific operations
+(`ReadWorkspaceTrashOperationType`, `EmptyWorkspaceTrashOperationType`, etc.) are
+registered in `trash_operation_type_registry` and gate who can see/empty what.
+
+## Gotchas
+
+- **Cascading via the FK, not via business logic.** If you trash a table, you
+  *don't* iterate its rows and trash each one — you just create one trash entry
+  for the table and the row data sits there until the parent's entry hits the
+  retention window. Restoring the table makes all the rows visible again.
+- **Search indexes.** Most trashable types' `permanently_delete_item()` is
+  responsible for tearing down the search index entries for the deleted item.
+  When adding a new trashable type, double-check this is wired up.
+- **Trashed fields stay in the generated table model.** A trashed `Field` is
+  filtered out of `_field_objects` on the dynamic model, but the column itself
+  still exists in the user table so that NOT NULL constraints don't break on
+  restore. See [dynamic models](dynamic-models.md).
+- **Parent inference.** `get_parent()` must return the parent item, not just its
+  id, because the trash handler needs the type lookup to find the parent's
+  trash entry.
+
+## Related
+
+- [Systems overview — Trash system](systems-overview.md#trash-system).
+- [Architectural patterns](../patterns/architecture.md) — where trashing sits in
+  the request flow.


### PR DESCRIPTION
## Summary

Migrates the foundational architecture documentation from Notion into the repo and adds the system deep-dives a new engineer needs in their first month on the database team.

**Why now:** AI agents and new hires alike need this material in-repo. The Notion source is stale (still references GitLab), and several existing docs (`database-plugin.md` last touched 2022-02) hadn't kept up with the codebase.

**New high-level docs** (the start-here triple):
- `docs/technical/systems-overview.md` — map of the major subsystems
- `docs/patterns/architecture.md` — view → service → action → handler flow, signals, realtime, celery
- `docs/patterns/registries.md` — the extension pattern

**New system deep-dives:**
- `docs/technical/dynamic-models.md` — `Table.get_model()`, two-layer cache, invalidation
- `docs/technical/action-system.md` — `ActionType` / `Action` / `ActionHandler`, scopes, undo/redo
- `docs/technical/trash-system.md`, `notification-system.md`, `serialization-system.md`, `caching.md`
- `docs/technical/features-and-interactions.md` — feature catalogue + interaction matrix

**New patterns:**
- `docs/patterns/field-system.md` — `FieldHandler` ↔ `FieldType` architecture and lifecycle
- `docs/patterns/queries.md` — N+1 avoidance, prefetch, `specific_iterator`, `bulk_create` + `grouper`, when to drop to SQL/CTE
- `docs/patterns/creating-features.md` — how to add a view/action/handler/model + zero-downtime migrations + pre-PR checklist
- `docs/patterns/observability.md` — loguru, OTEL with `baserow_trace_methods`, verifying assumptions in production via Honeycomb

**New process doc:**
- `docs/development/engineering-workflow.md` — modernised for GitHub (the Notion draft was GitLab-era with `type::*` scoped labels that don't exist on the repo)

**Refreshed:**
- `docs/technical/database-plugin.md` — was 4 years stale
- `docs/technical/introduction.md` — added "start here" pointer
- `docs/development/directory-structure.md` — current `contrib/` contents + core/contrib/premium/enterprise import rules
- `docs/index.md` — restructured Technical Overviews and added the new pages

**Stats:** 19 files changed, 3,126 insertions, 114 deletions.

## Test plan

This is documentation only; no functional changes. To review:

- [ ] Read `docs/technical/systems-overview.md` top-to-bottom — is the systems list complete and accurate for the database team?
- [ ] Read `docs/patterns/architecture.md` — does the service-layer rule of thumb match how the team thinks about it today?
- [ ] Read `docs/patterns/field-system.md` and `docs/technical/dynamic-models.md` — are the lifecycle / cache / invalidation claims accurate?
- [ ] Scan `docs/index.md` — does the navigation feel right?
- [ ] Spot-check cross-doc links — they were checked automatically but pairs of human eyes are better.
- [ ] No changelog entry required (docs-only).

## Notes for review

- The Notion "systems" table included an owners column with names. Dropped on purpose so the doc doesn't go stale with turnover; suggest tracking ownership in a separate internal file or via `CODEOWNERS`.
- Some pattern coverage gaps are documented in a follow-up plan (locking, transactions, signals, exception mapping). Intentionally not in this PR to keep the size manageable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)