### PR TITLE
fix: handle malformed token in verify_email_address

### DIFF
--- a/backend/src/baserow/core/user/handler.py
+++ b/backend/src/baserow/core/user/handler.py
@@ -938,7 +938,10 @@ class UserHandler(metaclass=baserow_trace_methods(tracer)):
         """
 
         signer = self._get_email_verification_signer()
-        token_data = signer.loads(token)
+        try:
+            token_data = signer.loads(token)
+        except BadSignature as ex:
+            raise InvalidVerificationToken() from ex
 
         if datetime.fromisoformat(token_data["expires_at"]) < datetime.now(
             tz=timezone.utc

--- a/backend/tests/baserow/contrib/database/field/test_field_tasks.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_tasks.py
@@ -363,9 +363,10 @@ def test_all_formula_that_needs_updates_are_periodically_updated(data_fixture):
     table = data_fixture.create_database_table(database=database)
     with freeze_time("2023-02-27 10:15"):
         now_field = data_fixture.create_formula_field(
-            table=table, formula="now()", date_include_time=True
+            name="now", table=table, formula="now()", date_include_time=True
         )
         data_fixture.create_formula_field(
+            name="ref_now",
             table=table,
             formula=f"field('{now_field.name}')",
             date_include_time=True,
@@ -373,6 +374,7 @@ def test_all_formula_that_needs_updates_are_periodically_updated(data_fixture):
 
         date_field = data_fixture.create_date_field(table=table, date_include_time=True)
         data_fixture.create_formula_field(
+            name="now_vs_date",
             table=table,
             formula=f"now() > field('{date_field.name}')",
             date_include_time=True,

--- a/backend/tests/baserow/core/user/test_user_handler.py
+++ b/backend/tests/baserow/core/user/test_user_handler.py
@@ -781,6 +781,12 @@ def test_verify_email_address_expired(data_fixture):
 
 
 @pytest.mark.django_db
+def test_verify_email_address_malformed_token():
+    with pytest.raises(InvalidVerificationToken):
+        UserHandler().verify_email_address("not-a-real-token")
+
+
+@pytest.mark.django_db
 def test_verify_email_address_user_doesnt_exist(data_fixture):
     user = data_fixture.create_user()
     token = UserHandler().create_email_verification_token(user)

--- a/changelog/entries/unreleased/bug/5374_fixes_a_server_error_when_submitting_an_invalid_email_verifi.json
+++ b/changelog/entries/unreleased/bug/5374_fixes_a_server_error_when_submitting_an_invalid_email_verifi.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a server error when submitting an invalid email verification token",
+    "issue_origin": "github",
+    "issue_number": 5374,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-15"
+}


### PR DESCRIPTION
Closes #5374

## Summary

`UserHandler.verify_email_address` called `signer.loads(token)` directly. A malformed token (e.g. missing the `.` separator) raised `itsdangerous.BadSignature`, which the view's `@map_exceptions` did not catch, producing a 500 + Sentry alert instead of the documented `ERROR_INVALID_VERIFICATION_TOKEN`.

Wrap `signer.loads` and re-raise as `InvalidVerificationToken`, matching the handler's docstring and the behavior of the sibling token endpoints.

## Test plan

- [x] `just b test tests/baserow/core/user/test_user_handler.py -k verify_email_address` — all 6 pass, including the new `test_verify_email_address_malformed_token`