### PR TITLE
bug: further template regression testing changes

### DIFF
--- a/backend/src/baserow/contrib/builder/application_types.py
+++ b/backend/src/baserow/contrib/builder/application_types.py
@@ -587,7 +587,7 @@ class BuilderApplicationType(ApplicationType):
         regressions across template changes.
 
         Children are grouped by slot (place_in_container) and slots are ordered by
-        the minimum ``order`` value among their members, so the output is stable
+        the minimum element ``id`` among their members, so the output is stable
         regardless of cross-slot insertion history.
 
         :param builder: The builder application instance to serialize.
@@ -613,12 +613,13 @@ class BuilderApplicationType(ApplicationType):
                     by_slot[el.place_in_container or ""].append(el)
                 ordered = []
                 for slot in sorted(
-                    by_slot, key=lambda s: min(e.order for e in by_slot[s])
+                    by_slot, key=lambda s: min(e.id for e in by_slot[s])
                 ):
                     ordered.extend(sorted(by_slot[slot], key=lambda e: (e.order, e.id)))
                 return [
                     {
                         "type": element.get_type().type,
+                        "place_in_container": element.place_in_container or "",
                         "children": build_tree(element.id),
                     }
                     for element in ordered

--- a/backend/tests/baserow/core/templates/__snapshots__/ab-testing.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab-testing.ambr
@@ -6,11 +6,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -18,11 +20,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -30,109 +34,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -140,14 +166,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -155,44 +184,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'rating_input',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'rating_input',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -200,6 +238,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -207,104 +246,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -314,14 +374,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_agency_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_agency_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_baserow_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_baserow_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_coral_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_coral_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_corporate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_corporate_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_eclipse_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_eclipse_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_education_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_education_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_finance_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_finance_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_forest_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_forest_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_healthcare_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_healthcare_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_ivory_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_ivory_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_lavender_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_lavender_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_legal_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_legal_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_luxury_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_luxury_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_midnight_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_midnight_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_mint_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_mint_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_neon_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_neon_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_ocean_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_ocean_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_realestate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_realestate_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_slate_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_slate_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_startup_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_startup_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_sunset_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_sunset_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_tech_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_tech_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/ab_terracotta_theme.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/ab_terracotta_theme.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,44 +16,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -60,44 +70,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -105,62 +124,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -168,11 +200,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -180,27 +214,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -210,14 +250,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -225,14 +268,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -240,14 +286,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -255,14 +304,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
             dict({
@@ -270,14 +322,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'simple_container',
             }),
             dict({
@@ -285,17 +340,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '5',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -305,14 +364,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -320,14 +382,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -335,52 +400,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -390,9 +466,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -404,11 +482,13 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
@@ -416,88 +496,107 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'input_text',
                         }),
                       ]),
+                      'place_in_container': '2',
                       'type': 'form_container',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/action-plan-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/action-plan-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,6 +14,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
@@ -20,21 +22,25 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
@@ -42,14 +48,17 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
@@ -57,75 +66,91 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'datetime_picker',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'choice',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'form_container',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -133,11 +158,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -145,51 +172,61 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -197,12 +234,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -210,26 +250,31 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -237,29 +282,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -267,16 +318,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -284,16 +338,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -301,6 +358,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
@@ -308,39 +366,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
@@ -348,32 +414,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -381,99 +454,119 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -483,14 +576,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -498,17 +594,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -516,31 +616,37 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -550,6 +656,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -557,14 +664,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -572,12 +682,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/andon-calls.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/andon-calls.ambr
@@ -6,11 +6,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -18,44 +20,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -63,16 +74,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -80,16 +94,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -97,9 +114,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -107,21 +126,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -129,9 +152,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -139,16 +164,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
       ]),
@@ -158,6 +186,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -165,17 +194,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/asset-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/asset-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,34 +14,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -48,6 +56,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -55,44 +64,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -100,6 +118,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -107,11 +126,13 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
@@ -119,29 +140,35 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -149,32 +176,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -182,6 +216,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -189,49 +224,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -239,11 +284,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -251,124 +298,149 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -376,19 +448,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -396,19 +472,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -416,14 +496,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -431,6 +514,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -438,14 +522,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -453,6 +540,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -460,29 +548,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -490,6 +584,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -497,41 +592,49 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
@@ -539,32 +642,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -572,36 +682,43 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -609,11 +726,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -621,6 +740,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -628,31 +748,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
@@ -660,27 +786,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -688,6 +820,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -695,84 +828,101 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -782,29 +932,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/brand-assets-manager.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/brand-assets-manager.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,31 +14,85 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
@@ -45,62 +100,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'form_container',
             }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -108,19 +128,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -128,11 +152,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -140,11 +166,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -154,19 +182,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/business-goal-tracker-okrs.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/business-goal-tracker-okrs.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,89 +14,107 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -105,14 +124,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -122,49 +144,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -172,11 +204,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -184,74 +218,89 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -261,14 +310,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -276,16 +328,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -293,11 +348,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -305,49 +362,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -357,14 +424,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -374,6 +444,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -381,14 +452,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -396,27 +470,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/campaign-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/campaign-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,61 +14,73 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
@@ -75,62 +88,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -138,9 +164,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -148,26 +176,31 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -175,34 +208,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -210,6 +250,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -217,99 +258,119 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -317,21 +378,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -339,6 +404,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -348,77 +414,93 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -426,11 +508,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -438,21 +522,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -460,24 +548,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'iframe',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -485,24 +578,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -512,19 +610,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/car-dealership-inventory.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/car-dealership-inventory.ambr
@@ -6,11 +6,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -18,19 +20,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -38,6 +44,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -45,114 +52,137 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -162,24 +192,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -187,209 +222,251 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -397,6 +474,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -404,104 +482,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -509,6 +608,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -516,101 +616,121 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -618,17 +738,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -636,6 +760,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -643,139 +768,167 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -783,6 +936,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -792,27 +946,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
@@ -822,67 +982,81 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -890,6 +1064,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -897,24 +1072,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -922,51 +1102,61 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -976,49 +1166,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1026,69 +1226,83 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1098,37 +1312,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1138,37 +1360,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1176,21 +1406,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -1200,19 +1434,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1220,19 +1458,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1240,69 +1482,83 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1312,6 +1568,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -1319,32 +1576,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
         dict({
@@ -1354,62 +1618,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'footer',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/city-tours.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/city-tours.ambr
@@ -8,24 +8,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -33,21 +38,25 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
@@ -55,17 +64,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
       ]),
@@ -73,6 +86,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -82,17 +96,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -102,39 +120,47 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -144,27 +170,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -174,14 +206,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -191,42 +226,51 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -236,9 +280,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/commercial-property-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/commercial-property-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,31 +14,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -45,27 +52,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -73,6 +86,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -82,42 +96,51 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -125,6 +148,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -132,34 +156,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -167,16 +198,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -184,16 +218,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -201,49 +238,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -251,14 +298,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -266,26 +316,31 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -295,6 +350,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -302,22 +358,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/competitor-analysis.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/competitor-analysis.ambr
@@ -6,56 +6,67 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -65,22 +76,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -90,17 +106,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -108,26 +128,31 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -137,9 +162,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/compliance-assessment-builder.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/compliance-assessment-builder.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,14 +14,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -28,21 +32,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -50,6 +58,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
@@ -57,14 +66,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -72,17 +84,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -90,6 +106,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -99,20 +116,25 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '1',
                   'type': 'simple_container',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -120,11 +142,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -132,21 +156,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -154,11 +182,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -166,11 +196,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -178,21 +210,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
       ]),
@@ -200,6 +236,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -207,14 +244,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -222,6 +262,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -229,14 +270,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'rating_input',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -244,6 +288,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -251,14 +296,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -266,6 +314,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -275,22 +324,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -298,6 +352,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -305,29 +360,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -335,6 +396,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -342,14 +404,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -357,6 +422,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -364,14 +430,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'rating_input',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -379,6 +448,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -386,14 +456,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -403,19 +476,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/custom-code-demos.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/custom-code-demos.ambr
@@ -6,21 +6,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -28,19 +32,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -50,9 +58,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/electronic-health-record.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/electronic-health-record.ambr
@@ -6,41 +6,49 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
       ]),
@@ -48,6 +56,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -57,32 +66,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -90,11 +106,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -102,11 +120,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -114,49 +134,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -164,9 +194,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -174,14 +206,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
@@ -189,9 +224,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -199,24 +236,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -224,9 +266,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -234,24 +278,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -259,19 +308,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -279,19 +332,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -299,6 +356,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -306,49 +364,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -356,29 +424,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -386,14 +460,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -401,14 +478,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -416,14 +496,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -431,14 +514,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -448,6 +534,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -455,17 +542,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/esg-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/esg-management.ambr
@@ -8,34 +8,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -43,79 +50,95 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -123,9 +146,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
@@ -133,14 +158,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -150,29 +178,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -180,24 +214,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -207,59 +246,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -267,59 +318,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -327,59 +390,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -387,62 +462,75 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -452,29 +540,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -482,59 +576,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -544,29 +650,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -576,42 +688,51 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -621,29 +742,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -653,57 +780,69 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -713,34 +852,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -748,124 +894,149 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -875,29 +1046,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -905,44 +1082,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -952,64 +1138,77 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -1017,64 +1216,77 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -1082,64 +1294,77 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
             dict({
@@ -1147,67 +1372,81 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1215,16 +1454,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -1234,29 +1476,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1264,94 +1512,113 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'iframe',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1361,6 +1628,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -1368,17 +1636,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/event-planning.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/event-planning.ambr
@@ -6,11 +6,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -18,24 +20,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -43,6 +50,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -50,24 +58,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -75,21 +88,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -97,11 +114,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -109,19 +128,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -129,21 +152,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
       ]),
@@ -151,16 +178,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -168,29 +198,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -200,6 +236,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -207,17 +244,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/formulas.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/formulas.ambr
@@ -6,11 +6,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -18,71 +20,85 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -90,14 +106,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'image',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
@@ -105,12 +124,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/gemba-walks.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/gemba-walks.ambr
@@ -6,16 +6,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -23,76 +26,91 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -100,9 +118,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -110,6 +130,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -117,59 +138,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -177,86 +210,103 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -266,6 +316,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -273,17 +324,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/incident-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/incident-management.ambr
@@ -8,14 +8,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -23,74 +26,89 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -100,14 +118,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -115,44 +136,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -162,9 +192,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -172,19 +204,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -192,46 +228,55 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -239,9 +284,11 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -249,52 +296,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'checkbox',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'checkbox',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -302,19 +360,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -322,6 +384,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -329,24 +392,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -354,34 +422,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -391,19 +466,23 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -411,87 +490,105 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -499,16 +596,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -518,9 +618,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -528,19 +630,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -548,36 +654,43 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -585,9 +698,11 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -595,17 +710,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -615,6 +734,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -622,17 +742,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/inspections-compliance.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/inspections-compliance.ambr
@@ -8,9 +8,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -18,54 +20,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -73,6 +86,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -80,44 +94,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -125,11 +148,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -139,19 +164,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/intake-qualification.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/intake-qualification.ambr
@@ -10,17 +10,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -30,17 +34,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -50,17 +58,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -70,17 +82,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -90,24 +106,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'auth_form',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -115,11 +136,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -129,12 +152,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -142,9 +168,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -154,42 +182,51 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_file',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -197,11 +234,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -211,12 +250,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -224,9 +266,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -236,32 +280,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -269,11 +320,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -283,12 +336,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -296,9 +352,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -308,37 +366,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'checkbox',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -348,19 +414,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/lead-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/lead-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,49 +14,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -63,6 +74,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -70,109 +82,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -180,6 +214,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
@@ -187,27 +222,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -215,11 +256,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -227,6 +270,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -236,6 +280,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -243,15 +288,19 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -259,6 +308,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -268,6 +318,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -275,15 +326,19 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -291,11 +346,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -303,11 +360,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -315,31 +374,37 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -349,19 +414,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/lightweight-crm.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/lightweight-crm.ambr
@@ -8,24 +8,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -33,14 +38,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -48,6 +56,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
@@ -55,12 +64,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -68,6 +80,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
@@ -75,12 +88,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -90,24 +106,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -115,9 +136,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -125,29 +148,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -157,29 +186,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -187,54 +222,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -242,9 +288,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -254,29 +302,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -284,54 +338,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -339,9 +404,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -351,24 +418,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -376,14 +448,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -393,57 +468,69 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -453,57 +540,69 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -513,24 +612,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -538,9 +642,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -548,34 +654,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -585,34 +698,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -620,84 +740,101 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -705,19 +842,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -725,19 +866,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -747,24 +892,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -772,9 +922,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -782,34 +934,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -819,34 +978,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -854,64 +1020,77 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -919,19 +1098,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -941,34 +1124,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -976,39 +1166,47 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1016,19 +1214,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1038,24 +1240,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1063,14 +1270,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1080,47 +1290,57 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -1130,47 +1350,57 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1178,11 +1408,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1190,44 +1422,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1235,16 +1476,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -1254,24 +1498,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1279,9 +1528,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1289,44 +1540,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -1336,29 +1596,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1366,79 +1632,95 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1446,19 +1728,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1468,29 +1754,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1498,79 +1790,95 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1578,19 +1886,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1600,24 +1912,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1625,14 +1942,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1640,269 +1960,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
           ]),
-          'type': 'column',
-        }),
-        dict({
-          'children': list([
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-          ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1912,59 +1992,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -1972,59 +2064,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -2032,59 +2136,71 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -2092,62 +2208,369 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
+          'type': 'column',
+        }),
+        dict({
+          'children': list([
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+              ]),
+              'place_in_container': '0',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+              ]),
+              'place_in_container': '1',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+              ]),
+              'place_in_container': '2',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'link',
+                }),
+              ]),
+              'place_in_container': '3',
+              'type': 'repeat',
+            }),
+          ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -2157,6 +2580,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -2164,17 +2588,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/objectives-key-results.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/objectives-key-results.ambr
@@ -6,16 +6,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -23,36 +26,43 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -61,73 +71,88 @@
               'children': list([
                 dict({
                   'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'iframe',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'heading',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'datetime_picker',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'datetime_picker',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'input_text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'choice',
                     }),
                   ]),
+                  'place_in_container': '2',
                   'type': 'form_container',
                 }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'iframe',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'heading',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -135,6 +160,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -142,31 +168,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -174,12 +206,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -189,6 +224,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -196,14 +232,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -211,12 +250,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/online-freelancer-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/online-freelancer-management.ambr
@@ -6,16 +6,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -25,42 +28,51 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -68,16 +80,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
@@ -85,49 +100,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -135,29 +160,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -165,16 +196,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -182,16 +216,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -199,54 +236,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -254,29 +302,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -286,6 +340,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -293,22 +348,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/order-kiosk.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/order-kiosk.ambr
@@ -6,41 +6,49 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -48,9 +56,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -60,14 +70,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -75,9 +88,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -85,39 +100,47 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -127,24 +150,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -154,19 +182,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -176,52 +208,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -231,29 +274,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
@@ -261,49 +310,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -313,19 +372,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -335,19 +398,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -355,9 +422,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -365,44 +434,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -410,11 +488,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
       ]),
@@ -424,9 +504,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/password-reset.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/password-reset.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,14 +14,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
@@ -28,14 +32,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -43,6 +50,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
       ]),
@@ -50,16 +58,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
       ]),
@@ -67,6 +78,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -74,14 +86,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -91,17 +106,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -111,14 +130,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/policy-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/policy-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,59 +14,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -75,6 +88,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
@@ -82,9 +96,11 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
             dict({
@@ -92,6 +108,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
@@ -99,50 +116,61 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '2',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '0',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '1',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '3',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '3',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'column',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -150,11 +178,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -162,6 +192,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -169,11 +200,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -181,109 +214,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -291,11 +346,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -303,114 +360,137 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -418,14 +498,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -435,17 +518,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -453,11 +540,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -465,6 +554,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -472,14 +562,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -487,109 +580,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -597,49 +712,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -649,29 +774,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/program-management-kpi.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/program-management-kpi.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,17 +16,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -33,19 +38,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -53,6 +62,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -62,22 +72,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -85,14 +100,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -100,14 +118,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -115,6 +136,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -122,14 +144,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -137,14 +162,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -152,6 +180,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
@@ -159,32 +188,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -192,11 +228,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -204,6 +242,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -213,17 +252,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -231,19 +274,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -251,6 +298,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -260,17 +308,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -278,14 +330,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
         dict({
@@ -297,36 +352,43 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
@@ -336,26 +398,33 @@
                             dict({
                               'children': list([
                               ]),
+                              'place_in_container': '1',
                               'type': 'datetime_picker',
                             }),
                             dict({
                               'children': list([
                               ]),
+                              'place_in_container': '0',
                               'type': 'choice',
                             }),
                           ]),
+                          'place_in_container': '',
                           'type': 'column',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'form_container',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -365,19 +434,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/project-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/project-management.ambr
@@ -6,21 +6,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -30,39 +34,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -70,39 +82,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -110,39 +130,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -150,67 +178,81 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -218,11 +260,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -232,39 +276,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -272,39 +324,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
             dict({
@@ -312,39 +372,47 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -352,57 +420,69 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -410,6 +490,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'iframe',
             }),
             dict({
@@ -417,32 +498,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -452,9 +540,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/purchase-order-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/purchase-order-management.ambr
@@ -6,16 +6,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -23,24 +26,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -48,6 +56,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -55,19 +64,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -75,59 +88,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -135,6 +160,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
@@ -142,27 +168,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -170,31 +202,37 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -202,11 +240,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -214,16 +254,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -231,54 +274,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -286,49 +340,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -336,49 +400,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'button',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '5',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -386,11 +460,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -398,54 +474,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -453,54 +540,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -508,44 +606,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -555,6 +662,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -562,17 +670,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/risk-assessment-and-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/risk-assessment-and-management.ambr
@@ -8,14 +8,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -23,49 +26,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -75,14 +88,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -90,44 +106,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -137,14 +162,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -152,49 +180,59 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -204,104 +242,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
             dict({
               'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'form_container',
             }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -309,16 +368,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -328,14 +390,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -343,31 +408,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -375,22 +446,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -400,9 +476,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -410,104 +488,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
             dict({
               'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'text',
+            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -515,19 +614,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -535,19 +638,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -555,6 +662,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -562,24 +670,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -587,34 +700,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -624,14 +744,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -639,44 +762,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -684,32 +816,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -719,6 +858,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -726,17 +866,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/sales-pipeline-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/sales-pipeline-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,94 +14,113 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -108,9 +128,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -118,11 +140,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -130,6 +154,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -137,44 +162,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'choice',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -182,6 +216,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -189,24 +224,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -216,44 +256,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -261,44 +310,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -306,44 +364,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -351,52 +418,63 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -404,24 +482,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -431,44 +514,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -476,44 +568,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -521,44 +622,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -566,47 +676,57 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -614,11 +734,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -626,11 +748,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -638,84 +762,101 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -723,9 +864,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -733,11 +876,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -747,14 +892,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/santa-logistics.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/santa-logistics.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
         dict({
@@ -13,24 +14,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'heading',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -38,91 +44,109 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'iframe',
             }),
             dict({
@@ -130,49 +154,59 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -180,34 +214,41 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'iframe',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -215,32 +256,39 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/skill-discovery-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/skill-discovery-management.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,54 +14,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -68,6 +80,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -75,104 +88,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -180,6 +214,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -187,29 +222,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -217,6 +258,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -224,104 +266,125 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -329,6 +392,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -336,64 +400,77 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -401,6 +478,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -408,59 +486,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'checkbox',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -468,6 +558,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -475,109 +566,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -585,6 +698,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -592,34 +706,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -627,6 +748,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -634,109 +756,131 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -744,11 +888,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -756,144 +902,173 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -903,34 +1078,41 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -938,117 +1120,141 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1056,16 +1262,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'image',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -1073,6 +1282,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1080,64 +1290,77 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1145,6 +1368,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1152,64 +1376,77 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1217,6 +1454,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1224,64 +1462,77 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1291,6 +1542,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -1298,14 +1550,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -1313,27 +1568,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '3',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/sqcdp.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/sqcdp.ambr
@@ -10,17 +10,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
@@ -30,44 +34,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -75,44 +88,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -120,44 +142,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -165,44 +196,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '3',
               'type': 'repeat',
             }),
             dict({
@@ -210,47 +250,57 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '4',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/standard-operating-procedures.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/standard-operating-procedures.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -15,22 +16,27 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -38,11 +44,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -50,11 +58,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -62,19 +72,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -82,6 +96,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -89,37 +104,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -127,11 +150,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -141,26 +166,31 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
@@ -168,25 +198,31 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'input_text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'input_text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'button',
                     }),
                   ]),
+                  'place_in_container': '1',
                   'type': 'form_container',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -196,19 +232,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/supply-chain-procurement-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/supply-chain-procurement-management.ambr
@@ -6,26 +6,31 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -33,19 +38,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -53,6 +62,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -60,44 +70,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_file',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -105,6 +124,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -112,24 +132,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -137,6 +162,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -144,19 +170,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -164,11 +194,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -180,27 +212,33 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'rating_input',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'form_container',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
@@ -210,30 +248,37 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'rating_input',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'form_container',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -241,11 +286,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -253,94 +300,113 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'iframe',
         }),
       ]),
@@ -348,66 +414,79 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -415,11 +494,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -427,44 +508,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -472,11 +562,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -484,6 +576,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -491,179 +584,215 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -671,36 +800,43 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -708,86 +844,103 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
             dict({
               'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'link',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
+              'type': 'text',
+            }),
+            dict({
+              'children': list([
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'link',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'text',
-            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -795,6 +948,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -802,159 +956,191 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -962,11 +1148,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -976,19 +1164,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/task-management.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/task-management.ambr
@@ -8,69 +8,83 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -80,59 +94,71 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -142,39 +168,47 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -182,74 +216,89 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -259,19 +308,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -281,44 +334,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -326,124 +388,149 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
@@ -451,39 +538,47 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -493,37 +588,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -533,34 +636,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -570,44 +680,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'heading',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -615,6 +734,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
@@ -622,60 +742,73 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '1',
                   'type': 'repeat',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -685,34 +818,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -722,57 +862,69 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -782,34 +934,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -817,69 +976,83 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -889,54 +1062,65 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -944,126 +1128,151 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
@@ -1071,14 +1280,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'repeat',
             }),
             dict({
@@ -1086,17 +1298,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1104,9 +1320,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
         dict({
@@ -1114,14 +1332,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -1131,44 +1352,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '3',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '4',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1178,14 +1408,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
@@ -1193,56 +1426,7 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'link',
-                }),
-                dict({
-                  'children': list([
-                  ]),
+                  'place_in_container': '2',
                   'type': 'text',
                 }),
                 dict({
@@ -1250,20 +1434,85 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '2',
                   'type': 'repeat',
                 }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '0',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'link',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'text',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '1',
+                  'type': 'link',
+                }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -1271,34 +1520,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '2',
               'type': 'table',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1308,6 +1564,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'image',
             }),
             dict({
@@ -1315,17 +1572,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/trick-or-treat.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/trick-or-treat.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,19 +14,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -33,6 +38,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -40,24 +46,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -65,6 +76,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -72,9 +84,11 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'simple_container',
         }),
       ]),
@@ -82,16 +96,19 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -99,46 +116,55 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -146,41 +172,49 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'button',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
       ]),
@@ -188,46 +222,55 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -235,11 +278,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -247,24 +292,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -272,24 +322,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -297,24 +352,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -322,19 +382,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -342,11 +406,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -354,44 +420,53 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -399,34 +474,41 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -434,31 +516,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -466,17 +554,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -484,31 +576,37 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'text',
             }),
             dict({
@@ -516,12 +614,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'repeat',
         }),
       ]),
@@ -531,19 +632,23 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),

--- a/backend/tests/baserow/core/templates/__snapshots__/work-management-platform.ambr
+++ b/backend/tests/baserow/core/templates/__snapshots__/work-management-platform.ambr
@@ -6,6 +6,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -13,6 +14,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
@@ -22,22 +24,27 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -45,27 +52,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -73,6 +86,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -80,29 +94,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'input_text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'datetime_picker',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'record_selector',
             }),
           ]),
+          'place_in_container': '',
           'type': 'form_container',
         }),
       ]),
@@ -110,6 +130,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
@@ -117,6 +138,67 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '0',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '1',
+              'type': 'heading',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'link',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '1',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '2',
               'type': 'heading',
             }),
             dict({
@@ -124,117 +206,81 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'form_container',
             }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-              ]),
-              'type': 'heading',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'link',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'repeat',
-            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -244,24 +290,29 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
@@ -269,6 +320,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
@@ -276,14 +328,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'table',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -291,12 +346,15 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'table',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -304,6 +362,7 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
@@ -311,14 +370,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'table',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -328,20 +390,25 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'image',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -349,11 +416,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'auth_form',
         }),
       ]),
@@ -361,11 +430,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -377,19 +448,23 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
                 dict({
@@ -397,22 +472,27 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -422,22 +502,27 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -447,22 +532,27 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -472,27 +562,33 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'heading',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -500,9 +596,11 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
             dict({
@@ -510,37 +608,45 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -548,11 +654,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -560,21 +668,25 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
@@ -582,17 +694,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_file',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -600,18 +716,165 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
           'children': list([
             dict({
               'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
               ]),
+              'place_in_container': '2',
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '2',
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '2',
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'heading',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                    dict({
+                      'children': list([
+                      ]),
+                      'place_in_container': '',
+                      'type': 'text',
+                    }),
+                  ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '2',
+              'type': 'simple_container',
+            }),
+            dict({
+              'children': list([
+              ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
@@ -621,200 +884,97 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'repeat',
             }),
             dict({
               'children': list([
                 dict({
                   'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
                   ]),
-                  'type': 'simple_container',
-                }),
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'heading',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                    dict({
-                      'children': list([
-                      ]),
-                      'type': 'text',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
-              'type': 'simple_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -822,21 +982,25 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -844,11 +1008,13 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -857,15 +1023,60 @@
               'children': list([
                 dict({
                   'children': list([
+                    dict({
+                      'children': list([
+                        dict({
+                          'children': list([
+                          ]),
+                          'place_in_container': '',
+                          'type': 'image',
+                        }),
+                      ]),
+                      'place_in_container': '',
+                      'type': 'simple_container',
+                    }),
+                    dict({
+                      'children': list([
+                        dict({
+                          'children': list([
+                          ]),
+                          'place_in_container': '',
+                          'type': 'text',
+                        }),
+                        dict({
+                          'children': list([
+                          ]),
+                          'place_in_container': '',
+                          'type': 'button',
+                        }),
+                      ]),
+                      'place_in_container': '',
+                      'type': 'simple_container',
+                    }),
                   ]),
+                  'place_in_container': '',
+                  'type': 'simple_container',
+                }),
+              ]),
+              'place_in_container': '0',
+              'type': 'repeat',
+            }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -873,6 +1084,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -880,14 +1092,17 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -895,14 +1110,17 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -910,12 +1128,15 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
             dict({
@@ -927,9 +1148,11 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'image',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                     dict({
@@ -937,22 +1160,27 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'text',
                         }),
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'text',
                         }),
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'link',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
                 dict({
@@ -962,9 +1190,11 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'image',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                     dict({
@@ -972,63 +1202,35 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'text',
                         }),
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'text',
                         }),
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'link',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
-              'type': 'repeat',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                    dict({
-                      'children': list([
-                        dict({
-                          'children': list([
-                          ]),
-                          'type': 'image',
-                        }),
-                      ]),
-                      'type': 'simple_container',
-                    }),
-                    dict({
-                      'children': list([
-                        dict({
-                          'children': list([
-                          ]),
-                          'type': 'text',
-                        }),
-                        dict({
-                          'children': list([
-                          ]),
-                          'type': 'button',
-                        }),
-                      ]),
-                      'type': 'simple_container',
-                    }),
-                  ]),
-                  'type': 'simple_container',
-                }),
-              ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1036,36 +1238,43 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'link',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1073,6 +1282,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1080,14 +1290,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1095,29 +1308,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -1127,34 +1346,41 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'button',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'simple_container',
             }),
             dict({
@@ -1162,14 +1388,17 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
             dict({
@@ -1179,25 +1408,31 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1205,6 +1440,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1212,14 +1448,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1227,29 +1466,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -1259,29 +1504,17 @@
                 dict({
                   'children': list([
                   ]),
-                  'type': 'record_selector',
-                }),
-                dict({
-                  'children': list([
-                  ]),
-                  'type': 'text',
-                }),
-              ]),
-              'type': 'form_container',
-            }),
-            dict({
-              'children': list([
-                dict({
-                  'children': list([
-                  ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'form_container',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
@@ -1289,12 +1522,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'link',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
+            dict({
+              'children': list([
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'record_selector',
+                }),
+                dict({
+                  'children': list([
+                  ]),
+                  'place_in_container': '',
+                  'type': 'text',
+                }),
+              ]),
+              'place_in_container': '0',
+              'type': 'form_container',
+            }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1302,6 +1556,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1309,14 +1564,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1324,29 +1582,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -1354,61 +1618,73 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'text',
             }),
             dict({
@@ -1416,44 +1692,53 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'choice',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'datetime_picker',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'record_selector',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
             dict({
@@ -1461,6 +1746,7 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -1468,14 +1754,17 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'heading',
                 }),
                 dict({
@@ -1483,15 +1772,19 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'link',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'repeat',
                 }),
               ]),
+              'place_in_container': '2',
               'type': 'simple_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1499,6 +1792,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1506,14 +1800,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1521,29 +1818,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -1551,21 +1854,25 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'table',
             }),
             dict({
@@ -1573,17 +1880,21 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_file',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1591,6 +1902,7 @@
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
@@ -1598,14 +1910,17 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
@@ -1613,29 +1928,35 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'button',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'text',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'menu',
         }),
         dict({
@@ -1645,9 +1966,11 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '',
                   'type': 'input_text',
                 }),
               ]),
+              'place_in_container': '0',
               'type': 'form_container',
             }),
             dict({
@@ -1659,9 +1982,11 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'image',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                     dict({
@@ -1669,17 +1994,21 @@
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'link',
                         }),
                         dict({
                           'children': list([
                           ]),
+                          'place_in_container': '',
                           'type': 'text',
                         }),
                       ]),
+                      'place_in_container': '',
                       'type': 'simple_container',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
                 dict({
@@ -1687,9 +2016,11 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
                 dict({
@@ -1697,15 +2028,19 @@
                     dict({
                       'children': list([
                       ]),
+                      'place_in_container': '',
                       'type': 'text',
                     }),
                   ]),
+                  'place_in_container': '',
                   'type': 'simple_container',
                 }),
               ]),
+              'place_in_container': '1',
               'type': 'repeat',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
       ]),
@@ -1715,79 +2050,95 @@
             dict({
               'children': list([
               ]),
+              'place_in_container': '1',
               'type': 'image',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'heading',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'link',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '0',
               'type': 'text',
             }),
           ]),
+          'place_in_container': '',
           'type': 'column',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'heading',
         }),
         dict({
           'children': list([
           ]),
+          'place_in_container': '',
           'type': 'table',
         }),
       ]),
@@ -1799,27 +2150,33 @@
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '1',
                   'type': 'text',
                 }),
                 dict({
                   'children': list([
                   ]),
+                  'place_in_container': '0',
                   'type': 'image',
                 }),
               ]),
+              'place_in_container': '',
               'type': 'column',
             }),
             dict({
               'children': list([
               ]),
+              'place_in_container': '',
               'type': 'menu',
             }),
           ]),
+          'place_in_container': '',
           'type': 'header',
         }),
       ]),


### PR DESCRIPTION
#### Summary

This is the third in a series of small develop fixes to make the template snapshot tests (`test_template_snapshot`) a reliable regression baseline for the`refactor-graph-handler` branch.

#### Background
  
The snapshot tests call `serialize_for_regression_testing`, which builds a `{page: [{type, children}]}` tree from each builder template after import. The goal is to catch element hierarchy regressions — if a refactor breaks parent/child relationships or element ordering, the snapshots will fail.

#### Changes
1. Slot sort key: `min(e.order) → min(e.id)` When a parent element has children in multiple slots (`place_in_container`), those slots need to be sorted in a stable, reproducible order. The previous key was `min(e.order)` — the smallest order decimal among a slot's children. On `refactor-graph-handler`, element ordering is derived from `page.graph` rather than the order DB column. Synthetic order values on that branch are always 1 for each slot's first child, making `min(e.order)` a no-op that falls through to an insertion-order stable sort — which is equivalent to `min(e.id)`. Using `min(e.id)` here makes the key explicit and consistent across both branches.

2. Add `place_in_container` to snapshot output

Each serialized element now includes its `place_in_container` value (the slot name within its parent container, e.g. "0", "1", "left"). This extends regression coverage: previously a bug that placed an element in the wrong slot of its parent would go
  undetected; now it will show up as a snapshot failure.

#### Snapshot changes

- 6 snapshots updated due to the min(e.id) sort key change: brand-assets-manager, objectives-key-results, risk-assessment-and-management, supply-chain-procurement-management, task-management, work-management-platform
- 64 snapshots updated to include the new place_in_container field
- 156/156 snapshot tests pass

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
