### PR TITLE
fix: guard guided tour highlight against missing target elements

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_a_guided_tour_crash_when_the_highlighted_element_is_no.json
+++ b/changelog/entries/unreleased/bug/fixes_a_guided_tour_crash_when_the_highlighted_element_is_no.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a guided tour crash when the highlighted element is not on the page",
+    "issue_origin": "github",
+    "issue_number": 5377,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-15"
+}

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -112,6 +112,9 @@ export default {
 
       if (this.selector.length > 0) {
         const elements = this.getElements(this.selector)
+        if (elements.length === 0) {
+          return
+        }
         const parentRect = this._getParent().getBoundingClientRect()
         const elementRect = getCombinedBoundingClientRect(elements)
         position.top = elementRect.top - parentRect.top - this.padding + 'px'

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="selector !== null"
+    v-if="visible"
     class="highlight"
     :style="{
       left: `${position.left || '0px'}`,
@@ -37,6 +37,7 @@ export default {
     return {
       scrollableParents: new Set(),
       selector: null,
+      visible: false,
       position: {
         top: 0,
         right: 0,
@@ -107,12 +108,14 @@ export default {
       }
 
       if (this.selector === null) {
+        this.visible = false
         return
       }
 
       if (this.selector.length > 0) {
         const elements = this.getElements(this.selector)
         if (elements.length === 0) {
+          this.visible = false
           return
         }
         const parentRect = this._getParent().getBoundingClientRect()
@@ -127,9 +130,11 @@ export default {
       }
 
       this.position = position
+      this.visible = true
     },
     hide() {
       this.selector = null
+      this.visible = false
       this.clearScrollEvents()
     },
   },

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -37,7 +37,6 @@ export default {
     return {
       scrollableParents: new Set(),
       selector: null,
-      visible: false,
       position: {
         top: 0,
         right: 0,
@@ -45,6 +44,11 @@ export default {
         height: 0,
       },
     }
+  },
+  computed: {
+    visible() {
+      return this.selector !== null
+    },
   },
   mounted() {
     const parent = this._getParent()
@@ -108,16 +112,13 @@ export default {
       }
 
       if (this.selector === null) {
-        this.visible = false
         return
       }
 
-      if (this.selector.length > 0) {
-        const elements = this.getElements(this.selector)
-        if (elements.length === 0) {
-          this.visible = false
-          return
-        }
+      const elements =
+        this.selector.length > 0 ? this.getElements(this.selector) : []
+
+      if (elements.length > 0) {
         const parentRect = this._getParent().getBoundingClientRect()
         const elementRect = getCombinedBoundingClientRect(elements)
         position.top = elementRect.top - parentRect.top - this.padding + 'px'
@@ -125,16 +126,15 @@ export default {
         position.width = elementRect.width + this.padding * 2 + 'px'
         position.height = elementRect.height + this.padding * 2 + 'px'
       } else {
+        // Fall back to centered when no targets match
         position.top = '50%'
         position.left = '50%'
       }
 
       this.position = position
-      this.visible = true
     },
     hide() {
       this.selector = null
-      this.visible = false
       this.clearScrollEvents()
     },
   },


### PR DESCRIPTION
## Summary

Fixes #5377 — `Highlight.vue#update()` was crashing with `TypeError: null is not an object (evaluating 'r.top')` when the guided tour was triggered for selectors that didn't match anything in the DOM (mainly Mobile Safari users on the workspace layout — ~1k events, 435 users in Sentry).

`update()` only checked that selectors were *requested*, not that any *matched*. When `getElements()` returned an empty array, `getCombinedBoundingClientRect` returned `null` and the next line dereferenced `.top`. This PR bails out of `update()` early when no elements match.

Sentry: https://baserow-eu.sentry.io/issues/95426858

## Test plan

- [ ] Trigger a guided tour step that targets a selector with no DOM match — highlight should silently stay hidden instead of throwing.
- [ ] Trigger a guided tour step that targets a real element — highlight still positions correctly.
- [ ] Resize / scroll while a highlight is active — no regression.