### PR TITLE
fix: correct crudTable sort direction mapping

### DIFF
--- a/web-frontend/modules/core/crudTable/baseService.js
+++ b/web-frontend/modules/core/crudTable/baseService.js
@@ -33,7 +33,7 @@ export default (client, baseUrl, isPaginated = true) => {
       if (sorts.length > 0) {
         params.sorts = sorts
           .map((s) => {
-            const direction = s.direction === 'asc' ? '-' : '+'
+            const direction = s.direction === 'asc' ? '+' : '-'
             return `${direction}${s.key}`
           })
           .join(',')


### PR DESCRIPTION
## Summary

Fixes the sorting direction mapping in 'crudTable'.

The frontend was sending:

*  asc -> -
*  desc -> +

while the backend expects:

*  + for ascending
*  - for descending

This caused ascending and descending sorting behavior to be reversed.
