### PR TITLE
feat(api): allow excluding id and order fields from list rows response

### DIFF
--- a/backend/src/baserow/contrib/database/api/rows/serializers.py
+++ b/backend/src/baserow/contrib/database/api/rows/serializers.py
@@ -108,6 +108,8 @@ def get_row_serializer_class(
     include_id=False,
     required_fields=None,
     extra_kwargs=None,
+    exclude_id=False,
+    exclude_order=False,
 ):
     """
     Generates a Django rest framework model serializer based on the available fields
@@ -149,6 +151,10 @@ def get_row_serializer_class(
         passed to the field serializer, the key in this dictionary must be listed in the
         fieldType.serializer_extra_args list.
     :type extra_kwargs: dict
+    :param exclude_id: If True, the `id` field will be excluded from the response.
+    :type exclude_id: bool
+    :param exclude_order: If True, the `order` field will be excluded from the response.
+    :type exclude_order: bool
     :return: The generated serializer.
     :rtype: ModelSerializer
     """
@@ -214,11 +220,29 @@ def get_row_serializer_class(
         field_names.append("id")
         field_overrides["id"] = serializers.IntegerField()
 
+    effective_base_class = base_class
+    if (exclude_id or exclude_order) and base_class is not None:
+        base_meta_fields = list(getattr(base_class.Meta, "fields", ()))
+        if exclude_id and "id" in base_meta_fields:
+            base_meta_fields.remove("id")
+        if exclude_order and "order" in base_meta_fields:
+            base_meta_fields.remove("order")
+
+        class FilteredMeta:
+            fields = tuple(base_meta_fields)
+            extra_kwargs = getattr(base_class.Meta, "extra_kwargs", {})
+
+        effective_base_class = type(
+            f"Filtered{base_class.__name__}",
+            (base_class,),
+            {"Meta": FilteredMeta},
+        )
+
     return get_serializer_class(
         model,
         field_names,
         field_overrides,
-        base_class,
+        effective_base_class,
         required_fields=required_fields,
     )
 

--- a/backend/src/baserow/contrib/database/api/rows/views.py
+++ b/backend/src/baserow/contrib/database/api/rows/views.py
@@ -68,6 +68,7 @@ from baserow.contrib.database.api.tokens.errors import (
 )
 from baserow.contrib.database.api.utils import (
     extract_link_row_joins_from_request,
+    extract_row_metadata_field_exclusions,
     extract_send_webhook_events_from_params,
     extract_user_field_names_from_params,
     get_include_exclude_fields,
@@ -272,6 +273,9 @@ class RowsView(APIView):
                     "parameter `exclude=field_1,field_2` then the fields with id `1` "
                     "and id `2` are going to be excluded from the selection and "
                     "response. "
+                    "You can also exclude the built-in `id` and `order` fields by "
+                    "including them in the exclude parameter, for example "
+                    "`exclude=id,order` or `exclude=field_1,id`. "
                     "If the `user_field_names` parameter is provided then "
                     "instead exclude should be a comma separated list of the actual "
                     "field names. For field names with commas you should surround the "
@@ -399,6 +403,7 @@ class RowsView(APIView):
         order_by = query_params.get("order_by")
         include = query_params.get("include")
         exclude = query_params.get("exclude")
+        exclude_id, exclude_order = extract_row_metadata_field_exclusions(exclude)
         user_field_names = extract_user_field_names_from_params(request.GET)
         view_id = query_params.get("view_id")
         fields_base_queryset = Field.objects.select_related("content_type").filter(
@@ -471,6 +476,8 @@ class RowsView(APIView):
             field_ids=[f.id for f in fields] if fields else None,
             user_field_names=user_field_names,
             field_kwargs=field_kwargs,
+            exclude_id=exclude_id,
+            exclude_order=exclude_order,
         )
         serializer = serializer_class(page, many=True)
 

--- a/backend/src/baserow/contrib/database/api/utils.py
+++ b/backend/src/baserow/contrib/database/api/utils.py
@@ -179,6 +179,26 @@ def extract_user_field_names_from_params(query_params):
     return str_to_bool(value)
 
 
+def extract_row_metadata_field_exclusions(exclude_value):
+    """
+    Extracts `id` and `order` exclusions from the exclude parameter.
+    These are special row metadata fields that are not user-defined fields.
+
+    :param exclude_value: The raw exclude parameter value (comma-separated string).
+    :type exclude_value: str or None
+    :return: A tuple of (exclude_id, exclude_order) booleans.
+    :rtype: tuple[bool, bool]
+    """
+
+    if not exclude_value:
+        return False, False
+
+    parts = [p.strip().lower() for p in exclude_value.split(",")]
+    exclude_id = "id" in parts
+    exclude_order = "order" in parts
+    return exclude_id, exclude_order
+
+
 def extract_send_webhook_events_from_params(query_params) -> bool:
     """
     Extracts the send_webhook_events parameter from the query_params and returns


### PR DESCRIPTION
This PR adds the ability to exclude the built-in `id` and `order` fields from the list_database_table_rows API response.

Currently, the `exclude` parameter only works for user-created fields (field_1, field_2, etc.). The `id` and `order` fields are always included in the response even when not needed, which can be wasteful for clients that only care about the actual data.

With this change, users can pass `id` and `order` in the exclude query parameter:
- `GET /api/database/rows/table/{table_id}/?exclude=id` - excludes id
- `GET /api/database/rows/table/{table_id}/?exclude=order` - excludes order
- `GET /api/database/rows/table/{table_id}/?exclude=id,order` - excludes both
- `GET /api/database/rows/table/{table_id}/?exclude=id,order,field_1` - mix with field exclusions

The implementation adds:
1. `extract_row_metadata_field_exclusions()` helper in utils.py to detect id/order in exclude string
2. `exclude_id` and `exclude_order` parameters to `get_row_serializer_class()`
3. Updated API documentation for the exclude parameter

Closes #893