### PR TITLE
fix: guard guided tour highlight against missing target elements

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_a_guided_tour_crash_when_the_highlighted_element_is_no.json
+++ b/changelog/entries/unreleased/bug/fixes_a_guided_tour_crash_when_the_highlighted_element_is_no.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a guided tour crash when the highlighted element is not on the page",
+    "issue_origin": "github",
+    "issue_number": 5377,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-15"
+}

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -112,6 +112,9 @@ export default {
 
       if (this.selector.length > 0) {
         const elements = this.getElements(this.selector)
+        if (elements.length === 0) {
+          return
+        }
         const parentRect = this._getParent().getBoundingClientRect()
         const elementRect = getCombinedBoundingClientRect(elements)
         position.top = elementRect.top - parentRect.top - this.padding + 'px'

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="selector !== null"
+    v-if="visible"
     class="highlight"
     :style="{
       left: `${position.left || '0px'}`,
@@ -37,6 +37,7 @@ export default {
     return {
       scrollableParents: new Set(),
       selector: null,
+      visible: false,
       position: {
         top: 0,
         right: 0,
@@ -107,12 +108,14 @@ export default {
       }
 
       if (this.selector === null) {
+        this.visible = false
         return
       }
 
       if (this.selector.length > 0) {
         const elements = this.getElements(this.selector)
         if (elements.length === 0) {
+          this.visible = false
           return
         }
         const parentRect = this._getParent().getBoundingClientRect()
@@ -127,9 +130,11 @@ export default {
       }
 
       this.position = position
+      this.visible = true
     },
     hide() {
       this.selector = null
+      this.visible = false
       this.clearScrollEvents()
     },
   },

--- a/web-frontend/modules/core/components/Highlight.vue
+++ b/web-frontend/modules/core/components/Highlight.vue
@@ -37,7 +37,6 @@ export default {
     return {
       scrollableParents: new Set(),
       selector: null,
-      visible: false,
       position: {
         top: 0,
         right: 0,
@@ -45,6 +44,11 @@ export default {
         height: 0,
       },
     }
+  },
+  computed: {
+    visible() {
+      return this.selector !== null
+    },
   },
   mounted() {
     const parent = this._getParent()
@@ -108,16 +112,13 @@ export default {
       }
 
       if (this.selector === null) {
-        this.visible = false
         return
       }
 
-      if (this.selector.length > 0) {
-        const elements = this.getElements(this.selector)
-        if (elements.length === 0) {
-          this.visible = false
-          return
-        }
+      const elements =
+        this.selector.length > 0 ? this.getElements(this.selector) : []
+
+      if (elements.length > 0) {
         const parentRect = this._getParent().getBoundingClientRect()
         const elementRect = getCombinedBoundingClientRect(elements)
         position.top = elementRect.top - parentRect.top - this.padding + 'px'
@@ -125,16 +126,15 @@ export default {
         position.width = elementRect.width + this.padding * 2 + 'px'
         position.height = elementRect.height + this.padding * 2 + 'px'
       } else {
+        // Fall back to centered when no targets match
         position.top = '50%'
         position.left = '50%'
       }
 
       this.position = position
-      this.visible = true
     },
     hide() {
       this.selector = null
-      this.visible = false
       this.clearScrollEvents()
     },
   },


### PR DESCRIPTION
Resolves #5377

## Summary

- `Highlight.vue#update()` was only guarding on `selector.length > 0` (i.e. whether selectors were *requested*), not whether any actually matched. On mobile Safari the guided-tour targets aren't rendered, so `getElements()` returned `[]`, `getCombinedBoundingClientRect([])` returned `null`, and the next line crashed with `TypeError: null is not an object (evaluating 'r.top')` (Sentry: ~1k events, 435 users).
- `update()` now branches on the resolved element list instead of the raw selector length. When no elements match, it falls back to the same centred position that empty-selector steps already use, so the highlight root stays mounted and `GuidedTourStep`'s Next/Finish controls remain reachable — users can always advance or finish the tour rather than getting stuck.
- Visibility is gated by a `visible` computed so the dimming overlay can be toggled independently of `selector` if we need to extend this later.

## Test plan

- [ ] Trigger a guided-tour step whose selectors don't resolve on the current viewport (e.g. mobile workspace layout) and confirm no console error and the Next/Finish button is reachable
- [ ] Verify a normal guided-tour step still highlights its target correctly on desktop
- [ ] `just f test web-frontend/modules/core` (or targeted Highlight tests if present)