### PR TITLE
fix: context_data disappearing when database lookup fails

### DIFF
--- a/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
@@ -138,7 +138,7 @@ class LocalBaserowIntegrationType(IntegrationType):
                 instance
             )
         except Exception:
-            logger.warning(
+            logger.exception(
                 "Failed to compute context_data for integration %s; "
                 "returning empty databases list.",
                 instance.id,

--- a/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/integration_types.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
@@ -17,6 +18,7 @@ from baserow.core.integrations.types import IntegrationDict
 from baserow.core.models import Application
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class LocalBaserowIntegrationType(IntegrationType):
@@ -131,11 +133,19 @@ class LocalBaserowIntegrationType(IntegrationType):
         return queryset.select_related("authorized_user")
 
     def get_context_data(self, instance: LocalBaserowIntegration) -> Optional[Dict]:
-        return {
-            "databases": LocalBaserowIntegrationType.get_local_baserow_databases(
+        try:
+            databases = LocalBaserowIntegrationType.get_local_baserow_databases(
                 instance
             )
-        }
+        except Exception:
+            logger.warning(
+                "Failed to compute context_data for integration %s; "
+                "returning empty databases list.",
+                instance.id,
+                exc_info=True,
+            )
+            databases = []
+        return {"databases": databases}
 
     @staticmethod
     def get_local_baserow_databases(integration: LocalBaserowIntegration) -> List:

--- a/backend/tests/baserow/api/integrations/test_integration_views.py
+++ b/backend/tests/baserow/api/integrations/test_integration_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 import pytest
@@ -374,3 +376,29 @@ def test_delete_integration_integration_not_exist(api_client, data_fixture):
 
     assert response.status_code == HTTP_404_NOT_FOUND
     assert response.json()["error"] == "ERROR_INTEGRATION_DOES_NOT_EXIST"
+
+
+@pytest.mark.django_db
+def test_get_integrations_context_data_present_when_databases_raises(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(user=user)
+    application = data_fixture.create_builder_application(workspace=workspace)
+    data_fixture.create_local_baserow_integration(
+        application=application, authorized_user=user
+    )
+
+    with patch(
+        "baserow.contrib.integrations.local_baserow.integration_types"
+        ".LocalBaserowIntegrationType.get_local_baserow_databases",
+        side_effect=AttributeError("simulated failure"),
+    ):
+        url = reverse(
+            "api:integrations:list", kwargs={"application_id": application.id}
+        )
+        response = api_client.get(url, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json[0]["context_data"] == {"databases": []}

--- a/changelog/entries/unreleased/bug/fixes_a_crash_when_opening_user_source_settings_in_the_appli.json
+++ b/changelog/entries/unreleased/bug/fixes_a_crash_when_opening_user_source_settings_in_the_appli.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a crash when opening user source settings in the application builder",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-05-19"
+}


### PR DESCRIPTION
### What is in this PR

- Addresses Sentry ticket 120895327
- When `get_local_baserow_databases` raises any exception during serialization, DRF's `get_attribute` silently catches `AttributeError` via its `SkipField` mechanism and omits `context_data` from the API response entirely. The frontend then stores the integration without a `context_data` key, causing a `TypeError: Cannot read properties of undefined (reading 'databases')` when the user source settings panel opens in the app builder.
- `get_context_data` now wraps the database lookup in a try/except, logs a warning with the full traceback, and falls back to `{"databases": []}` so the field is always present in the response.
 
### How to test this PR

In develop: add

```python
raise AttributeError("simulating error")
```

Inside `LocalBaserowIntegrationType.get_local_baserow_databases`. Open a user source user form (you may have to click the Local Baserow integration), and you'll get a JS error like in that Sentry ticket:

<img width="1801" height="96" alt="Screenshot 2026-05-19 at 11 37 07" src="https://github.com/user-attachments/assets/a30815d1-b0aa-42f6-b76b-9fbc8a46332d" />

Swap back to this branch, put the same `AttributeError` back in. No JS error in the frontend, because the API is returning a blank array of `databases` in the response.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
