### PR TITLE
Add license checks for view type CRUD operations

### DIFF
--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -834,6 +834,9 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             workspace=view.table.database.workspace,
             context=view,
         )
+        view_type_registry.get_by_model(view).check_license(
+            user, view.table.database.workspace
+        )
         return view
 
     def get_view(
@@ -960,6 +963,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             workspace=workspace,
             context=table,
         )
+        view_type.check_license(user, workspace)
         view_type.before_view_create(kwargs, table, user)
 
         model_class = view_type.model_class
@@ -1027,6 +1031,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         )
 
         view_type = view_type_registry.get_by_model(original_view)
+        view_type.check_license(user, workspace)
 
         config = ImportExportConfig(
             include_permission_data=True,
@@ -1120,6 +1125,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
 
         view_type = view_type_registry.get_by_model(view)
         view_type.check_view_update_permissions(user, view, data)
+        view_type.check_license(user, view.table.database.workspace)
         view_type.before_view_update(data, view, user)
 
         old_view = deepcopy(view)
@@ -1297,6 +1303,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         CoreHandler().check_permissions(
             user, DeleteViewOperationType.type, workspace=workspace, context=view
         )
+        view_type_registry.get_by_model(view).check_license(user, workspace)
 
         view_id = view.id
 

--- a/backend/src/baserow/contrib/database/views/registries.py
+++ b/backend/src/baserow/contrib/database/views/registries.py
@@ -227,6 +227,17 @@ class ViewType(
                 ),
             }
 
+    def check_license(self, user: AbstractUser, workspace: Workspace) -> None:
+        """
+        Hook for non-OSS view types to raise when the user cannot use this view type.
+
+        OSS view types do not require an additional license check. Premium and
+        enterprise view types can override this method to enforce their feature gate
+        for generic view CRUD operations.
+        """
+
+        return None
+
     def export_serialized(
         self,
         view: "View",

--- a/backend/tests/baserow/contrib/database/api/views/test_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/test_view_views.py
@@ -367,6 +367,63 @@ def test_delete_view(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_view_crud_calls_view_type_license_check(api_client, data_fixture):
+    checked_workspaces = []
+
+    class LicenseCheckedGridViewType(GridViewType):
+        def check_license(self, user, workspace):
+            checked_workspaces.append((user.id, workspace.id))
+
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    view = data_fixture.create_grid_view(table=table)
+
+    with patch.dict(
+        view_type_registry.registry, {"grid": LicenseCheckedGridViewType()}
+    ):
+        view_type_registry.get_for_class.cache_clear()
+
+        response = api_client.post(
+            reverse("api:database:views:list", kwargs={"table_id": table.id}),
+            {"type": "grid", "name": "New grid"},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_200_OK
+
+        response = api_client.get(
+            reverse("api:database:views:item", kwargs={"view_id": view.id}),
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_200_OK
+
+        response = api_client.patch(
+            reverse("api:database:views:item", kwargs={"view_id": view.id}),
+            {"name": "Updated grid"},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_200_OK
+
+        response = api_client.post(
+            reverse("api:database:views:duplicate", kwargs={"view_id": view.id}),
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_200_OK
+
+        response = api_client.delete(
+            reverse("api:database:views:item", kwargs={"view_id": view.id}),
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_204_NO_CONTENT
+
+    assert checked_workspaces == [(user.id, table.database.workspace_id)] * 5
+
+
+@pytest.mark.django_db
 def test_duplicate_views(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token(
         email="test@test.nl", password="password", first_name="Test1"

--- a/premium/backend/src/baserow_premium/views/view_types.py
+++ b/premium/backend/src/baserow_premium/views/view_types.py
@@ -43,6 +43,8 @@ from baserow_premium.api.views.timeline.errors import (
 from baserow_premium.api.views.timeline.serializers import (
     TimelineViewFieldOptionsSerializer,
 )
+from baserow_premium.license.features import PREMIUM
+from baserow_premium.license.handler import LicenseHandler
 
 from .exceptions import (
     KanbanViewFieldDoesNotBelongToSameTable,
@@ -58,7 +60,13 @@ from .models import (
 )
 
 
-class KanbanViewType(ViewType):
+class PremiumViewTypeMixin:
+    def check_license(self, user: AbstractUser, workspace) -> None:
+        if not workspace.has_template():
+            LicenseHandler.raise_if_user_doesnt_have_feature(PREMIUM, user, workspace)
+
+
+class KanbanViewType(PremiumViewTypeMixin, ViewType):
     type = "kanban"
     model_class = KanbanView
     field_options_model_class = KanbanViewFieldOptions
@@ -308,7 +316,7 @@ class KanbanViewType(ViewType):
             )
 
 
-class CalendarViewType(ViewType):
+class CalendarViewType(PremiumViewTypeMixin, ViewType):
     type = "calendar"
     model_class = CalendarView
     field_options_model_class = CalendarViewFieldOptions
@@ -553,7 +561,7 @@ class CalendarViewType(ViewType):
         CalendarView.objects.filter(date_field_id=field.id).update(date_field_id=None)
 
 
-class TimelineViewType(ViewType):
+class TimelineViewType(PremiumViewTypeMixin, ViewType):
     type = "timeline"
     model_class = TimelineView
     field_options_model_class = TimelineViewFieldOptions


### PR DESCRIPTION
﻿## Summary

Addresses #2847 by adding a generic license-check hook to view types and invoking it from the generic view CRUD paths.

## What changed

- Adds `ViewType.check_license(user, workspace)` as a no-op hook for OSS view types.
- Calls the hook when creating, reading, updating, duplicating, and deleting views via `ViewHandler`.
- Makes premium view types enforce the premium license through a shared mixin while preserving template-workspace behavior.
- Adds API coverage to ensure the generic view CRUD path calls the view-type license hook.

## Validation

- `git diff --check`
- `py -3.14 -m py_compile backend/src/baserow/contrib/database/views/handler.py backend/src/baserow/contrib/database/views/registries.py backend/tests/baserow/contrib/database/api/views/test_view_views.py premium/backend/src/baserow_premium/views/view_types.py`

I could not run the full Django pytest target in this Windows checkout because the repo's local `uv` shim points to a missing `Python314\Scripts\uv.exe` path.
