### PR TITLE
Fix Azure AD SAML metadata import

### DIFF
--- a/changelog/entries/unreleased/bug/1673_allow_azure_ad_saml_metadata.json
+++ b/changelog/entries/unreleased/bug/1673_allow_azure_ad_saml_metadata.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Allow Microsoft Entra ID/Azure AD SAML metadata to be imported without manually removing WS-Federation role descriptors",
+    "issue_origin": "github",
+    "issue_number": 1673,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-20"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
+++ b/enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py
@@ -1,11 +1,20 @@
 import io
+from typing import Any, Iterable
 
 from django.db.models import QuerySet
 
+from defusedxml import ElementTree
+from defusedxml.common import DefusedXmlException
 from rest_framework import serializers
 
 from baserow_enterprise.sso.saml.exceptions import SamlProviderForDomainAlreadyExists
 from baserow_enterprise.sso.saml.models import SamlAuthProviderModel
+
+SAML_METADATA_NAMESPACE = "urn:oasis:names:tc:SAML:2.0:metadata"
+SAML_ROLE_DESCRIPTOR_TAG = f"{{{SAML_METADATA_NAMESPACE}}}RoleDescriptor"
+SAML_METADATA_VALIDATION_ERROR = (
+    "The metadata is not valid according to the XML schema."
+)
 
 
 def validate_unique_saml_domain(
@@ -24,16 +33,48 @@ def validate_unique_saml_domain(
     return domain
 
 
+def _remove_matching_children(root: Any, child_tags: Iterable[str]) -> bool:
+    child_tags = set(child_tags)
+    removed = False
+
+    for parent in root.iter():
+        for child in list(parent):
+            if child.tag in child_tags:
+                parent.remove(child)
+                removed = True
+
+    return removed
+
+
+def normalize_saml_metadata(value):
+    """
+    Remove unsupported extension role descriptors from SAML metadata.
+
+    Microsoft Entra ID/Azure AD can include WS-Federation RoleDescriptor nodes in
+    its federation metadata alongside the SAML IDPSSODescriptor. PySAML2 rejects
+    those extension role descriptors during schema validation even though Baserow
+    only needs the SAML descriptor.
+    """
+
+    try:
+        root = ElementTree.fromstring(value)
+    except (ElementTree.ParseError, DefusedXmlException):
+        return value
+
+    if not _remove_matching_children(root, [SAML_ROLE_DESCRIPTOR_TAG]):
+        return value
+
+    return ElementTree.tostring(root, encoding="unicode")
+
+
 def validate_saml_metadata(value):
     from saml2.xml.schema import XMLSchemaError
     from saml2.xml.schema import validate as validate_saml_metadata_schema
 
-    metadata = io.StringIO(value)
+    metadata = io.StringIO(normalize_saml_metadata(value))
     try:
         validate_saml_metadata_schema(metadata)
     except XMLSchemaError:
-        raise serializers.ValidationError(
-            "The metadata is not valid according to the XML schema."
-        )
+        raise serializers.ValidationError(SAML_METADATA_VALIDATION_ERROR)
 
     return value

--- a/enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py
+++ b/enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py
@@ -14,6 +14,7 @@ from baserow_enterprise.api.sso.saml.errors import (
     ERROR_SAML_PROVIDER_FOR_DOMAIN_ALREADY_EXISTS,
 )
 from baserow_enterprise.api.sso.saml.validators import (
+    normalize_saml_metadata,
     validate_saml_metadata,
     validate_unique_saml_domain,
 )
@@ -105,6 +106,14 @@ class SamlAuthProviderTypeMixin:
         Returns the login URL for this auth_provider. The login URL is used to initiate
         the Saml login process.
         """
+
+    def prepare_values(self, values: Dict[str, Any], user, instance=None):
+        prepared_values = super().prepare_values(values, user, instance=instance)
+        if "metadata" in prepared_values:
+            prepared_values["metadata"] = normalize_saml_metadata(
+                prepared_values["metadata"]
+            )
+        return prepared_values
 
 
 class SamlAuthProviderType(SamlAuthProviderTypeMixin, AuthProviderType):

--- a/enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py
@@ -4,7 +4,32 @@ import pytest
 
 from baserow.core.auth_provider.handler import AuthProviderHandler
 from baserow.core.registries import auth_provider_type_registry
+from baserow_enterprise.api.sso.saml.validators import (
+    normalize_saml_metadata,
+    validate_saml_metadata,
+)
 from baserow_enterprise.sso.saml.exceptions import SamlProviderForDomainAlreadyExists
+
+AZURE_AD_ROLE_DESCRIPTOR = (
+    '<RoleDescriptor xmlns:fed="http://docs.oasis-open.org/wsfed/federation/200706" '
+    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+    'xsi:type="fed:SecurityTokenServiceType" '
+    'protocolSupportEnumeration="http://docs.oasis-open.org/wsfed/federation/200706">'
+    "<fed:PassiveRequestorEndpoint>"
+    '<EndpointReference xmlns="http://www.w3.org/2005/08/addressing">'
+    "<Address>https://login.microsoftonline.com/example/wsfed</Address>"
+    "</EndpointReference>"
+    "</fed:PassiveRequestorEndpoint>"
+    "</RoleDescriptor>"
+)
+
+
+def add_azure_ad_role_descriptor(metadata):
+    return metadata.replace(
+        "<IDPSSODescriptor",
+        f"{AZURE_AD_ROLE_DESCRIPTOR}<IDPSSODescriptor",
+        1,
+    )
 
 
 @pytest.mark.django_db
@@ -49,3 +74,46 @@ def test_cannot_create_two_saml_providers_for_the_same_domain(enterprise_data_fi
             domain="test.com",
             metadata=enterprise_data_fixture.get_test_saml_idp_metadata(),
         )
+
+
+def test_saml_metadata_validator_accepts_azure_ad_role_descriptors(
+    enterprise_data_fixture,
+):
+    metadata = add_azure_ad_role_descriptor(
+        enterprise_data_fixture.get_test_saml_idp_metadata()
+    )
+
+    assert "<RoleDescriptor" in metadata
+    assert validate_saml_metadata(metadata) == metadata
+
+
+def test_normalize_saml_metadata_removes_azure_ad_role_descriptors(
+    enterprise_data_fixture,
+):
+    metadata = add_azure_ad_role_descriptor(
+        enterprise_data_fixture.get_test_saml_idp_metadata()
+    )
+
+    normalized_metadata = normalize_saml_metadata(metadata)
+
+    assert "RoleDescriptor" not in normalized_metadata
+    assert "IDPSSODescriptor" in normalized_metadata
+
+
+@pytest.mark.django_db()
+@override_settings(DEBUG=True)
+def test_saml_provider_stores_normalized_azure_ad_metadata(enterprise_data_fixture):
+    user, _ = enterprise_data_fixture.create_enterprise_admin_user_and_token()
+    metadata = add_azure_ad_role_descriptor(
+        enterprise_data_fixture.get_test_saml_idp_metadata()
+    )
+
+    provider = AuthProviderHandler.create_auth_provider(
+        user,
+        auth_provider_type_registry.get("saml"),
+        domain="test.com",
+        metadata=metadata,
+    )
+
+    assert "RoleDescriptor" not in provider.metadata
+    assert "IDPSSODescriptor" in provider.metadata


### PR DESCRIPTION
### What is in this PR
- Fixes #1673.
- Normalizes SAML metadata by removing unsupported SAML `RoleDescriptor` elements before PySAML2 schema validation.
- Applies the same normalization before create/update persistence so Microsoft Entra ID/Azure AD metadata is stored in the form PySAML2 can use during login.
- Adds focused tests for accepting Azure-style metadata and storing the normalized metadata.

### How to test this PR
- Import Microsoft Entra ID/Azure AD federation metadata that includes a WS-Federation `RoleDescriptor`; it should no longer fail with the SAML XML schema validation error.
- Run `just b test ../enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py`.

Local verification performed:
- `python -m py_compile enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py`
- `python -m ruff check --config backend/pyproject.toml enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py`
- `python -m ruff format --config backend/pyproject.toml --check enterprise/backend/src/baserow_enterprise/api/sso/saml/validators.py enterprise/backend/src/baserow_enterprise/sso/saml/auth_provider_types.py enterprise/backend/tests/baserow_enterprise_tests/sso/saml/test_auth_provider_types.py`
- PySAML2 schema smoke check: raw Azure-style metadata with `RoleDescriptor` fails schema validation, while `validate_saml_metadata` accepts it after normalization.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered