### PR TITLE
fix: Automation history performance

### DIFF
--- a/backend/src/baserow/contrib/automation/api/history/errors.py
+++ b/backend/src/baserow/contrib/automation/api/history/errors.py
@@ -1,0 +1,19 @@
+from rest_framework.status import HTTP_404_NOT_FOUND
+
+ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST = (
+    "ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST",
+    HTTP_404_NOT_FOUND,
+    "The automation workflow history does not exist.",
+)
+
+ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST = (
+    "ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST",
+    HTTP_404_NOT_FOUND,
+    "The automation node history does not exist.",
+)
+
+ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST = (
+    "ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST",
+    HTTP_404_NOT_FOUND,
+    "The automation node result does not exist.",
+)

--- a/backend/src/baserow/contrib/automation/api/history/serializers.py
+++ b/backend/src/baserow/contrib/automation/api/history/serializers.py
@@ -1,0 +1,78 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from baserow.contrib.automation.history.models import (
+    AutomationNodeHistory,
+    AutomationNodeResult,
+)
+
+
+class AutomationNodeHistorySerializer(serializers.ModelSerializer):
+    node_type = serializers.SerializerMethodField()
+    node_label = serializers.SerializerMethodField()
+    parent_node_id = serializers.SerializerMethodField()
+    iteration = serializers.SerializerMethodField()
+    iteration_path = serializers.SerializerMethodField()
+    edge_label = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AutomationNodeHistory
+        fields = (
+            "id",
+            "started_on",
+            "completed_on",
+            "message",
+            "status",
+            "workflow_history",
+            "node",
+            "node_type",
+            "node_label",
+            "parent_node_id",
+            "iteration",
+            "iteration_path",
+            "edge_label",
+        )
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_node_type(self, obj):
+        return obj.node.get_type().type
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_node_label(self, obj):
+        return obj.node.label
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_parent_node_id(self, obj):
+        parent_nodes = obj.node.get_parent_nodes()
+        if not parent_nodes:
+            return None
+        return parent_nodes[-1].id
+
+    def _get_first_node_result(self, obj):
+        results = obj.node_results.all()
+        return results[0] if results else None
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_iteration(self, obj):
+        result = self._get_first_node_result(obj)
+        if result is None:
+            return None
+        if result.iteration_path:
+            return int(result.iteration_path.rsplit(".", 1)[-1])
+        return 0
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_iteration_path(self, obj):
+        result = self._get_first_node_result(obj)
+        return result.iteration_path if result else ""
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_edge_label(self, obj):
+        return self.context.get("edge_labels", {}).get(obj.id, "")
+
+
+class AutomationNodeResultSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AutomationNodeResult
+        fields = ("result",)

--- a/backend/src/baserow/contrib/automation/api/history/urls.py
+++ b/backend/src/baserow/contrib/automation/api/history/urls.py
@@ -1,0 +1,21 @@
+from django.urls import re_path
+
+from baserow.contrib.automation.api.history.views import (
+    AutomationNodeHistoriesView,
+    AutomationNodeResultView,
+)
+
+app_name = "baserow.contrib.automation.api.history"
+
+urlpatterns = [
+    re_path(
+        r"workflow_histories/(?P<workflow_history_id>[0-9]+)/node_histories/$",
+        AutomationNodeHistoriesView.as_view(),
+        name="node_histories",
+    ),
+    re_path(
+        r"node_histories/(?P<node_history_id>[0-9]+)/result/$",
+        AutomationNodeResultView.as_view(),
+        name="node_result",
+    ),
+]

--- a/backend/src/baserow/contrib/automation/api/history/views.py
+++ b/backend/src/baserow/contrib/automation/api/history/views.py
@@ -1,0 +1,109 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from baserow.api.decorators import map_exceptions
+from baserow.api.schemas import CLIENT_SESSION_ID_SCHEMA_PARAMETER, get_error_schema
+from baserow.contrib.automation.api.history.errors import (
+    ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST,
+    ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST,
+    ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST,
+)
+from baserow.contrib.automation.api.history.serializers import (
+    AutomationNodeHistorySerializer,
+    AutomationNodeResultSerializer,
+)
+from baserow.contrib.automation.history.exceptions import (
+    AutomationNodeHistoryDoesNotExist,
+    AutomationWorkflowHistoryDoesNotExist,
+    AutomationWorkflowHistoryNodeResultDoesNotExist,
+)
+from baserow.contrib.automation.history.service import AutomationHistoryService
+
+AUTOMATION_HISTORY_TAG = "Automation history"
+
+
+class AutomationNodeHistoriesView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="workflow_history_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The id of the workflow history.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+        ],
+        tags=[AUTOMATION_HISTORY_TAG],
+        operation_id="get_automation_node_histories",
+        description="Returns all node histories for the given workflow history.",
+        responses={
+            200: AutomationNodeHistorySerializer(many=True),
+            404: get_error_schema(["ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST"]),
+        },
+    )
+    @map_exceptions(
+        {
+            AutomationWorkflowHistoryDoesNotExist: (
+                ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST
+            ),
+        }
+    )
+    def get(self, request, workflow_history_id: int):
+        service = AutomationHistoryService()
+        node_histories = service.get_node_histories(request.user, workflow_history_id)
+        edge_labels = service.get_edge_labels(request.user, node_histories)
+        serializer = AutomationNodeHistorySerializer(
+            node_histories,
+            many=True,
+            context={"edge_labels": edge_labels},
+        )
+        return Response(serializer.data)
+
+
+class AutomationNodeResultView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="node_history_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The id of the node history.",
+            ),
+            CLIENT_SESSION_ID_SCHEMA_PARAMETER,
+        ],
+        tags=[AUTOMATION_HISTORY_TAG],
+        operation_id="get_automation_node_result",
+        description="Returns the node history's result JSON.",
+        responses={
+            200: AutomationNodeResultSerializer,
+            404: get_error_schema(
+                [
+                    "ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST",
+                    "ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST",
+                ]
+            ),
+        },
+    )
+    @map_exceptions(
+        {
+            AutomationNodeHistoryDoesNotExist: (
+                ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST
+            ),
+            AutomationWorkflowHistoryNodeResultDoesNotExist: (
+                ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST
+            ),
+        }
+    )
+    def get(self, request, node_history_id: int):
+        node_result = AutomationHistoryService().get_node_history_result(
+            request.user, node_history_id
+        )
+        serializer = AutomationNodeResultSerializer(node_result)
+        return Response(serializer.data)

--- a/backend/src/baserow/contrib/automation/api/urls.py
+++ b/backend/src/baserow/contrib/automation/api/urls.py
@@ -1,5 +1,6 @@
 from django.urls import include, path, re_path
 
+from baserow.contrib.automation.api.history import urls as history_urls
 from baserow.contrib.automation.api.nodes import urls as node_urls
 from baserow.contrib.automation.api.workflows import urls as workflow_urls
 
@@ -28,6 +29,13 @@ paths_without_automation_id = [
         include(
             node_urls,
             namespace="nodes",
+        ),
+    ),
+    path(
+        "",
+        include(
+            history_urls,
+            namespace="history",
         ),
     ),
 ]

--- a/backend/src/baserow/contrib/automation/api/workflows/serializers.py
+++ b/backend/src/baserow/contrib/automation/api/workflows/serializers.py
@@ -5,7 +5,6 @@ from rest_framework import serializers
 from baserow.api.pagination import PageNumberPagination
 from baserow.contrib.automation.models import (
     AutomationHistory,
-    AutomationNodeHistory,
     AutomationWorkflow,
     AutomationWorkflowHistory,
 )
@@ -118,70 +117,12 @@ class AutomationHistorySerializer(serializers.ModelSerializer):
         )
 
 
-class AutomationNodeHistorySerializer(AutomationHistorySerializer):
-    parent_node_id = serializers.SerializerMethodField()
-    iteration = serializers.SerializerMethodField()
-    result = serializers.SerializerMethodField()
-    node_type = serializers.SerializerMethodField()
-    node_label = serializers.SerializerMethodField()
-
-    class Meta:
-        model = AutomationNodeHistory
-        fields = AutomationHistorySerializer.Meta.fields + (
-            "workflow_history",
-            "node",
-            "node_type",
-            "node_label",
-            "parent_node_id",
-            "iteration",
-            "result",
-        )
-
-    def _get_first_node_result(self, obj):
-        results = obj.node_results.all()
-        return results[0] if results else None
-
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_node_type(self, obj):
-        return obj.node.get_type().type
-
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_node_label(self, obj):
-        return obj.node.label
-
-    @extend_schema_field(OpenApiTypes.INT)
-    def get_parent_node_id(self, obj):
-        parent_nodes = obj.node.get_parent_nodes()
-        if not parent_nodes:
-            return None
-        return parent_nodes[-1].id
-
-    @extend_schema_field(OpenApiTypes.INT)
-    def get_iteration(self, obj):
-        result = self._get_first_node_result(obj)
-        if result is None:
-            return None
-
-        if result.iteration_path:
-            return int(result.iteration_path.rsplit(".", 1)[-1])
-
-        return 0
-
-    def get_result(self, obj):
-        result = self._get_first_node_result(obj)
-        return result.result if result else {}
-
-
 class AutomationWorkflowHistorySerializer(AutomationHistorySerializer):
-    node_histories = AutomationNodeHistorySerializer(read_only=True, many=True)
-
     class Meta:
         model = AutomationWorkflowHistory
         fields = AutomationHistorySerializer.Meta.fields + (
             "is_test_run",
-            "event_payload",
             "simulate_until_node",
-            "node_histories",
         )
 
 

--- a/backend/src/baserow/contrib/automation/history/exceptions.py
+++ b/backend/src/baserow/contrib/automation/history/exceptions.py
@@ -19,3 +19,15 @@ class AutomationWorkflowHistoryDoesNotExist(AutomationWorkflowHistoryError):
 
 class AutomationWorkflowHistoryNodeResultDoesNotExist(AutomationWorkflowHistoryError):
     """When the result entry doesn't exist for the given node/history."""
+
+
+class AutomationNodeHistoryDoesNotExist(AutomationWorkflowHistoryError):
+    """When the node history entry doesn't exist."""
+
+    def __init__(self, node_history_id=None, *args, **kwargs):
+        self.node_history_id = node_history_id
+        super().__init__(
+            f"The automation node history {node_history_id} does not exist.",
+            *args,
+            **kwargs,
+        )

--- a/backend/src/baserow/contrib/automation/history/handler.py
+++ b/backend/src/baserow/contrib/automation/history/handler.py
@@ -5,6 +5,7 @@ from django.db.models import Prefetch, QuerySet
 
 from baserow.contrib.automation.history.constants import HistoryStatusChoices
 from baserow.contrib.automation.history.exceptions import (
+    AutomationNodeHistoryDoesNotExist,
     AutomationWorkflowHistoryDoesNotExist,
     AutomationWorkflowHistoryNodeResultDoesNotExist,
 )
@@ -33,15 +34,6 @@ class AutomationHistoryHandler:
         return base_queryset.filter(
             original_workflow=workflow,
             simulate_until_node__isnull=True,
-        ).prefetch_related(
-            Prefetch(
-                "node_histories",
-                queryset=AutomationNodeHistory.objects.select_related(
-                    "node", "node__workflow"
-                )
-                .prefetch_related("node_results")
-                .order_by("started_on"),
-            ),
         )
 
     def get_workflow_history(
@@ -143,3 +135,72 @@ class AutomationHistoryHandler:
             raise AutomationWorkflowHistoryNodeResultDoesNotExist()
 
         return node_result.result
+
+    def get_node_history(
+        self,
+        node_history_id: int,
+        base_queryset: Optional[QuerySet] = None,
+    ) -> AutomationNodeHistory:
+        """Returns an AutomationNodeHistory by its ID."""
+
+        if base_queryset is None:
+            base_queryset = AutomationNodeHistory.objects.all()
+
+        try:
+            return base_queryset.select_related(
+                "workflow_history__original_workflow__automation__workspace",
+            ).get(id=node_history_id)
+        except AutomationNodeHistory.DoesNotExist:
+            raise AutomationNodeHistoryDoesNotExist(node_history_id)
+
+    def get_node_histories(
+        self, workflow_history: AutomationWorkflowHistory
+    ) -> QuerySet[AutomationNodeHistory]:
+        """Returns a queryset of AutomationNodeHistory by the workflow history."""
+
+        return (
+            AutomationNodeHistory.objects.filter(workflow_history=workflow_history)
+            .select_related("node", "node__workflow")
+            .prefetch_related(
+                Prefetch(
+                    "node_results",
+                    queryset=AutomationNodeResult.objects.only(
+                        "id", "node_history_id", "iteration_path"
+                    ),
+                )
+            )
+            .order_by("started_on", "id")
+        )
+
+    def get_node_history_result(
+        self, node_history: AutomationNodeHistory
+    ) -> AutomationNodeResult:
+        """Returns the AutomationNodeResult for the given node history."""
+
+        try:
+            return AutomationNodeResult.objects.only("result").get(
+                node_history=node_history
+            )
+        except AutomationNodeResult.DoesNotExist:
+            raise AutomationWorkflowHistoryNodeResultDoesNotExist()
+
+    def get_edge_labels(
+        self, node_histories: List[AutomationNodeHistory]
+    ) -> Dict[int, str]:
+        """
+        For each node history whose result has an edge label, return a
+        mapping of `node_history_id -> label` of the edge taken.
+        """
+
+        if not node_histories:
+            return {}
+
+        results = AutomationNodeResult.objects.filter(
+            node_history_id__in=[nh.id for nh in node_histories],
+        ).only("node_history_id", "result")
+
+        return {
+            nr.node_history_id: label
+            for nr in results
+            if (label := nr.result.get("edge", {}).get("label"))
+        }

--- a/backend/src/baserow/contrib/automation/history/service.py
+++ b/backend/src/baserow/contrib/automation/history/service.py
@@ -1,9 +1,16 @@
+from typing import Dict, List
+
 from django.contrib.auth.models import AbstractUser
 from django.db.models import QuerySet
 
 from baserow.contrib.automation.history.handler import AutomationHistoryHandler
-from baserow.contrib.automation.history.models import AutomationWorkflowHistory
+from baserow.contrib.automation.history.models import (
+    AutomationNodeHistory,
+    AutomationNodeResult,
+    AutomationWorkflowHistory,
+)
 from baserow.contrib.automation.workflows.handler import AutomationWorkflowHandler
+from baserow.contrib.automation.workflows.models import AutomationWorkflow
 from baserow.contrib.automation.workflows.operations import (
     ReadAutomationWorkflowOperationType,
 )
@@ -15,19 +22,9 @@ class AutomationHistoryService:
         self.handler = AutomationHistoryHandler()
         self.workflow_handler = AutomationWorkflowHandler()
 
-    def get_workflow_histories(
-        self, user: AbstractUser, workflow_id: int
-    ) -> QuerySet[AutomationWorkflowHistory]:
-        """
-        Returns an AutomationWorkflowHistory queryset related to a workflow.
-
-        :param user: The user requesting the workflow history.
-        :param workflow_id: The ID of the workflow.
-        :return: A queryset of workflow histories.
-        """
-
-        workflow = self.workflow_handler.get_workflow(workflow_id)
-
+    def _check_workflow_permissions(
+        self, user: AbstractUser, workflow: AutomationWorkflow
+    ) -> None:
         CoreHandler().check_permissions(
             user,
             ReadAutomationWorkflowOperationType.type,
@@ -35,4 +32,37 @@ class AutomationHistoryService:
             context=workflow,
         )
 
+    def get_workflow_histories(
+        self, user: AbstractUser, workflow_id: int
+    ) -> QuerySet[AutomationWorkflowHistory]:
+        workflow = self.workflow_handler.get_workflow(workflow_id)
+        self._check_workflow_permissions(user, workflow)
         return self.handler.get_workflow_histories(workflow)
+
+    def get_node_histories(
+        self, user: AbstractUser, workflow_history_id: int
+    ) -> List[AutomationNodeHistory]:
+        workflow_history = self.handler.get_workflow_history(workflow_history_id)
+        workflow = workflow_history.original_workflow
+        self._check_workflow_permissions(user, workflow)
+        return list(self.handler.get_node_histories(workflow_history))
+
+    def get_node_history_result(
+        self, user: AbstractUser, node_history_id: int
+    ) -> AutomationNodeResult:
+        node_history = self.handler.get_node_history(node_history_id)
+        workflow = node_history.workflow_history.original_workflow
+        self._check_workflow_permissions(user, workflow)
+        return self.handler.get_node_history_result(node_history)
+
+    def get_edge_labels(
+        self,
+        user: AbstractUser,
+        node_histories: List[AutomationNodeHistory],
+    ) -> Dict[int, str]:
+        if not node_histories:
+            return {}
+
+        workflow = node_histories[0].workflow_history.original_workflow
+        self._check_workflow_permissions(user, workflow)
+        return self.handler.get_edge_labels(node_histories)

--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -1216,7 +1216,7 @@ class CoreRouterServiceType(CoreServiceType):
 
         return super().get_sample_data(service, dispatch_context)
 
-    def get_edges(self, service):
+    def get_edges(self, service: Service) -> Dict[str, Dict[str, str]]:
         return {str(e.uid): {"label": e.label} for e in service.edges.all()} | {
             "": {"label": service.default_edge_label}
         }

--- a/backend/src/baserow/core/services/registries.py
+++ b/backend/src/baserow/core/services/registries.py
@@ -524,7 +524,7 @@ class ServiceType(
 
         return property_name
 
-    def get_edges(self, service):
+    def get_edges(self, service: Service) -> Dict[str, Dict[str, str]]:
         return {"": {"label": ""}}
 
 

--- a/backend/tests/baserow/contrib/automation/api/history/test_history_views.py
+++ b/backend/tests/baserow/contrib/automation/api/history/test_history_views.py
@@ -1,0 +1,174 @@
+from django.urls import reverse
+
+import pytest
+from rest_framework.status import (
+    HTTP_200_OK,
+    HTTP_401_UNAUTHORIZED,
+    HTTP_404_NOT_FOUND,
+)
+
+from baserow.contrib.automation.history.constants import HistoryStatusChoices
+from tests.baserow.contrib.automation.api.utils import get_api_kwargs
+
+API_URL_NODE_HISTORIES = "api:automation:history:node_histories"
+API_URL_NODE_RESULT = "api:automation:history:node_result"
+
+
+@pytest.mark.django_db
+def test_get_node_histories(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+    trigger_history = data_fixture.create_automation_node_history(
+        workflow_history=workflow_history,
+        node=trigger,
+        status=HistoryStatusChoices.SUCCESS,
+    )
+
+    url = reverse(
+        API_URL_NODE_HISTORIES, kwargs={"workflow_history_id": workflow_history.id}
+    )
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_200_OK
+    rows = response.json()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == trigger_history.id
+    assert row["node"] == trigger.id
+    assert row["edge_label"] == ""
+    assert row["status"] == "success"
+
+
+@pytest.mark.django_db
+def test_get_node_histories_surfaces_router_edge_label(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    core_router = data_fixture.create_core_router_action_node_with_edges(
+        workflow=workflow,
+    )
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+    router_history = data_fixture.create_automation_node_history(
+        workflow_history=workflow_history, node=core_router.router
+    )
+    data_fixture.create_automation_node_result(
+        node_history=router_history,
+        result={"edge": {"label": "Foo label"}},
+    )
+
+    url = reverse(
+        API_URL_NODE_HISTORIES, kwargs={"workflow_history_id": workflow_history.id}
+    )
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_200_OK
+    rows = {row["id"]: row for row in response.json()}
+    assert rows[router_history.id]["edge_label"] == "Foo label"
+
+
+@pytest.mark.django_db
+def test_get_node_histories_permission_error(api_client, data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+
+    _, token = data_fixture.create_user_and_token()
+
+    url = reverse(
+        API_URL_NODE_HISTORIES, kwargs={"workflow_history_id": workflow_history.id}
+    )
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    assert response.json()["error"] == "PERMISSION_DENIED"
+
+
+@pytest.mark.django_db
+def test_get_node_histories_workflow_history_does_not_exist(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token()
+
+    url = reverse(API_URL_NODE_HISTORIES, kwargs={"workflow_history_id": 999999})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert (
+        response.json()["error"] == "ERROR_AUTOMATION_WORKFLOW_HISTORY_DOES_NOT_EXIST"
+    )
+
+
+@pytest.mark.django_db
+def test_get_node_result(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        workflow_history=workflow_history, node=workflow.get_trigger()
+    )
+    data_fixture.create_automation_node_result(
+        node_history=node_history, result={"rows": [1, 2]}
+    )
+
+    url = reverse(API_URL_NODE_RESULT, kwargs={"node_history_id": node_history.id})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {"result": {"rows": [1, 2]}}
+
+
+@pytest.mark.django_db
+def test_get_node_result_permission_error(api_client, data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        workflow_history=workflow_history, node=workflow.get_trigger()
+    )
+    data_fixture.create_automation_node_result(node_history=node_history)
+
+    _, token = data_fixture.create_user_and_token()
+
+    url = reverse(API_URL_NODE_RESULT, kwargs={"node_history_id": node_history.id})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+    assert response.json()["error"] == "PERMISSION_DENIED"
+
+
+@pytest.mark.django_db
+def test_get_node_result_node_history_does_not_exist(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token()
+
+    url = reverse(API_URL_NODE_RESULT, kwargs={"node_history_id": 999999})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.json()["error"] == "ERROR_AUTOMATION_NODE_HISTORY_DOES_NOT_EXIST"
+
+
+@pytest.mark.django_db
+def test_get_node_result_does_not_exist(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    workflow_history = data_fixture.create_automation_workflow_history(
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        workflow_history=workflow_history, node=workflow.get_trigger()
+    )
+
+    url = reverse(API_URL_NODE_RESULT, kwargs={"node_history_id": node_history.id})
+    response = api_client.get(url, **get_api_kwargs(token))
+
+    assert response.status_code == HTTP_404_NOT_FOUND
+    assert response.json()["error"] == "ERROR_AUTOMATION_NODE_RESULT_DOES_NOT_EXIST"

--- a/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
+++ b/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
@@ -654,8 +654,6 @@ def test_get_workflow_histories(api_client, data_fixture):
                 "is_test_run": False,
                 "message": "",
                 "status": "success",
-                "event_payload": None,
-                "node_histories": [],
                 "simulate_until_node": None,
             },
         ],
@@ -749,7 +747,7 @@ def test_get_workflow_histories_query_count(data_fixture, django_assert_num_quer
     _create_histories(3)
     local_cache.clear()
 
-    expected_queries = 10
+    expected_queries = 2
     with django_assert_num_queries(expected_queries):
         queryset = handler.get_workflow_histories(workflow)
         queryset.aggregate(
@@ -768,79 +766,6 @@ def test_get_workflow_histories_query_count(data_fixture, django_assert_num_quer
             fail_count=Count("id", filter=Q(status=HistoryStatusChoices.ERROR)),
         )
         AutomationWorkflowHistorySerializer(list(queryset), many=True).data
-
-
-@pytest.mark.django_db
-def test_get_workflow_histories_with_node_histories(api_client, data_fixture):
-    user, token = data_fixture.create_user_and_token()
-    workflow = data_fixture.create_automation_workflow(user=user)
-    trigger = workflow.get_trigger()
-    action_node = data_fixture.create_local_baserow_create_row_action_node(
-        user=user, workflow=workflow, label="My Action"
-    )
-
-    now = timezone.now()
-    workflow_history = data_fixture.create_automation_workflow_history(
-        user=user,
-        workflow=workflow,
-        status=HistoryStatusChoices.SUCCESS,
-        completed_on=now,
-    )
-    node_history_1 = data_fixture.create_automation_node_history(
-        user=user,
-        workflow_history=workflow_history,
-        node=trigger,
-        completed_on=now,
-    )
-    node_result_1 = data_fixture.create_automation_node_result(
-        user=user,
-        node_history=node_history_1,
-        result={"rows": [1, 2]},
-    )
-    node_history_2 = data_fixture.create_automation_node_history(
-        user=user,
-        workflow_history=workflow_history,
-        node=action_node,
-        completed_on=now,
-    )
-    node_result_2 = data_fixture.create_automation_node_result(
-        user=user,
-        node_history=node_history_2,
-        result={"created_row_id": 99},
-        iteration_path="0.2.1",
-    )
-
-    url = reverse(API_URL_WORKFLOW_HISTORY, kwargs={"workflow_id": workflow.id})
-    response = api_client.get(url, **get_api_kwargs(token))
-
-    assert response.status_code == HTTP_200_OK
-    data = response.json()
-
-    assert data["count"] == 1
-    assert data["success_count"] == 1
-    assert data["fail_count"] == 0
-
-    w_history = data["results"][0]
-    assert w_history["id"] == workflow_history.id
-    assert w_history["status"] == "success"
-    assert len(w_history["node_histories"]) == 2
-
-    n_history_1 = w_history["node_histories"][0]
-    assert n_history_1["node"] == trigger.id
-    assert n_history_1["workflow_history"] == workflow_history.id
-    assert n_history_1["node_type"] == trigger.get_type().type
-    assert n_history_1["node_label"] == trigger.label
-    assert n_history_1["parent_node_id"] is None
-    assert n_history_1["iteration"] == 0
-    assert n_history_1["result"] == {"rows": [1, 2]}
-
-    n_history_2 = w_history["node_histories"][1]
-    assert n_history_2["node"] == action_node.id
-    assert n_history_2["workflow_history"] == workflow_history.id
-    assert n_history_2["node_type"] == action_node.get_type().type
-    assert n_history_2["node_label"] == "My Action"
-    assert n_history_2["iteration"] == 1
-    assert n_history_2["result"] == {"created_row_id": 99}
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/automation/history/test_history_handler.py
+++ b/backend/tests/baserow/contrib/automation/history/test_history_handler.py
@@ -3,10 +3,15 @@ from django.utils import timezone
 import pytest
 
 from baserow.contrib.automation.history.exceptions import (
+    AutomationNodeHistoryDoesNotExist,
     AutomationWorkflowHistoryDoesNotExist,
+    AutomationWorkflowHistoryNodeResultDoesNotExist,
 )
 from baserow.contrib.automation.history.handler import AutomationHistoryHandler
-from baserow.contrib.automation.history.models import AutomationWorkflowHistory
+from baserow.contrib.automation.history.models import (
+    AutomationNodeHistory,
+    AutomationWorkflowHistory,
+)
 from baserow.contrib.automation.workflows.constants import WorkflowState
 
 
@@ -128,3 +133,254 @@ def test_get_workflow_history_respects_base_queryset(data_fixture):
             history_id=history.id,
             base_queryset=AutomationWorkflowHistory.objects.exclude(id=history.id),
         )
+
+
+@pytest.mark.django_db
+def test_get_node_history(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    result = AutomationHistoryHandler().get_node_history(
+        node_history_id=node_history.id
+    )
+
+    assert result == node_history
+
+
+@pytest.mark.django_db
+def test_get_node_history_does_not_exist():
+    with pytest.raises(AutomationNodeHistoryDoesNotExist) as e:
+        AutomationHistoryHandler().get_node_history(node_history_id=100)
+
+    assert str(e.value) == "The automation node history 100 does not exist."
+
+
+@pytest.mark.django_db
+def test_get_node_history_respects_base_queryset(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    with pytest.raises(AutomationNodeHistoryDoesNotExist):
+        AutomationHistoryHandler().get_node_history(
+            node_history_id=node_history.id,
+            base_queryset=AutomationNodeHistory.objects.exclude(id=node_history.id),
+        )
+
+
+@pytest.mark.django_db
+def test_get_node_histories_returns_empty_when_no_histories(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    result = AutomationHistoryHandler().get_node_histories(workflow_history)
+
+    assert list(result) == []
+
+
+@pytest.mark.django_db
+def test_get_node_histories_filters_by_workflow_history(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    other_workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=other_workflow_history,
+        node=trigger,
+    )
+
+    result = AutomationHistoryHandler().get_node_histories(workflow_history)
+
+    assert list(result) == [node_history]
+
+
+@pytest.mark.django_db
+def test_get_node_histories_ordering(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    earlier = timezone.now()
+    later = earlier + timezone.timedelta(seconds=10)
+
+    node_history_2 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+        started_on=later,
+    )
+    node_history_1 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+        started_on=earlier,
+    )
+    node_history_3 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+        started_on=later,
+    )
+
+    result = AutomationHistoryHandler().get_node_histories(workflow_history)
+
+    assert list(result) == [node_history_1, node_history_2, node_history_3]
+
+
+@pytest.mark.django_db
+def test_get_node_histories_prefetches_node_results(
+    data_fixture, django_assert_num_queries
+):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    node_result = data_fixture.create_automation_node_result(
+        node_history=node_history,
+    )
+
+    result = list(AutomationHistoryHandler().get_node_histories(workflow_history))
+
+    with django_assert_num_queries(0):
+        result = list(result[0].node_results.all())
+
+    assert result == [node_result]
+
+
+@pytest.mark.django_db
+def test_get_node_history_result(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    node_result = data_fixture.create_automation_node_result(
+        node_history=node_history,
+        result={"foo": "bar"},
+    )
+
+    result = AutomationHistoryHandler().get_node_history_result(node_history)
+
+    assert result == node_result
+    assert result.result == {"foo": "bar"}
+
+
+@pytest.mark.django_db
+def test_get_node_history_result_does_not_exist(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    with pytest.raises(AutomationWorkflowHistoryNodeResultDoesNotExist):
+        AutomationHistoryHandler().get_node_history_result(node_history)
+
+
+@pytest.mark.django_db
+def test_get_edge_labels_returns_empty_dict():
+    assert AutomationHistoryHandler().get_edge_labels([]) == {}
+
+
+@pytest.mark.django_db
+def test_get_edge_labels_returns_expected_data(data_fixture):
+    user, _ = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    node_history_1 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    data_fixture.create_automation_node_result(
+        node_history=node_history_1,
+        result={"edge": {"label": "foo label"}},
+    )
+
+    node_history_2 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    data_fixture.create_automation_node_result(
+        node_history=node_history_2,
+        result={"edge": {"label": "bar label"}},
+    )
+
+    result = AutomationHistoryHandler().get_edge_labels(
+        [node_history_1, node_history_2]
+    )
+
+    assert result == {
+        node_history_1.id: "foo label",
+        node_history_2.id: "bar label",
+    }

--- a/backend/tests/baserow/contrib/automation/history/test_history_service.py
+++ b/backend/tests/baserow/contrib/automation/history/test_history_service.py
@@ -38,3 +38,171 @@ def test_get_workflow_histories_returns_ordered_histories(data_fixture):
     )
 
     assert list(result) == [history_2, history_1]
+
+
+@pytest.mark.django_db
+def test_get_node_histories_permission_error(data_fixture):
+    user = data_fixture.create_user()
+    history = data_fixture.create_workflow_history(user=user)
+
+    user_2 = data_fixture.create_user()
+
+    with pytest.raises(UserNotInWorkspace) as e:
+        AutomationHistoryService().get_node_histories(user_2, history.id)
+
+    assert str(e.value) == (
+        f"User {user_2.email} doesn't belong to "
+        f"workspace {history.workflow.automation.workspace}."
+    )
+
+
+@pytest.mark.django_db
+def test_get_node_histories_returns_node_histories(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    node_history_1 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    node_history_2 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    result = AutomationHistoryService().get_node_histories(user, workflow_history.id)
+
+    assert result == [node_history_1, node_history_2]
+
+
+@pytest.mark.django_db
+def test_get_node_history_result_permission_error(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    user_2 = data_fixture.create_user()
+
+    with pytest.raises(UserNotInWorkspace) as e:
+        AutomationHistoryService().get_node_history_result(user_2, node_history.id)
+
+    assert str(e.value) == (
+        f"User {user_2.email} doesn't belong to "
+        f"workspace {workflow.automation.workspace}."
+    )
+
+
+@pytest.mark.django_db
+def test_get_node_history_result_returns_result(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    node_result = data_fixture.create_automation_node_result(
+        node_history=node_history,
+        result={"foo": "bar"},
+    )
+
+    result = AutomationHistoryService().get_node_history_result(user, node_history.id)
+
+    assert result == node_result
+    assert result.result == {"foo": "bar"}
+
+
+@pytest.mark.django_db
+def test_get_edge_labels_returns_empty_dict(data_fixture):
+    user = data_fixture.create_user()
+
+    result = AutomationHistoryService().get_edge_labels(user, [])
+
+    assert result == {}
+
+
+@pytest.mark.django_db
+def test_get_edge_labels_permission_error(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+    node_history = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+
+    user_2 = data_fixture.create_user()
+
+    with pytest.raises(UserNotInWorkspace) as e:
+        AutomationHistoryService().get_edge_labels(user_2, [node_history])
+
+    assert str(e.value) == (
+        f"User {user_2.email} doesn't belong to "
+        f"workspace {workflow.automation.workspace}."
+    )
+
+
+@pytest.mark.django_db
+def test_get_edge_labels_returns_mapping(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user=user)
+    trigger = workflow.get_trigger()
+    workflow_history = data_fixture.create_automation_workflow_history(
+        user=user,
+        workflow=workflow,
+    )
+
+    node_history_1 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    data_fixture.create_automation_node_result(
+        node_history=node_history_1,
+        result={"edge": {"label": "foo label"}},
+    )
+
+    node_history_2 = data_fixture.create_automation_node_history(
+        user=user,
+        workflow_history=workflow_history,
+        node=trigger,
+    )
+    data_fixture.create_automation_node_result(
+        node_history=node_history_2,
+        result={"edge": {"label": "bar label"}},
+    )
+
+    result = AutomationHistoryService().get_edge_labels(
+        user, [node_history_1, node_history_2]
+    )
+
+    assert result == {
+        node_history_1.id: "foo label",
+        node_history_2.id: "bar label",
+    }

--- a/changelog/entries/unreleased/refactor/5239_improved_the_performance_of_the_automation_workflow_and_node.json
+++ b/changelog/entries/unreleased/refactor/5239_improved_the_performance_of_the_automation_workflow_and_node.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Improved the performance of the Automation Workflow and Node history.",
+    "issue_origin": "github",
+    "issue_number": 5239,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-05-21"
+}

--- a/web-frontend/modules/automation/components/workflow/sidePanels/HistorySidePanel.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/HistorySidePanel.vue
@@ -77,6 +77,7 @@ const workflowHistoryItems = computed(() => {
 const refreshData = async () => {
   loading.value = true
   try {
+    store.dispatch('automationHistory/invalidate')
     await store.dispatch('automationHistory/fetchWorkflowHistory', {
       workflowId: workflow.value.id,
     })

--- a/web-frontend/modules/automation/components/workflow/sidePanels/NodeHistory.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/NodeHistory.vue
@@ -85,11 +85,12 @@
             <div class="node-history__nested-scroll">
               <div class="node-history__nested-scroll-inner">
                 <NodeHistory
-                  v-for="nodeHistory in group.histories"
-                  :key="nodeHistory.id"
-                  :node-id="nodeHistory.node"
-                  :node-histories="[nodeHistory]"
+                  v-for="nh in group.histories"
+                  :key="nh.id"
+                  :workflow-history-id="workflowHistoryId"
+                  :node-history="nh"
                   :child-node-histories-by-parent="childNodeHistoriesByParent"
+                  :error-descendant-node-ids="errorDescendantNodeIds"
                   :depth="depth + 1"
                 />
               </div>
@@ -174,6 +175,7 @@
         ref="nodeResultContextToggle"
         type="secondary"
         full-width
+        :loading="fetchingResult"
         icon="iconoir-code-brackets node-history__show-result-button-icon"
         @click="showNodeResultModal"
       >
@@ -184,31 +186,38 @@
     <SampleDataModal
       v-if="!hasChildren"
       ref="nodeResultModal"
-      :sample-data="nodeResultData"
+      :sample-data="resolvedSampleData"
       :title="nodeTypeLabel"
     />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useStore } from 'vuex'
 
 import SampleDataModal from '@baserow/modules/automation/components/sidebar/SampleDataModal'
+import { notifyIf } from '@baserow/modules/core/utils/error'
 
 const app = useNuxtApp()
+const store = useStore()
 
 const props = defineProps({
-  nodeId: {
+  workflowHistoryId: {
     type: Number,
     required: true,
   },
-  nodeHistories: {
-    type: Array,
-    default: () => [],
+  nodeHistory: {
+    type: Object,
+    required: true,
   },
   childNodeHistoriesByParent: {
     type: Object,
     default: () => ({}),
+  },
+  errorDescendantNodeIds: {
+    type: Set,
+    default: () => new Set(),
   },
   depth: {
     type: Number,
@@ -219,9 +228,11 @@ const props = defineProps({
 const nodeResultButtonContext = ref(null)
 const nodeResultButtonContextToggle = ref(null)
 const nodeResultModal = ref(null)
+const fetchingResult = ref(false)
+const resolvedSampleData = ref(null)
 
 const nodeType = computed(() => {
-  return app.$registry.get('node', props.nodeHistories[0].node_type)
+  return app.$registry.get('node', props.nodeHistory.node_type)
 })
 
 const nodeIconClass = computed(() => {
@@ -229,51 +240,27 @@ const nodeIconClass = computed(() => {
 })
 
 const nodeTypeLabel = computed(() => {
-  const nodeHistory = props.nodeHistories[0]
-  const baseLabel = nodeHistory.node_label || nodeType.value.name
-  const result = nodeHistory.result
-  if (result.edge) {
+  const baseLabel = props.nodeHistory.node_label || nodeType.value.name
+  if (props.nodeHistory.node_type === 'router') {
     // Show which branch was taken.
-    return `${baseLabel} (${result.edge?.label || app.$i18n.t('nodeType.defaultEdgeLabelFallback')})`
+    const edgeLabel =
+      props.nodeHistory.edge_label ||
+      app.$i18n.t('nodeType.defaultEdgeLabelFallback')
+    return `${baseLabel} (${edgeLabel})`
   }
   return baseLabel
 })
 
-const nodeResultData = computed(() => {
-  // Since the SampleDataModal is only shown for final nodes (not nodes with
-  // children), the history will only ever have just one result.
-  const result = props.nodeHistories[0].result
-
-  if (result?._error) {
-    return result._error
-  }
-  if (nodeType.value.serviceType.returnsList && result?.results) {
-    return result.results
-  }
-  return result
-})
-
-const hasDescendantError = (nodeId) => {
-  const children = props.childNodeHistoriesByParent[nodeId] || []
-  return children.some(
-    (child) => child.status === 'error' || hasDescendantError(child.node)
-  )
-}
-
 const iterationHasError = (group) => {
   return group.histories.some(
-    (h) => h.status === 'error' || hasDescendantError(h.node)
+    (h) => h.status === 'error' || props.errorDescendantNodeIds.has(h.node)
   )
 }
 
-const hasOwnError = computed(() =>
-  props.nodeHistories.some((nh) => nh.status === 'error')
-)
+const hasOwnError = computed(() => props.nodeHistory.status === 'error')
 
 const status = computed(() => {
-  if (props.nodeHistories.length === 0) return 'success'
-
-  const childError = hasDescendantError(props.nodeId)
+  const childError = props.errorDescendantNodeIds.has(props.nodeHistory.node)
   return hasOwnError.value || childError ? 'error' : 'success'
 })
 
@@ -283,16 +270,31 @@ const statusLabel = computed(() => {
     : app.$i18n.t('historySidePanel.statusErrorBadge')
 })
 
-const errorMessage = computed(() => {
-  const historyWithError = props.nodeHistories.find(
-    (nh) => nh.status === 'error'
-  )
-  return historyWithError.message
-})
+const errorMessage = computed(() => props.nodeHistory.message)
 
-const childNodeHistories = computed(
-  () => props.childNodeHistoriesByParent[props.nodeId] || []
-)
+/**
+ * Direct children of this node that belong to this node's iteration.
+ */
+const childNodeHistories = computed(() => {
+  const allChildHistories =
+    props.childNodeHistoriesByParent[props.nodeHistory.node]
+  if (!allChildHistories) return []
+
+  // This node's own iteration_path
+  const ownPath = props.nodeHistory.iteration_path
+
+  return allChildHistories.filter((child) => {
+    const childPath = child.iteration_path
+
+    const lastDotIndex = childPath.lastIndexOf('.')
+    // Strip the child's last segment (its own iteration index) to get the
+    // path of the iteration it belongs to. A child at depth 1 has no dot,
+    // so its parent's path is "".
+    const parentPath = lastDotIndex >= 0 ? childPath.slice(0, lastDotIndex) : ''
+    // Keep only the children that belong to this iteration of the parent.
+    return parentPath === ownPath
+  })
+})
 
 const hasChildren = computed(() => childNodeHistories.value.length > 0)
 
@@ -331,7 +333,25 @@ const openNodeResultButtonContext = () => {
   }
 }
 
-const showNodeResultModal = () => {
-  nodeResultModal.value.show()
+const showNodeResultModal = async () => {
+  fetchingResult.value = true
+  try {
+    const nodeHistoryId = props.nodeHistory.id
+    await store.dispatch('automationHistory/fetchNodeResult', {
+      nodeHistoryId,
+    })
+    let result = store.getters['automationHistory/getNodeResult'](nodeHistoryId)
+    if (result?._error) {
+      result = result._error
+    } else if (nodeType.value.serviceType.returnsList && result?.results) {
+      result = result.results
+    }
+    resolvedSampleData.value = result
+    nodeResultModal.value.show()
+  } catch (error) {
+    notifyIf(error)
+  } finally {
+    fetchingResult.value = false
+  }
 }
 </script>

--- a/web-frontend/modules/automation/components/workflow/sidePanels/WorkflowHistory.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/WorkflowHistory.vue
@@ -1,5 +1,5 @@
 <template>
-  <Expandable toggle-on-click>
+  <Expandable toggle-on-click @toggle="onToggle">
     <template #header="{ expanded }">
       <div class="workflow-history__divider"></div>
       <div class="workflow-history__header">
@@ -26,20 +26,29 @@
     <template #default>
       <template v-if="item.status !== 'started'">
         <div
-          v-if="!item.node_histories.length && item.message"
+          v-if="nodeHistoriesEntry === null"
           class="workflow-history__message"
         >
-          {{ item.message }}
+          <div class="loading"></div>
         </div>
-        <NodeHistory
-          v-for="nodeId in rootNodeIds"
-          v-else
-          :key="nodeId"
-          :node-id="nodeId"
-          :node-histories="nodeHistoriesByNode[nodeId] || []"
-          :child-node-histories-by-parent="childNodeHistoriesByParent"
-          :depth="0"
-        />
+        <template v-else>
+          <div
+            v-if="!rootNodeHistories.length && item.message"
+            class="workflow-history__message"
+          >
+            {{ item.message }}
+          </div>
+          <NodeHistory
+            v-for="nh in rootNodeHistories"
+            v-else
+            :key="nh.node"
+            :workflow-history-id="item.id"
+            :node-history="nh"
+            :child-node-histories-by-parent="childNodeHistoriesByParent"
+            :error-descendant-node-ids="errorDescendantNodeIds"
+            :depth="0"
+          />
+        </template>
         <div class="workflow-history__run-time">
           {{ totalRunTimeMessage }}
         </div>
@@ -54,6 +63,7 @@
 </template>
 
 <script setup>
+import { useStore } from 'vuex'
 import moment from '@baserow/modules/core/moment'
 import { getUserTimeZone } from '@baserow/modules/core/utils/date'
 
@@ -63,6 +73,7 @@ import historyDisabledIcon from '@baserow/modules/core/assets/images/history-dis
 import NodeHistory from '@baserow/modules/automation/components/workflow/sidePanels/NodeHistory.vue'
 
 const app = useNuxtApp()
+const store = useStore()
 
 const props = defineProps({
   item: {
@@ -88,9 +99,25 @@ watch(
     } else if (timer) {
       clearInterval(timer)
       timer = null
+      // When the workflow run completes, if the WorkflowHistory is already
+      // expanded, we should fetch the node histories.
+      store.dispatch('automationHistory/fetchNodeHistories', {
+        workflowHistoryId: props.item.id,
+      })
     }
   },
   { immediate: true }
+)
+
+const onToggle = () => {
+  if (props.item.status === 'started') return
+  store.dispatch('automationHistory/fetchNodeHistories', {
+    workflowHistoryId: props.item.id,
+  })
+}
+
+const nodeHistoriesEntry = computed(() =>
+  store.getters['automationHistory/getNodeHistories'](props.item.id)
 )
 
 const statusTitle = computed(() => {
@@ -124,41 +151,18 @@ const historyTitlePrefix = computed(() => {
 })
 
 /**
- * Return an array of root node IDs, e.g. nodes that do not have a parent node.
- *
- * WorkflowHistory only renders the root nodes directly via NodeHistory.
- * NodeHistory then renders any child nodes recursively. This makes it easy
- * to correctly nest child nodes as well as their expandable content.
+ * Return an array of root nodes, e.g. nodes that do not have a parent node.
+ * They are rendered directly by WorkflowHistory. All other nodes are rendered
+ * recursively by NodeHistory.
  */
-const rootNodeIds = computed(() => {
-  const _rootNodeIds = []
-  for (const nodeHistory of props.item.node_histories) {
-    if (
-      nodeHistory.parent_node_id == null &&
-      !_rootNodeIds.includes(nodeHistory.node)
-    ) {
-      _rootNodeIds.push(nodeHistory.node)
+const rootNodeHistories = computed(() => {
+  const roots = []
+  for (const nh of nodeHistoriesEntry.value ?? []) {
+    if (nh.parent_node_id == null) {
+      roots.push(nh)
     }
   }
-  return _rootNodeIds
-})
-
-/**
- * Return an object where keys are node IDs and values are an array of node
- * histories for that node.
- *
- * This is used to show the correct histories (node status, run number) are
- * shown in the NodeHistory.
- */
-const nodeHistoriesByNode = computed(() => {
-  const _nodeHistoriesByNode = {}
-  for (const nodeHistory of props.item.node_histories) {
-    if (!_nodeHistoriesByNode[nodeHistory.node]) {
-      _nodeHistoriesByNode[nodeHistory.node] = []
-    }
-    _nodeHistoriesByNode[nodeHistory.node].push(nodeHistory)
-  }
-  return _nodeHistoriesByNode
+  return roots
 })
 
 /**
@@ -170,7 +174,7 @@ const nodeHistoriesByNode = computed(() => {
  */
 const childNodeHistoriesByParent = computed(() => {
   const _childNodeHistoriesByParent = {}
-  for (const nodeHistory of props.item.node_histories) {
+  for (const nodeHistory of nodeHistoriesEntry.value ?? []) {
     if (nodeHistory.parent_node_id != null) {
       const parent = nodeHistory.parent_node_id
       if (!_childNodeHistoriesByParent[parent])
@@ -179,6 +183,38 @@ const childNodeHistoriesByParent = computed(() => {
     }
   }
   return _childNodeHistoriesByParent
+})
+
+/**
+ * Precomputed set of parent node IDs that have at least one errored
+ * node history in their descendant subtree.
+ */
+const errorDescendantNodeIds = computed(() => {
+  const items = nodeHistoriesEntry.value ?? []
+  const nodesParents = new Map()
+  for (const nh of items) {
+    if (!nodesParents.has(nh.node)) {
+      nodesParents.set(nh.node, nh.parent_node_id)
+    }
+  }
+
+  const parentsWithErroredChild = new Set()
+  for (const nh of items) {
+    if (nh.status !== 'error') continue
+
+    // We exclude the node itself so that different iterations of the same
+    // node aren't tied to each other's own error status.
+    let current = nodesParents.get(nh.node)
+
+    // If a parent has already been marked as having an errored child, we
+    // stop early to avoid unnecessary walks - since all of its ancestors
+    // have already been marked.
+    while (current != null && !parentsWithErroredChild.has(current)) {
+      parentsWithErroredChild.add(current)
+      current = nodesParents.get(current)
+    }
+  }
+  return parentsWithErroredChild
 })
 
 const historyIconPath = computed(() => {

--- a/web-frontend/modules/automation/services/history.js
+++ b/web-frontend/modules/automation/services/history.js
@@ -3,5 +3,13 @@ export default (client) => {
     getWorkflowHistory(workflowId) {
       return client.get(`automation/workflows/${workflowId}/history/`)
     },
+    getNodeHistories(workflowHistoryId) {
+      return client.get(
+        `automation/workflow_histories/${workflowHistoryId}/node_histories/`
+      )
+    },
+    getNodeResult(nodeHistoryId) {
+      return client.get(`automation/node_histories/${nodeHistoryId}/result/`)
+    },
   }
 }

--- a/web-frontend/modules/automation/store/automationHistory.js
+++ b/web-frontend/modules/automation/store/automationHistory.js
@@ -4,11 +4,23 @@ import AutomationHistoryService from '@baserow/modules/automation/services/histo
 const state = {
   // Holds the value of which workflow history is currently selected
   workflowHistory: {},
+  nodeHistoriesByWorkflowHistory: {},
+  nodeResults: {},
 }
 
 const mutations = {
   SET_WORKFLOW_HISTORY(state, { data }) {
     state.workflowHistory = data
+  },
+  SET_NODE_HISTORIES(state, { workflowHistoryId, data }) {
+    state.nodeHistoriesByWorkflowHistory[workflowHistoryId] = data
+  },
+  SET_NODE_RESULT(state, { nodeHistoryId, data }) {
+    state.nodeResults[nodeHistoryId] = data
+  },
+  CLEAR_HISTORY_CACHES(state) {
+    state.nodeHistoriesByWorkflowHistory = {}
+    state.nodeResults = {}
   },
 }
 
@@ -22,11 +34,41 @@ const actions = {
 
     return data
   },
+  async fetchNodeHistories({ state, commit }, { workflowHistoryId }) {
+    if (workflowHistoryId in state.nodeHistoriesByWorkflowHistory) return
+
+    const { data } = await AutomationHistoryService(
+      useNuxtApp().$client
+    ).getNodeHistories(workflowHistoryId)
+    commit('SET_NODE_HISTORIES', {
+      workflowHistoryId,
+      data: Object.freeze(data),
+    })
+  },
+  async fetchNodeResult({ state, commit }, { nodeHistoryId }) {
+    if (nodeHistoryId in state.nodeResults) return
+
+    const { data } = await AutomationHistoryService(
+      useNuxtApp().$client
+    ).getNodeResult(nodeHistoryId)
+    commit('SET_NODE_RESULT', { nodeHistoryId, data: data.result })
+  },
+  invalidate({ commit }) {
+    commit('CLEAR_HISTORY_CACHES')
+  },
 }
 
 const getters = {
   getWorkflowHistory: (state) => () => {
     return state.workflowHistory
+  },
+  // Returns null if the data hasn't been fetched yet.
+  getNodeHistories: (state) => (workflowHistoryId) => {
+    return state.nodeHistoriesByWorkflowHistory[workflowHistoryId] ?? null
+  },
+
+  getNodeResult: (state) => (nodeHistoryId) => {
+    return state.nodeResults[nodeHistoryId]
   },
 }
 


### PR DESCRIPTION
### What is in this PR
This PR improves the performance of the Automation's Workflow History.

Currently, when viewing the History side panel, the entire workflow history is fetched, including:
- All workflow history entries (capped at 200 entries by the paginator).
- , including the `event_payload` field which could be large.
- Each workflow history entry, includes the `event_payload` field (which can be large), and also fetches all node history entries (which can be numerous).
- Each node history entry includes the `result` JSON payload, which also can be large.

As a result, we see these issues:
- It can take a while to display the history side panel.
- Expanding a workflow history entry can take a long time, due to:
  - the large HTTP response size (because we're front-loading all the history data)
  - inefficient recursive lookups in the node history tree, just to derive which parent nodes have errored child nodes (so that we can display the error label)

This PR improves the performance and removes almost all of the performance issues:
- The history panel now only fetches the basic meta data about the workflow histories. Node history data isn't front-loaded anymore.
- When the workflow history is expanded, only then do we fetch node histories for that workflow.
- The node histories do not include the `result` payload, which greatly reduces the response size.
- The "Show result" button lazy loads/fetches the `result` data.
- The errored child nodes are now pre-computed in the frontend.

Closes https://github.com/baserow/baserow/issues/5239

### How to test this PR
Create a workflow with some nested iterators, and test the workflow. You'll want to create 3-4 nested iterators with some action nodes (list rows). Test the workflow, which should generate a lot of history entries.

In `develop`, you'll notice the problems I describe above. In this branch, you should see the history panel interactions are much more snappy and responsive.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
