### PR TITLE
Add search to Kanban view

### DIFF
--- a/changelog/entries/unreleased/feature/768_add_search_to_kanban_view.json
+++ b/changelog/entries/unreleased/feature/768_add_search_to_kanban_view.json
@@ -1,0 +1,9 @@
+{
+  "type": "feature",
+  "message": "Add search to kanban view",
+  "issue_origin": "github",
+  "issue_number": 768,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-05-20"
+}

--- a/premium/backend/src/baserow_premium/api/views/kanban/views.py
+++ b/premium/backend/src/baserow_premium/api/views/kanban/views.py
@@ -4,14 +4,20 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from baserow.api.decorators import allowed_includes, map_exceptions
+from baserow.api.decorators import (
+    allowed_includes,
+    map_exceptions,
+    validate_query_parameters,
+)
 from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.schemas import get_error_schema
+from baserow.api.search.serializers import SearchQueryParamSerializer
 from baserow.contrib.database.api.constants import (
     ADHOC_FILTERS_API_PARAMS,
     ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
     ADHOC_SORTING_API_PARAM,
     LIMIT_LINKED_ITEMS_API_PARAM,
+    SEARCH_MODE_API_PARAM,
 )
 from baserow.contrib.database.api.fields.errors import (
     ERROR_FIELD_DOES_NOT_EXIST,
@@ -124,6 +130,14 @@ class KanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            OpenApiParameter(
+                name="search",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                description="If provided only rows with data that matches the search "
+                "query are going to be returned.",
+            ),
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
             LIMIT_LINKED_ITEMS_API_PARAM,
         ],
@@ -167,7 +181,8 @@ class KanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options", "row_metadata")
-    def get(self, request, view_id, field_options, row_metadata):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, view_id, field_options, row_metadata, query_params):
         """Responds with the rows grouped by the view's select option field value."""
 
         adhoc_filters = AdHocFilters.from_request(request)
@@ -206,6 +221,13 @@ class KanbanViewView(APIView):
 
         model = view.table.get_model()
         hidden_field_ids = get_hidden_field_ids_for_view_user(request.user, view)
+        only_search_by_field_ids = None
+        if hidden_field_ids:
+            only_search_by_field_ids = [
+                field_id
+                for field_id in model._field_objects.keys()
+                if field_id not in hidden_field_ids
+            ]
 
         limit_linked_items = parse_limit_linked_items_params(request)
         serializer_extra_kwargs = {"limit_linked_items": limit_linked_items}
@@ -225,6 +247,9 @@ class KanbanViewView(APIView):
             option_settings=included_select_options,
             default_limit=default_limit,
             default_offset=default_offset,
+            search=query_params.get("search"),
+            search_mode=query_params.get("search_mode"),
+            only_search_by_field_ids=only_search_by_field_ids,
             model=model,
         )
 
@@ -307,6 +332,14 @@ class PublicKanbanViewView(APIView):
                     "option id `1` with a limit of `10` and and offset of `20`."
                 ),
             ),
+            OpenApiParameter(
+                name="search",
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
+                description="If provided only rows with data that matches the search "
+                "query are going to be returned.",
+            ),
+            SEARCH_MODE_API_PARAM,
             *ADHOC_FILTERS_API_PARAMS,
             ADHOC_SORTING_API_PARAM,
             LIMIT_LINKED_ITEMS_API_PARAM,
@@ -356,7 +389,8 @@ class PublicKanbanViewView(APIView):
         }
     )
     @allowed_includes("field_options")
-    def get(self, request, slug: str, field_options: bool):
+    @validate_query_parameters(SearchQueryParamSerializer, return_validated=True)
+    def get(self, request, slug: str, field_options: bool, query_params):
         """
         Lists all the rows of a kanban view that is publicly shared. The rows are
         grouped by the view's single select field options.
@@ -394,6 +428,8 @@ class PublicKanbanViewView(APIView):
             publicly_visible_field_options,
         ) = ViewHandler().get_public_rows_queryset_and_field_ids(
             view,
+            search=query_params.get("search"),
+            search_mode=query_params.get("search_mode"),
             adhoc_filters=adhoc_filters,
             order_by=order_by,
             table_model=model,

--- a/premium/backend/src/baserow_premium/views/handler.py
+++ b/premium/backend/src/baserow_premium/views/handler.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth.models import AbstractUser
@@ -35,6 +35,9 @@ def get_rows_grouped_by_single_select_field(
     option_settings: Dict[str, Dict[str, int]] = None,
     default_limit: int = 40,
     default_offset: int = 0,
+    search: Optional[str] = None,
+    search_mode: Optional[str] = None,
+    only_search_by_field_ids: Optional[Iterable[int]] = None,
     adhoc_filters: Optional[AdHocFilters] = None,
     model: Optional[GeneratedTableModel] = None,
     base_queryset: Optional[QuerySet] = None,
@@ -68,6 +71,9 @@ def get_rows_grouped_by_single_select_field(
         specific settings for that field have been provided.
     :param default_offset: The default offset that applies to all options if no
         specific settings for that field have been provided.
+    :param search: Optional search term to apply before grouping the rows.
+    :param search_mode: The type of search to perform if a search term is provided.
+    :param only_search_by_field_ids: Restricts searching to the provided field ids.
     :param adhoc_filters: The optional ad hoc filters if they should be used
         instead of view filters.
     :param model: Additionally, an existing model can be provided so that it doesn't
@@ -95,6 +101,13 @@ def get_rows_grouped_by_single_select_field(
 
     if apply_view_sorts:
         base_queryset = ViewHandler().apply_sorting(view, base_queryset)
+
+    if search is not None:
+        base_queryset = base_queryset.search_all_fields(
+            search,
+            only_search_by_field_ids=only_search_by_field_ids,
+            search_mode=search_mode,
+        )
 
     if adhoc_filters is None:
         adhoc_filters = AdHocFilters()

--- a/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
@@ -245,6 +245,65 @@ def test_list_all_rows(api_client, premium_data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_list_rows_with_search(api_client, premium_data_fixture):
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    single_select_field = premium_data_fixture.create_single_select_field(table=table)
+    option_a = premium_data_fixture.create_select_option(
+        field=single_select_field, value="A", color="blue"
+    )
+    option_b = premium_data_fixture.create_select_option(
+        field=single_select_field, value="B", color="red"
+    )
+    kanban = premium_data_fixture.create_kanban_view(
+        table=table, single_select_field=single_select_field
+    )
+
+    model = table.get_model()
+    row_none = model.objects.create(
+        **{
+            f"field_{text_field.id}": "needle without an option",
+            f"field_{single_select_field.id}_id": None,
+        }
+    )
+    row_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "needle in option A",
+            f"field_{single_select_field.id}_id": option_a.id,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{text_field.id}": "not matching",
+            f"field_{single_select_field.id}_id": option_b.id,
+        }
+    )
+
+    url = reverse("api:database:views:kanban:list", kwargs={"view_id": kanban.id})
+    response = api_client.get(
+        f"{url}?search=needle&search_mode=compat",
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+
+    assert response_json["rows"]["null"]["count"] == 1
+    assert [row["id"] for row in response_json["rows"]["null"]["results"]] == [
+        row_none.id
+    ]
+    assert response_json["rows"][str(option_a.id)]["count"] == 1
+    assert [
+        row["id"] for row in response_json["rows"][str(option_a.id)]["results"]
+    ] == [row_a.id]
+    assert response_json["rows"][str(option_b.id)]["count"] == 0
+    assert response_json["rows"][str(option_b.id)]["results"] == []
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_list_with_specific_select_options(api_client, premium_data_fixture):
     user, token = premium_data_fixture.create_user_and_token(
         has_active_premium_license=True
@@ -1870,6 +1929,69 @@ def test_list_public_rows_doesnt_show_hidden_columns(api_client, premium_data_fi
                 "hidden": True,
                 "order": single_select_field_options.order,
             },
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_list_public_rows_with_search(api_client, premium_data_fixture):
+    user, _ = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+
+    kanban_view = premium_data_fixture.create_kanban_view(
+        table=table,
+        user=user,
+        public=True,
+    )
+
+    public_field = premium_data_fixture.create_text_field(table=table, name="public")
+    hidden_field = premium_data_fixture.create_text_field(table=table, name="hidden")
+
+    premium_data_fixture.create_kanban_view_field_option(
+        kanban_view, public_field, hidden=False
+    )
+    premium_data_fixture.create_kanban_view_field_option(
+        kanban_view, hidden_field, hidden=True
+    )
+
+    row_public = RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{public_field.id}": "needle",
+            f"field_{hidden_field.id}": "other",
+        },
+    )
+    RowHandler().create_row(
+        user,
+        table,
+        values={
+            f"field_{public_field.id}": "other",
+            f"field_{hidden_field.id}": "needle",
+        },
+    )
+
+    response = api_client.get(
+        reverse(
+            "api:database:views:kanban:public_rows", kwargs={"slug": kanban_view.slug}
+        )
+        + "?search=needle&search_mode=compat"
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+    assert response_json == {
+        "rows": {
+            "null": {
+                "count": 1,
+                "results": [
+                    {
+                        "id": row_public.id,
+                        "order": "1.00000000000000000000",
+                        f"field_{public_field.id}": "needle",
+                        f"field_{kanban_view.single_select_field_id}": None,
+                    },
+                ],
+            }
         },
     }
 

--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
@@ -80,21 +80,34 @@
         @update-cover-image-field="updateCoverImageField"
       ></ViewFieldsContext>
     </li>
+    <li
+      v-if="singleSelectFieldId !== -1"
+      class="header__filter-item header__filter-item--full-width"
+    >
+      <ViewSearch
+        :view="view"
+        :fields="fields"
+        :store-prefix="storePrefix"
+        :always-hide-rows-not-matching-search="true"
+        @refresh="$emit('refresh', $event)"
+      ></ViewSearch>
+    </li>
   </ul>
 </template>
 
 <script>
-import { mapState, mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import ViewFieldsContext from '@baserow/modules/database/components/view/ViewFieldsContext'
+import ViewSearch from '@baserow/modules/database/components/view/ViewSearch'
 import KanbanViewStackedBy from '@baserow_premium/components/views/kanban/KanbanViewStackedBy'
 import kanbanViewHelper from '@baserow_premium/mixins/kanbanViewHelper'
 
 export default {
   name: 'KanbanViewHeader',
   emits: ['refresh'],
-  components: { KanbanViewStackedBy, ViewFieldsContext },
+  components: { KanbanViewStackedBy, ViewFieldsContext, ViewSearch },
   mixins: [kanbanViewHelper],
   props: {
     database: {

--- a/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/services/views/kanban.js
@@ -17,6 +17,8 @@ export default (client) => {
       publicUrl = false,
       publicAuthToken = null,
       orderBy = null,
+      search = '',
+      searchMode = '',
       filters = {},
       limitLinkedItems = null,
     }) {
@@ -30,6 +32,13 @@ export default (client) => {
 
       if (orderBy !== null && orderBy !== '') {
         params.append('order_by', orderBy)
+      }
+
+      if (search) {
+        params.append('search', search)
+        if (searchMode) {
+          params.append('search_mode', searchMode)
+        }
       }
 
       if (includeFieldOptions) {

--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -4,6 +4,7 @@ import { GroupTaskQueue } from '@baserow/modules/core/utils/queue'
 import ViewService from '@baserow/modules/database/services/view'
 import KanbanService from '@baserow_premium/services/views/kanban'
 import {
+  calculateSingleRowSearchMatches,
   extractRowMetadata,
   getFilters,
   getOrderBy,
@@ -20,11 +21,16 @@ import {
   prepareRowForRequest,
   updateRowMetadataType,
 } from '@baserow/modules/database/utils/row'
+import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 
 export function populateRow(row, metadata = {}, fullyLoaded = true) {
   row._ = {
     metadata: getRowMetadata(row, metadata),
     dragging: false,
+    // Whether the row should be displayed based on the current activeSearchTerm.
+    matchSearch: true,
+    // Contains the field ids which match the activeSearchTerm.
+    fieldSearchMatches: [],
     fetching: false,
     fullyLoaded,
   }
@@ -57,6 +63,11 @@ export const state = () => ({
   adhocFiltering: false,
   // If true, ad hoc sorting is used
   adhocSorting: false,
+  // A user provided optional search term which can be used to filter down rows.
+  activeSearchTerm: '',
+  // If true then the activeSearchTerm will be sent to the server to filter rows
+  // entirely out. Kanban always hides rows that don't match the active search.
+  hideRowsNotMatchingSearch: true,
   // Indicates whether row(s) are currently being created.
   creating: false,
 })
@@ -67,6 +78,12 @@ export const mutations = {
     state.singleSelectFieldId = -1
     state.stacks = {}
     state.fieldOptions = {}
+    state.activeSearchTerm = ''
+    state.hideRowsNotMatchingSearch = true
+  },
+  SET_SEARCH(state, { activeSearchTerm, hideRowsNotMatchingSearch }) {
+    state.activeSearchTerm = activeSearchTerm.trim()
+    state.hideRowsNotMatchingSearch = hideRowsNotMatchingSearch
   },
   SET_LAST_KANBAN_ID(state, kanbanId) {
     state.lastKanbanId = kanbanId
@@ -76,6 +93,10 @@ export const mutations = {
   },
   SET_ROW_LOADING(state, { row, value }) {
     row._.loading = value
+  },
+  SET_ROW_SEARCH_MATCHES(state, { row, matchSearch, fieldSearchMatches }) {
+    row._.matchSearch = matchSearch
+    row._.fieldSearchMatches = [...fieldSearchMatches]
   },
   REPLACE_ALL_STACKS(state, stacks) {
     state.stacks = stacks
@@ -234,10 +255,17 @@ export const actions = {
       includeFieldOptions = true,
     }
   ) {
+    const viewHasChanged = kanbanId !== getters.getLastKanbanId
+    if (viewHasChanged) {
+      commit('SET_SEARCH', {
+        activeSearchTerm: '',
+        hideRowsNotMatchingSearch: true,
+      })
+    }
     commit('SET_ADHOC_FILTERING', adhocFiltering)
     commit('SET_ADHOC_SORTING', adhocSorting)
     commit('SET_LAST_KANBAN_ID', kanbanId)
-    const { $client } = this
+    const { $client, $config } = this
     const view = rootGetters['view/get'](kanbanId)
     const { data } = await KanbanService($client).fetchRows({
       kanbanId,
@@ -248,6 +276,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       orderBy: getOrderBy(view, adhocSorting),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
       filters: getFilters(view, adhocFiltering),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
@@ -274,7 +304,7 @@ export const actions = {
     { dispatch, commit, getters, rootGetters },
     { selectOptionId }
   ) {
-    const { $client } = this
+    const { $client, $config } = this
     const kanbanId = getters.getLastKanbanId
     const stack = getters.getStack(selectOptionId)
     const view = rootGetters['view/get'](kanbanId)
@@ -293,6 +323,8 @@ export const actions = {
       publicUrl: rootGetters['page/view/public/getIsPublic'],
       publicAuthToken: rootGetters['page/view/public/getAuthToken'],
       orderBy: getOrderBy(view, getters.getAdhocSorting),
+      search: getters.getServerSearchTerm,
+      searchMode: getDefaultSearchModeFromEnv($config),
       filters: getFilters(view, getters.getAdhocFiltering),
     })
     // Don't do anything if the kanbanId does not match the current view kanbanId
@@ -473,7 +505,9 @@ export const actions = {
       row,
       fields,
     })
-    if (!matchesFilters) {
+    dispatch('updateSearchMatchesForRow', { row, fields })
+
+    if (!matchesFilters || !row._.matchSearch) {
       return
     }
 
@@ -547,7 +581,9 @@ export const actions = {
       row,
       fields,
     })
-    if (!matchesFilters) {
+    dispatch('updateSearchMatchesForRow', { row, fields })
+
+    if (!matchesFilters || !row._.matchSearch) {
       return
     }
 
@@ -609,13 +645,15 @@ export const actions = {
       row: oldRow,
       fields,
     })
+    dispatch('updateSearchMatchesForRow', { row: oldRow, fields })
     const oldOption = oldRow[fieldName]
     const oldStackId = oldOption !== null ? oldOption.id : 'null'
     const oldStackResults = clone(getters.getStack(oldStackId).results)
     const oldExistingIndex = oldStackResults.findIndex(
       (r) => r.id === oldRow.id
     )
-    const oldExists = oldExistingIndex > -1 && oldRowMatchesFilters
+    const oldExists =
+      oldExistingIndex > -1 && oldRowMatchesFilters && oldRow._.matchSearch
 
     // Second, we need to figure out if the row should be visible in the new stack.
     const newRow = Object.assign(populateRow(clone(row)), values)
@@ -624,6 +662,7 @@ export const actions = {
       row: newRow,
       fields,
     })
+    dispatch('updateSearchMatchesForRow', { row: newRow, fields })
     const newOption = newRow[fieldName]
     const newStackId = newOption !== null ? newOption.id : 'null'
     const newStack = getters.getStack(newStackId)
@@ -643,7 +682,8 @@ export const actions = {
     const newIsLast = newIndex === newStackResults.length - 1
     const newExists =
       (!newIsLast || newStackResults.length === newStackCount) &&
-      newRowMatchesFilters
+      newRowMatchesFilters &&
+      newRow._.matchSearch
 
     commit('UPDATE_ROW', { row, values })
 
@@ -1118,6 +1158,48 @@ export const actions = {
     commit('ADD_FIELD_TO_ALL_ROWS', { field, value })
   },
   /**
+   * Changes the current search parameters if provided and optionally refreshes which
+   * cards match the new search parameters.
+   */
+  updateSearch(
+    { commit, dispatch, getters, state },
+    {
+      fields,
+      activeSearchTerm = state.activeSearchTerm,
+      hideRowsNotMatchingSearch = state.hideRowsNotMatchingSearch,
+      refreshMatchesOnClient = true,
+    }
+  ) {
+    commit('SET_SEARCH', { activeSearchTerm, hideRowsNotMatchingSearch })
+    if (refreshMatchesOnClient) {
+      getters.getAllRows.forEach((row) =>
+        dispatch('updateSearchMatchesForRow', {
+          row,
+          fields,
+          forced: true,
+        })
+      )
+    }
+  },
+  updateSearchMatchesForRow(
+    { commit, getters },
+    { row, fields, overrides, forced = false }
+  ) {
+    const { $config, $registry } = this
+    if (getters.getActiveSearchTerm || forced) {
+      const rowSearchMatches = calculateSingleRowSearchMatches(
+        row,
+        getters.getActiveSearchTerm,
+        getters.isHidingRowsNotMatchingSearch,
+        fields,
+        $registry,
+        getDefaultSearchModeFromEnv($config),
+        overrides
+      )
+      commit('SET_ROW_SEARCH_MATCHES', rowSearchMatches)
+    }
+  },
+  /**
    * Updates a single row's row._.metadata based on the provided rowMetadataType and
    * updateFunction.
    */
@@ -1134,6 +1216,15 @@ export const actions = {
 }
 
 export const getters = {
+  getServerSearchTerm(state) {
+    return state.activeSearchTerm
+  },
+  getActiveSearchTerm(state) {
+    return state.activeSearchTerm
+  },
+  isHidingRowsNotMatchingSearch(state) {
+    return state.hideRowsNotMatchingSearch
+  },
   getLastKanbanId(state) {
     return state.lastKanbanId
   },

--- a/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
@@ -110,6 +110,7 @@ describe('Kanban view store', () => {
         ],
       },
     }
+
     const state = Object.assign(kanbanStore.state(), {
       singleSelectFieldId: 1,
       stacks,
@@ -137,6 +138,58 @@ describe('Kanban view store', () => {
     expect(store.state.kanban.stacks['1'].results[0].id).toBe(10)
     expect(store.state.kanban.stacks['1'].results[1].id).toBe(9)
     expect(store.state.kanban.stacks['1'].results[2].id).toBe(11)
+  })
+
+  test('createdNewRow respects active search', async () => {
+    const stacks = {
+      null: {
+        count: 0,
+        results: [],
+      },
+    }
+    const state = Object.assign(kanbanStore.state(), {
+      singleSelectFieldId: 1,
+      stacks,
+    })
+    store.replaceState({ ...store.state, kanban: state })
+
+    const fields = [
+      { id: 1, name: 'Status', type: 'single_select' },
+      { id: 2, name: 'Name', type: 'text' },
+    ]
+    await store.dispatch('kanban/updateSearch', {
+      fields,
+      activeSearchTerm: 'keep',
+      hideRowsNotMatchingSearch: true,
+    })
+
+    await store.dispatch('kanban/createdNewRow', {
+      view,
+      values: {
+        id: 1,
+        order: '1.00',
+        field_1: null,
+        field_2: 'discard',
+      },
+      fields,
+    })
+
+    expect(store.state.kanban.stacks.null.count).toBe(0)
+    expect(store.state.kanban.stacks.null.results).toEqual([])
+
+    await store.dispatch('kanban/createdNewRow', {
+      view,
+      values: {
+        id: 2,
+        order: '2.00',
+        field_1: null,
+        field_2: 'keep this row',
+      },
+      fields,
+    })
+
+    expect(store.state.kanban.stacks.null.count).toBe(1)
+    expect(store.state.kanban.stacks.null.results[0].id).toBe(2)
   })
 
   test('deletedExistingRow', async () => {


### PR DESCRIPTION
## What
- Adds the standard view search control to Kanban headers.
- Threads search/search_mode through the Kanban row API and grouped row handler.
- Keeps Kanban realtime row create/update/delete behavior consistent with active search.
- Adds backend coverage for authenticated and public Kanban search, plus a frontend store regression test.

Fixes #768.

## Testing
- uff format --check premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
- uff check premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py
- python -m py_compile premium/backend/src/baserow_premium/api/views/kanban/views.py premium/backend/src/baserow_premium/views/handler.py premium/backend/tests/baserow_premium_tests/api/views/views/test_kanban_views.py
- 
ode --check premium/web-frontend/modules/baserow_premium/services/views/kanban.js
- 
ode --check premium/web-frontend/modules/baserow_premium/store/view/kanban.js
- 
ode --check premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
- python -m json.tool changelog/entries/unreleased/feature/768_add_search_to_kanban_view.json
- git diff --check

Targeted pytest/vitest runs were not runnable in this local checkout: system Python has no pytest and is 3.13 while backend pyproject requires 3.14; web-frontend has no node_modules/vitest installed.