### PR TITLE
Add sorting to calendar view

### DIFF
--- a/changelog/entries/unreleased/feature/1729_add_sorting_to_calendar_view.json
+++ b/changelog/entries/unreleased/feature/1729_add_sorting_to_calendar_view.json
@@ -1,0 +1,9 @@
+{
+  "type": "feature",
+  "message": "Add sorting to calendar view rows within each day",
+  "issue_origin": "github",
+  "issue_number": 1729,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-05-20"
+}

--- a/premium/backend/src/baserow_premium/views/handler.py
+++ b/premium/backend/src/baserow_premium/views/handler.py
@@ -191,6 +191,7 @@ def get_rows_grouped_by_date_field(
     search_mode: Optional[str] = None,
     limit: int = 40,
     offset: int = 0,
+    apply_view_sorts: bool = True,
     model: Optional[GeneratedTableModel] = None,
     base_queryset: Optional[QuerySet] = None,
     adhoc_filters: Optional[AdHocFilters] = None,
@@ -214,6 +215,9 @@ def get_rows_grouped_by_date_field(
     :param offset: The offset in number of rows to fetch per date bucket. For example
         when offset=0 rows will be returned starting from the 0th row in each bucket,
         when offset=40 the first 40 rows will be skipped in each bucket.
+    :param apply_view_sorts: Whether to apply the view's saved sortings to each
+        date bucket. If there are no saved sortings, rows are ordered by the date
+        field value and then row order.
     :param model: Additionally, an existing model can be provided so that it doesn't
         have to be generated again.
     :param base_queryset: Optionally an alternative base queryset can be provided
@@ -238,11 +242,11 @@ def get_rows_grouped_by_date_field(
     if not date_field_type.can_represent_date(date_field):
         raise CalendarViewHasNoDateField()
     if base_queryset is None:
-        base_queryset = (
-            model.objects.all()
-            .enhance_by_fields()
-            .order_by(f"field_{date_field.id}", "order", "id")
-        )
+        base_queryset = model.objects.all().enhance_by_fields()
+    if apply_view_sorts and view.viewsort_set.exists():
+        base_queryset = ViewHandler().apply_sorting(view, base_queryset)
+    elif not base_queryset.ordered:
+        base_queryset = base_queryset.order_by(f"field_{date_field.id}", "order", "id")
     if search is not None:
         base_queryset = base_queryset.search_all_fields(search, search_mode=search_mode)
 

--- a/premium/backend/tests/baserow_premium_tests/api/views/views/test_calendar_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/views/views/test_calendar_views.py
@@ -340,6 +340,74 @@ def test_list_all_rows(api_client, premium_data_fixture):
 @pytest.mark.django_db
 @pytest.mark.view_calendar
 @override_settings(DEBUG=True)
+def test_list_rows_applies_view_sortings_within_each_day(
+    api_client, premium_data_fixture
+):
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    date_field = premium_data_fixture.create_date_field(
+        table=table, date_include_time=True
+    )
+    calendar = premium_data_fixture.create_calendar_view(
+        table=table, date_field=date_field
+    )
+    premium_data_fixture.create_view_sort(view=calendar, field=text_field, order="ASC")
+
+    model = table.get_model()
+    row_jan_1_c = model.objects.create(
+        **{
+            f"field_{text_field.id}": "C",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_1_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "A",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_1_b = model.objects.create(
+        **{
+            f"field_{text_field.id}": "B",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_2_b = model.objects.create(
+        **{
+            f"field_{text_field.id}": "B",
+            f"field_{date_field.id}": datetime(2023, 1, 2, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_2_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "A",
+            f"field_{date_field.id}": datetime(2023, 1, 2, tzinfo=timezone.utc),
+        }
+    )
+
+    response = api_client.get(
+        get_list_url(calendar.id), **{"HTTP_AUTHORIZATION": f"JWT {token}"}
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+
+    jan_1_results = response_json["rows"]["2023-01-01"]["results"]
+    assert [r["id"] for r in jan_1_results] == [
+        row_jan_1_a.id,
+        row_jan_1_b.id,
+        row_jan_1_c.id,
+    ]
+
+    jan_2_results = response_json["rows"]["2023-01-02"]["results"]
+    assert [r["id"] for r in jan_2_results] == [row_jan_2_a.id, row_jan_2_b.id]
+
+
+@pytest.mark.django_db
+@pytest.mark.view_calendar
+@override_settings(DEBUG=True)
 def test_list_all_rows_limit_offset(api_client, premium_data_fixture):
     user, token = premium_data_fixture.create_user_and_token(
         has_active_premium_license=True
@@ -1199,6 +1267,62 @@ def test_list_public_rows_limit_offset(api_client, premium_data_fixture):
             "2023-01-10T16:00:00Z",
             "2023-01-10T17:00:00Z",
         ]
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_list_public_rows_applies_view_sortings_within_each_day(
+    api_client, premium_data_fixture
+):
+    user, _ = premium_data_fixture.create_user_and_token()
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table, primary=True)
+    date_field = premium_data_fixture.create_date_field(
+        table=table, date_include_time=True
+    )
+    calendar_view = premium_data_fixture.create_calendar_view(
+        table=table,
+        user=user,
+        public=True,
+        date_field=date_field,
+    )
+    premium_data_fixture.create_calendar_view_field_option(
+        calendar_view, text_field, hidden=False
+    )
+    premium_data_fixture.create_view_sort(
+        view=calendar_view, field=text_field, order="DESC"
+    )
+
+    model = table.get_model()
+    row_jan_1_a = model.objects.create(
+        **{
+            f"field_{text_field.id}": "A",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_1_c = model.objects.create(
+        **{
+            f"field_{text_field.id}": "C",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+    row_jan_1_b = model.objects.create(
+        **{
+            f"field_{text_field.id}": "B",
+            f"field_{date_field.id}": datetime(2023, 1, 1, tzinfo=timezone.utc),
+        }
+    )
+
+    response = api_client.get(get_public_list_url(calendar_view.slug))
+    response_json = response.json()
+    assert response.status_code == HTTP_200_OK
+
+    jan_1_results = response_json["rows"]["2023-01-01"]["results"]
+    assert [r["id"] for r in jan_1_results] == [
+        row_jan_1_c.id,
+        row_jan_1_b.id,
+        row_jan_1_a.id,
+    ]
 
 
 @pytest.mark.django_db

--- a/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/calendar.js
@@ -54,6 +54,19 @@ export function populateDateStack(stack, data) {
 
 const updateRowQueue = new GroupTaskQueue()
 
+function getCalendarRowSortings(view, dateFieldId) {
+  return view.sortings && view.sortings.length > 0
+    ? view.sortings
+    : [
+        {
+          field: dateFieldId,
+          value: 'ASC',
+          order: 'ASC',
+          type: DEFAULT_SORT_TYPE_KEY,
+        },
+      ]
+}
+
 export const state = () => ({
   loading: false,
   loadingRows: false,
@@ -606,14 +619,7 @@ export const actions = {
     if (stack === undefined) {
       return
     }
-    const sortings = [
-      {
-        field: dateFieldId,
-        value: 'ASC',
-        order: 'ASC',
-        type: DEFAULT_SORT_TYPE_KEY,
-      },
-    ]
+    const sortings = getCalendarRowSortings(view, dateFieldId)
     const sortedRows = clone(stack.results)
     sortedRows.push(row)
     sortedRows.sort(getRowSortFunction($registry, sortings, fields))
@@ -764,14 +770,7 @@ export const actions = {
       }
       newStackResults.push(newRow)
       newStackCount++
-      const sortings = [
-        {
-          field: dateFieldId,
-          value: 'ASC',
-          order: 'ASC',
-          type: DEFAULT_SORT_TYPE_KEY,
-        },
-      ]
+      const sortings = getCalendarRowSortings(view, dateFieldId)
       newStackResults.sort(getRowSortFunction($registry, sortings, fields))
       newIndex = newStackResults.findIndex((r) => r.id === newRow.id)
       const newIsLast = newIndex === newStackResults.length - 1

--- a/premium/web-frontend/modules/baserow_premium/viewTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/viewTypes.js
@@ -322,7 +322,7 @@ export class CalendarViewType extends PremiumViewType {
   }
 
   canSort() {
-    return false
+    return true
   }
 
   canShare() {

--- a/premium/web-frontend/test/unit/premium/store/view/calendar.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/calendar.spec.js
@@ -1,6 +1,7 @@
 import calendarStore from '@baserow_premium/store/view/calendar'
 import { TestApp } from '@baserow/test/helpers/testApp'
 import moment from '@baserow/modules/core/moment'
+import { DEFAULT_SORT_TYPE_KEY } from '@baserow/modules/database/constants'
 
 const fields = [
   {
@@ -318,6 +319,56 @@ describe('Calendar view store', () => {
           expect(resultStack.results[1].id).toBe(3)
           expect(resultStack.results[2].id).toBe(10)
           expect(resultStack.results[3].id).toBe(11)
+        })
+
+        test('new rows use view sortings within the same date', async () => {
+          const dateStacks = {}
+          dateStacks['2023-01-01'] = {
+            count: 100,
+            results: [
+              {
+                id: 10,
+                order: '10.00',
+                field_1: 'Delta',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 11,
+                order: '11.00',
+                field_1: 'Echo',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+            ],
+          }
+
+          const state = Object.assign(calendarStore.state(), {
+            dateFieldId: 2,
+            dateStacks,
+          })
+          store.replaceState({ ...store.state, calendar: state })
+
+          await store.dispatch('calendar/createdNewRow', {
+            view: {
+              ...view,
+              sortings: [
+                {
+                  field: 1,
+                  order: 'ASC',
+                  type: DEFAULT_SORT_TYPE_KEY,
+                },
+              ],
+            },
+            values: {
+              id: 1,
+              order: '99.00',
+              field_1: 'Alpha',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            fields,
+          })
+
+          const resultStack = store.state.calendar.dateStacks['2023-01-01']
+          expect(resultStack.results.map((row) => row.id)).toEqual([1, 10, 11])
         })
 
         test('new rows added across dates', async () => {
@@ -886,6 +937,65 @@ describe('Calendar view store', () => {
           expect(resultStack.results[0].id).toBe(100)
           expect(resultStack.results[1].id).toBe(22)
           expect(resultStack.results[2].id).toBe(10)
+        })
+
+        test('updated rows use view sortings within the same date', async () => {
+          const dateStacks = {}
+          dateStacks['2023-01-01'] = {
+            count: 3,
+            results: [
+              {
+                id: 10,
+                order: '10.00',
+                field_1: 'Charlie',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 11,
+                order: '11.00',
+                field_1: 'Delta',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+              {
+                id: 12,
+                order: '12.00',
+                field_1: 'Echo',
+                field_2: '2023-01-01T00:00:00Z',
+              },
+            ],
+          }
+
+          const state = Object.assign(calendarStore.state(), {
+            dateFieldId: 2,
+            dateStacks,
+          })
+          store.replaceState({ ...store.state, calendar: state })
+
+          await store.dispatch('calendar/updatedExistingRow', {
+            view: {
+              ...view,
+              sortings: [
+                {
+                  field: 1,
+                  order: 'ASC',
+                  type: DEFAULT_SORT_TYPE_KEY,
+                },
+              ],
+            },
+            row: {
+              id: 12,
+              order: '12.00',
+              field_1: 'Echo',
+              field_2: '2023-01-01T00:00:00Z',
+            },
+            values: {
+              field_1: 'Alpha',
+            },
+            fields,
+          })
+
+          const resultStack = store.state.calendar.dateStacks['2023-01-01']
+          expect(resultStack.results.map((row) => row.id)).toEqual([12, 10, 11])
         })
 
         test('moving rows across dates', async () => {


### PR DESCRIPTION
Fixes #1729.

## What changed
- Enables sorting for calendar views in the frontend.
- Applies saved view sortings when calendar rows are grouped into day buckets.
- Keeps newly created and updated calendar rows ordered by the view sortings in the frontend store.
- Adds backend coverage for authenticated and public calendar row listing, plus frontend store coverage for create/update behavior.

## Verification
- `..\.pydeps\bin\ruff.exe format premium\backend\src\baserow_premium\views\handler.py premium\backend\tests\baserow_premium_tests\api\views\views\test_calendar_views.py`
- `..\.pydeps\bin\ruff.exe check premium\backend\src\baserow_premium\views\handler.py`
- `python -m py_compile premium\backend\src\baserow_premium\views\handler.py premium\backend\tests\baserow_premium_tests\api\views\views\test_calendar_views.py`
- `node --check premium\web-frontend\modules\baserow_premium\store\view\calendar.js`
- `node --check premium\web-frontend\modules\baserow_premium\viewTypes.js`
- `node --check premium\web-frontend\test\unit\premium\store\view\calendar.spec.js`
- `python -m json.tool changelog\entries\unreleased\feature\1729_add_sorting_to_calendar_view.json`
- `git diff --check`

Could not run the targeted pytest locally because this environment has no `pytest` module installed. The frontend dependency install is also unavailable here (`premium/web-frontend/node_modules` is not a dependency directory), so I used syntax checks for the changed JS test/source files.