### PR TITLE
fix: support SMTP integrations with null configurations

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/integration_types.py
+++ b/backend/src/baserow/contrib/integrations/core/integration_types.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from baserow.contrib.integrations.core.models import SMTPIntegration
 from baserow.core.integrations.registries import IntegrationType
 from baserow.core.integrations.types import IntegrationDict
@@ -20,3 +22,18 @@ class SMTPIntegrationType(IntegrationType):
 
     request_serializer_field_names = ["host", "port", "use_tls", "username", "password"]
     request_serializer_field_overrides = {}
+
+    def deserialize_property(
+        self,
+        prop_name: str,
+        value: Any,
+        id_mapping: Dict[str, Any],
+        **kwargs,
+    ) -> Any:
+        if prop_name == "host":
+            return value if value is not None else ""
+        if prop_name == "port":
+            return value if value is not None else 587
+        if prop_name == "use_tls":
+            return value if value is not None else True
+        return super().deserialize_property(prop_name, value, id_mapping, **kwargs)

--- a/backend/tests/baserow/contrib/integrations/core/test_smtp_integration_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_smtp_integration_type.py
@@ -275,6 +275,35 @@ def test_smtp_integration_import_serialized(data_fixture):
 
 
 @pytest.mark.django_db
+def test_smtp_integration_import_serialized_with_null_sensitive_fields(data_fixture):
+    user = data_fixture.create_user()
+    application = data_fixture.create_builder_application(user=user)
+
+    integration_type = SMTPIntegrationType()
+
+    serialized_data = {
+        "id": 1,
+        "type": "smtp",
+        "host": None,
+        "port": None,
+        "use_tls": None,
+        "username": None,
+        "password": None,
+    }
+
+    imported_integration = integration_type.import_serialized(
+        application, serialized_data, {}, lambda x, d: x
+    )
+
+    assert imported_integration.host == ""
+    assert imported_integration.port == 587
+    assert imported_integration.use_tls is True
+    assert imported_integration.username is None
+    assert imported_integration.password is None
+    assert imported_integration.application_id == application.id
+
+
+@pytest.mark.django_db
 def test_smtp_integration_deletion(data_fixture):
     user = data_fixture.create_user()
     integration = data_fixture.create_smtp_integration(

--- a/changelog/entries/unreleased/bug/fix_importing_applications_with_an_smtp_integration_that_has.json
+++ b/changelog/entries/unreleased/bug/fix_importing_applications_with_an_smtp_integration_that_has.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix importing applications with an SMTP integration that has blank credentials",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-05-21"
+}


### PR DESCRIPTION
### What is in this PR

Ensure that SMTP integrations exports with `null` values in `host`, `port` and `use_tls` can be imported correctly.

### How to test this PR

- Use the export shared in the support channel.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
