### PR TITLE
fix: kanban view create row sort bug

### DIFF
--- a/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
+++ b/premium/web-frontend/modules/baserow_premium/store/view/kanban.js
@@ -484,7 +484,7 @@ export const actions = {
 
     const sortedRows = clone(stack.results)
     sortedRows.push(row)
-    sortedRows.sort(getRowSortFunction($registry, [], fields))
+    sortedRows.sort(getRowSortFunction($registry, view.sortings, fields))
     const index = sortedRows.findIndex((r) => r.id === row.id)
     const isLast = index === sortedRows.length - 1
 

--- a/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
+++ b/premium/web-frontend/test/unit/premium/store/view/kanban.spec.js
@@ -95,6 +95,50 @@ describe('Kanban view store', () => {
     expect(store.state.kanban.stacks['1'].results[2].id).toBe(11)
   })
 
+  test('createdNewRow respects view sortings when placing the new row', async () => {
+    // Stack '1' has 2 loaded rows out of 100. Rows are sorted by a number
+    // field (field_2) ascending. The new row's field_2 value (10) falls
+    // between the two loaded rows (5 and 15), so it must be inserted at
+    // index 1, not appended to the end.
+    const stacks = {
+      null: { count: 0, results: [] },
+      1: {
+        count: 100,
+        results: [
+          { id: 10, order: '1.00', field_1: { id: 1 }, field_2: 5 },
+          { id: 11, order: '2.00', field_1: { id: 1 }, field_2: 15 },
+        ],
+      },
+    }
+    const state = Object.assign(kanbanStore.state(), {
+      singleSelectFieldId: 1,
+      stacks,
+    })
+    store.replaceState({ ...store.state, kanban: state })
+
+    const fields = [{ id: 2, type: 'number', number_decimal_places: 0 }]
+    const sortedView = {
+      filters: [],
+      filters_disabled: false,
+      sortings: [{ field: 2, order: 'ASC', type: 'default' }],
+    }
+
+    // New row has order '3.00' (which would place it last without sortings),
+    // but field_2=10 which is between 5 and 15, so with sortings it must land
+    // at index 1.
+    await store.dispatch('kanban/createdNewRow', {
+      view: sortedView,
+      values: { id: 9, order: '3.00', field_1: { id: 1 }, field_2: 10 },
+      fields,
+    })
+
+    expect(store.state.kanban.stacks['1'].count).toBe(101)
+    expect(store.state.kanban.stacks['1'].results.length).toBe(3)
+    expect(store.state.kanban.stacks['1'].results[0].id).toBe(10)
+    expect(store.state.kanban.stacks['1'].results[1].id).toBe(9)
+    expect(store.state.kanban.stacks['1'].results[2].id).toBe(11)
+  })
+
   test('deletedExistingRow', async () => {
     const stacks = {}
     stacks.null = {


### PR DESCRIPTION
### What is in this PR

Fix related to these recently merged changes (https://github.com/baserow/baserow/pull/5341). It fixes a bug where a row that was created was placed in the correct position.

### How to test this PR

- Create a kanban view and group by a single select field.
- Sort by a text field.
- Create a new row where that text field is equal to `a` (or another value that should give one of the first positions)
- Observe that the row placed in the correct position in the stack.
- Confirm that the real-time collaboration also works when a row is created.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
