### PR TITLE
Revert API docs button styling

### DIFF
--- a/web-frontend/modules/database/pages/APIDocsDatabase.vue
+++ b/web-frontend/modules/database/pages/APIDocsDatabase.vue
@@ -4,17 +4,16 @@
       <nuxt-link :to="{ name: 'index' }" class="api-docs__logo">
         <Logo />
       </nuxt-link>
-      <button
+      <a
         ref="databasesToggle"
-        type="button"
         class="api-docs__switch"
         :aria-expanded="databasesOpen"
         aria-controls="api-docs-databases"
-        @click="databasesOpen = !databasesOpen"
+        @click.prevent="databasesOpen = !databasesOpen"
       >
         <i class="api-docs__switch-icon iconoir-db"></i>
         {{ $t('apiDocsDatabase.pageTitle', database) }}
-      </button>
+      </a>
       <div class="api-docs__open">
         <Button
           v-if="database.tables.length > 0"


### PR DESCRIPTION
### What is in this PR

It looks like this PR (https://github.com/baserow/baserow/pull/5213) changes the button from `<a>` to a `<button>`. Because a button tag changes the styling, it did not look good anymore. This PR changes it back to a `<a>`.

Before:

<img width="876" height="197" alt="image" src="https://github.com/user-attachments/assets/6ad19bb3-2062-4046-b9d9-073a1d3f4cf7" />

After:

<img width="876" height="197" alt="image" src="https://github.com/user-attachments/assets/47d38539-7447-4d02-9558-1ef14aaabcad" />

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
