### PR TITLE
fix: Ensure Core HTTP request service returns status code for timeouts

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -583,6 +583,10 @@ class CoreHTTPRequestServiceType(CoreServiceType):
             raise UnexpectedDispatchException(
                 f"Invalid URL: {resolved_values['url']}"
             ) from e
+        except request_exceptions.Timeout:
+            return {
+                "data": {"raw_body": "", "body": "", "headers": {}, "status_code": 504}
+            }
         except request_exceptions.RequestException as e:
             raise UnexpectedDispatchException(str(e)) from e
         except Exception as e:

--- a/backend/src/baserow/test_utils/pytest_conftest.py
+++ b/backend/src/baserow/test_utils/pytest_conftest.py
@@ -13,10 +13,12 @@ from typing import Any, AsyncGenerator, Dict, List, Optional
 from unittest.mock import patch
 
 from django.conf import settings as django_settings
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.core.management import call_command
 from django.db import DEFAULT_DB_ALIAS, OperationalError, connection, transaction
 from django.db.migrations.executor import MigrationExecutor
+from django.db.models.options import Options
 from django.test.utils import CaptureQueriesContext
 
 import pytest
@@ -165,6 +167,14 @@ def clear_cache():
 
     _generate_search_table_model.cache_clear()
     _workspace_search_table_exists.cache_clear()
+
+    # baserow.contrib.database.apps pins User._meta._expire_cache to a no-op
+    # for prod safety, but in tests that causes generated-table reverse FKs
+    # (LastModifiedBy/CreatedBy/Collaborators -> User, on_delete=SET_NULL) to
+    # leak into User._meta._relation_tree across tests in the same xdist
+    # worker. A later user.delete() then UPDATEs dropped database_table_* rows.
+    # Call the original class-level _expire_cache, bypassing the instance patch.
+    Options._expire_cache(get_user_model()._meta)
 
     # Thread-local cache
     with local_cache.context():

--- a/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
@@ -107,6 +107,39 @@ def test_core_http_request_request_error(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "timeout_exception",
+    [
+        request_exceptions.ReadTimeout(),
+        request_exceptions.ConnectTimeout(),
+        request_exceptions.Timeout(),
+    ],
+)
+def test_core_http_request_timeout_returns_504(data_fixture, timeout_exception):
+    """
+    When the request times out, instead of failing we return a 504
+    status code so that the caller can decide the next step to take.
+    """
+
+    service = data_fixture.create_core_http_request_service(
+        url="'http://foo.localhost/'", timeout=1, http_method=HTTP_METHOD.POST
+    )
+    service_type = service.get_type()
+
+    dispatch_context = FakeDispatchContext()
+
+    with mock_advocate_request(raise_exception=timeout_exception):
+        dispatch_data = service_type.dispatch(service, dispatch_context)
+
+    assert dispatch_data.data == {
+        "raw_body": "",
+        "body": "",
+        "headers": {},
+        "status_code": 504,
+    }
+
+
+@pytest.mark.django_db
 def test_core_http_request_basic_body_raw(
     data_fixture,
 ):

--- a/changelog/entries/unreleased/refactor/4973_refactored_the_core_http_request_service_type_to_return_a_st.json
+++ b/changelog/entries/unreleased/refactor/4973_refactored_the_core_http_request_service_type_to_return_a_st.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Refactored the Core HTTP Request service type to return a status code for timeouts.",
+    "issue_origin": "github",
+    "issue_number": 4973,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-25"
+}


### PR DESCRIPTION
### What is in this PR
When an HTTP Request node times out, the status code of the request should be available to subsequent nodes in the data explorer.

Right now, if the HTTP Request node runs into a network timeout, we get an error for the node:
> <img width="369" height="145" alt="Image" src="https://github.com/user-attachments/assets/eecc9c6d-49ee-4155-b601-5d55f0771f3e" />
```
ValidatingHTTPSConnectionPool(host='webhook.site', port=443): Read timed out. (read timeout=1)
```

And the next node can't be tested, so we can't check the previous node's status code.

This originates from a [community post](https://community.baserow.io/t/handling-timeouts-on-external-http-gets/12154).

Closes https://github.com/baserow/baserow/issues/4973

### How to test this PR
- Create a webhook on webhook.site that times out after 5 seconds
- Create an HTTP Request node with a timeout of 1 second
- Test the node

In `develop`,  you'll notice the error mentioned above. The workflow errors out, and subsequent nodes aren't dispatched.

In this branch, you'll see that a 504 status code is available in the node result, which a subsequent node (e.g. Router node) can action.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
