### PR TITLE
Fix: impersonate a user result in 403 error page 

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_use.json
+++ b/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_use.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a 403 error that could appear when impersonating a user     \n from the admin area",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-23"
+}

--- a/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_use.json
+++ b/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_use.json
@@ -1,9 +1,0 @@
-{
-    "type": "bug",
-    "message": "Fixes a 403 error that could appear when impersonating a user     \n from the admin area",
-    "issue_origin": "github",
-    "issue_number": null,
-    "domain": "core",
-    "bullet_points": [],
-    "created_at": "2026-05-23"
-}

--- a/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_user.json
+++ b/changelog/entries/unreleased/bug/fixes_a_403_error_that_could_appear_when_impersonating_a_user.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixes a 403 error that could appear when impersonating a user from the admin area",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "core",
+  "bullet_points": [],
+  "created_at": "2026-05-23"
+}

--- a/web-frontend/modules/core/middleware/impersonate.js
+++ b/web-frontend/modules/core/middleware/impersonate.js
@@ -1,20 +1,26 @@
 import UserService from '@baserow/modules/core/services/admin/users'
 
 /**
- * We only want to allow impersonation when a page loads for the first time because
- * on first load several endpoints are called to fetch initial data like workspace,
- * applications, etc. Starting the impersonation when the page first loads, makes
- * sure that we never have to take this situation into account because it only
- * happens on first page load before everything is fetched.
+ * Core impersonate logic, extracted so it can be unit tested without going
+ * through Nuxt's auto-imports and the SSR-only guard.
  */
-export default defineNuxtRouteMiddleware(async (to) => {
-  if (!import.meta.server) return
-
-  const nuxtApp = useNuxtApp()
+export const impersonateMiddleware = async (to, { nuxtApp }) => {
   const store = nuxtApp.$store
 
   // If the query param is not provided, we don't want to do anything.
   if (!Object.prototype.hasOwnProperty.call(to.query, '__impersonate-user')) {
+    return
+  }
+
+  // The impersonate endpoint requires a staff user. If the SSR auth state
+  // hasn't been established yet (e.g. the refresh token cookie is missing or
+  // too close to expiry for `authentication` middleware to refresh), or the
+  // current user isn't staff, calling the endpoint would always yield a 403.
+  // Bail out early so we don't fire a guaranteed-failing request.
+  if (
+    !store.getters['auth/isAuthenticated'] ||
+    !store.getters['auth/isStaff']
+  ) {
     return
   }
 
@@ -34,4 +40,18 @@ export default defineNuxtRouteMiddleware(async (to) => {
   // Set the impersonating state to true so that the warning in the top left corner
   // is visible.
   store.dispatch('impersonating/setImpersonating', true)
+}
+
+/**
+ * We only want to allow impersonation when a page loads for the first time because
+ * on first load several endpoints are called to fetch initial data like workspace,
+ * applications, etc. Starting the impersonation when the page first loads, makes
+ * sure that we never have to take this situation into account because it only
+ * happens on first page load before everything is fetched.
+ */
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (!import.meta.server) return
+
+  const nuxtApp = useNuxtApp()
+  return impersonateMiddleware(to, { nuxtApp })
 })

--- a/web-frontend/modules/core/middleware/impersonate.js
+++ b/web-frontend/modules/core/middleware/impersonate.js
@@ -1,9 +1,5 @@
 import UserService from '@baserow/modules/core/services/admin/users'
 
-/**
- * Core impersonate logic, extracted so it can be unit tested without going
- * through Nuxt's auto-imports and the SSR-only guard.
- */
 export const impersonateMiddleware = async (to, { nuxtApp }) => {
   const store = nuxtApp.$store
 
@@ -12,19 +8,21 @@ export const impersonateMiddleware = async (to, { nuxtApp }) => {
     return
   }
 
-  // The impersonate endpoint requires a staff user. If the SSR auth state
-  // hasn't been established yet (e.g. the refresh token cookie is missing or
-  // too close to expiry for `authentication` middleware to refresh), or the
-  // current user isn't staff, calling the endpoint would always yield a 403.
-  // Bail out early so we don't fire a guaranteed-failing request.
-  if (
-    !store.getters['auth/isAuthenticated'] ||
-    !store.getters['auth/isStaff']
-  ) {
+  // No session yet — `authentication` middleware normally redirects first,
+  // but bail if it didn't so we don't fire a request that will 401.
+  if (!store.getters['auth/isAuthenticated']) {
     return
   }
 
   const userId = to.query['__impersonate-user']
+
+  // Already impersonating this user. A redirect after impersonation (e.g.
+  // `dashboardRedirect`) makes Nuxt re-run middlewares with the impersonated
+  // user in the store; without this guard we'd call the endpoint again as
+  // that user.
+  if (String(store.getters['auth/getUserId']) === String(userId)) {
+    return
+  }
 
   // Request the impersonate user data, this contains the `token` and `user` object.
   // This is needed to impersonate the user.

--- a/web-frontend/test/unit/core/middleware/impersonate.spec.js
+++ b/web-frontend/test/unit/core/middleware/impersonate.spec.js
@@ -11,11 +11,11 @@ vi.mock('@baserow/modules/core/services/admin/users', () => ({
  * Builds a minimal `nuxtApp` stub backed by configurable store getters and a
  * spy-able `dispatch`. Mirrors the surface area the middleware actually uses.
  */
-const buildNuxtApp = ({ isAuthenticated, isStaff } = {}) => {
+const buildNuxtApp = ({ isAuthenticated, userId } = {}) => {
   const dispatch = vi.fn()
   const getters = {
     'auth/isAuthenticated': !!isAuthenticated,
-    'auth/isStaff': !!isStaff,
+    'auth/getUserId': userId,
   }
   return {
     nuxtApp: {
@@ -39,7 +39,7 @@ describe('impersonate middleware', () => {
   test('does nothing when the __impersonate-user query param is missing', async () => {
     const { nuxtApp, dispatch } = buildNuxtApp({
       isAuthenticated: true,
-      isStaff: true,
+      userId: 1,
     })
 
     await impersonateMiddleware({ query: {} }, { nuxtApp })
@@ -51,7 +51,6 @@ describe('impersonate middleware', () => {
   test('bails out when the user is not authenticated, even if the query param is set', async () => {
     const { nuxtApp, dispatch } = buildNuxtApp({
       isAuthenticated: false,
-      isStaff: false,
     })
 
     await impersonateMiddleware(
@@ -63,10 +62,10 @@ describe('impersonate middleware', () => {
     expect(dispatch).not.toHaveBeenCalled()
   })
 
-  test('bails out when the user is authenticated but not staff', async () => {
+  test('bails out when the current user is already the impersonated user', async () => {
     const { nuxtApp, dispatch } = buildNuxtApp({
       isAuthenticated: true,
-      isStaff: false,
+      userId: 5,
     })
 
     await impersonateMiddleware(
@@ -78,10 +77,25 @@ describe('impersonate middleware', () => {
     expect(dispatch).not.toHaveBeenCalled()
   })
 
-  test('impersonates the user and updates the store when staff and authenticated', async () => {
+  test('matches when the store id is already a string equal to the query param', async () => {
     const { nuxtApp, dispatch } = buildNuxtApp({
       isAuthenticated: true,
-      isStaff: true,
+      userId: '5',
+    })
+
+    await impersonateMiddleware(
+      { query: { '__impersonate-user': '5' } },
+      { nuxtApp }
+    )
+
+    expect(impersonate).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  test('impersonates the user and updates the store when authenticated as a different user', async () => {
+    const { nuxtApp, dispatch } = buildNuxtApp({
+      isAuthenticated: true,
+      userId: 1,
     })
 
     await impersonateMiddleware(

--- a/web-frontend/test/unit/core/middleware/impersonate.spec.js
+++ b/web-frontend/test/unit/core/middleware/impersonate.spec.js
@@ -1,0 +1,104 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+
+import { impersonateMiddleware } from '@baserow/modules/core/middleware/impersonate'
+import UserService from '@baserow/modules/core/services/admin/users'
+
+vi.mock('@baserow/modules/core/services/admin/users', () => ({
+  default: vi.fn(),
+}))
+
+/**
+ * Builds a minimal `nuxtApp` stub backed by configurable store getters and a
+ * spy-able `dispatch`. Mirrors the surface area the middleware actually uses.
+ */
+const buildNuxtApp = ({ isAuthenticated, isStaff } = {}) => {
+  const dispatch = vi.fn()
+  const getters = {
+    'auth/isAuthenticated': !!isAuthenticated,
+    'auth/isStaff': !!isStaff,
+  }
+  return {
+    nuxtApp: {
+      $store: { getters, dispatch },
+      $client: {},
+    },
+    dispatch,
+  }
+}
+
+describe('impersonate middleware', () => {
+  let impersonate
+
+  beforeEach(() => {
+    impersonate = vi.fn().mockResolvedValue({
+      data: { user: { id: 42 }, access_token: 'a', refresh_token: 'b' },
+    })
+    UserService.mockReturnValue({ impersonate })
+  })
+
+  test('does nothing when the __impersonate-user query param is missing', async () => {
+    const { nuxtApp, dispatch } = buildNuxtApp({
+      isAuthenticated: true,
+      isStaff: true,
+    })
+
+    await impersonateMiddleware({ query: {} }, { nuxtApp })
+
+    expect(impersonate).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  test('bails out when the user is not authenticated, even if the query param is set', async () => {
+    const { nuxtApp, dispatch } = buildNuxtApp({
+      isAuthenticated: false,
+      isStaff: false,
+    })
+
+    await impersonateMiddleware(
+      { query: { '__impersonate-user': '5' } },
+      { nuxtApp }
+    )
+
+    expect(impersonate).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  test('bails out when the user is authenticated but not staff', async () => {
+    const { nuxtApp, dispatch } = buildNuxtApp({
+      isAuthenticated: true,
+      isStaff: false,
+    })
+
+    await impersonateMiddleware(
+      { query: { '__impersonate-user': '5' } },
+      { nuxtApp }
+    )
+
+    expect(impersonate).not.toHaveBeenCalled()
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  test('impersonates the user and updates the store when staff and authenticated', async () => {
+    const { nuxtApp, dispatch } = buildNuxtApp({
+      isAuthenticated: true,
+      isStaff: true,
+    })
+
+    await impersonateMiddleware(
+      { query: { '__impersonate-user': '5' } },
+      { nuxtApp }
+    )
+
+    expect(impersonate).toHaveBeenCalledWith('5')
+    expect(dispatch).toHaveBeenCalledWith('auth/forceSetUserData', {
+      user: { id: 42 },
+      access_token: 'a',
+      refresh_token: 'b',
+    })
+    expect(dispatch).toHaveBeenCalledWith('auth/preventSetToken')
+    expect(dispatch).toHaveBeenCalledWith(
+      'impersonating/setImpersonating',
+      true
+    )
+  })
+})


### PR DESCRIPTION
### What is in this PR
- Fixed impersonating a user result in 403 error page bug

### How to test this PR
- Go to the Admin panel and select the Users tab
- Find the user you want to impersonate and click the Impersonate button

Do the same step on current develop branch and this fix branch.  check the testing video 

https://github.com/user-attachments/assets/bd8949c7-4ae7-4824-830e-c59bc2f5ceaa



Closes #5330 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] Security impact of change has been considered



