### PR TITLE
feat: add membership management for all app types

### DIFF
--- a/backend/src/baserow/contrib/automation/operations.py
+++ b/backend/src/baserow/contrib/automation/operations.py
@@ -9,6 +9,7 @@ class AutomationOperationType(OperationType, metaclass=ABCMeta):
 
 class ListAutomationWorkflowsOperationType(AutomationOperationType):
     type = "automation.list_workflows"
+    object_scope_name = "automation_workflow"
 
 
 class OrderAutomationWorkflowsOperationType(AutomationOperationType):

--- a/backend/src/baserow/contrib/builder/operations.py
+++ b/backend/src/baserow/contrib/builder/operations.py
@@ -9,6 +9,7 @@ class BuilderOperationType(OperationType, metaclass=ABCMeta):
 
 class ListPagesBuilderOperationType(BuilderOperationType):
     type = "builder.list_pages"
+    object_scope_name = "builder_page"
 
 
 class OrderPagesBuilderOperationType(BuilderOperationType):
@@ -17,6 +18,7 @@ class OrderPagesBuilderOperationType(BuilderOperationType):
 
 class ListDomainsBuilderOperationType(BuilderOperationType):
     type = "builder.list_domains"
+    object_scope_name = "builder_domain"
 
 
 class OrderDomainsBuilderOperationType(BuilderOperationType):

--- a/changelog/entries/unreleased/feature/add_members_management_to_builder_applications_automations_a.json
+++ b/changelog/entries/unreleased/feature/add_members_management_to_builder_applications_automations_a.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add members management to builder applications, automations and dashboards",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-05-25"
+}

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
@@ -110,3 +110,59 @@ def test_get_database_application_with_tables_filtered_by_roles(
 
     assert len(response_json["tables"]) == 1
     assert [t["id"] for t in response_json["tables"]] == [table_1.id]
+
+
+@pytest.mark.django_db
+def test_get_builder_application_with_application_role_includes_pages(
+    api_client, data_fixture
+):
+    admin = data_fixture.create_user()
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    builder = data_fixture.create_builder_application(workspace=workspace)
+    page = data_fixture.create_builder_page(builder=builder, name="Visible page")
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=builder.application_ptr
+    )
+
+    url = reverse("api:applications:item", kwargs={"application_id": builder.id})
+
+    response = api_client.get(url, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+    response_json = response.json()
+
+    assert response.status_code == 200
+    assert response_json["id"] == builder.id
+    assert page.id in [p["id"] for p in response_json["pages"]]
+
+
+@pytest.mark.django_db
+def test_get_automation_application_with_application_role_includes_workflows(
+    api_client, data_fixture
+):
+    admin = data_fixture.create_user()
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    automation = data_fixture.create_automation_application(workspace=workspace)
+    workflow = data_fixture.create_automation_workflow(
+        automation=automation, name="Visible workflow"
+    )
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=automation.application_ptr
+    )
+
+    url = reverse("api:applications:item", kwargs={"application_id": automation.id})
+
+    response = api_client.get(url, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+    response_json = response.json()
+
+    assert response.status_code == 200
+    assert response_json["id"] == automation.id
+    assert workflow.id in [w["id"] for w in response_json["workflows"]]

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
@@ -272,6 +272,6 @@ def test_application_role_frontend_permissions_include_dashboard_data_sources(
         p["permissions"] for p in permissions if p["name"] == "role"
     )
 
-    assert data_source.id in role_permissions["dashboard.data_source.update"][
-        "exceptions"
-    ]
+    assert (
+        data_source.id in role_permissions["dashboard.data_source.update"]["exceptions"]
+    )

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
@@ -2,6 +2,7 @@ from django.shortcuts import reverse
 
 import pytest
 
+from baserow.core.handler import CoreHandler
 from baserow_enterprise.role.handler import RoleAssignmentHandler
 
 
@@ -166,3 +167,55 @@ def test_get_automation_application_with_application_role_includes_workflows(
     assert response.status_code == 200
     assert response_json["id"] == automation.id
     assert workflow.id in [w["id"] for w in response_json["workflows"]]
+
+
+@pytest.mark.django_db
+def test_application_role_frontend_permissions_include_builder_elements(
+    data_fixture,
+):
+    admin = data_fixture.create_user()
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    builder = data_fixture.create_builder_application(workspace=workspace)
+    page = data_fixture.create_builder_page(builder=builder)
+    element = data_fixture.create_builder_heading_element(page=page)
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=builder.application_ptr
+    )
+
+    permissions = CoreHandler().get_permissions(user, workspace)
+    role_permissions = next(
+        p["permissions"] for p in permissions if p["name"] == "role"
+    )
+
+    assert element.id in role_permissions["builder.page.element.update"]["exceptions"]
+
+
+@pytest.mark.django_db
+def test_application_role_frontend_permissions_include_automation_nodes(
+    data_fixture,
+):
+    admin = data_fixture.create_user()
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    automation = data_fixture.create_automation_application(workspace=workspace)
+    workflow = data_fixture.create_automation_workflow(automation=automation)
+    node = workflow.automation_workflow_nodes.first()
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=automation.application_ptr
+    )
+
+    permissions = CoreHandler().get_permissions(user, workspace)
+    role_permissions = next(
+        p["permissions"] for p in permissions if p["name"] == "role"
+    )
+
+    assert node.id in role_permissions["automation.node.update"]["exceptions"]

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/role/test_views_filtered_by_roles.py
@@ -196,6 +196,35 @@ def test_application_role_frontend_permissions_include_builder_elements(
 
 
 @pytest.mark.django_db
+def test_application_role_frontend_permissions_include_builder_data_sources(
+    data_fixture,
+):
+    admin = data_fixture.create_user()
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    builder = data_fixture.create_builder_application(workspace=workspace)
+    page = data_fixture.create_builder_page(builder=builder)
+    data_source = data_fixture.create_builder_data_source(page=page)
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=builder.application_ptr
+    )
+
+    permissions = CoreHandler().get_permissions(user, workspace)
+    role_permissions = next(
+        p["permissions"] for p in permissions if p["name"] == "role"
+    )
+
+    assert (
+        data_source.id
+        in role_permissions["builder.page.data_source.update"]["exceptions"]
+    )
+
+
+@pytest.mark.django_db
 def test_application_role_frontend_permissions_include_automation_nodes(
     data_fixture,
 ):
@@ -219,3 +248,30 @@ def test_application_role_frontend_permissions_include_automation_nodes(
     )
 
     assert node.id in role_permissions["automation.node.update"]["exceptions"]
+
+
+@pytest.mark.django_db
+def test_application_role_frontend_permissions_include_dashboard_data_sources(
+    data_fixture,
+):
+    admin = data_fixture.create_user()
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(
+        user=admin, custom_permissions=[(user, "NO_ACCESS")]
+    )
+    dashboard = data_fixture.create_dashboard_application(workspace=workspace)
+    data_source = data_fixture.create_dashboard_data_source(dashboard=dashboard)
+
+    builder_role = RoleAssignmentHandler().get_role_by_uid("BUILDER")
+    RoleAssignmentHandler().assign_role(
+        user, workspace, role=builder_role, scope=dashboard.application_ptr
+    )
+
+    permissions = CoreHandler().get_permissions(user, workspace)
+    role_permissions = next(
+        p["permissions"] for p in permissions if p["name"] == "role"
+    )
+
+    assert data_source.id in role_permissions["dashboard.data_source.update"][
+        "exceptions"
+    ]

--- a/enterprise/backend/tests/baserow_enterprise_tests/sso/test_auth_provider_handler.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/sso/test_auth_provider_handler.py
@@ -18,7 +18,8 @@ def test_get_or_create_user_from_sso_user_info(enterprise_data_fixture):
     user_info = UserInfo("john@acme.com", "John")
 
     User = get_user_model()
-    assert User.objects.count() == 0
+    initial_user_count = User.objects.count()
+    assert not User.objects.filter(email=user_info.email).exists()
 
     # test the user is created if not already present in the database
     (
@@ -33,7 +34,7 @@ def test_get_or_create_user_from_sso_user_info(enterprise_data_fixture):
     assert user.email == user_info.email
     assert user.first_name == user_info.name
     assert user.password == ""
-    assert User.objects.count() == 1
+    assert User.objects.count() == initial_user_count + 1
     assert user.workspaceuser_set.count() == 0
     assert user.auth_providers.filter(id=auth_provider_1.id).exists()
 
@@ -61,7 +62,7 @@ def test_get_or_create_user_from_sso_user_info(enterprise_data_fixture):
                 auth_provider_2, user_info
             )
 
-    assert User.objects.count() == 1
+    assert User.objects.count() == initial_user_count + 1
     assert not user.auth_providers.filter(id=auth_provider_2.id).exists()
 
     with override_settings(BASEROW_ALLOW_MULTIPLE_SSO_PROVIDERS_FOR_SAME_ACCOUNT=True):
@@ -101,7 +102,7 @@ def test_get_or_create_user_from_sso_user_info(enterprise_data_fixture):
     assert user2.first_name == user2_info.name
     assert user2.profile.language == user2_info.language
     assert user2.password == ""
-    assert User.objects.count() == 2
+    assert User.objects.count() == initial_user_count + 2
     assert user2.workspaceuser_set.count() == 1
     assert user2.workspaceuser_set.first().workspace == workspace_user.workspace
     assert user2.auth_providers.filter(id=auth_provider_1.id).exists()

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesApplicationContextItem.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesApplicationContextItem.vue
@@ -18,7 +18,7 @@
         <i class="iconoir-lock"></i>
       </div>
     </a>
-    <MemberRolesModal ref="memberRolesModal" :database="application" />
+    <MemberRolesModal ref="memberRolesModal" :application="application" />
     <PaidFeaturesModal
       ref="paidFeaturesModal"
       initial-selected-type="rbac"
@@ -33,7 +33,7 @@ import EnterpriseFeatures from '@baserow_enterprise/features'
 import PaidFeaturesModal from '@baserow_premium/components/PaidFeaturesModal'
 
 export default {
-  name: 'MemberRolesDatabaseContextItem',
+  name: 'MemberRolesApplicationContextItem',
   components: { PaidFeaturesModal, MemberRolesModal },
   props: {
     application: {

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesModal.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesModal.vue
@@ -15,7 +15,6 @@
           :role-assignments="databaseRoleAssignments"
           :teams="teams"
           scope-type="application"
-          :scope-type-name="applicationTypeNameLower"
           @invite-members="inviteDatabaseMembers"
           @invite-teams="inviteDatabaseTeams"
           @role-updated="
@@ -125,9 +124,6 @@ export default {
         this.applicationType?.getName() ||
         this.$t('memberRolesModal.memberRolesDatabaseTabTitle')
       )
-    },
-    applicationTypeNameLower() {
-      return this.applicationTypeName.toLowerCase()
     },
     canManageApplication() {
       return this.$hasPermission(

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesModal.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesModal.vue
@@ -7,17 +7,15 @@
       :selected-index="selectedTabIndex"
       @update:selected-index="selectedTabIndex = $event"
     >
-      <Tab
-        v-if="canManageDatabase"
-        :title="$t('memberRolesModal.memberRolesDatabaseTabTitle')"
-      >
+      <Tab v-if="canManageApplication" :title="applicationTypeName">
         <MemberRolesTab
           :loading="loading"
           :workspace="workspace"
-          :scope="database"
+          :scope="applicationScope"
           :role-assignments="databaseRoleAssignments"
           :teams="teams"
           scope-type="application"
+          :scope-type-name="applicationTypeNameLower"
           @invite-members="inviteDatabaseMembers"
           @invite-teams="inviteDatabaseTeams"
           @role-updated="
@@ -79,9 +77,15 @@ export default {
   components: { MemberRolesTab },
   mixins: [Modal, error],
   props: {
+    application: {
+      type: Object,
+      required: false,
+      default: null,
+    },
     database: {
       type: Object,
-      required: true,
+      required: false,
+      default: null,
     },
     table: {
       type: Object,
@@ -105,13 +109,30 @@ export default {
     }
   },
   computed: {
-    workspace() {
-      return this.$store.getters['workspace/get'](this.database.workspace.id)
+    applicationScope() {
+      return this.application || this.database
     },
-    canManageDatabase() {
+    workspace() {
+      return this.$store.getters['workspace/get'](
+        this.applicationScope.workspace.id
+      )
+    },
+    applicationType() {
+      return this.$registry.get('application', this.applicationScope.type)
+    },
+    applicationTypeName() {
+      return (
+        this.applicationType?.getName() ||
+        this.$t('memberRolesModal.memberRolesDatabaseTabTitle')
+      )
+    },
+    applicationTypeNameLower() {
+      return this.applicationTypeName.toLowerCase()
+    },
+    canManageApplication() {
       return this.$hasPermission(
         'application.read_role',
-        this.database,
+        this.applicationScope,
         this.workspace.id
       )
     },
@@ -153,11 +174,11 @@ export default {
     },
     async fetchMembers() {
       try {
-        if (this.canManageDatabase) {
+        if (this.canManageApplication) {
           const { data: databaseRoleAssignments } =
             await RoleAssignmentsService(this.$client).getRoleAssignments(
               this.workspace.id,
-              this.database.id,
+              this.applicationScope.id,
               'application'
             )
           this.databaseRoleAssignments = databaseRoleAssignments
@@ -210,7 +231,7 @@ export default {
         'auth.User',
         role,
         'application',
-        this.database.id
+        this.applicationScope.id
       )
       this.databaseRoleAssignments =
         this.databaseRoleAssignments.concat(roleAssignments)
@@ -221,7 +242,7 @@ export default {
         'baserow_enterprise.Team',
         role,
         'application',
-        this.database.id
+        this.applicationScope.id
       )
       this.databaseRoleAssignments =
         this.databaseRoleAssignments.concat(roleAssignments)

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesTab.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesTab.vue
@@ -3,7 +3,10 @@
     <div class="member-roles-tab__header">
       <h2 class="member-roles-tab__header-title">
         {{
-          $t(`memberRolesTab.${translationPrefix}.title`, { name: scope.name })
+          $t(`memberRolesTab.${translationPrefix}.title`, {
+            name: scope.name,
+            type: scopeTypeName,
+          })
         }}
       </h2>
       <div>
@@ -78,6 +81,11 @@ export default {
       type: String,
       required: true,
     },
+    scopeTypeName: {
+      type: String,
+      required: false,
+      default: '',
+    },
     roleAssignments: {
       type: Array,
       required: false,
@@ -106,6 +114,8 @@ export default {
     },
     translationPrefix() {
       switch (this.scopeType) {
+        case 'application':
+          return 'application'
         case 'database':
           return 'database'
         case 'database_table':
@@ -113,7 +123,7 @@ export default {
         case 'database_view':
           return 'view'
         default:
-          return 'database'
+          return 'application'
       }
     },
     descriptionText() {

--- a/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesTab.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/components/member-roles/MemberRolesTab.vue
@@ -2,16 +2,11 @@
   <div>
     <div class="member-roles-tab__header">
       <h2 class="member-roles-tab__header-title">
-        {{
-          $t(`memberRolesTab.${translationPrefix}.title`, {
-            name: scope.name,
-            type: scopeTypeName,
-          })
-        }}
+        {{ $t('memberRolesTab.title', translationParams) }}
       </h2>
       <div>
         <HelpIcon
-          :tooltip="$t(`memberRolesTab.${translationPrefix}.headerTooltip`)"
+          :tooltip="$t('memberRolesTab.headerTooltip', translationParams)"
           class="margin-right-1"
         ></HelpIcon>
         <Button
@@ -19,17 +14,17 @@
           :disabled="loading"
           :loading="loading"
           @click="loading ? null : $refs.roleAssignmentModal.show()"
-          >{{ $t(`memberRolesTab.${translationPrefix}.selectMembers`) }}</Button
+          >{{ $t('memberRolesTab.selectMembers') }}</Button
         >
       </div>
     </div>
     <div v-if="loading" class="loading"></div>
     <div v-else>
       <Alert type="warning">
-        <template #title>{{
-          $t(`memberRolesTab.${translationPrefix}.warningTitle`)
-        }}</template>
-        <p>{{ $t(`memberRolesTab.${translationPrefix}.warningMessage`) }}</p>
+        <template #title>{{ $t('memberRolesTab.warningTitle') }}</template>
+        <p>
+          {{ $t('memberRolesTab.warningMessage', translationParams) }}
+        </p>
       </Alert>
       <MemberRolesMembersList
         :role-assignments="roleAssignments"
@@ -61,6 +56,24 @@ import { mapGetters } from 'vuex'
 import MemberRolesMembersList from '@baserow_enterprise/components/member-roles/MemberRolesMembersList'
 import RoleAssignmentModal from '@baserow_enterprise/components/member-roles/RoleAssignmentModal'
 
+const MEMBER_ROLE_SCOPE_CONFIG = {
+  application: {
+    type: 'application',
+    parent: ['workspace'],
+    overrides: ['workspace'],
+  },
+  database_table: {
+    type: 'table',
+    parent: ['database', 'workspace'],
+    overrides: ['workspace', 'database'],
+  },
+  database_view: {
+    type: 'view',
+    parent: ['table', 'database', 'workspace'],
+    overrides: ['workspace', 'database', 'table'],
+  },
+}
+
 export default {
   name: 'MemberRolesTab',
   emits: ['invite-members', 'invite-teams', 'role-updated'],
@@ -81,11 +94,6 @@ export default {
       type: String,
       required: true,
     },
-    scopeTypeName: {
-      type: String,
-      required: false,
-      default: '',
-    },
     roleAssignments: {
       type: Array,
       required: false,
@@ -102,39 +110,33 @@ export default {
       default: false,
     },
   },
-  data() {
-    return {
-      isSharedWithEveryone: true,
-    }
-  },
   computed: {
     ...mapGetters({ userId: 'auth/getUserId' }),
     scopeId() {
       return this.scope.id || null
     },
-    translationPrefix() {
-      switch (this.scopeType) {
-        case 'application':
-          return 'application'
-        case 'database':
-          return 'database'
-        case 'database_table':
-          return 'table'
-        case 'database_view':
-          return 'view'
-        default:
-          return 'application'
+    memberRoleScope() {
+      const config =
+        MEMBER_ROLE_SCOPE_CONFIG[this.scopeType] ||
+        MEMBER_ROLE_SCOPE_CONFIG.application
+
+      return {
+        ...config,
+        type: this.scopeLabel(config.type),
+        parent: this.formatScopeLabels(config.parent, 'disjunction'),
+        overrides: this.formatScopeLabels(config.overrides, 'conjunction'),
       }
     },
-    descriptionText() {
-      return this.isSharedWithEveryone
-        ? this.$t(
-            `memberRolesTab.${this.translationPrefix}.everyoneHasAccess`,
-            {
-              name: this.scope.name,
-            }
-          )
-        : this.$t(`memberRolesTab.${this.translationPrefix}.onlyYouHaveAccess`)
+    translationParams() {
+      return {
+        name: this.scope.name,
+        type: this.memberRoleScope.type,
+        parent: this.memberRoleScope.parent,
+        overrides: this.memberRoleScope.overrides,
+      }
+    },
+    locale() {
+      return this.$i18n.locale?.value || this.$i18n.locale
     },
     userRoleAssignments() {
       return this.roleAssignments.filter(
@@ -160,6 +162,35 @@ export default {
     teamsNotInvited() {
       const teamIds = this.teamRoleAssignments.map(({ subject }) => subject.id)
       return this.teams.filter(({ id }) => !teamIds.includes(id))
+    },
+  },
+  methods: {
+    scopeLabel(scope) {
+      let label = null
+
+      switch (scope) {
+        case 'application':
+          label = this.$registry.get('application', this.scope.type).getName()
+          break
+        case 'table':
+          label = this.$t('trashType.table')
+          break
+        case 'view':
+          label = this.$t('trashType.view')
+          break
+        case 'workspace':
+          label = this.$t('common.workspace')
+          break
+      }
+
+      return label?.toLocaleLowerCase(this.locale) || scope
+    },
+    formatScopeLabels(scopes, type) {
+      const labels = scopes.map((scope) => this.scopeLabel(scope))
+      return new Intl.ListFormat(this.locale, {
+        style: 'long',
+        type,
+      }).format(labels)
     },
   },
 }

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -314,6 +314,15 @@
     }
   },
   "memberRolesTab": {
+    "application": {
+      "title": "{name} {type}",
+      "selectMembers": "Select members",
+      "everyoneHasAccess": "Everyone at {name} workspace can access this application.",
+      "onlyYouHaveAccess": "Only you can access this application.",
+      "warningTitle": "Other users might inherit access!",
+      "warningMessage": "Other users might inherit access via their respective roles on the parent workspace.",
+      "headerTooltip": "Application roles will override workspace roles."
+    },
     "database": {
       "title": "{name} database",
       "selectMembers": "Select members",

--- a/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
+++ b/enterprise/web-frontend/modules/baserow_enterprise/locales/en.json
@@ -314,42 +314,13 @@
     }
   },
   "memberRolesTab": {
-    "application": {
-      "title": "{name} {type}",
-      "selectMembers": "Select members",
-      "everyoneHasAccess": "Everyone at {name} workspace can access this application.",
-      "onlyYouHaveAccess": "Only you can access this application.",
-      "warningTitle": "Other users might inherit access!",
-      "warningMessage": "Other users might inherit access via their respective roles on the parent workspace.",
-      "headerTooltip": "Application roles will override workspace roles."
-    },
-    "database": {
-      "title": "{name} database",
-      "selectMembers": "Select members",
-      "everyoneHasAccess": "Everyone at {name} workspace can access this database.",
-      "onlyYouHaveAccess": "Only you can access this database.",
-      "warningTitle": "Other users might inherit access!",
-      "warningMessage": "Other users might inherit access via their respective roles on the parent workspace.",
-      "headerTooltip": "Database roles will override workspace roles."
-    },
-    "table": {
-      "title": "{name} table",
-      "selectMembers": "Select members",
-      "everyoneHasAccess": "Everyone at {name} workspace can access this table.",
-      "onlyYouHaveAccess": "Only you can access this table.",
-      "warningTitle": "Other users might inherit access!",
-      "warningMessage": "Other users might inherit access via their respective roles on the parent database or workspace.",
-      "headerTooltip": "Table roles will override workspace and database roles."
-    },
-    "view": {
-      "title": "{name} view",
-      "selectMembers": "Select members",
-      "everyoneHasAccess": "Everyone at {name} workspace can access this view.",
-      "onlyYouHaveAccess": "Only you can access this view.",
-      "warningTitle": "Other users might inherit access!",
-      "warningMessage": "Other users might inherit access via their respective roles on the parent table, database or workspace.",
-      "headerTooltip": "View roles will override workspace, database, and table roles."
-    }
+    "title": "{name} {type}",
+    "selectMembers": "Select members",
+    "everyoneHasAccess": "Everyone at {name} workspace can access this {type}.",
+    "onlyYouHaveAccess": "Only you can access this {type}.",
+    "warningTitle": "Other users might inherit access!",
+    "warningMessage": "Other users might inherit access via their respective roles on the parent {parent}.",
+    "headerTooltip": "Roles on this {type} will override {overrides} roles."
   },
   "memberRolesShareToggle": {
     "label": "Share with everyone at {name}",

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -43,13 +43,7 @@ export class EnterprisePlugin extends BaserowPlugin {
       applicationComponents.push(MemberRolesApplicationContextItem)
     }
 
-    return {
-      database: applicationComponents,
-      builder: applicationComponents,
-      automation: applicationComponents,
-      dashboard: applicationComponents,
-      [application.type]: applicationComponents,
-    }
+    return applicationComponents
   }
 
   getAdditionalApplicationChildContextComponents(workspace, application, item) {

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -33,7 +33,7 @@ export class EnterprisePlugin extends BaserowPlugin {
   }
 
   getAdditionalApplicationContextComponents(workspace, application) {
-    const additionalComponents = []
+    const databaseComponents = []
     const hasReadRolePermission = this.app.$hasPermission(
       'application.read_role',
       application,
@@ -43,26 +43,39 @@ export class EnterprisePlugin extends BaserowPlugin {
       hasReadRolePermission &&
       application.type === DatabaseApplicationType.getType()
     ) {
-      additionalComponents.push(MemberRolesDatabaseContextItem)
+      databaseComponents.push(MemberRolesDatabaseContextItem)
     }
-    return additionalComponents
+
+    return {
+      database: databaseComponents,
+      builder: [],
+      automation: [],
+    }
+  }
+
+  getAdditionalApplicationChildContextComponents(workspace, application, item) {
+    const databaseComponents = []
+
+    if (application.type === DatabaseApplicationType.getType()) {
+      if (
+        this.app.$hasPermission('database.table.read_role', item, workspace.id)
+      ) {
+        databaseComponents.push(MemberRolesTableContextItem)
+      }
+      databaseComponents.push(DateDependencyMenuItem)
+    }
+
+    return {
+      database: databaseComponents,
+      builder: [],
+      automation: [],
+    }
   }
 
   getRightSidebarWorkspaceComponents(workspace) {
     const rightSidebarItems = []
     rightSidebarItems.push(AssistantPanel)
     return rightSidebarItems
-  }
-
-  getAdditionalTableContextComponents(workspace, table) {
-    const out = []
-    if (
-      this.app.$hasPermission('database.table.read_role', table, workspace.id)
-    ) {
-      out.push(MemberRolesTableContextItem)
-    }
-    out.push(DateDependencyMenuItem)
-    return out
   }
 
   getGridViewFieldTypeIconsBefore(workspace, view, field) {

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -47,22 +47,19 @@ export class EnterprisePlugin extends BaserowPlugin {
   }
 
   getAdditionalApplicationChildContextComponents(workspace, application, item) {
+    if (application.type !== DatabaseApplicationType.getType()) {
+      return []
+    }
+
     const databaseComponents = []
-
-    if (application.type === DatabaseApplicationType.getType()) {
-      if (
-        this.app.$hasPermission('database.table.read_role', item, workspace.id)
-      ) {
-        databaseComponents.push(MemberRolesTableContextItem)
-      }
-      databaseComponents.push(DateDependencyMenuItem)
+    if (
+      this.app.$hasPermission('database.table.read_role', item, workspace.id)
+    ) {
+      databaseComponents.push(MemberRolesTableContextItem)
     }
+    databaseComponents.push(DateDependencyMenuItem)
 
-    return {
-      database: databaseComponents,
-      builder: [],
-      automation: [],
-    }
+    return databaseComponents
   }
 
   getRightSidebarWorkspaceComponents(workspace) {

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -1,7 +1,7 @@
 import { BaserowPlugin } from '@baserow/modules/core/plugins'
 import ChatwootSupportSidebarWorkspace from '@baserow_enterprise/components/ChatwootSupportSidebarWorkspace'
 import AuditLogSidebarWorkspace from '@baserow_enterprise/components/AuditLogSidebarWorkspace'
-import MemberRolesDatabaseContextItem from '@baserow_enterprise/components/member-roles/MemberRolesDatabaseContextItem'
+import MemberRolesApplicationContextItem from '@baserow_enterprise/components/member-roles/MemberRolesApplicationContextItem'
 import MemberRolesTableContextItem from '@baserow_enterprise/components/member-roles/MemberRolesTableContextItem'
 import MemberRolesViewContextItem from '@baserow_enterprise/components/member-roles/MemberRolesViewContextItem'
 import EnterpriseFeatures from '@baserow_enterprise/features'
@@ -33,23 +33,21 @@ export class EnterprisePlugin extends BaserowPlugin {
   }
 
   getAdditionalApplicationContextComponents(workspace, application) {
-    const databaseComponents = []
+    const applicationComponents = []
     const hasReadRolePermission = this.app.$hasPermission(
       'application.read_role',
       application,
       workspace.id
     )
-    if (
-      hasReadRolePermission &&
-      application.type === DatabaseApplicationType.getType()
-    ) {
-      databaseComponents.push(MemberRolesDatabaseContextItem)
+    if (hasReadRolePermission) {
+      applicationComponents.push(MemberRolesApplicationContextItem)
     }
 
     return {
-      database: databaseComponents,
-      builder: [],
-      automation: [],
+      database: applicationComponents,
+      builder: applicationComponents,
+      automation: applicationComponents,
+      [application.type]: applicationComponents,
     }
   }
 

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -47,6 +47,7 @@ export class EnterprisePlugin extends BaserowPlugin {
       database: applicationComponents,
       builder: applicationComponents,
       automation: applicationComponents,
+      dashboard: applicationComponents,
       [application.type]: applicationComponents,
     }
   }

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -16,6 +16,7 @@
     "optional": "Optional",
     "or": "or",
     "and": "and",
+    "workspace": "workspace",
     "monday": "Monday",
     "tuesday": "Tuesday",
     "wednesday": "Wednesday",

--- a/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
+++ b/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
@@ -31,6 +31,19 @@
       </div>
       <ul class="context__menu">
         <li
+          v-for="(component, index) in additionalContextComponents"
+          :key="index"
+          class="context__menu-item"
+          @click="$refs.context.hide()"
+        >
+          <component
+            :is="component"
+            :application="automation"
+            :automation="automation"
+            :workflow="workflow"
+          ></component>
+        </li>
+        <li
           v-if="
             $hasPermission(
               'automation.workflow.update',
@@ -122,6 +135,7 @@ export default {
   computed: {
     showOptions() {
       return (
+        this.additionalContextComponents.length > 0 ||
         this.$hasPermission(
           'automation.workflow.run_export',
           this.workflow,
@@ -138,6 +152,19 @@ export default {
           this.automation.workspace.id
         )
       )
+    },
+    additionalContextComponents() {
+      return Object.values(this.$registry.getAll('plugin'))
+        .reduce((components, plugin) => {
+          const componentsByType =
+            plugin.getAdditionalApplicationChildContextComponents(
+              this.automation.workspace,
+              this.automation,
+              this.workflow
+            )
+          return components.concat(componentsByType?.automation || [])
+        }, [])
+        .filter((component) => component !== null)
     },
     ...mapGetters({ duplicateJob: 'automationWorkflow/getDuplicateJob' }),
   },

--- a/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
+++ b/web-frontend/modules/automation/components/sidebar/SidebarItemAutomation.vue
@@ -156,13 +156,13 @@ export default {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce((components, plugin) => {
-          const componentsByType =
+          return components.concat(
             plugin.getAdditionalApplicationChildContextComponents(
               this.automation.workspace,
               this.automation,
               this.workflow
             )
-          return components.concat(componentsByType?.automation || [])
+          )
         }, [])
         .filter((component) => component !== null)
     },

--- a/web-frontend/modules/automation/store/automationWorkflowNode.js
+++ b/web-frontend/modules/automation/store/automationWorkflowNode.js
@@ -158,7 +158,7 @@ const actions = {
     )
   },
   async create(
-    { commit, dispatch, getters, rootGetters },
+    { commit, dispatch, getters },
     { workflow, type, referenceNode, position, output }
   ) {
     // Using the `previousNodeId` and `previousNodeOutput` to determine
@@ -202,17 +202,9 @@ const actions = {
       // Remove temp node and add real one
       commit('DELETE_ITEM', { workflow, nodeId: tempNode.id })
 
-      const automation = rootGetters['application/get'](workflow.automation_id)
-      if (
-        automation?.workspace &&
-        rootGetters['workspace/haveWorkspacePermissionsBeenLoaded'](
-          automation.workspace.id
-        )
-      ) {
-        await dispatch('workspace/forceFetchPermissions', automation.workspace, {
-          root: true,
-        })
-      }
+      await dispatch('application/refreshPermissions', workflow.automation_id, {
+        root: true,
+      })
 
       setTimeout(() => {
         const populatedNode = getters.findById(workflow, node.id)

--- a/web-frontend/modules/automation/store/automationWorkflowNode.js
+++ b/web-frontend/modules/automation/store/automationWorkflowNode.js
@@ -158,7 +158,7 @@ const actions = {
     )
   },
   async create(
-    { commit, dispatch, getters },
+    { commit, dispatch, getters, rootGetters },
     { workflow, type, referenceNode, position, output }
   ) {
     // Using the `previousNodeId` and `previousNodeOutput` to determine
@@ -201,6 +201,18 @@ const actions = {
 
       // Remove temp node and add real one
       commit('DELETE_ITEM', { workflow, nodeId: tempNode.id })
+
+      const automation = rootGetters['application/get'](workflow.automation_id)
+      if (
+        automation?.workspace &&
+        rootGetters['workspace/haveWorkspacePermissionsBeenLoaded'](
+          automation.workspace.id
+        )
+      ) {
+        await dispatch('workspace/forceFetchPermissions', automation.workspace, {
+          root: true,
+        })
+      }
 
       setTimeout(() => {
         const populatedNode = getters.findById(workflow, node.id)

--- a/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
+++ b/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
@@ -33,6 +33,19 @@
       <div class="context__menu-title">{{ page.name }} ({{ page.id }})</div>
       <ul class="context__menu">
         <li
+          v-for="(component, index) in additionalContextComponents"
+          :key="index"
+          class="context__menu-item"
+          @click="$refs.context.hide()"
+        >
+          <component
+            :is="component"
+            :application="builder"
+            :builder="builder"
+            :page="page"
+          ></component>
+        </li>
+        <li
           v-if="
             $hasPermission('builder.page.update', page, builder.workspace.id)
           "
@@ -113,6 +126,7 @@ export default {
   computed: {
     showOptions() {
       return (
+        this.additionalContextComponents.length > 0 ||
         this.$hasPermission(
           'builder.page.run_export',
           this.page,
@@ -132,6 +146,19 @@ export default {
     },
     visibilityLoggedIn() {
       return VISIBILITY_LOGGED_IN
+    },
+    additionalContextComponents() {
+      return Object.values(this.$registry.getAll('plugin'))
+        .reduce((components, plugin) => {
+          const componentsByType =
+            plugin.getAdditionalApplicationChildContextComponents(
+              this.builder.workspace,
+              this.builder,
+              this.page
+            )
+          return components.concat(componentsByType?.builder || [])
+        }, [])
+        .filter((component) => component !== null)
     },
     ...mapGetters({ duplicateJob: 'page/getDuplicateJob' }),
   },

--- a/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
+++ b/web-frontend/modules/builder/components/sidebar/SidebarItemBuilder.vue
@@ -150,13 +150,13 @@ export default {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce((components, plugin) => {
-          const componentsByType =
+          return components.concat(
             plugin.getAdditionalApplicationChildContextComponents(
               this.builder.workspace,
               this.builder,
               this.page
             )
-          return components.concat(componentsByType?.builder || [])
+          )
         }, [])
         .filter((component) => component !== null)
     },

--- a/web-frontend/modules/builder/store/dataSource.js
+++ b/web-frontend/modules/builder/store/dataSource.js
@@ -109,6 +109,9 @@ const actions = {
     )
 
     await dispatch('forceCreate', { page, dataSource, beforeId })
+    await dispatch('application/refreshPermissions', page.builder_id, {
+      root: true,
+    })
     commit('SET_LOADING', { page, value: false })
 
     return dataSource

--- a/web-frontend/modules/builder/store/element.js
+++ b/web-frontend/modules/builder/store/element.js
@@ -253,7 +253,7 @@ const actions = {
     commit('SELECT_ITEM', { builder, element })
   },
   async create(
-    { dispatch, rootGetters },
+    { dispatch },
     {
       builder,
       page,
@@ -275,15 +275,7 @@ const actions = {
 
     if (forceCreate) {
       await dispatch('forceCreate', { page, element })
-      if (
-        rootGetters['workspace/haveWorkspacePermissionsBeenLoaded'](
-          builder.workspace.id
-        )
-      ) {
-        await dispatch('workspace/forceFetchPermissions', builder.workspace, {
-          root: true,
-        })
-      }
+      await dispatch('application/refreshPermissions', builder, { root: true })
 
       await dispatch('select', { builder, element })
     }

--- a/web-frontend/modules/builder/store/element.js
+++ b/web-frontend/modules/builder/store/element.js
@@ -253,7 +253,7 @@ const actions = {
     commit('SELECT_ITEM', { builder, element })
   },
   async create(
-    { dispatch },
+    { dispatch, rootGetters },
     {
       builder,
       page,
@@ -275,6 +275,15 @@ const actions = {
 
     if (forceCreate) {
       await dispatch('forceCreate', { page, element })
+      if (
+        rootGetters['workspace/haveWorkspacePermissionsBeenLoaded'](
+          builder.workspace.id
+        )
+      ) {
+        await dispatch('workspace/forceFetchPermissions', builder.workspace, {
+          root: true,
+        })
+      }
 
       await dispatch('select', { builder, element })
     }

--- a/web-frontend/modules/core/components/application/ApplicationContext.vue
+++ b/web-frontend/modules/core/components/application/ApplicationContext.vue
@@ -158,13 +158,11 @@ export default {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
           (components, plugin) => {
-            const componentsByType =
+            return components.concat(
               plugin.getAdditionalApplicationContextComponents(
                 this.workspace,
                 this.application
               )
-            return components.concat(
-              componentsByType?.[this.application.type] || []
             )
           },
           []

--- a/web-frontend/modules/core/components/application/ApplicationContext.vue
+++ b/web-frontend/modules/core/components/application/ApplicationContext.vue
@@ -156,17 +156,14 @@ export default {
   computed: {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
-        .reduce(
-          (components, plugin) => {
-            return components.concat(
-              plugin.getAdditionalApplicationContextComponents(
-                this.workspace,
-                this.application
-              )
+        .reduce((components, plugin) => {
+          return components.concat(
+            plugin.getAdditionalApplicationContextComponents(
+              this.workspace,
+              this.application
             )
-          },
-          []
-        )
+          )
+        }, [])
         .filter((component) => component !== null)
     },
     applicationType() {

--- a/web-frontend/modules/core/components/application/ApplicationContext.vue
+++ b/web-frontend/modules/core/components/application/ApplicationContext.vue
@@ -157,13 +157,16 @@ export default {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
-          (components, plugin) =>
-            components.concat(
+          (components, plugin) => {
+            const componentsByType =
               plugin.getAdditionalApplicationContextComponents(
                 this.workspace,
                 this.application
               )
-            ),
+            return components.concat(
+              componentsByType?.[this.application.type] || []
+            )
+          },
           []
         )
         .filter((component) => component !== null)

--- a/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
@@ -94,17 +94,14 @@ export default {
   computed: {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
-        .reduce(
-          (components, plugin) => {
-            return components.concat(
-              plugin.getAdditionalApplicationContextComponents(
-                this.workspace,
-                this.application
-              )
+        .reduce((components, plugin) => {
+          return components.concat(
+            plugin.getAdditionalApplicationContextComponents(
+              this.workspace,
+              this.application
             )
-          },
-          []
-        )
+          )
+        }, [])
         .filter((component) => component !== null)
     },
     applicationType() {

--- a/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
@@ -96,13 +96,11 @@ export default {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
           (components, plugin) => {
-            const componentsByType =
+            return components.concat(
               plugin.getAdditionalApplicationContextComponents(
                 this.workspace,
                 this.application
               )
-            return components.concat(
-              componentsByType?.[this.application.type] || []
             )
           },
           []

--- a/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarApplication.vue
@@ -95,13 +95,16 @@ export default {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
-          (components, plugin) =>
-            components.concat(
+          (components, plugin) => {
+            const componentsByType =
               plugin.getAdditionalApplicationContextComponents(
                 this.workspace,
                 this.application
               )
-            ),
+            return components.concat(
+              componentsByType?.[this.application.type] || []
+            )
+          },
           []
         )
         .filter((component) => component !== null)

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -138,16 +138,11 @@ export class BaserowPlugin extends Registerable {
   /**
    * Every registered plugin can display multiple additional context items in the
    * application context displayed by the sidebar when opening the context menu of
-   * an application, grouped by application type.
-   * @returns {Object<string, *[] | null>}
+   * an application.
+   * @returns {*[]}
    */
   getAdditionalApplicationContextComponents(workspace, application) {
-    return {
-      database: [],
-      builder: [],
-      automation: [],
-      dashboard: [],
-    }
+    return []
   }
 
   /**

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -146,6 +146,7 @@ export class BaserowPlugin extends Registerable {
       database: [],
       builder: [],
       automation: [],
+      dashboard: [],
     }
   }
 
@@ -166,6 +167,7 @@ export class BaserowPlugin extends Registerable {
       database: [],
       builder: [],
       automation: [],
+      dashboard: [],
     }
   }
 

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -137,22 +137,36 @@ export class BaserowPlugin extends Registerable {
 
   /**
    * Every registered plugin can display multiple additional context items in the
-   * application context displayed by the sidebar when opening the context menu of a
-   * application.
-   * @returns {*[]}
+   * application context displayed by the sidebar when opening the context menu of
+   * an application, grouped by application type.
+   * @returns {Object<string, *[] | null>}
    */
   getAdditionalApplicationContextComponents(workspace, application) {
-    return []
+    return {
+      database: [],
+      builder: [],
+      automation: [],
+    }
   }
 
   /**
    * Every registered plugin can display multiple additional context items in the
-   * table context displayed by the sidebar when opening the context menu of a
-   * table.
-   * @returns {*[]}
+   * context menu of an application child item, grouped by application type.
+   *
+   * For example, the `database` key is used for table context menus, `builder`
+   * for page context menus, and `automation` for workflow context menus.
+   * @returns {Object<string, *[] | null>}
    */
-  getAdditionalTableContextComponents(workspace, table) {
-    return []
+  getAdditionalApplicationChildContextComponents(
+    workspace,
+    application,
+    item
+  ) {
+    return {
+      database: [],
+      builder: [],
+      automation: [],
+    }
   }
 
   /**

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -147,23 +147,15 @@ export class BaserowPlugin extends Registerable {
 
   /**
    * Every registered plugin can display multiple additional context items in the
-   * context menu of an application child item, grouped by application type.
-   *
-   * For example, the `database` key is used for table context menus, `builder`
-   * for page context menus, and `automation` for workflow context menus.
-   * @returns {Object<string, *[] | null>}
+   * context menu of an application child item.
+   * @returns {*[]}
    */
   getAdditionalApplicationChildContextComponents(
     workspace,
     application,
     item
   ) {
-    return {
-      database: [],
-      builder: [],
-      automation: [],
-      dashboard: [],
-    }
+    return []
   }
 
   /**

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -150,11 +150,7 @@ export class BaserowPlugin extends Registerable {
    * context menu of an application child item.
    * @returns {*[]}
    */
-  getAdditionalApplicationChildContextComponents(
-    workspace,
-    application,
-    item
-  ) {
+  getAdditionalApplicationChildContextComponents(workspace, application, item) {
     return []
   }
 

--- a/web-frontend/modules/core/store/application.js
+++ b/web-frontend/modules/core/store/application.js
@@ -182,7 +182,10 @@ export const actions = {
     }
     return getters.get(app.id)
   },
-  async refreshPermissions({ dispatch, getters, rootGetters }, applicationOrId) {
+  async refreshPermissions(
+    { dispatch, getters, rootGetters },
+    applicationOrId
+  ) {
     const application =
       typeof applicationOrId === 'object'
         ? applicationOrId

--- a/web-frontend/modules/core/store/application.js
+++ b/web-frontend/modules/core/store/application.js
@@ -182,6 +182,23 @@ export const actions = {
     }
     return getters.get(app.id)
   },
+  async refreshPermissions({ dispatch, getters, rootGetters }, applicationOrId) {
+    const application =
+      typeof applicationOrId === 'object'
+        ? applicationOrId
+        : getters.get(applicationOrId)
+
+    if (
+      application?.workspace &&
+      rootGetters['workspace/haveWorkspacePermissionsBeenLoaded'](
+        application.workspace.id
+      )
+    ) {
+      await dispatch('workspace/forceFetchPermissions', application.workspace, {
+        root: true,
+      })
+    }
+  },
   /**
    * Updates the values of an existing application.
    */

--- a/web-frontend/modules/dashboard/store/dashboardApplication.js
+++ b/web-frontend/modules/dashboard/store/dashboardApplication.js
@@ -198,10 +198,12 @@ export const actions = {
       commit('DELETE_WIDGET', tempId)
       throw error
     }
-    return await dispatch('handleNewWidgetCreated', {
+    const createdWidget = await dispatch('handleNewWidgetCreated', {
       tempWidgetId: tempId,
       createdWidget: widgetData,
     })
+    await dispatch('application/refreshPermissions', dashboard, { root: true })
+    return createdWidget
   },
   async handleNewWidgetCreated(
     { commit, dispatch },

--- a/web-frontend/modules/database/components/sidebar/SidebarItem.vue
+++ b/web-frontend/modules/database/components/sidebar/SidebarItem.vue
@@ -241,6 +241,7 @@ export default {
   computed: {
     showOptions() {
       return (
+        this.additionalContextComponents.length > 0 ||
         this.$hasPermission(
           'database.table.run_export',
           this.table,
@@ -266,13 +267,15 @@ export default {
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
-          (components, plugin) =>
-            components.concat(
-              plugin.getAdditionalTableContextComponents(
+          (components, plugin) => {
+            const componentsByType =
+              plugin.getAdditionalApplicationChildContextComponents(
                 this.database.workspace,
+                this.database,
                 this.table
               )
-            ),
+            return components.concat(componentsByType?.database || [])
+          },
           []
         )
         .filter((component) => component !== null)

--- a/web-frontend/modules/database/components/sidebar/SidebarItem.vue
+++ b/web-frontend/modules/database/components/sidebar/SidebarItem.vue
@@ -266,18 +266,15 @@ export default {
     },
     additionalContextComponents() {
       return Object.values(this.$registry.getAll('plugin'))
-        .reduce(
-          (components, plugin) => {
-            return components.concat(
-              plugin.getAdditionalApplicationChildContextComponents(
-                this.database.workspace,
-                this.database,
-                this.table
-              )
+        .reduce((components, plugin) => {
+          return components.concat(
+            plugin.getAdditionalApplicationChildContextComponents(
+              this.database.workspace,
+              this.database,
+              this.table
             )
-          },
-          []
-        )
+          )
+        }, [])
         .filter((component) => component !== null)
     },
     syncTooltipOptions() {

--- a/web-frontend/modules/database/components/sidebar/SidebarItem.vue
+++ b/web-frontend/modules/database/components/sidebar/SidebarItem.vue
@@ -268,13 +268,13 @@ export default {
       return Object.values(this.$registry.getAll('plugin'))
         .reduce(
           (components, plugin) => {
-            const componentsByType =
+            return components.concat(
               plugin.getAdditionalApplicationChildContextComponents(
                 this.database.workspace,
                 this.database,
                 this.table
               )
-            return components.concat(componentsByType?.database || [])
+            )
           },
           []
         )


### PR DESCRIPTION
### What is in this PR

Add the RBAC modal to manage member access to all application types: builder, automation and dashboard.

### How to test this PR

On this branch:
- Check you can open the member modal for all application type now
- Assign two users to each application type:
  - One builder with no access
  - One editor with builder access
- And check they have or not access to these application according to their new role.
- Check if the user with low default role can actually edit the pages of an application, a dashboald and a workflow (but they should still not be able to create a new one or access other application they are not assigned to)

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
