### PR TITLE
test(isValidEmail): EP, BVA e MC/DC - caixa-preta e caixa-branca

### DIFF
--- a/web-frontend/modules/core/validators.js
+++ b/web-frontend/modules/core/validators.js
@@ -12,3 +12,11 @@ export const passwordValidation = {
   maxLength: maxLength(256),
   minLength: minLength(8),
 }
+
+export function isValidEmail(email) {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!email || typeof email !== 'string') {
+    return false
+  }
+  return emailRegex.test(email.trim())
+}

--- a/web-frontend/test/unit/validators/isValidEmail.spec.js
+++ b/web-frontend/test/unit/validators/isValidEmail.spec.js
@@ -1,0 +1,83 @@
+import { isValidEmail } from '../../../modules/core/validators'
+
+describe('isValidEmail - Testes de Caixa-Preta e Caixa-Branca', () => {
+
+  // ==========================================
+  // CAIXA-PRETA: Particionamento de Equivalência (EP)
+  // ==========================================
+  describe('Caixa-Preta: Particionamento de Equivalência (EP)', () => {
+    test('EP-01: e-mail válido retorna true', () => {
+      expect(isValidEmail('usuario@dominio.com')).toBe(true)
+    })
+
+    test('EP-02: e-mail com subdomínio retorna true', () => {
+      expect(isValidEmail('a@sub.dominio.org')).toBe(true)
+    })
+
+    test('EP-03: sem arroba retorna false', () => {
+      expect(isValidEmail('usuariodominio.com')).toBe(false)
+    })
+
+    test('EP-04: sem extensão de domínio retorna false', () => {
+      expect(isValidEmail('usuario@dominio')).toBe(false)
+    })
+
+    test('EP-05: string vazia retorna false', () => {
+      expect(isValidEmail('')).toBe(false)
+    })
+
+    test('EP-06: null retorna false', () => {
+      expect(isValidEmail(null)).toBe(false)
+    })
+
+    test('EP-07: espaços internos retorna false', () => {
+      expect(isValidEmail('usu ario@dominio.com')).toBe(false)
+    })
+    
+    test('EP-08: dois arrobas retorna false', () => {
+      expect(isValidEmail('a@@dominio.com')).toBe(false)
+    })
+  })
+
+  // ==========================================
+  // CAIXA-PRETA: Análise de Valor Limite (BVA)
+  // ==========================================
+  describe('Caixa-Preta: Análise de Valor Limite (BVA)', () => {
+    test('BVA-01: mínimo válido possível (a@b.c) retorna true', () => {
+      expect(isValidEmail('a@b.c')).toBe(true)
+    })
+
+    test('BVA-02: mínimo inválido (@.) retorna false', () => {
+      expect(isValidEmail('@.')).toBe(false)
+    })
+
+    test('BVA-03: ponto no final do domínio (a@b.) retorna false', () => {
+      expect(isValidEmail('a@b.')).toBe(false)
+    })
+  })
+  // ==========================================
+  // CAIXA-BRANCA: Branch Coverage e MC/DC
+  // ==========================================
+  describe('Caixa-Branca: Cobertura de Branches e MC/DC', () => {
+    
+    // Condição 1 (C1): !email
+    // Condição 2 (C2): typeof email !== 'string'
+
+    test('MC/DC [M1]: email válido (C1=false, C2=false) -> Branch falso (avança pro regex)', () => {
+      // Como não é vazio e é string, passa pelo IF e o regex decide.
+      expect(isValidEmail('teste@teste.com')).toBe(true)
+    })
+
+    test('MC/DC [M2]: email falsy como undefined (C1=true) -> Branch verdadeiro (retorna false)', () => {
+      // Testa a independência da primeira condição
+      expect(isValidEmail(undefined)).toBe(false)
+    })
+
+    test('MC/DC [M3]: tipo não é string, ex: número (C1=false, C2=true) -> Branch verdadeiro (retorna false)', () => {
+      // Testa a independência da segunda condição. Existe um valor (C1=false), mas o tipo é errado (C2=true).
+      // Os testes de Caixa-Preta do PDF não incluíam explicitamente testar a passagem de um número ou objeto!
+      expect(isValidEmail(12345)).toBe(false)
+      expect(isValidEmail(['array@teste.com'])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
**What is in this PR**

* Adiciona a função corrigida `isValidEmail(email)` em `web-frontend/modules/core/validators.js` para validar formatos de e-mail no frontend.
* A função cobre os cenários funcionais e estruturais:
  * e-mail com formato válido retorna `true`
  * e-mail sem `@` ou sem domínio retorna `false`
  * espaços internos ou caracteres inválidos retornam `false`
  * entrada inválida (null, undefined ou string vazia) retorna `false` (Branch Coverage)
  * valor passado com tipo numérico ou array retorna `false` (Tratamento MC/DC para `typeof`)
* Adiciona testes unitários completos de caixa-preta (EP e BVA) e caixa-branca (MC/DC) em `web-frontend/test/unit/validators/isValidEmail.spec.js`.

**How to test this PR**

1. Entrar no pacote frontend:
```bash
cd web-frontend
```
2. Rodar os testes da função (isolados do restante do ecossistema):
```
yarn vitest run test/unit/validators/isValidEmail.spec.js
```
3. Gerar e verificar a cobertura (100%):
```
yarn vitest run test/unit/validators/isValidEmail.spec.js --coverage --coverage.include="**/validators.js"
```
**Checklist**

- [ ] A changelog entry has been added...
- [ ] New/updated Premium/Enterprise features...
- [ ] The latest Chrome and Firefox have been used...
- [ ] Documentation has been updated
- [ ] Quality Standards are met
- [ ] Performance: tables are still fast...
- [ ] The redoc API pages have been updated...
- [ ] Our custom API docs are updated...
- [ ] The UI/UX has been updated following the UI Style Guide
- [x] Security impact of change has been considered

**Notes**

* Mudança é de baixo risco e focada em validação de inputs de formulário no frontend.
* Os testes foram pensados primeiro em caixa-preta (especificação via Regex) e depois complementados com caixa-branca (MC/DC) para garantir a tipagem estrita do JavaScript.
* O relatório do PTOSS-2 já traz a análise das branches, tabelas de EP/BVA e a explicação da estratégia de integração usada.