### PR TITLE
feat: Improve duration support in advanced formulas

### DIFF
--- a/backend/src/baserow/contrib/database/fields/utils/duration.py
+++ b/backend/src/baserow/contrib/database/fields/utils/duration.py
@@ -25,6 +25,7 @@ from baserow.core.duration import (
     H_M_S_S,
     H_M_S_SS,
     H_M_S_SSS,
+    format_value_with_duration_format,
     parse_duration_value,
     postgres_interval_to_seconds,  # noqa: F401
 )
@@ -189,6 +190,25 @@ DURATION_FORMATS = {
             r"(\d+\.?\d*)s",
         ),
     },
+}
+
+
+# Maps each field `DURATION_FORMATS` key to the equivalent token-engine format
+# consumed by `format_value_with_duration_format`. The `s`-fraction forms become
+# `f` runs, and the `d`-prefixed display formats use backslash-escaped literal
+# unit letters (e.g. `d\d h\h` -> "1d 2h"), which the token engine cannot emit
+# otherwise. Keep in sync with duration.js::DURATION_TOKEN_FORMATS.
+DURATION_TOKEN_FORMATS = {
+    H_M: "h:mm",
+    H_M_S: "h:mm:ss",
+    H_M_S_S: "h:mm:ss.f",
+    H_M_S_SS: "h:mm:ss.ff",
+    H_M_S_SSS: "h:mm:ss.fff",
+    D_H: r"d\d h\h",
+    D_H_M: r"d\d h:mm",
+    D_H_M_S: r"d\d h:mm:ss",
+    D_H_M_NO_COLONS: r"d\d h\h mm\m",
+    D_H_M_S_NO_COLONS: r"d\d h\h mm\m ss\s",
 }
 
 
@@ -392,24 +412,20 @@ def format_duration_value(
     """
     Format a duration value according to the provided format.
 
+    Thin adapter over the token formatter
+    (`baserow.core.duration.format_value_with_duration_format`), which is the
+    single source of truth for duration display. The field's `DURATION_FORMATS`
+    key is translated to the equivalent token format first; both take a
+    `timedelta`, so no value conversion is needed.
+
     :param duration: The duration to format.
     :param duration_format: The format to use.
     :return: The formatted duration.
     """
 
-    if duration is None:
-        return None
-    sign = ""
-    if duration < timedelta(0):
-        duration = -1 * duration
-        sign = "-"
-    days = duration.days
-    hours = duration.seconds // 3600
-    mins = duration.seconds % 3600 // 60
-    secs = duration.seconds % 60 + duration.microseconds / 10**6
-
-    format_func = DURATION_FORMATS[duration_format]["format_func"]
-    return f"{sign}{format_func(days, hours, mins, secs)}"
+    return format_value_with_duration_format(
+        duration, DURATION_TOKEN_FORMATS[duration_format]
+    )
 
 
 def tokenize_formatted_duration(duration_format: str) -> List[str]:

--- a/backend/src/baserow/core/apps.py
+++ b/backend/src/baserow/core/apps.py
@@ -47,6 +47,7 @@ class CoreConfig(AppConfig):
             RuntimeDateTimeFormat,
             RuntimeDay,
             RuntimeDivide,
+            RuntimeDurationFormat,
             RuntimeEqual,
             RuntimeGenerateUUID,
             RuntimeGet,
@@ -141,6 +142,7 @@ class CoreConfig(AppConfig):
         formula_runtime_function_registry.register(RuntimeNull())
         formula_runtime_function_registry.register(RuntimeNumberFormat())
         formula_runtime_function_registry.register(RuntimeToDuration())
+        formula_runtime_function_registry.register(RuntimeDurationFormat())
         formula_runtime_function_registry.register(RuntimeToDatetime())
 
         from baserow.core.permission_manager import (

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -37,7 +37,7 @@ def tokenize_duration_format(
     duration unit ("d", "hh", etc) can appear at most once. All other
     characters are matched literally.
 
-    E.g. given a format_str like "d h:mm", the return value would be:
+    E.g. given a format_str like "h:mm:ss", the return value would be:
     (
         re.compile("^-?(\\d+):(\\d+):(\\d+)$"),
         ["hours", "minutes", "seconds"]

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -54,12 +54,23 @@ def tokenize_duration_format(
     seen = set()
     i = 0
     while i < len(format_str):
+        # A backslash escapes the next character so it is matched/emitted as a
+        # literal, even token letters (d/h/m/s/f) or the backslash itself. This
+        # lets formats carry literal unit suffixes, e.g. `d\d h\h` -> "1d 2h".
+        # A trailing backslash has nothing to escape and is invalid. Keep in
+        # sync with duration.js::tokenizeDurationFormat.
+        if format_str[i] == "\\":
+            if i + 1 >= len(format_str):
+                return None
+            pattern.append(re.escape(format_str[i + 1]))
+            i += 2
+            continue
+
         # The fractional-seconds token "f" is consumed as a run ("f", "ff",
         # "fff", …) whose length is the precision (mirrors the hh/mm/ss width
         # semantics). It is a distinct field that may appear at most once, and
         # the separator before it stays a literal so arbitrary delimiters work
-        # ("ss.fff", "s fff", "mm:ss,ff"). Keep in sync with
-        # duration.js::tokenizeDurationFormat.
+        # ("ss.fff", "s fff", "mm:ss,ff").
         if format_str[i] == "f":
             if "fraction" in seen:
                 return None
@@ -154,6 +165,29 @@ def parse_value_with_duration_format(
     return -delta if negative else delta
 
 
+def _fraction_precision(format_str: str) -> int:
+    """
+    Return the precision (length of the `f` run) of a validated token format,
+    or 0 if it has no fractional token. Walks the format honoring backslash
+    escapes so an escaped `\\f` literal is not mistaken for the fraction token.
+    Keep in sync with duration.js::fractionPrecision.
+    """
+
+    i = 0
+    while i < len(format_str):
+        if format_str[i] == "\\":
+            i += 2
+            continue
+        if format_str[i] == "f":
+            precision = 0
+            while i < len(format_str) and format_str[i] == "f":
+                precision += 1
+                i += 1
+            return precision
+        i += 1
+    return 0
+
+
 # Keep in sync with duration.js::formatValueWithDurationFormat
 def format_value_with_duration_format(
     duration: timedelta, format_str: object
@@ -180,10 +214,7 @@ def format_value_with_duration_format(
 
     # Precision is the number of `f`s in the format, or 0 for integer-second
     # formats (no fraction token).
-    if "fraction" in field_set:
-        precision = len(re.search(r"f+", format_str).group())
-    else:
-        precision = 0
+    precision = _fraction_precision(format_str) if "fraction" in field_set else 0
 
     # Round the total to the target precision *before* decomposing, so a
     # rounded-up value carries across fields: 59.9996 at precision 3 -> 60.000
@@ -235,6 +266,13 @@ def format_value_with_duration_format(
     out = []
     i = 0
     while i < len(format_str):
+        if format_str[i] == "\\":
+            # Escaped literal — emit the next character verbatim. The format is
+            # already validated (tokenize succeeded), so a following char exists.
+            out.append(format_str[i + 1])
+            i += 2
+            continue
+
         if format_str[i] == "f":
             # Render the fractional component as `precision` zero-padded digits
             # (mirrors printf's %0width.Nf).

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -54,6 +54,25 @@ def tokenize_duration_format(
     seen = set()
     i = 0
     while i < len(format_str):
+        # The fractional-seconds token "f" is consumed as a run ("f", "ff",
+        # "fff", …) whose length is the precision (mirrors the hh/mm/ss width
+        # semantics). It is a distinct field that may appear at most once, and
+        # the separator before it stays a literal so arbitrary delimiters work
+        # ("ss.fff", "s fff", "mm:ss,ff"). Keep in sync with
+        # duration.js::tokenizeDurationFormat.
+        if format_str[i] == "f":
+            if "fraction" in seen:
+                return None
+            seen.add("fraction")
+            precision = 0
+            while i < len(format_str) and format_str[i] == "f":
+                precision += 1
+                i += 1
+            fields.append("fraction")
+            # capture up to `precision` digits; extra digits won't match
+            pattern.append(rf"(\d{{1,{precision}}})")
+            continue
+
         matched = False
         for token, field in DURATION_FORMAT_TOKENS:
             if format_str.startswith(token, i):
@@ -117,14 +136,20 @@ def parse_value_with_duration_format(
         return None
 
     parts = {"days": 0, "hours": 0, "minutes": 0, "seconds": 0}
+    fraction_seconds = 0.0
     for field, group in zip(fields, match.groups()):
-        parts[field] = int(group)
+        if field == "fraction":
+            # The captured digits are a positional decimal: "5" -> 0.5,
+            # "05" -> 0.05, "234" -> 0.234.
+            fraction_seconds = int(group) / 10 ** len(group)
+        else:
+            parts[field] = int(group)
 
     delta = timedelta(
         days=parts["days"],
         hours=parts["hours"],
         minutes=parts["minutes"],
-        seconds=parts["seconds"],
+        seconds=parts["seconds"] + fraction_seconds,
     )
     return -delta if negative else delta
 
@@ -152,7 +177,20 @@ def format_value_with_duration_format(
 
     negative = duration < timedelta(0)
     abs_duration = -duration if negative else duration
-    total_seconds = int(abs_duration.total_seconds())
+
+    if "fraction" in field_set:
+        # Render fractional seconds at the format's precision (the number of
+        # `f`s). Round the total to that precision *before* decomposing so a
+        # rounded-up value carries across fields (e.g. 59.9996 at precision 3
+        # -> 60.000 rolls seconds into minutes).
+        precision = len(re.search(r"f+", format_str).group())
+        total = round(abs_duration.total_seconds(), precision)
+        total_seconds = int(total)
+        fraction_value = total - total_seconds
+    else:
+        total_seconds = int(abs_duration.total_seconds())
+        fraction_value = 0.0
+        precision = 0
 
     if "days" in field_set:
         days = total_seconds // 86400
@@ -193,6 +231,14 @@ def format_value_with_duration_format(
     out = []
     i = 0
     while i < len(format_str):
+        if format_str[i] == "f":
+            # Render the fractional component as `precision` zero-padded digits
+            # (mirrors printf's %0width.Nf).
+            digits = round(fraction_value * (10**precision))
+            out.append(f"{digits:0{precision}d}")
+            i += precision
+            continue
+
         matched = False
         for token, field in DURATION_FORMAT_TOKENS:
             if format_str.startswith(token, i):

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -178,19 +178,23 @@ def format_value_with_duration_format(
     negative = duration < timedelta(0)
     abs_duration = -duration if negative else duration
 
+    # Precision is the number of `f`s in the format, or 0 for integer-second
+    # formats (no fraction token).
     if "fraction" in field_set:
-        # Render fractional seconds at the format's precision (the number of
-        # `f`s). Round the total to that precision *before* decomposing so a
-        # rounded-up value carries across fields (e.g. 59.9996 at precision 3
-        # -> 60.000 rolls seconds into minutes).
         precision = len(re.search(r"f+", format_str).group())
-        total = round(abs_duration.total_seconds(), precision)
-        total_seconds = int(total)
-        fraction_value = total - total_seconds
     else:
-        total_seconds = int(abs_duration.total_seconds())
-        fraction_value = 0.0
         precision = 0
+
+    # Round the total to the target precision *before* decomposing, so a
+    # rounded-up value carries across fields: 59.9996 at precision 3 -> 60.000
+    # rolls seconds into minutes, and 59.6 at precision 0 -> 60 rolls into a
+    # minute. We round half away from zero on the absolute value (matching the
+    # database field's `rround` and JS `Math.round` on positives, keeping the
+    # backend and frontend formatters byte-identical). Keep in sync with duration.js.
+    factor = 10**precision
+    total = int(abs_duration.total_seconds() * factor + 0.5) / factor
+    total_seconds = int(total)
+    fraction_value = total - total_seconds
 
     if "days" in field_set:
         days = total_seconds // 86400

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -129,6 +129,90 @@ def parse_value_with_duration_format(
     return -delta if negative else delta
 
 
+# Keep in sync with duration.js::formatValueWithDurationFormat
+def format_value_with_duration_format(
+    duration: timedelta, format_str: object
+) -> Optional[str]:
+    """
+    Format a timedelta into a string using a token-based format.
+
+    Returns the formatted string, or None if format_str is invalid or
+    duration is not a timedelta.
+    """
+
+    if not isinstance(duration, timedelta):
+        return None
+
+    tokenized = tokenize_duration_format(format_str)
+    if tokenized is None:
+        return None
+
+    _, fields = tokenized
+    field_set = set(fields)
+
+    negative = duration < timedelta(0)
+    abs_duration = -duration if negative else duration
+    total_seconds = int(abs_duration.total_seconds())
+
+    if "days" in field_set:
+        days = total_seconds // 86400
+    else:
+        days = 0
+
+    if "hours" in field_set:
+        if "days" in field_set:
+            hours = (total_seconds % 86400) // 3600
+        else:
+            hours = total_seconds // 3600
+    else:
+        hours = 0
+
+    if "minutes" in field_set:
+        if "hours" in field_set or "days" in field_set:
+            minutes = (total_seconds % 3600) // 60
+        else:
+            minutes = total_seconds // 60
+    else:
+        minutes = 0
+
+    if "seconds" in field_set:
+        if "minutes" in field_set or "hours" in field_set or "days" in field_set:
+            seconds = total_seconds % 60
+        else:
+            seconds = total_seconds
+    else:
+        seconds = 0
+
+    field_values = {
+        "days": days,
+        "hours": hours,
+        "minutes": minutes,
+        "seconds": seconds,
+    }
+
+    out = []
+    i = 0
+    while i < len(format_str):
+        matched = False
+        for token, field in DURATION_FORMAT_TOKENS:
+            if format_str.startswith(token, i):
+                value = field_values[field]
+                if len(token) == 2:
+                    out.append(f"{value:02d}")
+                else:
+                    out.append(str(value))
+                i += len(token)
+                matched = True
+                break
+
+        if not matched:
+            out.append(format_str[i])
+            i += 1
+
+    result = "".join(out)
+    return f"-{result}" if negative else result
+
+
 DURATION_PATTERNS = [
     (re.compile(r"^(\d+)\s+years?$", re.IGNORECASE), "days", 365),
     (re.compile(r"^(\d+)\s+months?$", re.IGNORECASE), "days", 30),

--- a/backend/src/baserow/core/duration.py
+++ b/backend/src/baserow/core/duration.py
@@ -1,6 +1,6 @@
 import re
 from datetime import timedelta
-from typing import Optional, Union
+from typing import List, Optional, Tuple, Union
 
 H_M = "h:mm"
 H_M_S = "h:mm:ss"
@@ -14,6 +14,120 @@ D_H_M_NO_COLONS = "d h mm"  # 1d 2h 3m, 1d 3m
 D_H_M_S_NO_COLONS = "d h mm ss"  # 1d2h3m4s, 1h 2m
 
 MOST_ACCURATE_DURATION_FORMAT = H_M_S_SSS
+
+# Keep in sync with duration.js::tokenizeDurationFormat
+DURATION_FORMAT_TOKENS = [
+    ("hh", "hours"),
+    ("mm", "minutes"),
+    ("ss", "seconds"),
+    ("d", "days"),
+    ("h", "hours"),
+    ("m", "minutes"),
+    ("s", "seconds"),
+]
+
+
+def tokenize_duration_format(
+    format_str: str,
+) -> Optional[Tuple[re.Pattern[str], List[str]]]:
+    """
+    Compile a duration format string into a (regex, fields) pair.
+
+    The format string is a template like "h:mm" or "d h:mm:ss". Each
+    duration unit ("d", "hh", etc) can appear at most once. All other
+    characters are matched literally.
+
+    E.g. given a format_str like "d h:mm", the return value would be:
+    (
+        re.compile("^-?(\\d+):(\\d+):(\\d+)$"),
+        ["hours", "minutes", "seconds"]
+    )
+
+    Returns None if the format_str is invalid.
+    """
+
+    if not isinstance(format_str, str) or not format_str:
+        return None
+
+    pattern = ["^-?"]
+    fields = []
+    seen = set()
+    i = 0
+    while i < len(format_str):
+        matched = False
+        for token, field in DURATION_FORMAT_TOKENS:
+            if format_str.startswith(token, i):
+                # If the token was already seen, it means that the token
+                # was repeated, which is invalid. E.g. for "h:mm:h", the
+                # "h" token is repeated.
+                if field in seen:
+                    return None
+                else:
+                    seen.add(field)
+
+                fields.append(field)
+                pattern.append(r"(\d+)")
+                # moves the index to the end of the token, e.g.
+                # if the format is "h:mm:s" and the current token is "mm",
+                # we move on to the "s" token.
+                i += len(token)
+                matched = True
+                break
+
+        if not matched:
+            # If there is no match, that means it's a literal char, like an
+            # empty space, colon, etc, which we add to the regex as-is.
+            pattern.append(re.escape(format_str[i]))
+            i += 1
+
+    if not fields:
+        return None
+
+    pattern.append("$")
+    return re.compile("".join(pattern)), fields
+
+
+def is_valid_duration_format(value: object) -> bool:
+    """Return True if the value is a valid duration format string."""
+
+    return tokenize_duration_format(value) is not None
+
+
+def parse_value_with_duration_format(
+    value: object, format_str: object
+) -> Optional[timedelta]:
+    """
+    Parse value against format_str using token-based matching.
+
+    Returns a timedelta, or None if the value or format_str are invalid.
+    """
+
+    if not isinstance(value, str):
+        return None
+
+    tokenized = tokenize_duration_format(format_str)
+    if tokenized is None:
+        return None
+
+    regex, fields = tokenized
+    stripped = value.strip()
+    negative = stripped.startswith("-")
+    match = regex.match(stripped)
+    if match is None:
+        return None
+
+    parts = {"days": 0, "hours": 0, "minutes": 0, "seconds": 0}
+    for field, group in zip(fields, match.groups()):
+        parts[field] = int(group)
+
+    delta = timedelta(
+        days=parts["days"],
+        hours=parts["hours"],
+        minutes=parts["minutes"],
+        seconds=parts["seconds"],
+    )
+    return -delta if negative else delta
+
 
 DURATION_PATTERNS = [
     (re.compile(r"^(\d+)\s+years?$", re.IGNORECASE), "days", 365),

--- a/backend/src/baserow/core/formula/argument_types.py
+++ b/backend/src/baserow/core/formula/argument_types.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 
 import pytz
 
+from baserow.core.duration import is_valid_duration_format
 from baserow.core.formula.utils.date import (
     is_valid_datetime_format,
 )
@@ -237,4 +238,21 @@ class DatetimeFormatBaserowRuntimeFormulaArgumentType(
         return (
             f"'{value}' is not a valid datetime format. "
             f"Examples: 'YYYY-MM-DD' or 'DD/MM/YYYY HH:mm:ss'."
+        )
+
+
+class DurationFormatBaserowRuntimeFormulaArgumentType(
+    BaserowRuntimeFormulaArgumentType
+):
+    def test(self, value):
+        return is_valid_duration_format(value)
+
+    def parse(self, value):
+        return ensure_string(value)
+
+    def get_error_message(self, value) -> Optional[str]:
+        return (
+            f"'{value}' is not a valid duration format. "
+            f"Use 'd' (days), 'h' (hours), 'm' (minutes), 's' (seconds), "
+            f"e.g. 'd:h', 'd h:mm:ss'."
         )

--- a/backend/src/baserow/core/formula/parser/formula_validation_visitor.py
+++ b/backend/src/baserow/core/formula/parser/formula_validation_visitor.py
@@ -132,27 +132,26 @@ class BaserowFormulaValidationVisitor(BaserowFormulaVisitor):
         Parse arguments for validation, skipping DeferredValue instances.
 
         During validation, nested function calls return DeferredValue markers
-        since their actual values aren't available yet. We pass these through
-        unchanged rather than attempting to parse/cast them.
+        since their actual values aren't available yet. When any arg is deferred
+        we pass the list through unchanged and the caller should detect the
+        DeferredValue and skip validate_args.
+
+        Otherwise we defer to the function type's `parse_args` so per-function
+        overrides (e.g. RuntimeToDuration leaving arg 0 as a string when a
+        format is provided) take effect during validation too.
 
         :param formula_function_type: The function type with arg definitions.
         :param accepted_args: The arguments from visiting child expressions.
-        :return: Parsed arguments with DeferredValue instances preserved.
+        :return: Parsed arguments, or the original list if any are deferred.
         """
 
         if formula_function_type.args is None:
             return accepted_args
 
-        result = []
-        for index, arg in enumerate(accepted_args):
-            if isinstance(arg, DeferredValue):
-                # Preserve deferred values - they'll be resolved at execution time
-                result.append(arg)
-            elif index < len(formula_function_type.args):
-                result.append(formula_function_type.args[index].parse(arg))
-            else:
-                result.append(arg)
-        return result
+        if any(isinstance(arg, DeferredValue) for arg in accepted_args):
+            return accepted_args
+
+        return formula_function_type.parse_args(accepted_args)
 
     def visitFunctionCall(
         self, ctx: BaserowFormula.FunctionCallContext, function_name: str = None

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -103,7 +103,12 @@ class RuntimeAdd(RuntimeFormulaFunction):
             num = NumberBaserowRuntimeFormulaArgumentType()
             dt = DateTimeBaserowRuntimeFormulaArgumentType()
             td = TimedeltaBaserowRuntimeFormulaArgumentType()
+
             if num.test(a) and num.test(b):
+                return []
+            if td.test(a) and td.test(b):
+                return []
+            if (td.test(a) and num.test(b)) or (num.test(a) and td.test(b)):
                 return []
             if (dt.test(a) and td.test(b)) or (td.test(a) and dt.test(b)):
                 return []
@@ -111,7 +116,10 @@ class RuntimeAdd(RuntimeFormulaFunction):
                 return [(0, a)]
             if not (num.test(b) or dt.test(b) or td.test(b)):
                 return [(1, b)]
+
+            # Reject invalid pairs, e.g.: datetime + number, datetime + datetime, etc.
             return [(0, a)]
+
         return super().validate_type_of_args(args)
 
     def parse_args(self, args: FormulaArgs) -> FormulaArgs:
@@ -120,7 +128,14 @@ class RuntimeAdd(RuntimeFormulaFunction):
         return super().parse_args(args)
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
-        return args[0] + args[1]
+        a, b = args
+
+        if isinstance(a, timedelta) and not isinstance(b, (datetime, timedelta)):
+            b = timedelta(seconds=b)
+        elif isinstance(b, timedelta) and not isinstance(a, (datetime, timedelta)):
+            a = timedelta(seconds=a)
+
+        return a + b
 
 
 class RuntimeMinus(RuntimeFormulaFunction):
@@ -137,13 +152,21 @@ class RuntimeMinus(RuntimeFormulaFunction):
             num = NumberBaserowRuntimeFormulaArgumentType()
             dt = DateTimeBaserowRuntimeFormulaArgumentType()
             td = TimedeltaBaserowRuntimeFormulaArgumentType()
+
             if num.test(a) and num.test(b):
+                return []
+            if td.test(a) and td.test(b):
+                return []
+            if (td.test(a) and num.test(b)) or (num.test(a) and td.test(b)):
                 return []
             if dt.test(a) and td.test(b):
                 return []
-            if not (num.test(a) or dt.test(a)):
+            if not (num.test(a) or dt.test(a) or td.test(a)):
                 return [(0, a)]
+
+            # Reject invalid pairs, e.g.: datetime - number, etc.
             return [(1, b)]
+
         return super().validate_type_of_args(args)
 
     def parse_args(self, args: FormulaArgs) -> FormulaArgs:
@@ -152,7 +175,14 @@ class RuntimeMinus(RuntimeFormulaFunction):
         return super().parse_args(args)
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
-        return args[0] - args[1]
+        a, b = args
+
+        if isinstance(a, timedelta) and not isinstance(b, (datetime, timedelta)):
+            b = timedelta(seconds=b)
+        elif isinstance(b, timedelta) and not isinstance(a, (datetime, timedelta)):
+            a = timedelta(seconds=a)
+
+        return a - b
 
 
 class RuntimeMultiply(RuntimeFormulaFunction):
@@ -162,6 +192,29 @@ class RuntimeMultiply(RuntimeFormulaFunction):
         NumberBaserowRuntimeFormulaArgumentType(),
         NumberBaserowRuntimeFormulaArgumentType(),
     ]
+
+    def validate_type_of_args(self, args) -> list[tuple[int, FormulaArg]]:
+        if len(args) == 2:
+            a, b = args
+            num = NumberBaserowRuntimeFormulaArgumentType()
+            td = TimedeltaBaserowRuntimeFormulaArgumentType()
+
+            if num.test(a) and num.test(b):
+                return []
+            if (td.test(a) and num.test(b)) or (num.test(a) and td.test(b)):
+                return []
+            if not (num.test(a) or td.test(a)):
+                return [(0, a)]
+
+            # Reject invalid pairs, e.g.: datetime * number, etc.
+            return [(1, b)]
+
+        return super().validate_type_of_args(args)
+
+    def parse_args(self, args: FormulaArgs) -> FormulaArgs:
+        if any(isinstance(a, timedelta) for a in args):
+            return list(args)
+        return super().parse_args(args)
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
         return args[0] * args[1]
@@ -174,6 +227,29 @@ class RuntimeDivide(RuntimeFormulaFunction):
         NumberBaserowRuntimeFormulaArgumentType(),
         NumberBaserowRuntimeFormulaArgumentType(),
     ]
+
+    def validate_type_of_args(self, args) -> list[tuple[int, FormulaArg]]:
+        if len(args) == 2:
+            a, b = args
+            num = NumberBaserowRuntimeFormulaArgumentType()
+            td = TimedeltaBaserowRuntimeFormulaArgumentType()
+
+            if num.test(a) and num.test(b):
+                return []
+            if td.test(a) and num.test(b):
+                return []
+            if not (num.test(a) or td.test(a)):
+                return [(0, a)]
+
+            # Reject invalid pairs, e.g.: datetime / number, etc.
+            return [(1, b)]
+
+        return super().validate_type_of_args(args)
+
+    def parse_args(self, args: FormulaArgs) -> FormulaArgs:
+        if any(isinstance(a, timedelta) for a in args):
+            return list(args)
+        return super().parse_args(args)
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
         return args[0] / args[1]

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -829,13 +829,6 @@ class RuntimeToDuration(RuntimeFormulaFunction):
             return
 
         value, duration_format = args
-        # The validation visitor pre-parses arg 0 via the argument type's
-        # parse(). By the time validate_args() is called, arg 0 may already
-        # be a timedelta.
-        if isinstance(value, timedelta):
-            raise BaserowFormulaSyntaxError(
-                "A duration format cannot be applied to a timedelta value."
-            )
         if isinstance(value, str):
             if parse_value_with_duration_format(value, duration_format) is None:
                 raise BaserowFormulaSyntaxError(

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -7,7 +7,10 @@ from zoneinfo import ZoneInfo
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from baserow.core.duration import parse_value_with_duration_format
+from baserow.core.duration import (
+    format_value_with_duration_format,
+    parse_value_with_duration_format,
+)
 from baserow.core.exceptions import InstanceTypeDoesNotExist
 from baserow.core.formula import BaserowFormulaSyntaxError
 from baserow.core.formula.argument_types import (
@@ -791,6 +794,21 @@ class RuntimeToDuration(RuntimeFormulaFunction):
             return result
 
         return args[0]
+
+
+class RuntimeDurationFormat(RuntimeFormulaFunction):
+    type = "duration_format"
+
+    args = [
+        DurationBaserowRuntimeFormulaArgumentType(),
+        DurationFormatBaserowRuntimeFormulaArgumentType(),
+    ]
+
+    def execute(self, context: FormulaContext, args: FormulaArgs):
+        duration, duration_format = args
+        if duration is None:
+            return None
+        return format_value_with_duration_format(duration, duration_format)
 
 
 class RuntimeToDatetime(RuntimeFormulaFunction):

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -7,6 +7,7 @@ from zoneinfo import ZoneInfo
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
+from baserow.core.duration import parse_value_with_duration_format
 from baserow.core.exceptions import InstanceTypeDoesNotExist
 from baserow.core.formula import BaserowFormulaSyntaxError
 from baserow.core.formula.argument_types import (
@@ -18,6 +19,7 @@ from baserow.core.formula.argument_types import (
     DecimalSeparatorBaserowRuntimeFormulaArgumentType,
     DictBaserowRuntimeFormulaArgumentType,
     DurationBaserowRuntimeFormulaArgumentType,
+    DurationFormatBaserowRuntimeFormulaArgumentType,
     NumberBaserowRuntimeFormulaArgumentType,
     TextBaserowRuntimeFormulaArgumentType,
     ThousandSeparatorBaserowRuntimeFormulaArgumentType,
@@ -723,9 +725,71 @@ class RuntimeNumberFormat(RuntimeFormulaFunction):
 class RuntimeToDuration(RuntimeFormulaFunction):
     type = "to_duration"
 
-    args = [DurationBaserowRuntimeFormulaArgumentType()]
+    args = [
+        DurationBaserowRuntimeFormulaArgumentType(),
+        DurationFormatBaserowRuntimeFormulaArgumentType(optional=True),
+    ]
+
+    def _format_error(self, value, duration_format):
+        return f"'{value}' could not be parsed using format '{duration_format}'."
+
+    def validate_type_of_args(self, args) -> list[tuple[int, FormulaArg]]:
+        # When a format is provided, arg 0's validity depends on the format.
+        # Defer checking arg 0 to validate_args() in that case.
+        if len(args) == 2:
+            if not self.args[1].test(args[1]):
+                return [(1, args[1])]
+            return []
+
+        return super().validate_type_of_args(args)
+
+    def validate_args(self, args, validation_context=None):
+        super().validate_args(args, validation_context)
+
+        if len(args) != 2:
+            return
+
+        value, duration_format = args
+        # The validation visitor pre-parses arg 0 via the argument type's
+        # parse(). By the time validate_args() is called, arg 0 may already
+        # be a timedelta.
+        if isinstance(value, timedelta):
+            raise BaserowFormulaSyntaxError(
+                "A duration format cannot be applied to a timedelta value."
+            )
+        if isinstance(value, str):
+            if parse_value_with_duration_format(value, duration_format) is None:
+                raise BaserowFormulaSyntaxError(
+                    self._format_error(value, duration_format)
+                )
+
+    def parse_args(self, args: FormulaArgs) -> FormulaArgs:
+        # When the format arg is provided, defer parsing of the 1st arg to
+        # execute() so the raw value arg is checked later in combination
+        # with the format arg.
+        if len(args) == 2:
+            return [args[0], self.args[1].parse(args[1])]
+
+        return super().parse_args(args)
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
+        if len(args) == 2:
+            value, duration_format = args
+            # Arg 0 may resolve to a timedelta at runtime (e.g. from a
+            # get() on a duration field), in which case it doesn't make sense
+            # to apply the format.
+            if isinstance(value, timedelta):
+                raise BaserowFormulaSyntaxError(
+                    "A duration format cannot be applied to a timedelta value."
+                )
+
+            result = parse_value_with_duration_format(value, duration_format)
+            if result is None:
+                raise BaserowFormulaSyntaxError(
+                    self._format_error(value, duration_format)
+                )
+            return result
+
         return args[0]
 
 

--- a/backend/tests/baserow/contrib/database/field/test_duration_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_duration_field_type.py
@@ -9,6 +9,7 @@ from pytest_unordered import unordered
 from baserow.contrib.database.fields.actions import UpdateFieldActionType
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import DurationField
+from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.fields.utils.duration import (
     DURATION_FORMAT_TOKENS,
     DURATION_FORMATS,
@@ -481,6 +482,45 @@ def test_convert_duration_field_to_text_to_duration_field(
         formatted,
         text_value_sql_to_duration(updated_field),
     )
+
+
+@pytest.mark.field_duration
+@pytest.mark.parametrize(
+    "duration_format,value,expected",
+    [
+        # One representative value per DURATION_FORMATS key, exercising the
+        # display path through the field type (DurationFieldType.format_duration,
+        # which the CSV/JSON exporters, row history and notifications all route
+        # through).
+        ("h:mm", timedelta(hours=1, minutes=1), "1:01"),
+        ("h:mm:ss", timedelta(hours=1, minutes=1, seconds=6), "1:01:06"),
+        ("h:mm:ss.s", timedelta(hours=1, minutes=1, seconds=6.6), "1:01:06.6"),
+        ("h:mm:ss.ss", timedelta(hours=1, minutes=1, seconds=6.66), "1:01:06.66"),
+        (
+            "h:mm:ss.sss",
+            timedelta(hours=1, minutes=1, seconds=6.666),
+            "1:01:06.666",
+        ),
+        ("d h", timedelta(days=1, hours=1), "1d 1h"),
+        ("d h:mm", timedelta(days=1, hours=1, minutes=1), "1d 1:01"),
+        (
+            "d h:mm:ss",
+            timedelta(days=1, hours=1, minutes=1, seconds=6),
+            "1d 1:01:06",
+        ),
+        # "no colons" formats, missing from the interesting-table export guard
+        ("d h mm", timedelta(days=1, hours=2, minutes=3), "1d 2h 03m"),
+        (
+            "d h mm ss",
+            timedelta(days=1, hours=2, minutes=3, seconds=4),
+            "1d 2h 03m 04s",
+        ),
+    ],
+)
+def test_duration_field_type_format_duration(duration_format, value, expected):
+    field_type = field_type_registry.get("duration")
+
+    assert field_type.format_duration(value, duration_format) == expected
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/baserow/core/formula/test_argument_types.py
+++ b/backend/tests/baserow/core/formula/test_argument_types.py
@@ -8,6 +8,7 @@ from baserow.core.formula.argument_types import (
     DecimalSeparatorBaserowRuntimeFormulaArgumentType,
     DictBaserowRuntimeFormulaArgumentType,
     DurationBaserowRuntimeFormulaArgumentType,
+    DurationFormatBaserowRuntimeFormulaArgumentType,
     NumberBaserowRuntimeFormulaArgumentType,
     TextBaserowRuntimeFormulaArgumentType,
     ThousandSeparatorBaserowRuntimeFormulaArgumentType,
@@ -333,3 +334,31 @@ def test_datetime_format_get_error_message_returns_human_readable_string():
     arg_type = DatetimeFormatBaserowRuntimeFormulaArgumentType()
     message = arg_type.get_error_message("SS")
     assert "is not a valid datetime format" in message
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("h:mm", True),
+        ("h:mm:ss", True),
+        ("d h:mm:ss", True),
+        ("d h mm ss", True),
+        ("d", True),
+        ("hh:mm:ss", True),
+        # repeated token
+        ("h:mm:h", False),
+        # only literals, no token
+        (":::", False),
+        ("", False),
+        (123, False),
+        (None, False),
+    ],
+)
+def test_duration_format_test_method(value, expected):
+    assert DurationFormatBaserowRuntimeFormulaArgumentType().test(value) == expected
+
+
+def test_duration_format_get_error_message_returns_human_readable_string():
+    arg_type = DurationFormatBaserowRuntimeFormulaArgumentType()
+    message = arg_type.get_error_message("not valid")
+    assert "is not a valid duration format" in message

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -2532,6 +2532,7 @@ def test_runtime_number_format_validate_args_raises_human_readable_error_for_bad
 @pytest.mark.parametrize(
     "args,expected",
     [
+        # Single-arg form: delegates to DurationBaserowRuntimeFormulaArgumentType.parse()
         (["1 day"], timedelta(days=1)),
         (["2 days"], timedelta(days=2)),
         (["3 weeks"], timedelta(weeks=3)),
@@ -2550,6 +2551,17 @@ def test_runtime_number_format_validate_args_raises_human_readable_error_for_bad
         (["12.5"], timedelta(seconds=12.5)),
         (["0 days"], timedelta(0)),
         (["-1:30"], timedelta(seconds=-90)),
+        # Two-arg form: value + format string
+        (["1:30", "h:mm"], timedelta(hours=1, minutes=30)),
+        (
+            ["1:23:45", "h:mm:ss"],
+            timedelta(hours=1, minutes=23, seconds=45),
+        ),
+        (
+            ["2 3:04:05", "d h:mm:ss"],
+            timedelta(days=2, hours=3, minutes=4, seconds=5),
+        ),
+        (["-1:30", "h:mm"], -timedelta(hours=1, minutes=30)),
     ],
 )
 def test_runtime_to_duration_execute(args, expected):
@@ -2558,17 +2570,42 @@ def test_runtime_to_duration_execute(args, expected):
     assert result == expected
 
 
+def test_runtime_to_duration_execute_raises_for_timedelta_with_format():
+    # At runtime, arg 0 may resolve to a timedelta (e.g. via a get() on a
+    # duration field), in which case applying a format doesn't make sense.
+    parsed_args = RuntimeToDuration().parse_args([timedelta(hours=1), "h:mm"])
+    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
+        RuntimeToDuration().execute({}, parsed_args)
+    assert "A duration format cannot be applied to a timedelta" in str(exc_info.value)
+
+
+def test_runtime_to_duration_execute_raises_when_value_does_not_match_format():
+    parsed_args = RuntimeToDuration().parse_args(["not a duration", "h:mm"])
+    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
+        RuntimeToDuration().execute({}, parsed_args)
+    assert "could not be parsed using format 'h:mm'" in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "args,expected",
     [
-        # Valid duration strings — arg passes
+        # Single-arg form
         (["1 day"], []),
         (["2 days"], []),
         ([1], []),
-        # Invalid strings — arg is returned as invalid
+        # Invalid single-arg — arg is returned as invalid
         (["foo"], [(0, "foo")]),
         ([""], [(0, "")]),
         ([None], [(0, None)]),
+        # Two-arg form: arg 0 check is deferred to validate_args(), so any
+        # arg 0 is accepted at this stage when the format is valid.
+        (["1:30", "h:mm"], []),
+        (["whatever", "h:mm"], []),
+        # Invalid format strings → arg 1 reported as invalid
+        (["1:30", ":::"], [(1, ":::")]),
+        (["1:30", "h h"], [(1, "h h")]),
+        (["1:30", ""], [(1, "")]),
+        (["1:30", 123], [(1, 123)]),
     ],
 )
 def test_runtime_to_duration_validate_type_of_args(args, expected):
@@ -2581,12 +2618,25 @@ def test_runtime_to_duration_validate_type_of_args(args, expected):
     [
         ([], False),
         (["1 day"], True),
-        (["1 day", "extra"], False),
+        (["1 day", "h:mm"], True),
+        (["1 day", "h:mm", "extra"], False),
     ],
 )
 def test_runtime_to_duration_validate_number_of_args(args, expected):
     result = RuntimeToDuration().validate_number_of_args(args)
     assert result is expected
+
+
+def test_runtime_to_duration_validate_args_raises_for_timedelta_with_format():
+    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
+        RuntimeToDuration().validate_args([timedelta(hours=1), "h:mm"])
+    assert "A duration format cannot be applied to a timedelta" in str(exc_info.value)
+
+
+def test_runtime_to_duration_validate_args_raises_when_value_does_not_match_format():
+    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
+        RuntimeToDuration().validate_args(["not a duration", "h:mm"])
+    assert "could not be parsed using format 'h:mm'" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -2628,12 +2628,6 @@ def test_runtime_to_duration_validate_number_of_args(args, expected):
     assert result is expected
 
 
-def test_runtime_to_duration_validate_args_raises_for_timedelta_with_format():
-    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
-        RuntimeToDuration().validate_args([timedelta(hours=1), "h:mm"])
-    assert "A duration format cannot be applied to a timedelta" in str(exc_info.value)
-
-
 def test_runtime_to_duration_validate_args_raises_when_value_does_not_match_format():
     with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
         RuntimeToDuration().validate_args(["not a duration", "h:mm"])

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -2723,6 +2723,17 @@ def test_runtime_duration_format_validate_number_of_args(args, expected):
             [datetime(2025, 6, 15), timedelta(hours=3)],
             datetime(2025, 6, 15, 3, 0, 0),
         ),
+        # timedelta + timedelta
+        (
+            [timedelta(hours=1), timedelta(minutes=30)],
+            timedelta(hours=1, minutes=30),
+        ),
+        # timedelta + number (number = seconds)
+        ([timedelta(hours=1), 60], timedelta(hours=1, seconds=60)),
+        # number + timedelta (number = seconds)
+        ([60, timedelta(hours=1)], timedelta(hours=1, seconds=60)),
+        # fractional seconds
+        ([timedelta(seconds=1), 1.5], timedelta(seconds=2, microseconds=500000)),
     ],
 )
 def test_runtime_add_with_datetime_and_timedelta(args, expected):
@@ -2736,8 +2747,16 @@ def test_runtime_add_with_datetime_and_timedelta(args, expected):
     [
         ([datetime(2025, 1, 1, 12, 0, 0), timedelta(days=1)], []),
         ([timedelta(days=1), datetime(2025, 1, 1, 12, 0, 0)], []),
-        ([timedelta(days=1), timedelta(days=2)], [(0, timedelta(days=1))]),
+        ([timedelta(days=1), timedelta(days=2)], []),
+        ([timedelta(days=1), 60], []),
+        ([60, timedelta(days=1)], []),
         (["foo", timedelta(days=1)], [(0, "foo")]),
+        ([timedelta(days=1), "foo"], [(1, "foo")]),
+        # datetime + datetime is invalid
+        (
+            [datetime(2025, 1, 1), datetime(2025, 1, 2)],
+            [(0, datetime(2025, 1, 1))],
+        ),
     ],
 )
 def test_runtime_add_validate_type_of_args_with_timedelta(args, expected):
@@ -2756,6 +2775,15 @@ def test_runtime_add_validate_type_of_args_with_timedelta(args, expected):
             [datetime(2025, 6, 15, 3, 0, 0), timedelta(hours=3)],
             datetime(2025, 6, 15, 0, 0, 0),
         ),
+        # timedelta - timedelta
+        (
+            [timedelta(hours=2), timedelta(minutes=30)],
+            timedelta(hours=1, minutes=30),
+        ),
+        # timedelta - number (number = seconds)
+        ([timedelta(seconds=30), 1], timedelta(seconds=29)),
+        # number - timedelta (number = seconds)
+        ([90, timedelta(seconds=30)], timedelta(seconds=60)),
     ],
 )
 def test_runtime_minus_with_datetime_and_timedelta(args, expected):
@@ -2768,13 +2796,96 @@ def test_runtime_minus_with_datetime_and_timedelta(args, expected):
     "args,expected",
     [
         ([datetime(2025, 1, 2, 12, 0, 0), timedelta(days=1)], []),
-        ([timedelta(days=1), datetime(2025, 1, 1, 12, 0, 0)], [(0, timedelta(days=1))]),
-        ([timedelta(days=1), timedelta(days=2)], [(0, timedelta(days=1))]),
+        (
+            [timedelta(days=1), datetime(2025, 1, 1, 12, 0, 0)],
+            [(1, datetime(2025, 1, 1, 12, 0, 0))],
+        ),
+        ([timedelta(days=1), timedelta(days=2)], []),
+        ([timedelta(days=1), 60], []),
+        ([60, timedelta(days=1)], []),
         (["foo", timedelta(days=1)], [(0, "foo")]),
+        ([timedelta(days=1), "foo"], [(1, "foo")]),
+        # datetime - datetime is invalid
+        (
+            [datetime(2025, 1, 2), datetime(2025, 1, 1)],
+            [(1, datetime(2025, 1, 1))],
+        ),
     ],
 )
 def test_runtime_minus_validate_type_of_args_with_timedelta(args, expected):
     result = RuntimeMinus().validate_type_of_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        # timedelta * number
+        ([timedelta(hours=1), 2], timedelta(hours=2)),
+        # number * timedelta
+        ([2, timedelta(hours=1)], timedelta(hours=2)),
+        # fractional scaling
+        ([timedelta(minutes=10), 0.5], timedelta(minutes=5)),
+    ],
+)
+def test_runtime_multiply_with_timedelta(args, expected):
+    parsed_args = RuntimeMultiply().parse_args(args)
+    result = RuntimeMultiply().execute({}, parsed_args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([1, 2], []),
+        ([timedelta(hours=1), 2], []),
+        ([2, timedelta(hours=1)], []),
+        # timedelta * timedelta is invalid
+        (
+            [timedelta(hours=1), timedelta(hours=1)],
+            [(1, timedelta(hours=1))],
+        ),
+        (["foo", timedelta(hours=1)], [(0, "foo")]),
+        ([timedelta(hours=1), "foo"], [(1, "foo")]),
+    ],
+)
+def test_runtime_multiply_validate_type_of_args_with_timedelta(args, expected):
+    result = RuntimeMultiply().validate_type_of_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        # timedelta / number
+        ([timedelta(hours=1), 2], timedelta(minutes=30)),
+        ([timedelta(seconds=30), 2], timedelta(seconds=15)),
+    ],
+)
+def test_runtime_divide_with_timedelta(args, expected):
+    parsed_args = RuntimeDivide().parse_args(args)
+    result = RuntimeDivide().execute({}, parsed_args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([1, 2], []),
+        ([timedelta(hours=1), 2], []),
+        # number / timedelta is invalid
+        ([2, timedelta(hours=1)], [(1, timedelta(hours=1))]),
+        # timedelta / timedelta is invalid
+        (
+            [timedelta(hours=1), timedelta(hours=1)],
+            [(1, timedelta(hours=1))],
+        ),
+        (["foo", timedelta(hours=1)], [(0, "foo")]),
+        ([timedelta(hours=1), "foo"], [(1, "foo")]),
+    ],
+)
+def test_runtime_divide_validate_type_of_args_with_timedelta(args, expected):
+    result = RuntimeDivide().validate_type_of_args(args)
     assert result == expected
 
 

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -2810,6 +2810,10 @@ def test_runtime_minus_with_datetime_and_timedelta(args, expected):
             [datetime(2025, 1, 2), datetime(2025, 1, 1)],
             [(1, datetime(2025, 1, 1))],
         ),
+        # datetime - number is invalid
+        ([datetime(2025, 1, 1), 5], [(1, 5)]),
+        # number - datetime is invalid
+        ([5, datetime(2025, 1, 1)], [(1, datetime(2025, 1, 1))]),
     ],
 )
 def test_runtime_minus_validate_type_of_args_with_timedelta(args, expected):
@@ -2847,6 +2851,13 @@ def test_runtime_multiply_with_timedelta(args, expected):
         ),
         (["foo", timedelta(hours=1)], [(0, "foo")]),
         ([timedelta(hours=1), "foo"], [(1, "foo")]),
+        # datetime operands are invalid for multiply
+        ([datetime(2025, 1, 1), 2], [(0, datetime(2025, 1, 1))]),
+        ([2, datetime(2025, 1, 1)], [(1, datetime(2025, 1, 1))]),
+        (
+            [datetime(2025, 1, 1), timedelta(hours=1)],
+            [(0, datetime(2025, 1, 1))],
+        ),
     ],
 )
 def test_runtime_multiply_validate_type_of_args_with_timedelta(args, expected):
@@ -2882,6 +2893,13 @@ def test_runtime_divide_with_timedelta(args, expected):
         ),
         (["foo", timedelta(hours=1)], [(0, "foo")]),
         ([timedelta(hours=1), "foo"], [(1, "foo")]),
+        # datetime operands are invalid for divide
+        ([datetime(2025, 1, 1), 2], [(0, datetime(2025, 1, 1))]),
+        ([2, datetime(2025, 1, 1)], [(1, datetime(2025, 1, 1))]),
+        (
+            [datetime(2025, 1, 1), timedelta(hours=1)],
+            [(0, datetime(2025, 1, 1))],
+        ),
     ],
 )
 def test_runtime_divide_validate_type_of_args_with_timedelta(args, expected):

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -18,6 +18,7 @@ from baserow.core.formula.runtime_formula_types import (
     RuntimeDateTimeFormat,
     RuntimeDay,
     RuntimeDivide,
+    RuntimeDurationFormat,
     RuntimeEqual,
     RuntimeGenerateUUID,
     RuntimeGet,
@@ -2637,6 +2638,74 @@ def test_runtime_to_duration_validate_args_raises_when_value_does_not_match_form
     with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
         RuntimeToDuration().validate_args(["not a duration", "h:mm"])
     assert "could not be parsed using format 'h:mm'" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([timedelta(hours=1, minutes=30), "h:mm"], "1:30"),
+        (
+            [timedelta(hours=1, minutes=23, seconds=45), "h:mm:ss"],
+            "1:23:45",
+        ),
+        (
+            [timedelta(days=2, hours=3, minutes=4, seconds=5), "d h:mm:ss"],
+            "2 3:04:05",
+        ),
+        # rollup variations
+        ([timedelta(hours=1, minutes=30), "mm:ss"], "90:00"),
+        ([timedelta(hours=25, minutes=30), "h:mm"], "25:30"),
+        ([timedelta(hours=25, minutes=30), "d h:mm"], "1 1:30"),
+        # negative durations
+        ([-timedelta(hours=1, minutes=30), "h:mm"], "-1:30"),
+        # zero duration
+        ([timedelta(0), "h:mm"], "0:00"),
+    ],
+)
+def test_runtime_duration_format_execute(args, expected):
+    parsed_args = RuntimeDurationFormat().parse_args(args)
+    result = RuntimeDurationFormat().execute({}, parsed_args)
+    assert result == expected
+
+
+def test_runtime_duration_format_execute_returns_none_for_null_duration():
+    result = RuntimeDurationFormat().execute({}, [None, "h:mm"])
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([timedelta(hours=1), "h:mm"], []),
+        ([timedelta(0), "d h:mm:ss"], []),
+        # arg 0 must be a duration/timedelta-coercible value
+        (["not a duration", "h:mm"], [(0, "not a duration")]),
+        ([123, "h:mm"], []),
+        ([None, "h:mm"], [(0, None)]),
+        # arg 1 must be a valid format string
+        ([timedelta(hours=1), ":::"], [(1, ":::")]),
+        ([timedelta(hours=1), "h h"], [(1, "h h")]),
+        ([timedelta(hours=1), ""], [(1, "")]),
+        ([timedelta(hours=1), 123], [(1, 123)]),
+    ],
+)
+def test_runtime_duration_format_validate_type_of_args(args, expected):
+    result = RuntimeDurationFormat().validate_type_of_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], False),
+        ([timedelta(hours=1)], False),
+        ([timedelta(hours=1), "h:mm"], True),
+        ([timedelta(hours=1), "h:mm", "extra"], False),
+    ],
+)
+def test_runtime_duration_format_validate_number_of_args(args, expected):
+    result = RuntimeDurationFormat().validate_number_of_args(args)
+    assert result is expected
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/baserow/core/test_duration.py
+++ b/backend/tests/baserow/core/test_duration.py
@@ -1,0 +1,180 @@
+import re
+from datetime import timedelta
+
+import pytest
+
+from baserow.core.duration import (
+    is_valid_duration_format,
+    parse_value_with_duration_format,
+    tokenize_duration_format,
+)
+
+
+class TestTokenizeDurationFormat:
+    @pytest.mark.parametrize(
+        "format_str,value,expected_fields,expected_groups",
+        [
+            ("h:mm", "1:30", ["hours", "minutes"], ("1", "30")),
+            # literal `:` separators are escaped
+            (
+                "h:mm:ss",
+                "1:23:45",
+                ["hours", "minutes", "seconds"],
+                ("1", "23", "45"),
+            ),
+            # space-separated tokens
+            (
+                "d h mm ss",
+                "2 3 04 05",
+                ["days", "hours", "minutes", "seconds"],
+                ("2", "3", "04", "05"),
+            ),
+            # two-char tokens take precedence over one-char (hh, not h+h)
+            ("hh:mm", "12:34", ["hours", "minutes"], ("12", "34")),
+            # arbitrary literal chars (avoid d/h/m/s, which are token letters)
+            ("d|h.", "2|5.", ["days", "hours"], ("2", "5")),
+            # leading minus is optional
+            ("h:mm", "-1:30", ["hours", "minutes"], ("1", "30")),
+        ],
+    )
+    def test_tokenizes_valid_format(
+        self, format_str, value, expected_fields, expected_groups
+    ):
+        result = tokenize_duration_format(format_str)
+
+        assert result is not None
+        regex, fields = result
+        assert isinstance(regex, re.Pattern)
+        assert fields == expected_fields
+        match = regex.match(value)
+        assert match is not None
+        assert match.groups() == expected_groups
+
+    @pytest.mark.parametrize(
+        "format_str,value",
+        [
+            # anchored to start of string
+            ("h:mm", "prefix 1:30"),
+            # anchored to end of string
+            ("h:mm", "1:30 trailing"),
+            # literal mismatch (`|` in format, `/` in value)
+            ("d|h.", "2/5."),
+        ],
+    )
+    def test_value_does_not_match_format(self, format_str, value):
+        regex, _ = tokenize_duration_format(format_str)
+
+        assert regex.match(value) is None
+
+    @pytest.mark.parametrize(
+        "format_str",
+        [
+            "h:mm:h",  # h repeated
+            "mm mm",  # mm repeated
+            "h hh",  # h then hh — both map to "hours"
+            "ss s",  # ss then s — both map to "seconds"
+        ],
+    )
+    def test_repeated_tokens_are_invalid(self, format_str):
+        assert tokenize_duration_format(format_str) is None
+
+    @pytest.mark.parametrize(
+        "format_str",
+        [
+            "",
+            ":::",  # only literals, no token
+            "   ",  # only whitespace, no token
+        ],
+    )
+    def test_format_with_no_tokens_is_invalid(self, format_str):
+        assert tokenize_duration_format(format_str) is None
+
+    @pytest.mark.parametrize("value", [None, 1, 1.5, [], {}, object()])
+    def test_non_string_input_returns_none(self, value):
+        assert tokenize_duration_format(value) is None
+
+
+class TestIsValidDurationFormat:
+    @pytest.mark.parametrize(
+        "format_str",
+        [
+            "h:mm",
+            "h:mm:ss",
+            "d h:mm:ss",
+            "d h mm ss",
+            "d",
+            "hh:mm:ss",
+        ],
+    )
+    def test_returns_true_for_valid_formats(self, format_str):
+        assert is_valid_duration_format(format_str) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "h:h",  # repeated token
+            ":::",  # only literals
+            None,
+            123,
+            [],
+            {},
+        ],
+    )
+    def test_returns_false_for_invalid_inputs(self, value):
+        assert is_valid_duration_format(value) is False
+
+
+class TestParseValueWithDurationFormat:
+    @pytest.mark.parametrize(
+        "value,format_str,expected",
+        [
+            ("1:30", "h:mm", timedelta(hours=1, minutes=30)),
+            ("1:23:45", "h:mm:ss", timedelta(hours=1, minutes=23, seconds=45)),
+            (
+                "2 3:04:05",
+                "d h:mm:ss",
+                timedelta(days=2, hours=3, minutes=4, seconds=5),
+            ),
+            ("3 4", "d h", timedelta(days=3, hours=4)),
+            ("-1:30", "h:mm", -timedelta(hours=1, minutes=30)),
+            # surrounding whitespace is stripped
+            ("  1:30  ", "h:mm", timedelta(hours=1, minutes=30)),
+            ("0:00", "h:mm", timedelta(0)),
+            # negative zero is still zero
+            ("-0:00", "h:mm", timedelta(0)),
+            # the generated regex uses \d+ for every field, so single-digit
+            # values are accepted even where the format suggests two digits
+            ("1:5", "h:mm", timedelta(hours=1, minutes=5)),
+            # "hh:mm" tokenizes as hh + mm, not h + h + mm
+            ("12:34", "hh:mm", timedelta(hours=12, minutes=34)),
+            # 25 hours rolls over into 1d 1h in the resulting timedelta
+            ("25:00", "h:mm", timedelta(days=1, hours=1)),
+        ],
+    )
+    def test_parses_valid_values(self, value, format_str, expected):
+        assert parse_value_with_duration_format(value, format_str) == expected
+
+    @pytest.mark.parametrize(
+        "value,format_str",
+        [
+            # value doesn't match the format's literal separator
+            ("1.30", "h:mm"),
+            # value has trailing garbage
+            ("1:30 extra", "h:mm"),
+            # non-string values
+            (None, "h:mm"),
+            (1, "h:mm"),
+            (1.5, "h:mm"),
+            ([], "h:mm"),
+            ({}, "h:mm"),
+            # invalid format strings
+            ("1:30", None),
+            ("1:30", ""),
+            ("1:30", "h:h"),
+            ("1:30", 123),
+            ("1:30", ":::"),
+        ],
+    )
+    def test_returns_none_for_invalid_input(self, value, format_str):
+        assert parse_value_with_duration_format(value, format_str) is None

--- a/backend/tests/baserow/core/test_duration.py
+++ b/backend/tests/baserow/core/test_duration.py
@@ -63,6 +63,35 @@ class TestTokenizeDurationFormat:
                 ["minutes", "seconds", "fraction"],
                 ("01", "02", "34"),
             ),
+            # backslash escapes a token letter so it becomes a literal suffix:
+            # `d\d h\h` matches "1d 2h" (the d/h after the backslash are literal)
+            (
+                r"d\d h\h",
+                "1d 2h",
+                ["days", "hours"],
+                ("1", "2"),
+            ),
+            (
+                r"d\d h\h mm\m ss\s",
+                "1d 2h 03m 04s",
+                ["days", "hours", "minutes", "seconds"],
+                ("1", "2", "03", "04"),
+            ),
+            # an escaped backslash is a literal backslash
+            (
+                r"h\\mm",
+                "1\\23",
+                ["hours", "minutes"],
+                ("1", "23"),
+            ),
+            # an escaped `f` is a literal `f`, not the fraction token, so a real
+            # fraction can still follow and its precision is read correctly
+            (
+                r"\f ss.ff",
+                "f 01.50",
+                ["seconds", "fraction"],
+                ("01", "50"),
+            ),
         ],
     )
     def test_tokenizes_valid_format(
@@ -117,6 +146,16 @@ class TestTokenizeDurationFormat:
         ],
     )
     def test_format_with_no_tokens_is_invalid(self, format_str):
+        assert tokenize_duration_format(format_str) is None
+
+    @pytest.mark.parametrize(
+        "format_str",
+        [
+            "h:mm\\",  # trailing backslash has nothing to escape
+            "\\",  # lone backslash
+        ],
+    )
+    def test_trailing_backslash_is_invalid(self, format_str):
         assert tokenize_duration_format(format_str) is None
 
     @pytest.mark.parametrize("value", [None, 1, 1.5, [], {}, object()])
@@ -323,6 +362,18 @@ class TestFormatValueWithDurationFormat:
                 "ss.fff",
                 "-01.250",
             ),
+            # escaped token letters are emitted as literal unit suffixes
+            (timedelta(days=1, hours=2), r"d\d h\h", "1d 2h"),
+            (
+                timedelta(days=1, hours=2, minutes=3, seconds=4),
+                r"d\d h\h mm\m ss\s",
+                "1d 2h 03m 04s",
+            ),
+            (timedelta(days=1, hours=2, minutes=34), r"d\d h:mm", "1d 2:34"),
+            # escaped backslash renders as a literal backslash
+            (timedelta(hours=1, minutes=5), r"h\\mm", "1\\05"),
+            # escaped `f` literal alongside a real fraction (precision read as 2)
+            (timedelta(seconds=1, milliseconds=500), r"\f ss.ff", "f 01.50"),
         ],
     )
     def test_formats_valid_durations(self, duration, format_str, expected):
@@ -369,6 +420,9 @@ class TestFormatValueWithDurationFormat:
             (timedelta(seconds=1, milliseconds=500), "ss.f"),
             (timedelta(seconds=1, milliseconds=234), "s fff"),
             (-timedelta(seconds=1, milliseconds=250), "ss.fff"),
+            # escaped literal unit suffixes round-trip
+            (timedelta(days=1, hours=2), r"d\d h\h"),
+            (timedelta(days=1, hours=2, minutes=3, seconds=4), r"d\d h\h mm\m ss\s"),
         ],
     )
     def test_parsed_format_returns_correct_duration(self, duration, format_str):

--- a/backend/tests/baserow/core/test_duration.py
+++ b/backend/tests/baserow/core/test_duration.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import pytest
 
 from baserow.core.duration import (
+    format_value_with_duration_format,
     is_valid_duration_format,
     parse_value_with_duration_format,
     tokenize_duration_format,
@@ -178,3 +179,89 @@ class TestParseValueWithDurationFormat:
     )
     def test_returns_none_for_invalid_input(self, value, format_str):
         assert parse_value_with_duration_format(value, format_str) is None
+
+
+class TestFormatValueWithDurationFormat:
+    @pytest.mark.parametrize(
+        "duration,format_str,expected",
+        [
+            (timedelta(hours=1, minutes=30), "h:mm", "1:30"),
+            (
+                timedelta(hours=1, minutes=23, seconds=45),
+                "h:mm:ss",
+                "1:23:45",
+            ),
+            (
+                timedelta(days=2, hours=3, minutes=4, seconds=5),
+                "d h:mm:ss",
+                "2 3:04:05",
+            ),
+            (timedelta(days=3, hours=4), "d h", "3 4"),
+            # h-only rollup: 1d 2h → 26 total hours
+            (timedelta(days=1, hours=2), "h", "26"),
+            # mm-only rollup: 1h 30m → 90 total minutes (zero-padded by mm)
+            (timedelta(hours=1, minutes=30), "mm", "90"),
+            # mm:ss rollup: 1h 30m → 90 minutes, 0 seconds
+            (timedelta(hours=1, minutes=30), "mm:ss", "90:00"),
+            # ss-only rollup: 5m → 300 total seconds
+            (timedelta(minutes=5), "ss", "300"),
+            # within-day hours when d is present: 25h → 1d 1h
+            (timedelta(hours=25, minutes=30), "d h:mm", "1 1:30"),
+            # without d, hours roll up: 25h → 25 total hours
+            (timedelta(hours=25, minutes=30), "h:mm", "25:30"),
+            # negative values get a leading minus
+            (-timedelta(hours=1, minutes=30), "h:mm", "-1:30"),
+            (-timedelta(hours=1, minutes=30), "mm:ss", "-90:00"),
+            # zero in every position
+            (timedelta(0), "h:mm", "0:00"),
+            (timedelta(0), "d h:mm:ss", "0 0:00:00"),
+            # two-char tokens are zero-padded; one-char tokens are not
+            (timedelta(hours=1, minutes=5), "h:mm", "1:05"),
+            (timedelta(hours=1, minutes=5), "hh:mm", "01:05"),
+            # arbitrary literal chars are preserved
+            (timedelta(days=2, hours=5), "d|h.", "2|5."),
+            # sub-second precision is truncated
+            (timedelta(seconds=1, milliseconds=500), "s", "1"),
+        ],
+    )
+    def test_formats_valid_durations(self, duration, format_str, expected):
+        assert format_value_with_duration_format(duration, format_str) == expected
+
+    @pytest.mark.parametrize(
+        "duration,format_str",
+        [
+            # non-timedelta values
+            (None, "h:mm"),
+            (1, "h:mm"),
+            (1.5, "h:mm"),
+            ("1:30", "h:mm"),
+            ([], "h:mm"),
+            ({}, "h:mm"),
+            # invalid format strings
+            (timedelta(hours=1), None),
+            (timedelta(hours=1), ""),
+            (timedelta(hours=1), "h:h"),
+            (timedelta(hours=1), 123),
+            (timedelta(hours=1), ":::"),
+        ],
+    )
+    def test_returns_none_for_invalid_input(self, duration, format_str):
+        assert format_value_with_duration_format(duration, format_str) is None
+
+    @pytest.mark.parametrize(
+        "duration,format_str",
+        [
+            (timedelta(hours=1, minutes=30), "h:mm"),
+            (timedelta(hours=1, minutes=23, seconds=45), "h:mm:ss"),
+            (
+                timedelta(days=2, hours=3, minutes=4, seconds=5),
+                "d h:mm:ss",
+            ),
+            (-timedelta(hours=1, minutes=30), "h:mm"),
+            (timedelta(hours=25, minutes=30), "h:mm"),
+            (timedelta(hours=1, minutes=30), "mm:ss"),
+        ],
+    )
+    def test_parsed_format_returns_correct_duration(self, duration, format_str):
+        formatted = format_value_with_duration_format(duration, format_str)
+        assert parse_value_with_duration_format(formatted, format_str) == duration

--- a/backend/tests/baserow/core/test_duration.py
+++ b/backend/tests/baserow/core/test_duration.py
@@ -271,8 +271,21 @@ class TestFormatValueWithDurationFormat:
             (timedelta(hours=1, minutes=5), "hh:mm", "01:05"),
             # arbitrary literal chars are preserved
             (timedelta(days=2, hours=5), "d|h.", "2|5."),
-            # sub-second precision is truncated when there's no fraction token
-            (timedelta(seconds=1, milliseconds=500), "s", "1"),
+            # integer-second formats (no fraction token) round to whole seconds
+            # rather than truncating: 1.5s -> "2", 1.4s -> "1"
+            (timedelta(seconds=1, milliseconds=500), "s", "2"),
+            (timedelta(seconds=1, milliseconds=400), "s", "1"),
+            # rounding is half away from zero, so 0.5s -> "1" (not "0")
+            (timedelta(milliseconds=500), "s", "1"),
+            (-timedelta(milliseconds=500), "s", "-1"),
+            # integer rounding carries across fields: 59.6s -> 1:00
+            (timedelta(seconds=59, milliseconds=600), "mm:ss", "01:00"),
+            # 59m 59.6s -> 1:00:00
+            (
+                timedelta(minutes=59, seconds=59, milliseconds=600),
+                "h:mm:ss",
+                "1:00:00",
+            ),
             # fractional seconds rendered zero-padded to the format precision
             (
                 timedelta(hours=1, minutes=23, seconds=45, milliseconds=678),

--- a/backend/tests/baserow/core/test_duration.py
+++ b/backend/tests/baserow/core/test_duration.py
@@ -36,6 +36,33 @@ class TestTokenizeDurationFormat:
             ("d|h.", "2|5.", ["days", "hours"], ("2", "5")),
             # leading minus is optional
             ("h:mm", "-1:30", ["hours", "minutes"], ("1", "30")),
+            # fractional-seconds run with a dot separator
+            (
+                "h:mm:ss.fff",
+                "1:23:45.678",
+                ["hours", "minutes", "seconds", "fraction"],
+                ("1", "23", "45", "678"),
+            ),
+            # single `f` accepts a single fractional digit
+            (
+                "ss.f",
+                "45.6",
+                ["seconds", "fraction"],
+                ("45", "6"),
+            ),
+            # the separator before `f` is a literal, so non-dot delimiters work
+            (
+                "s fff",
+                "1 234",
+                ["seconds", "fraction"],
+                ("1", "234"),
+            ),
+            (
+                "mm:ss,ff",
+                "01:02,34",
+                ["minutes", "seconds", "fraction"],
+                ("01", "02", "34"),
+            ),
         ],
     )
     def test_tokenizes_valid_format(
@@ -74,6 +101,8 @@ class TestTokenizeDurationFormat:
             "mm mm",  # mm repeated
             "h hh",  # h then hh — both map to "hours"
             "ss s",  # ss then s — both map to "seconds"
+            "ss.f.f",  # fraction run appears twice
+            "f.fff",  # fraction run appears twice
         ],
     )
     def test_repeated_tokens_are_invalid(self, format_str):
@@ -105,6 +134,10 @@ class TestIsValidDurationFormat:
             "d h mm ss",
             "d",
             "hh:mm:ss",
+            "h:mm:ss.f",
+            "h:mm:ss.ff",
+            "h:mm:ss.fff",
+            "s fff",
         ],
     )
     def test_returns_true_for_valid_formats(self, format_str):
@@ -151,6 +184,24 @@ class TestParseValueWithDurationFormat:
             ("12:34", "hh:mm", timedelta(hours=12, minutes=34)),
             # 25 hours rolls over into 1d 1h in the resulting timedelta
             ("25:00", "h:mm", timedelta(days=1, hours=1)),
+            # fractional seconds: digits are a positional decimal
+            (
+                "1:23:45.678",
+                "h:mm:ss.fff",
+                timedelta(hours=1, minutes=23, seconds=45, milliseconds=678),
+            ),
+            # "5" at precision 1 is 0.5s, not 0.05s
+            ("0:00:00.5", "h:mm:ss.f", timedelta(milliseconds=500)),
+            # "05" is 0.05s
+            ("0:00:00.05", "h:mm:ss.ff", timedelta(milliseconds=50)),
+            # non-dot separator before the fraction
+            ("1 234", "s fff", timedelta(seconds=1, milliseconds=234)),
+            # negative carries the sub-second component
+            (
+                "-0:00:01.250",
+                "h:mm:ss.fff",
+                -timedelta(seconds=1, milliseconds=250),
+            ),
         ],
     )
     def test_parses_valid_values(self, value, format_str, expected):
@@ -220,8 +271,45 @@ class TestFormatValueWithDurationFormat:
             (timedelta(hours=1, minutes=5), "hh:mm", "01:05"),
             # arbitrary literal chars are preserved
             (timedelta(days=2, hours=5), "d|h.", "2|5."),
-            # sub-second precision is truncated
+            # sub-second precision is truncated when there's no fraction token
             (timedelta(seconds=1, milliseconds=500), "s", "1"),
+            # fractional seconds rendered zero-padded to the format precision
+            (
+                timedelta(hours=1, minutes=23, seconds=45, milliseconds=678),
+                "h:mm:ss.fff",
+                "1:23:45.678",
+            ),
+            # 0.5s at precision 1 -> "5"; at precision 3 -> "500"
+            (timedelta(milliseconds=500), "ss.f", "00.5"),
+            (timedelta(milliseconds=500), "ss.fff", "00.500"),
+            # 0.05s -> "05" at precision 2
+            (timedelta(milliseconds=50), "ss.ff", "00.05"),
+            # non-dot separator preserved on output
+            (timedelta(seconds=1, milliseconds=234), "s fff", "1 234"),
+            # rounding up carries across fields: 59.9996 -> 1:00.000
+            (
+                timedelta(seconds=59, microseconds=999600),
+                "mm:ss.fff",
+                "01:00.000",
+            ),
+            # carry that rolls all the way over: 59:59.9996 -> 1:00:00.000
+            (
+                timedelta(minutes=59, seconds=59, microseconds=999600),
+                "h:mm:ss.fff",
+                "1:00:00.000",
+            ),
+            # values beyond the precision are rounded, not truncated
+            (
+                timedelta(seconds=1, microseconds=236000),
+                "ss.ff",
+                "01.24",
+            ),
+            # negative fractional value keeps the sign
+            (
+                -timedelta(seconds=1, milliseconds=250),
+                "ss.fff",
+                "-01.250",
+            ),
         ],
     )
     def test_formats_valid_durations(self, duration, format_str, expected):
@@ -260,6 +348,14 @@ class TestFormatValueWithDurationFormat:
             (-timedelta(hours=1, minutes=30), "h:mm"),
             (timedelta(hours=25, minutes=30), "h:mm"),
             (timedelta(hours=1, minutes=30), "mm:ss"),
+            # fractional formats round-trip when the value fits the precision
+            (
+                timedelta(hours=1, minutes=23, seconds=45, milliseconds=678),
+                "h:mm:ss.fff",
+            ),
+            (timedelta(seconds=1, milliseconds=500), "ss.f"),
+            (timedelta(seconds=1, milliseconds=234), "s fff"),
+            (-timedelta(seconds=1, milliseconds=250), "ss.fff"),
         ],
     )
     def test_parsed_format_returns_correct_duration(self, duration, format_str):

--- a/changelog/entries/unreleased/feature/5420_added_the_from_duration_advanced_formula_arithmetic_support_.json
+++ b/changelog/entries/unreleased/feature/5420_added_the_from_duration_advanced_formula_arithmetic_support_.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Added the duration_format() advanced formula, arithmetic support for durations, and an optional duration format argument for the to_duration() function.",
+    "issue_origin": "github",
+    "issue_number": 5420,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-01"
+}

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -718,7 +718,8 @@
     "invalidDecimalSeparator": "'{value}' is not a valid decimal separator. Valid options are: ',' or '.'.",
     "sameSeparators": "The thousand separator and decimal separator cannot be the same.",
     "invalidDuration": "'{value}' is not a valid duration. Valid options are: '1 day', '2 hours', etc.",
-    "invalidDatetimeFormat": "'{value}' is not a valid datetime format. Valid options are: 'YYYY-MM-DD', 'DD/MM/YYYY HH:mm:ss', etc."
+    "invalidDatetimeFormat": "'{value}' is not a valid datetime format. Valid options are: 'YYYY-MM-DD', 'DD/MM/YYYY HH:mm:ss', etc.",
+    "invalidDurationFormat": "'{value}' is not a valid duration format. Use 'd' (days), 'h' (hours), 'm' (minutes), 's' (seconds), e.g. 'd:h', 'd h:mm:ss'."
   },
   "runtimeGetErrors": {
     "invalidPath": "The 'get' argument '{path}' must be a dot-delimited path (e.g., 'provider.property').",

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -715,6 +715,7 @@
     "categoryUtility": "Utility"
   },
   "runtimeFormulaTypeErrors": {
+    "invalidNumber": "'{value}' is not a valid number.",
     "invalidTimezone": "'{value}' is not a valid timezone. Use a valid IANA timezone (e.g. 'Europe/Amsterdam').",
     "invalidThousandSeparator": "'{value}' is not a valid thousand separator. Valid options are: ',', '.', ' ', or '' (empty string).",
     "invalidDecimalSeparator": "'{value}' is not a valid decimal separator. Valid options are: ',' or '.'.",

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -711,7 +711,8 @@
     "categoryNumber": "Number",
     "categoryBoolean": "Boolean",
     "categoryDate": "Date",
-    "categoryCondition": "Condition"
+    "categoryCondition": "Condition",
+    "categoryUtility": "Utility"
   },
   "runtimeFormulaTypeErrors": {
     "invalidTimezone": "'{value}' is not a valid timezone. Use a valid IANA timezone (e.g. 'Europe/Amsterdam').",

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -702,6 +702,7 @@
     "numberFormatDescription": "Formats a number as a string with configurable decimal places, thousand separator, and decimal separator.",
     "toDatetimeDescription": "Parses a string into a datetime object. An optional second argument specifies the format (e.g. 'DD/MM/YYYY'). If omitted, ISO 8601 format is assumed.",
     "toDurationDescription": "Returns the duration corresponding to the provided argument.",
+    "durationFormatDescription": "Formats a duration as text using a format string with tokens 'd' (days), 'h' (hours), 'm' (minutes), 's' (seconds), e.g. 'h:mm', 'd h:mm:ss'.",
     "formulaTypeFormula": "Function | Functions",
     "formulaTypeOperator": "Operator | Operators",
     "formulaTypeData": "Data",

--- a/web-frontend/modules/core/enums.js
+++ b/web-frontend/modules/core/enums.js
@@ -80,4 +80,8 @@ export const FORMULA_CATEGORY = {
     category: 'categoryCondition',
     iconClass: 'iconoir-code-brackets-square',
   },
+  UTILITY: {
+    category: 'categoryUtility',
+    iconClass: 'iconoir-tools',
+  },
 }

--- a/web-frontend/modules/core/formula/parser/errors.js
+++ b/web-frontend/modules/core/formula/parser/errors.js
@@ -67,6 +67,13 @@ export class InvalidFormulaArgumentType extends BaseHumanReadableError {
     super()
     this.formulaFunctionType = formulaFunctionType
     this.arg = arg
+    const { app: { $i18n } = {} } = formulaFunctionType
+    this.message = $i18n
+      ? $i18n.t('formulaParserErrors.invalidArgumentType', {
+          funcType: formulaFunctionType.getType(),
+          value: arg,
+        })
+      : `'${arg}' is not a valid argument for '${formulaFunctionType.getType()}'.`
   }
 }
 

--- a/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
@@ -9,10 +9,7 @@ import { InvalidFormulaType, UnknownOperatorError } from '@baserow/modules/core/
  * because we can't type-check an unknown value, we return this marker to indicate
  * "this will be a valid value at runtime, skip type validation for now."
  */
-// Use the global symbol registry so identity checks hold even if this module
-// is evaluated more than once (e.g. when the alias resolves through both the
-// `.js` and extensionless paths under Vitest/Nuxt).
-export const DeferredValue = Symbol.for('baserow.formula.DeferredValue')
+export const DeferredValue = Symbol('DeferredValue')
 
 /**
  * A visitor that validates formula functions and their arguments during parsing.
@@ -165,20 +162,16 @@ export default class BaserowFormulaValidationVisitor extends BaserowFormulaVisit
       acceptedArgs
     )
 
-    // Only run validateArgs if none of the arguments are DeferredValue,
-    // or the function opts in to deferred-aware validation.
-    // 
+    // Only run validateArgs if none of the arguments are DeferredValue.
     // DeferredValue represents nested function calls whose values aren't
-    // available until execution time, so we usually can't type-check them.
-    // But a function that knows how to ignore deferred slots can still catch
-    // type errors on literal args.
+    // available until execution time, so we can't type-check them.
     const hasDeferred = argsParsed.some((arg) => arg === DeferredValue)
-    if (!hasDeferred || formulaFunctionType.canValidateWithDeferred) {
+    if (!hasDeferred) {
       formulaFunctionType.validateArgs(argsParsed, { ctx, validationContext: this.validationContext})
     }
 
-    // Return DeferredValue to indicate this function's result will only
-    // be available at execution time.
+    // Return DeferredValue to indicate this function's result
+    // will only be available at execution time
     return DeferredValue
   }
 }

--- a/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
@@ -162,16 +162,20 @@ export default class BaserowFormulaValidationVisitor extends BaserowFormulaVisit
       acceptedArgs
     )
 
-    // Only run validateArgs if none of the arguments are DeferredValue.
+    // Only run validateArgs if none of the arguments are DeferredValue,
+    // or the function opts in to deferred-aware validation.
+    // 
     // DeferredValue represents nested function calls whose values aren't
-    // available until execution time, so we can't type-check them.
+    // available until execution time, so we usually can't type-check them.
+    // But a function that knows how to ignore deferred slots can still catch
+    // type errors on literal args.
     const hasDeferred = argsParsed.some((arg) => arg === DeferredValue)
-    if (!hasDeferred) {
+    if (!hasDeferred || formulaFunctionType.canValidateWithDeferred) {
       formulaFunctionType.validateArgs(argsParsed, { ctx, validationContext: this.validationContext})
     }
 
-    // Return DeferredValue to indicate this function's result
-    // will only be available at execution time
+    // Return DeferredValue to indicate this function's result will only
+    // be available at execution time.
     return DeferredValue
   }
 }

--- a/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
@@ -116,24 +116,24 @@ export default class BaserowFormulaValidationVisitor extends BaserowFormulaVisit
    * Parse arguments for validation, skipping DeferredValue instances.
    *
    * During validation, nested function calls return DeferredValue markers
-   * since their actual values aren't available yet. We pass these through
-   * unchanged rather than attempting to parse/cast them.
+   * since their actual values aren't available yet. When any arg is deferred
+   * we pass the list through unchanged since the caller will detect the
+   * DeferredValue and skip validateArgs.
+   *
+   * Otherwise we defer to the function type's `parseArgs` so per-function
+   * overrides (e.g. RuntimeToDuration leaving arg 0 as a string when a
+   * format is provided) take effect during validation too.
    */
   _parseArgsForValidation(formulaFunctionType, acceptedArgs) {
     if (!formulaFunctionType.args) {
       return acceptedArgs
     }
 
-    return acceptedArgs.map((arg, index) => {
-      if (arg === DeferredValue) {
-        // Preserve deferred values - they'll be resolved at execution time
-        return arg
-      } else if (index < formulaFunctionType.args.length) {
-        return formulaFunctionType.args[index].parse(arg)
-      } else {
-        return arg
-      }
-    })
+    if (acceptedArgs.some((arg) => arg === DeferredValue)) {
+      return acceptedArgs
+    }
+
+    return formulaFunctionType.parseArgs(acceptedArgs)
   }
 
   /**

--- a/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
@@ -9,7 +9,10 @@ import { InvalidFormulaType, UnknownOperatorError } from '@baserow/modules/core/
  * because we can't type-check an unknown value, we return this marker to indicate
  * "this will be a valid value at runtime, skip type validation for now."
  */
-export const DeferredValue = Symbol('DeferredValue')
+// Use the global symbol registry so identity checks hold even if this module
+// is evaluated more than once (e.g. when the alias resolves through both the
+// `.js` and extensionless paths under Vitest/Nuxt).
+export const DeferredValue = Symbol.for('baserow.formula.DeferredValue')
 
 /**
  * A visitor that validates formula functions and their arguments during parsing.

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -872,7 +872,8 @@
   "formulaParserErrors": {
     "invalidArgCountMin": "The '{funcType}' function expects a minimum of {minArgs} arguments.",
     "invalidArgCountExact": "The '{funcType}' function expects exactly {minArgs} arguments.",
-    "invalidArgCountRange": "The '{funcType}' function expects between {minArgs} and {maxArgs} arguments."
+    "invalidArgCountRange": "The '{funcType}' function expects between {minArgs} and {maxArgs} arguments.",
+    "invalidArgumentType": "'{value}' is not a valid argument for the '{funcType}' function."
   },
   "dataExplorer": {
     "noMatchingNodesText": "No matching results were found.",

--- a/web-frontend/modules/core/plugin.js
+++ b/web-frontend/modules/core/plugin.js
@@ -98,6 +98,7 @@ import {
   RuntimeNull,
   RuntimeNumberFormat,
   RuntimeToDuration,
+  RuntimeDurationFormat,
   RuntimeToday,
   RuntimeGetProperty,
   RuntimeRandomInt,
@@ -306,6 +307,10 @@ export default defineNuxtPlugin({
       new RuntimeNumberFormat(context)
     )
     registry.register('runtimeFormulaFunction', new RuntimeToDuration(context))
+    registry.register(
+      'runtimeFormulaFunction',
+      new RuntimeDurationFormat(context)
+    )
     registry.register('runtimeFormulaFunction', new RuntimeToDatetime(context))
     registry.register('errorPage', new DefaultErrorPageType(context))
 

--- a/web-frontend/modules/core/runtimeFormulaArgumentTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaArgumentTypes.js
@@ -87,6 +87,10 @@ export class NumberBaserowRuntimeFormulaArgumentType extends BaserowRuntimeFormu
     }
     return val
   }
+
+  getErrorMessage(value, i18n) {
+    return i18n.t('runtimeFormulaTypeErrors.invalidNumber', { value })
+  }
 }
 
 export class TextBaserowRuntimeFormulaArgumentType extends BaserowRuntimeFormulaArgumentType {

--- a/web-frontend/modules/core/runtimeFormulaArgumentTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaArgumentTypes.js
@@ -13,6 +13,7 @@ import {
   isValidDatetimeFormat,
   parseDurationString,
 } from '@baserow/modules/core/utils/date'
+import { isValidDurationFormat } from '@baserow/modules/core/utils/duration'
 export { Timedelta, parseDurationString }
 
 const VALID_THOUSAND_SEPARATORS = new Set([',', '.', ' ', ''])
@@ -286,5 +287,19 @@ export class DatetimeFormatBaserowRuntimeFormulaArgumentType extends BaserowRunt
 
   getErrorMessage(value, i18n) {
     return i18n.t('runtimeFormulaTypeErrors.invalidDatetimeFormat', { value })
+  }
+}
+
+export class DurationFormatBaserowRuntimeFormulaArgumentType extends BaserowRuntimeFormulaArgumentType {
+  test(value) {
+    return isValidDurationFormat(value)
+  }
+
+  parse(value) {
+    return ensureString(value)
+  }
+
+  getErrorMessage(value, i18n) {
+    return i18n.t('runtimeFormulaTypeErrors.invalidDurationFormat', { value })
   }
 }

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -2950,14 +2950,6 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
     }
 
     const [value, durationFormat] = args
-    // The validation visitor pre-parses arg 0 via the argument type's parse(),
-    // so by the time we get here a literal string may already be a Timedelta.
-    if (value instanceof Timedelta) {
-      throw new InvalidFormulaArgument(
-        this.getType(),
-        this.timedeltaWithFormatError()
-      )
-    }
     if (typeof value === 'string') {
       if (parseValueWithDurationFormat(value, durationFormat) === null) {
         throw new InvalidFormulaArgument(

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -628,8 +628,8 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
       if (td.test(a) && td.test(b)) return []
       if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
       if (dt.test(a) && td.test(b)) return []
-      if (!(num.test(a) || dt.test(a))) return [[0, a]]
 
+      // Reject invalid pairs, e.g.: datetime - number, timedelta - datetime, etc.
       return [[1, b]]
     }
 

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -29,7 +29,10 @@ import {
   ensureArray,
   ensureDateTime,
 } from '@baserow/modules/core/utils/validator'
-import { parseValueWithDurationFormat } from '@baserow/modules/core/utils/duration'
+import {
+  formatValueWithDurationFormat,
+  parseValueWithDurationFormat,
+} from '@baserow/modules/core/utils/duration'
 import { Node, VueNodeViewRenderer } from '@tiptap/vue-3'
 import GetFormulaComponent from '@baserow/modules/core/components/formula/GetFormulaComponent'
 import { mergeAttributes } from '@tiptap/core'
@@ -2930,6 +2933,53 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
       {
         formula: "now() + to_duration('1 day')",
         result: "'2025-10-17 11:05:38'",
+      },
+    ]
+  }
+}
+
+export class RuntimeDurationFormat extends RuntimeFormulaFunction {
+  static getType() {
+    return 'duration_format'
+  }
+
+  static getFormulaType() {
+    return FORMULA_TYPE.FUNCTION
+  }
+
+  static getCategoryType() {
+    return FORMULA_CATEGORY.DATE
+  }
+
+  get args() {
+    return [
+      new DurationBaserowRuntimeFormulaArgumentType(),
+      new DurationFormatBaserowRuntimeFormulaArgumentType(),
+    ]
+  }
+
+  execute(context, args) {
+    const [duration, durationFormat] = args
+    if (duration === null || duration === undefined) {
+      return null
+    }
+    return formatValueWithDurationFormat(duration, durationFormat)
+  }
+
+  getDescription() {
+    const { $i18n: i18n } = this.app
+    return i18n.t('runtimeFormulaTypes.durationFormatDescription')
+  }
+
+  getExamples() {
+    return [
+      {
+        formula: "duration_format(to_duration('1:30', 'h:mm'), 'h:mm')",
+        result: "'1:30'",
+      },
+      {
+        formula: "duration_format(get('Duration'), 'd h:mm')",
+        result: "'1 2:30'",
       },
     ]
   }

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -22,7 +22,6 @@ import {
   InvalidFormulaArgumentType,
   InvalidNumberOfArguments,
 } from '@baserow/modules/core/formula/parser/errors'
-import { DeferredValue } from '@baserow/modules/core/formula/parser/formulaValidationVisitor.js'
 import { reverseString, generateUUID } from '@baserow/modules/core/utils/string'
 import { avg, sum } from '@baserow/modules/core/utils/number'
 import {
@@ -232,17 +231,6 @@ export class RuntimeFormulaFunction extends Registerable {
    */
   get getOperatorSymbol() {
     return null
-  }
-
-  /**
-   * Whether this function's validateArgs() can tolerate args that are deferred.
-   *
-   * When true, the validation visitor still calls validateArgs() even if some arguments
-   * are deferred, allowing validateTypeOfArgs() to type-check the literal args.
-   * @returns {boolean}
-   */
-  get canValidateWithDeferred() {
-    return false
   }
 }
 
@@ -483,10 +471,6 @@ export class RuntimeAdd extends RuntimeFormulaFunction {
     return '+'
   }
 
-  get canValidateWithDeferred() {
-    return true
-  }
-
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -497,31 +481,17 @@ export class RuntimeAdd extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
-      const isDeferred = (x) => x === DeferredValue
-      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const dt = new DateTimeBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
-      if (
-        !isDeferred(a) &&
-        (isEmptyLiteral(a) || !(num.test(a) || dt.test(a) || td.test(a)))
-      ) {
-        return [[0, a]]
-      }
-      if (
-        !isDeferred(b) &&
-        (isEmptyLiteral(b) || !(num.test(b) || dt.test(b) || td.test(b)))
-      ) {
-        return [[1, b]]
-      }
-      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
       if (td.test(a) && td.test(b)) return []
       if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
       if ((dt.test(a) && td.test(b)) || (td.test(a) && dt.test(b))) return []
+      if (!(num.test(a) || dt.test(a) || td.test(a))) return [[0, a]]
+      if (!(num.test(b) || dt.test(b) || td.test(b))) return [[1, b]]
 
-      // Ensure invalid pairs aren't allowed, e.g.: datetime + number,
-      // datetime + datetime, etc.
+      // Reject invalid pairs, e.g.: datetime + number, datetime + datetime, etc.
       return [[0, a]]
     }
 
@@ -591,10 +561,6 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
     return '-'
   }
 
-  get canValidateWithDeferred() {
-    return true
-  }
-
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -605,29 +571,14 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
-      const isDeferred = (x) => x === DeferredValue
-      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const dt = new DateTimeBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
-
-      if (
-        !isDeferred(a) &&
-        (isEmptyLiteral(a) || !(num.test(a) || dt.test(a) || td.test(a)))
-      ) {
-        return [[0, a]]
-      }
-      if (
-        !isDeferred(b) &&
-        (isEmptyLiteral(b) || !(num.test(b) || dt.test(b) || td.test(b)))
-      ) {
-        return [[1, b]]
-      }
-      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
       if (td.test(a) && td.test(b)) return []
       if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
       if (dt.test(a) && td.test(b)) return []
+      if (!(num.test(a) || dt.test(a) || td.test(a))) return [[0, a]]
 
       // Reject invalid pairs, e.g.: datetime - number, timedelta - datetime, etc.
       return [[1, b]]
@@ -696,10 +647,6 @@ export class RuntimeMultiply extends RuntimeFormulaFunction {
     return '*'
   }
 
-  get canValidateWithDeferred() {
-    return true
-  }
-
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -710,27 +657,13 @@ export class RuntimeMultiply extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
-      const isDeferred = (x) => x === DeferredValue
-      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
-
-      if (
-        !isDeferred(a) &&
-        (isEmptyLiteral(a) || !(num.test(a) || td.test(a)))
-      ) {
-        return [[0, a]]
-      }
-      if (
-        !isDeferred(b) &&
-        (isEmptyLiteral(b) || !(num.test(b) || td.test(b)))
-      ) {
-        return [[1, b]]
-      }
-      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
       if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
+      if (!(num.test(a) || td.test(a))) return [[0, a]]
 
+      // Reject invalid pairs, e.g.: timedelta * timedelta, etc.
       return [[1, b]]
     }
 
@@ -791,10 +724,6 @@ export class RuntimeDivide extends RuntimeFormulaFunction {
     return '/'
   }
 
-  get canValidateWithDeferred() {
-    return true
-  }
-
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -805,24 +734,13 @@ export class RuntimeDivide extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
-      const isDeferred = (x) => x === DeferredValue
-      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
-
-      if (
-        !isDeferred(a) &&
-        (isEmptyLiteral(a) || !(num.test(a) || td.test(a)))
-      ) {
-        return [[0, a]]
-      }
-      if (!isDeferred(b) && (isEmptyLiteral(b) || !num.test(b))) {
-        return [[1, b]]
-      }
-      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
       if (td.test(a) && num.test(b)) return []
+      if (!(num.test(a) || td.test(a))) return [[0, a]]
 
+      // Reject invalid pairs, e.g.: number / timedelta, timedelta / timedelta, etc.
       return [[1, b]]
     }
 

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -14,6 +14,7 @@ import {
   TimedeltaBaserowRuntimeFormulaArgumentType,
   DatetimeFormatBaserowRuntimeFormulaArgumentType,
   DurationBaserowRuntimeFormulaArgumentType,
+  DurationFormatBaserowRuntimeFormulaArgumentType,
   Timedelta,
 } from '@baserow/modules/core/runtimeFormulaArgumentTypes'
 import {
@@ -28,6 +29,7 @@ import {
   ensureArray,
   ensureDateTime,
 } from '@baserow/modules/core/utils/validator'
+import { parseValueWithDurationFormat } from '@baserow/modules/core/utils/duration'
 import { Node, VueNodeViewRenderer } from '@tiptap/vue-3'
 import GetFormulaComponent from '@baserow/modules/core/components/formula/GetFormulaComponent'
 import { mergeAttributes } from '@tiptap/core'
@@ -2825,10 +2827,88 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
   }
 
   get args() {
-    return [new DurationBaserowRuntimeFormulaArgumentType()]
+    return [
+      new DurationBaserowRuntimeFormulaArgumentType(),
+      new DurationFormatBaserowRuntimeFormulaArgumentType({ optional: true }),
+    ]
+  }
+
+  formatMismatchError(value, durationFormat) {
+    return `'${value}' could not be parsed using format '${durationFormat}'.`
+  }
+
+  timedeltaWithFormatError() {
+    return 'A duration format cannot be applied to a timedelta value.'
+  }
+
+  validateTypeOfArgs(args) {
+    // When a format is provided, arg 0's validity depends on the format.
+    // Defer checking arg 0 to validateArgs() in that case.
+    if (args.length === 2) {
+      if (!this.args[1].test(args[1])) {
+        return [[1, args[1]]]
+      }
+      return []
+    }
+    return super.validateTypeOfArgs(args)
+  }
+
+  validateArgs(args, { ctx = null, validationContext = {} } = {}) {
+    super.validateArgs(args, { ctx, validationContext })
+
+    if (args.length !== 2) {
+      return
+    }
+
+    const [value, durationFormat] = args
+    // The validation visitor pre-parses arg 0 via the argument type's parse(),
+    // so by the time we get here a literal string may already be a Timedelta.
+    if (value instanceof Timedelta) {
+      throw new InvalidFormulaArgument(
+        this.getType(),
+        this.timedeltaWithFormatError()
+      )
+    }
+    if (typeof value === 'string') {
+      if (parseValueWithDurationFormat(value, durationFormat) === null) {
+        throw new InvalidFormulaArgument(
+          this.getType(),
+          this.formatMismatchError(value, durationFormat)
+        )
+      }
+    }
+  }
+
+  parseArgs(args) {
+    // When the format arg is provided, defer parsing of the 1st arg to
+    // execute() so the raw value string is checked later.
+    if (args.length === 2) {
+      return [args[0], this.args[1].parse(args[1])]
+    }
+    return super.parseArgs(args)
   }
 
   execute(context, args) {
+    if (args.length === 2) {
+      const [value, durationFormat] = args
+      // Arg 0 may resolve to a Timedelta at runtime (e.g. from a get() on
+      // a duration field), in which case it doesn't make sense to
+      // apply a format.
+      if (value instanceof Timedelta) {
+        throw new InvalidFormulaArgument(
+          this.getType(),
+          this.timedeltaWithFormatError()
+        )
+      }
+      const result = parseValueWithDurationFormat(value, durationFormat)
+      if (result === null) {
+        throw new InvalidFormulaArgument(
+          this.getType(),
+          this.formatMismatchError(value, durationFormat)
+        )
+      }
+      return result
+    }
     return args[0]
   }
 
@@ -2842,6 +2922,10 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
       {
         formula: "to_duration('1 day')",
         result: '86400 seconds',
+      },
+      {
+        formula: "to_duration('1:30', 'h:mm')",
+        result: '5400 seconds',
       },
       {
         formula: "now() + to_duration('1 day')",

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -3001,12 +3001,12 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
   getExamples() {
     return [
       {
-        formula: "to_duration('1 day')",
-        result: '86400 seconds',
+        formula: "to_duration('1:30:15.234', 'h:mm:ss.fff')",
+        result: '5400 seconds',
       },
       {
-        formula: "to_duration('1:30', 'h:mm')",
-        result: '5400 seconds',
+        formula: "to_duration('1 day')",
+        result: '86400 seconds',
       },
       {
         formula: "now() + to_duration('1 day')",
@@ -3052,8 +3052,9 @@ export class RuntimeDurationFormat extends RuntimeFormulaFunction {
   getExamples() {
     return [
       {
-        formula: "duration_format(to_duration('1:30', 'h:mm'), 'h:mm')",
-        result: "'1:30'",
+        formula:
+          "duration_format(to_duration('1:30:25.234', 'h:mm:ss.fff'), 'h:mm:ss.f')",
+        result: "'1:30:25.2'",
       },
       {
         formula: "duration_format(get('Duration'), 'd h:mm')",

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -3002,7 +3002,7 @@ export class RuntimeToDuration extends RuntimeFormulaFunction {
     return [
       {
         formula: "to_duration('1:30:15.234', 'h:mm:ss.fff')",
-        result: '5400 seconds',
+        result: '5415 seconds',
       },
       {
         formula: "to_duration('1 day')",

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -313,7 +313,7 @@ export class RuntimeGet extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -1701,7 +1701,7 @@ export class RuntimeGetProperty extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -1856,7 +1856,7 @@ export class RuntimeGenerateUUID extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2075,7 +2075,7 @@ export class RuntimeLength extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2123,7 +2123,7 @@ export class RuntimeContains extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2177,7 +2177,7 @@ export class RuntimeReverse extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2333,7 +2333,7 @@ export class RuntimeIsEmpty extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.BOOLEAN
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2529,7 +2529,7 @@ export class RuntimeAt extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {
@@ -2621,7 +2621,7 @@ export class RuntimeNull extends RuntimeFormulaFunction {
   }
 
   static getCategoryType() {
-    return FORMULA_CATEGORY.TEXT
+    return FORMULA_CATEGORY.UTILITY
   }
 
   get args() {

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -22,6 +22,7 @@ import {
   InvalidFormulaArgumentType,
   InvalidNumberOfArguments,
 } from '@baserow/modules/core/formula/parser/errors'
+import { DeferredValue } from '@baserow/modules/core/formula/parser/formulaValidationVisitor.js'
 import { reverseString, generateUUID } from '@baserow/modules/core/utils/string'
 import { avg, sum } from '@baserow/modules/core/utils/number'
 import {
@@ -231,6 +232,17 @@ export class RuntimeFormulaFunction extends Registerable {
    */
   get getOperatorSymbol() {
     return null
+  }
+
+  /**
+   * Whether this function's validateArgs() can tolerate args that are deferred.
+   *
+   * When true, the validation visitor still calls validateArgs() even if some arguments
+   * are deferred, allowing validateTypeOfArgs() to type-check the literal args.
+   * @returns {boolean}
+   */
+  get canValidateWithDeferred() {
+    return false
   }
 }
 
@@ -471,6 +483,10 @@ export class RuntimeAdd extends RuntimeFormulaFunction {
     return '+'
   }
 
+  get canValidateWithDeferred() {
+    return true
+  }
+
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -481,14 +497,34 @@ export class RuntimeAdd extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
+      const isDeferred = (x) => x === DeferredValue
+      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const dt = new DateTimeBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
+      if (
+        !isDeferred(a) &&
+        (isEmptyLiteral(a) || !(num.test(a) || dt.test(a) || td.test(a)))
+      ) {
+        return [[0, a]]
+      }
+      if (
+        !isDeferred(b) &&
+        (isEmptyLiteral(b) || !(num.test(b) || dt.test(b) || td.test(b)))
+      ) {
+        return [[1, b]]
+      }
+      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
+      if (td.test(a) && td.test(b)) return []
+      if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
       if ((dt.test(a) && td.test(b)) || (td.test(a) && dt.test(b))) return []
-      if (!(num.test(a) || dt.test(a) || td.test(a))) return [[0, a]]
-      return [[1, b]]
+
+      // Ensure invalid pairs aren't allowed, e.g.: datetime + number,
+      // datetime + datetime, etc.
+      return [[0, a]]
     }
+
     return super.validateTypeOfArgs(args)
   }
 
@@ -501,6 +537,15 @@ export class RuntimeAdd extends RuntimeFormulaFunction {
 
   execute(context, args) {
     const [a, b] = args
+    if (a instanceof Timedelta && b instanceof Timedelta) {
+      return new Timedelta(a.ms + b.ms)
+    }
+    if (a instanceof Timedelta && typeof b === 'number') {
+      return new Timedelta(a.ms + b * 1000)
+    }
+    if (typeof a === 'number' && b instanceof Timedelta) {
+      return new Timedelta(a * 1000 + b.ms)
+    }
     if (a instanceof Date && b instanceof Timedelta) {
       return new Date(a.getTime() + b.ms)
     }
@@ -546,6 +591,10 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
     return '-'
   }
 
+  get canValidateWithDeferred() {
+    return true
+  }
+
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -556,14 +605,34 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
   validateTypeOfArgs(args) {
     if (args.length === 2) {
       const [a, b] = args
+      const isDeferred = (x) => x === DeferredValue
+      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
       const num = new NumberBaserowRuntimeFormulaArgumentType()
       const dt = new DateTimeBaserowRuntimeFormulaArgumentType()
       const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
+
+      if (
+        !isDeferred(a) &&
+        (isEmptyLiteral(a) || !(num.test(a) || dt.test(a) || td.test(a)))
+      ) {
+        return [[0, a]]
+      }
+      if (
+        !isDeferred(b) &&
+        (isEmptyLiteral(b) || !(num.test(b) || dt.test(b) || td.test(b)))
+      ) {
+        return [[1, b]]
+      }
+      if (isDeferred(a) || isDeferred(b)) return []
       if (num.test(a) && num.test(b)) return []
+      if (td.test(a) && td.test(b)) return []
+      if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
       if (dt.test(a) && td.test(b)) return []
       if (!(num.test(a) || dt.test(a))) return [[0, a]]
+
       return [[1, b]]
     }
+
     return super.validateTypeOfArgs(args)
   }
 
@@ -576,6 +645,15 @@ export class RuntimeMinus extends RuntimeFormulaFunction {
 
   execute(context, args) {
     const [a, b] = args
+    if (a instanceof Timedelta && b instanceof Timedelta) {
+      return new Timedelta(a.ms - b.ms)
+    }
+    if (a instanceof Timedelta && typeof b === 'number') {
+      return new Timedelta(a.ms - b * 1000)
+    }
+    if (typeof a === 'number' && b instanceof Timedelta) {
+      return new Timedelta(a * 1000 - b.ms)
+    }
     if (a instanceof Date && b instanceof Timedelta) {
       return new Date(a.getTime() - b.ms)
     }
@@ -618,6 +696,10 @@ export class RuntimeMultiply extends RuntimeFormulaFunction {
     return '*'
   }
 
+  get canValidateWithDeferred() {
+    return true
+  }
+
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -625,8 +707,52 @@ export class RuntimeMultiply extends RuntimeFormulaFunction {
     ]
   }
 
+  validateTypeOfArgs(args) {
+    if (args.length === 2) {
+      const [a, b] = args
+      const isDeferred = (x) => x === DeferredValue
+      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
+      const num = new NumberBaserowRuntimeFormulaArgumentType()
+      const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
+
+      if (
+        !isDeferred(a) &&
+        (isEmptyLiteral(a) || !(num.test(a) || td.test(a)))
+      ) {
+        return [[0, a]]
+      }
+      if (
+        !isDeferred(b) &&
+        (isEmptyLiteral(b) || !(num.test(b) || td.test(b)))
+      ) {
+        return [[1, b]]
+      }
+      if (isDeferred(a) || isDeferred(b)) return []
+      if (num.test(a) && num.test(b)) return []
+      if ((td.test(a) && num.test(b)) || (num.test(a) && td.test(b))) return []
+
+      return [[1, b]]
+    }
+
+    return super.validateTypeOfArgs(args)
+  }
+
+  parseArgs(args) {
+    if (args.some((a) => a instanceof Timedelta)) {
+      return args
+    }
+    return super.parseArgs(args)
+  }
+
   execute(context, args) {
-    return args[0] * args[1]
+    const [a, b] = args
+    if (a instanceof Timedelta && typeof b === 'number') {
+      return new Timedelta(a.ms * b)
+    }
+    if (typeof a === 'number' && b instanceof Timedelta) {
+      return new Timedelta(b.ms * a)
+    }
+    return a * b
   }
 
   getDescription() {
@@ -665,6 +791,10 @@ export class RuntimeDivide extends RuntimeFormulaFunction {
     return '/'
   }
 
+  get canValidateWithDeferred() {
+    return true
+  }
+
   get args() {
     return [
       new NumberBaserowRuntimeFormulaArgumentType(),
@@ -672,8 +802,46 @@ export class RuntimeDivide extends RuntimeFormulaFunction {
     ]
   }
 
+  validateTypeOfArgs(args) {
+    if (args.length === 2) {
+      const [a, b] = args
+      const isDeferred = (x) => x === DeferredValue
+      const isEmptyLiteral = (x) => x === '' || x === null || x === undefined
+      const num = new NumberBaserowRuntimeFormulaArgumentType()
+      const td = new TimedeltaBaserowRuntimeFormulaArgumentType()
+
+      if (
+        !isDeferred(a) &&
+        (isEmptyLiteral(a) || !(num.test(a) || td.test(a)))
+      ) {
+        return [[0, a]]
+      }
+      if (!isDeferred(b) && (isEmptyLiteral(b) || !num.test(b))) {
+        return [[1, b]]
+      }
+      if (isDeferred(a) || isDeferred(b)) return []
+      if (num.test(a) && num.test(b)) return []
+      if (td.test(a) && num.test(b)) return []
+
+      return [[1, b]]
+    }
+
+    return super.validateTypeOfArgs(args)
+  }
+
+  parseArgs(args) {
+    if (args.some((a) => a instanceof Timedelta)) {
+      return args
+    }
+    return super.parseArgs(args)
+  }
+
   execute(context, args) {
-    return args[0] / args[1]
+    const [a, b] = args
+    if (a instanceof Timedelta && typeof b === 'number') {
+      return new Timedelta(a.ms / b)
+    }
+    return a / b
   }
 
   getDescription() {

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -519,6 +519,24 @@ export const DURATION_FORMATS = new Map([
   ],
 ])
 
+// Maps each field DURATION_FORMATS key to the equivalent token-engine format
+// consumed by formatValueWithDurationFormat. The `s`-fraction forms become `f`
+// runs, and the `d`-prefixed display formats use backslash-escaped literal unit
+// letters (e.g. `d\d h\h` -> "1d 2h"), which the token engine cannot emit
+// otherwise. Keep in sync with duration.py::DURATION_TOKEN_FORMATS.
+const DURATION_TOKEN_FORMATS = {
+  [H_M]: 'h:mm',
+  [H_M_S]: 'h:mm:ss',
+  [H_M_S_S]: 'h:mm:ss.f',
+  [H_M_S_SS]: 'h:mm:ss.ff',
+  [H_M_S_SSS]: 'h:mm:ss.fff',
+  [D_H]: 'd\\d h\\h',
+  [D_H_M]: 'd\\d h:mm',
+  [D_H_M_S]: 'd\\d h:mm:ss',
+  [D_H_M_NO_COLONS]: 'd\\d h\\h mm\\m',
+  [D_H_M_S_NO_COLONS]: 'd\\d h\\h mm\\m ss\\s',
+}
+
 export const roundDurationValueToFormat = (value, format) => {
   if (value === null) {
     return null
@@ -605,22 +623,20 @@ export const parseDurationString = (value) => {
 }
 
 /**
- * It formats the given duration value using the given format.
+ * It formats the given duration value (a number of seconds) using the given
+ * format.
+ *
+ * Thin adapter over the token formatter (`formatValueWithDurationFormat`), which
+ * is the single source of truth for duration display. It converts the seconds
+ * value to a `Timedelta` (ms) and translates the field's DURATION_FORMATS key to
+ * the equivalent token format first.
  */
 export const formatDurationValue = (value, format) => {
   if (value === null || value === undefined || value === '') {
     return ''
   }
-  let sign = ''
-  if (value < 0) {
-    sign = '-'
-    value = -1 * value
-  }
-  const days = Math.floor(value / 86400)
-  const hours = Math.floor((value % 86400) / 3600)
-  const mins = Math.floor((value % 3600) / 60)
-  const secs = value % 60
-
-  const formatFunc = DURATION_FORMATS.get(format).toString
-  return `${sign}${formatFunc(days, hours, mins, secs)}`
+  return formatValueWithDurationFormat(
+    new Timedelta(value * 1000),
+    DURATION_TOKEN_FORMATS[format]
+  )
 }

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -49,6 +49,24 @@ export const tokenizeDurationFormat = (formatStr) => {
   const seen = new Set()
   let i = 0
   while (i < formatStr.length) {
+    // The fractional-seconds token "f" is consumed as a run ("f", "ff", "fff",
+    // …) whose length is the precision (mirrors the hh/mm/ss width semantics).
+    // It is a distinct field that may appear at most once, and the separator
+    // before it stays a literal so arbitrary delimiters work ("ss.fff",
+    // "s fff", "mm:ss,ff").
+    if (formatStr[i] === 'f') {
+      if (seen.has('fraction')) return null
+      seen.add('fraction')
+      let precision = 0
+      while (i < formatStr.length && formatStr[i] === 'f') {
+        precision += 1
+        i += 1
+      }
+      fields.push('fraction')
+      // capture up to `precision` digits; extra digits won't match
+      pattern.push(`(\\d{1,${precision}})`)
+      continue
+    }
     let matched = false
     for (const [token, field] of DURATION_FORMAT_TOKENS) {
       if (formatStr.startsWith(token, i)) {
@@ -87,15 +105,24 @@ export const parseValueWithDurationFormat = (value, formatStr) => {
   if (match === null) return null
 
   const parts = { days: 0, hours: 0, minutes: 0, seconds: 0 }
+  let fractionMs = 0
   tokenized.fields.forEach((field, idx) => {
-    parts[field] = parseInt(match[idx + 1], 10)
+    const group = match[idx + 1]
+    if (field === 'fraction') {
+      // The captured digits are a positional decimal: "5" -> 0.5,
+      // "05" -> 0.05, "234" -> 0.234.
+      fractionMs = (parseInt(group, 10) / 10 ** group.length) * 1000
+    } else {
+      parts[field] = parseInt(group, 10)
+    }
   })
 
   let ms =
     parts.days * SECS_IN_DAY * 1000 +
     parts.hours * SECS_IN_HOUR * 1000 +
     parts.minutes * SECS_IN_MIN * 1000 +
-    parts.seconds * 1000
+    parts.seconds * 1000 +
+    fractionMs
   if (negative) ms = -ms
   return new Timedelta(ms)
 }
@@ -108,7 +135,24 @@ export const formatValueWithDurationFormat = (value, formatStr) => {
 
   const fieldSet = new Set(tokenized.fields)
   const negative = value.ms < 0
-  const totalSeconds = Math.trunc(Math.abs(value.ms) / 1000)
+  const absMs = Math.abs(value.ms)
+
+  let precision = 0
+  let fractionValue = 0
+  let totalSeconds
+  if (fieldSet.has('fraction')) {
+    // Render fractional seconds at the format's precision (the number of
+    // `f`s). Round the total to that precision *before* decomposing so a
+    // rounded-up value carries across fields (e.g. 59.9996 at precision 3
+    // -> 60.000 rolls seconds into minutes).
+    precision = formatStr.match(/f+/)[0].length
+    const factor = 10 ** precision
+    const total = Math.round((absMs / 1000) * factor) / factor
+    totalSeconds = Math.trunc(total)
+    fractionValue = total - totalSeconds
+  } else {
+    totalSeconds = Math.trunc(absMs / 1000)
+  }
 
   let days = 0
   let hours = 0
@@ -139,6 +183,14 @@ export const formatValueWithDurationFormat = (value, formatStr) => {
   const out = []
   let i = 0
   while (i < formatStr.length) {
+    if (formatStr[i] === 'f') {
+      // Render the fractional component as `precision` zero-padded digits
+      // (mirrors printf's %0width.Nf).
+      const digits = Math.round(fractionValue * 10 ** precision)
+      out.push(String(digits).padStart(precision, '0'))
+      i += precision
+      continue
+    }
     let matched = false
     for (const [token, field] of DURATION_FORMAT_TOKENS) {
       if (formatStr.startsWith(token, i)) {

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -137,22 +137,21 @@ export const formatValueWithDurationFormat = (value, formatStr) => {
   const negative = value.ms < 0
   const absMs = Math.abs(value.ms)
 
-  let precision = 0
-  let fractionValue = 0
-  let totalSeconds
-  if (fieldSet.has('fraction')) {
-    // Render fractional seconds at the format's precision (the number of
-    // `f`s). Round the total to that precision *before* decomposing so a
-    // rounded-up value carries across fields (e.g. 59.9996 at precision 3
-    // -> 60.000 rolls seconds into minutes).
-    precision = formatStr.match(/f+/)[0].length
-    const factor = 10 ** precision
-    const total = Math.round((absMs / 1000) * factor) / factor
-    totalSeconds = Math.trunc(total)
-    fractionValue = total - totalSeconds
-  } else {
-    totalSeconds = Math.trunc(absMs / 1000)
-  }
+  // Precision is the number of `f`s in the format, or 0 for integer-second
+  // formats (no fraction token).
+  const precision = fieldSet.has('fraction')
+    ? formatStr.match(/f+/)[0].length
+    : 0
+
+  // Round the total to the target precision *before* decomposing, so a
+  // rounded-up value carries across fields: 59.9996 at precision 3 -> 60.000
+  // rolls seconds into minutes, and 59.6 at precision 0 -> 60 rolls into a
+  // minute. `Math.round` rounds half up, matching the backend's half-away-from-
+  // zero on the absolute value. Keep in sync with duration.py.
+  const factor = 10 ** precision
+  const total = Math.round((absMs / 1000) * factor) / factor
+  const totalSeconds = Math.trunc(total)
+  const fractionValue = total - totalSeconds
 
   let days = 0
   let hours = 0

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -49,6 +49,16 @@ export const tokenizeDurationFormat = (formatStr) => {
   const seen = new Set()
   let i = 0
   while (i < formatStr.length) {
+    // A backslash escapes the next character so it is matched/emitted as a
+    // literal, even token letters (d/h/m/s/f) or the backslash itself. This
+    // lets formats carry literal unit suffixes, e.g. `d\d h\h` -> "1d 2h". A
+    // trailing backslash has nothing to escape and is invalid.
+    if (formatStr[i] === '\\') {
+      if (i + 1 >= formatStr.length) return null
+      pattern.push(escapeRegExp(formatStr[i + 1]))
+      i += 2
+      continue
+    }
     // The fractional-seconds token "f" is consumed as a run ("f", "ff", "fff",
     // …) whose length is the precision (mirrors the hh/mm/ss width semantics).
     // It is a distinct field that may appear at most once, and the separator
@@ -93,6 +103,30 @@ export const tokenizeDurationFormat = (formatStr) => {
 
 export const isValidDurationFormat = (value) =>
   tokenizeDurationFormat(value) !== null
+
+// Return the precision (length of the `f` run) of a validated token format, or
+// 0 if it has no fractional token. Walks the format honoring backslash escapes
+// so an escaped `\f` literal is not mistaken for the fraction token. Keep in
+// sync with duration.py::_fraction_precision.
+const fractionPrecision = (formatStr) => {
+  let i = 0
+  while (i < formatStr.length) {
+    if (formatStr[i] === '\\') {
+      i += 2
+      continue
+    }
+    if (formatStr[i] === 'f') {
+      let precision = 0
+      while (i < formatStr.length && formatStr[i] === 'f') {
+        precision += 1
+        i += 1
+      }
+      return precision
+    }
+    i += 1
+  }
+  return 0
+}
 
 export const parseValueWithDurationFormat = (value, formatStr) => {
   if (typeof value !== 'string') return null
@@ -139,9 +173,7 @@ export const formatValueWithDurationFormat = (value, formatStr) => {
 
   // Precision is the number of `f`s in the format, or 0 for integer-second
   // formats (no fraction token).
-  const precision = fieldSet.has('fraction')
-    ? formatStr.match(/f+/)[0].length
-    : 0
+  const precision = fieldSet.has('fraction') ? fractionPrecision(formatStr) : 0
 
   // Round the total to the target precision *before* decomposing, so a
   // rounded-up value carries across fields: 59.9996 at precision 3 -> 60.000
@@ -182,6 +214,13 @@ export const formatValueWithDurationFormat = (value, formatStr) => {
   const out = []
   let i = 0
   while (i < formatStr.length) {
+    if (formatStr[i] === '\\') {
+      // Escaped literal, emit the next character verbatim. The format is
+      // already validated (tokenize succeeded), so a following char exists.
+      out.push(formatStr[i + 1])
+      i += 2
+      continue
+    }
     if (formatStr[i] === 'f') {
       // Render the fractional component as `precision` zero-padded digits
       // (mirrors printf's %0width.Nf).

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -28,6 +28,78 @@ export class Timedelta {
   }
 }
 
+// Keep in sync with duration.py::tokenize_duration_format
+const DURATION_FORMAT_TOKENS = [
+  ['hh', 'hours'],
+  ['mm', 'minutes'],
+  ['ss', 'seconds'],
+  ['d', 'days'],
+  ['h', 'hours'],
+  ['m', 'minutes'],
+  ['s', 'seconds'],
+]
+
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+export const tokenizeDurationFormat = (formatStr) => {
+  if (typeof formatStr !== 'string' || formatStr.length === 0) return null
+
+  const pattern = ['^-?']
+  const fields = []
+  const seen = new Set()
+  let i = 0
+  while (i < formatStr.length) {
+    let matched = false
+    for (const [token, field] of DURATION_FORMAT_TOKENS) {
+      if (formatStr.startsWith(token, i)) {
+        if (seen.has(field)) return null
+        seen.add(field)
+        fields.push(field)
+        pattern.push('(\\d+)')
+        i += token.length
+        matched = true
+        break
+      }
+    }
+    if (!matched) {
+      pattern.push(escapeRegExp(formatStr[i]))
+      i += 1
+    }
+  }
+
+  if (fields.length === 0) return null
+
+  pattern.push('$')
+  return { pattern: new RegExp(pattern.join('')), fields }
+}
+
+export const isValidDurationFormat = (value) =>
+  tokenizeDurationFormat(value) !== null
+
+export const parseValueWithDurationFormat = (value, formatStr) => {
+  if (typeof value !== 'string') return null
+  const tokenized = tokenizeDurationFormat(formatStr)
+  if (tokenized === null) return null
+
+  const stripped = value.trim()
+  const negative = stripped.startsWith('-')
+  const match = stripped.match(tokenized.pattern)
+  if (match === null) return null
+
+  const parts = { days: 0, hours: 0, minutes: 0, seconds: 0 }
+  tokenized.fields.forEach((field, idx) => {
+    parts[field] = parseInt(match[idx + 1], 10)
+  })
+
+  let ms =
+    parts.days * SECS_IN_DAY * 1000 +
+    parts.hours * SECS_IN_HOUR * 1000 +
+    parts.minutes * SECS_IN_MIN * 1000 +
+    parts.seconds * 1000
+  if (negative) ms = -ms
+  return new Timedelta(ms)
+}
+
 const DURATION_PATTERNS = [
   { regex: /^(\d+)\s+years?$/i, unit: 'days', factor: 365 },
   { regex: /^(\d+)\s+months?$/i, unit: 'days', factor: 30 },

--- a/web-frontend/modules/core/utils/duration.js
+++ b/web-frontend/modules/core/utils/duration.js
@@ -100,6 +100,65 @@ export const parseValueWithDurationFormat = (value, formatStr) => {
   return new Timedelta(ms)
 }
 
+// Keep in sync with duration.py::format_value_with_duration_format
+export const formatValueWithDurationFormat = (value, formatStr) => {
+  if (!(value instanceof Timedelta)) return null
+  const tokenized = tokenizeDurationFormat(formatStr)
+  if (tokenized === null) return null
+
+  const fieldSet = new Set(tokenized.fields)
+  const negative = value.ms < 0
+  const totalSeconds = Math.trunc(Math.abs(value.ms) / 1000)
+
+  let days = 0
+  let hours = 0
+  let minutes = 0
+  let seconds = 0
+  if (fieldSet.has('days')) {
+    days = Math.trunc(totalSeconds / SECS_IN_DAY)
+  }
+  if (fieldSet.has('hours')) {
+    hours = fieldSet.has('days')
+      ? Math.trunc((totalSeconds % SECS_IN_DAY) / SECS_IN_HOUR)
+      : Math.trunc(totalSeconds / SECS_IN_HOUR)
+  }
+  if (fieldSet.has('minutes')) {
+    minutes =
+      fieldSet.has('hours') || fieldSet.has('days')
+        ? Math.trunc((totalSeconds % SECS_IN_HOUR) / SECS_IN_MIN)
+        : Math.trunc(totalSeconds / SECS_IN_MIN)
+  }
+  if (fieldSet.has('seconds')) {
+    seconds =
+      fieldSet.has('minutes') || fieldSet.has('hours') || fieldSet.has('days')
+        ? totalSeconds % SECS_IN_MIN
+        : totalSeconds
+  }
+
+  const fieldValues = { days, hours, minutes, seconds }
+  const out = []
+  let i = 0
+  while (i < formatStr.length) {
+    let matched = false
+    for (const [token, field] of DURATION_FORMAT_TOKENS) {
+      if (formatStr.startsWith(token, i)) {
+        const v = fieldValues[field]
+        out.push(token.length === 2 ? String(v).padStart(2, '0') : String(v))
+        i += token.length
+        matched = true
+        break
+      }
+    }
+    if (!matched) {
+      out.push(formatStr[i])
+      i += 1
+    }
+  }
+
+  const result = out.join('')
+  return negative ? `-${result}` : result
+}
+
 const DURATION_PATTERNS = [
   { regex: /^(\d+)\s+years?$/i, unit: 'days', factor: 365 },
   { regex: /^(\d+)\s+months?$/i, unit: 'days', factor: 30 },

--- a/web-frontend/test/unit/core/formula/runtimeFormulaArgumentTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaArgumentTypes.spec.js
@@ -6,6 +6,7 @@ import {
   ThousandSeparatorBaserowRuntimeFormulaArgumentType,
   DecimalSeparatorBaserowRuntimeFormulaArgumentType,
   DurationBaserowRuntimeFormulaArgumentType,
+  DurationFormatBaserowRuntimeFormulaArgumentType,
   Timedelta,
 } from '@baserow/modules/core/runtimeFormulaArgumentTypes'
 
@@ -153,5 +154,34 @@ describe('DatetimeFormatBaserowRuntimeFormulaArgumentType', () => {
     }
     const message = argType.getErrorMessage('SS', mocki18n)
     expect(message).toContain("'SS' is not a valid datetime format.")
+  })
+})
+
+describe('DurationFormatBaserowRuntimeFormulaArgumentType', () => {
+  test.each([
+    { value: 'h:mm', expected: true },
+    { value: 'h:mm:ss', expected: true },
+    { value: 'd h:mm:ss', expected: true },
+    { value: 'd h mm ss', expected: true },
+    { value: 'd', expected: true },
+    { value: 'hh:mm:ss', expected: true },
+    { value: 'h:mm:h', expected: false }, // repeated token
+    { value: ':::', expected: false }, // only literals
+    { value: '', expected: false },
+    { value: 123, expected: false },
+    { value: null, expected: false },
+  ])('test() returns $expected for "$value"', ({ value, expected }) => {
+    expect(
+      new DurationFormatBaserowRuntimeFormulaArgumentType().test(value)
+    ).toBe(expected)
+  })
+
+  test('getErrorMessage returns a human-readable message', () => {
+    const argType = new DurationFormatBaserowRuntimeFormulaArgumentType()
+    const mocki18n = {
+      t: (key, params) => `'${params.value}' is not a valid duration format.`,
+    }
+    const message = argType.getErrorMessage('not valid', mocki18n)
+    expect(message).toContain("'not valid' is not a valid duration format.")
   })
 })

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -2354,13 +2354,6 @@ describe('RuntimeToDuration', () => {
     expect(result).toBe(expected)
   })
 
-  test('validateArgs throws when value is a Timedelta and format is provided', () => {
-    const formulaType = new RuntimeToDuration()
-    expect(() =>
-      formulaType.validateArgs([new Timedelta(3600000), 'h:mm'])
-    ).toThrow('A duration format cannot be applied to a timedelta value.')
-  })
-
   test('validateArgs throws when value does not match format', () => {
     const formulaType = new RuntimeToDuration()
     expect(() => formulaType.validateArgs(['not a duration', 'h:mm'])).toThrow(

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -54,7 +54,6 @@ import {
   RuntimeToDatetime,
 } from '@baserow/modules/core/runtimeFormulaTypes'
 import { Timedelta } from '@baserow/modules/core/runtimeFormulaArgumentTypes'
-import { DeferredValue } from '@baserow/modules/core/formula/parser/formulaValidationVisitor'
 import { expect } from 'vitest'
 
 /** Tests for the RuntimeConcat class. */
@@ -206,30 +205,6 @@ describe('RuntimeAdd', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
-
-  test.each([
-    // Deferred values are accepted at either position
-    { args: [DeferredValue, 5], expected: [] },
-    { args: [5, DeferredValue], expected: [] },
-    { args: [DeferredValue, DeferredValue], expected: [] },
-    // Deferred does not excuse a concrete invalid value
-    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
-    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
-    // Empty literals are rejected
-    { args: [null, 5], expected: [[0, null]] },
-    { args: [5, null], expected: [[1, null]] },
-    { args: ['', 5], expected: [[0, '']] },
-    { args: [5, ''], expected: [[1, '']] },
-    { args: [undefined, 5], expected: [[0, undefined]] },
-    { args: [5, undefined], expected: [[1, undefined]] },
-  ])(
-    'validates type of args with deferred or empty literal',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeAdd()
-      const result = formulaType.validateTypeOfArgs(args)
-      expect(result).toStrictEqual(expected)
-    }
-  )
 })
 
 describe('RuntimeMinus', () => {
@@ -330,30 +305,6 @@ describe('RuntimeMinus', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
-
-  test.each([
-    // Deferred values are accepted at either position
-    { args: [DeferredValue, 5], expected: [] },
-    { args: [5, DeferredValue], expected: [] },
-    { args: [DeferredValue, DeferredValue], expected: [] },
-    // Deferred does not excuse a concrete invalid value
-    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
-    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
-    // Empty literals are rejected
-    { args: [null, 5], expected: [[0, null]] },
-    { args: [5, null], expected: [[1, null]] },
-    { args: ['', 5], expected: [[0, '']] },
-    { args: [5, ''], expected: [[1, '']] },
-    { args: [undefined, 5], expected: [[0, undefined]] },
-    { args: [5, undefined], expected: [[1, undefined]] },
-  ])(
-    'validates type of args with deferred or empty literal',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeMinus()
-      const result = formulaType.validateTypeOfArgs(args)
-      expect(result).toStrictEqual(expected)
-    }
-  )
 })
 
 describe('RuntimeMultiply', () => {
@@ -439,30 +390,6 @@ describe('RuntimeMultiply', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
-
-  test.each([
-    // Deferred values are accepted at either position
-    { args: [DeferredValue, 5], expected: [] },
-    { args: [5, DeferredValue], expected: [] },
-    { args: [DeferredValue, DeferredValue], expected: [] },
-    // Deferred does not excuse a concrete invalid value
-    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
-    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
-    // Empty literals are rejected
-    { args: [null, 5], expected: [[0, null]] },
-    { args: [5, null], expected: [[1, null]] },
-    { args: ['', 5], expected: [[0, '']] },
-    { args: [5, ''], expected: [[1, '']] },
-    { args: [undefined, 5], expected: [[0, undefined]] },
-    { args: [5, undefined], expected: [[1, undefined]] },
-  ])(
-    'validates type of args with deferred or empty literal',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeMultiply()
-      const result = formulaType.validateTypeOfArgs(args)
-      expect(result).toStrictEqual(expected)
-    }
-  )
 })
 
 describe('RuntimeDivide', () => {
@@ -546,35 +473,6 @@ describe('RuntimeDivide', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
-
-  test.each([
-    // Deferred values are accepted at either position
-    { args: [DeferredValue, 5], expected: [] },
-    { args: [5, DeferredValue], expected: [] },
-    { args: [DeferredValue, DeferredValue], expected: [] },
-    // Deferred does not excuse a concrete invalid value
-    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
-    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
-    // Divisor must be a number even when dividend is deferred
-    {
-      args: [DeferredValue, new Timedelta(1000)],
-      expected: [[1, new Timedelta(1000)]],
-    },
-    // Empty literals are rejected
-    { args: [null, 5], expected: [[0, null]] },
-    { args: [5, null], expected: [[1, null]] },
-    { args: ['', 5], expected: [[0, '']] },
-    { args: [5, ''], expected: [[1, '']] },
-    { args: [undefined, 5], expected: [[0, undefined]] },
-    { args: [5, undefined], expected: [[1, undefined]] },
-  ])(
-    'validates type of args with deferred or empty literal',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeDivide()
-      const result = formulaType.validateTypeOfArgs(args)
-      expect(result).toStrictEqual(expected)
-    }
-  )
 })
 
 describe('RuntimeEqual', () => {

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -54,6 +54,7 @@ import {
   RuntimeToDatetime,
 } from '@baserow/modules/core/runtimeFormulaTypes'
 import { Timedelta } from '@baserow/modules/core/runtimeFormulaArgumentTypes'
+import { DeferredValue } from '@baserow/modules/core/formula/parser/formulaValidationVisitor'
 import { expect } from 'vitest'
 
 /** Tests for the RuntimeConcat class. */
@@ -137,6 +138,11 @@ describe('RuntimeAdd', () => {
       args: [new Timedelta(86400 * 1000), new Date(2025, 0, 1, 12, 0, 0)],
       expected: new Date(2025, 0, 2, 12, 0, 0),
     },
+    // Date + timedelta (sub-day)
+    {
+      args: [new Date(2025, 5, 15), new Timedelta(3 * 3600 * 1000)],
+      expected: new Date(2025, 5, 15, 3, 0, 0),
+    },
   ])('execute returns expected value with timedelta', ({ args, expected }) => {
     const formulaType = new RuntimeAdd()
     const parsedArgs = formulaType.parseArgs(args)
@@ -200,6 +206,30 @@ describe('RuntimeAdd', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
+
+  test.each([
+    // Deferred values are accepted at either position
+    { args: [DeferredValue, 5], expected: [] },
+    { args: [5, DeferredValue], expected: [] },
+    { args: [DeferredValue, DeferredValue], expected: [] },
+    // Deferred does not excuse a concrete invalid value
+    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
+    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
+    // Empty literals are rejected
+    { args: [null, 5], expected: [[0, null]] },
+    { args: [5, null], expected: [[1, null]] },
+    { args: ['', 5], expected: [[0, '']] },
+    { args: [5, ''], expected: [[1, '']] },
+    { args: [undefined, 5], expected: [[0, undefined]] },
+    { args: [5, undefined], expected: [[1, undefined]] },
+  ])(
+    'validates type of args with deferred or empty literal',
+    ({ args, expected }) => {
+      const formulaType = new RuntimeAdd()
+      const result = formulaType.validateTypeOfArgs(args)
+      expect(result).toStrictEqual(expected)
+    }
+  )
 })
 
 describe('RuntimeMinus', () => {
@@ -234,6 +264,11 @@ describe('RuntimeMinus', () => {
     {
       args: [new Date(2025, 0, 2, 12, 0, 0), new Timedelta(86400 * 1000)],
       expected: new Date(2025, 0, 1, 12, 0, 0),
+    },
+    // Date - timedelta (sub-day)
+    {
+      args: [new Date(2025, 5, 15, 3, 0, 0), new Timedelta(3 * 3600 * 1000)],
+      expected: new Date(2025, 5, 15, 0, 0, 0),
     },
   ])('execute returns expected value with timedelta', ({ args, expected }) => {
     const formulaType = new RuntimeMinus()
@@ -274,6 +309,11 @@ describe('RuntimeMinus', () => {
       args: [new Timedelta(1000), new Date(2025, 0, 1)],
       expected: [[1, new Date(2025, 0, 1)]],
     },
+    // Invalid: string - timedelta
+    {
+      args: ['foo', new Timedelta(1000)],
+      expected: [[0, 'foo']],
+    },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeMinus()
     const result = formulaType.validateTypeOfArgs(args)
@@ -290,6 +330,30 @@ describe('RuntimeMinus', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
+
+  test.each([
+    // Deferred values are accepted at either position
+    { args: [DeferredValue, 5], expected: [] },
+    { args: [5, DeferredValue], expected: [] },
+    { args: [DeferredValue, DeferredValue], expected: [] },
+    // Deferred does not excuse a concrete invalid value
+    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
+    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
+    // Empty literals are rejected
+    { args: [null, 5], expected: [[0, null]] },
+    { args: [5, null], expected: [[1, null]] },
+    { args: ['', 5], expected: [[0, '']] },
+    { args: [5, ''], expected: [[1, '']] },
+    { args: [undefined, 5], expected: [[0, undefined]] },
+    { args: [5, undefined], expected: [[1, undefined]] },
+  ])(
+    'validates type of args with deferred or empty literal',
+    ({ args, expected }) => {
+      const formulaType = new RuntimeMinus()
+      const result = formulaType.validateTypeOfArgs(args)
+      expect(result).toStrictEqual(expected)
+    }
+  )
 })
 
 describe('RuntimeMultiply', () => {
@@ -375,6 +439,30 @@ describe('RuntimeMultiply', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
+
+  test.each([
+    // Deferred values are accepted at either position
+    { args: [DeferredValue, 5], expected: [] },
+    { args: [5, DeferredValue], expected: [] },
+    { args: [DeferredValue, DeferredValue], expected: [] },
+    // Deferred does not excuse a concrete invalid value
+    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
+    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
+    // Empty literals are rejected
+    { args: [null, 5], expected: [[0, null]] },
+    { args: [5, null], expected: [[1, null]] },
+    { args: ['', 5], expected: [[0, '']] },
+    { args: [5, ''], expected: [[1, '']] },
+    { args: [undefined, 5], expected: [[0, undefined]] },
+    { args: [5, undefined], expected: [[1, undefined]] },
+  ])(
+    'validates type of args with deferred or empty literal',
+    ({ args, expected }) => {
+      const formulaType = new RuntimeMultiply()
+      const result = formulaType.validateTypeOfArgs(args)
+      expect(result).toStrictEqual(expected)
+    }
+  )
 })
 
 describe('RuntimeDivide', () => {
@@ -458,6 +546,35 @@ describe('RuntimeDivide', () => {
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toStrictEqual(expected)
   })
+
+  test.each([
+    // Deferred values are accepted at either position
+    { args: [DeferredValue, 5], expected: [] },
+    { args: [5, DeferredValue], expected: [] },
+    { args: [DeferredValue, DeferredValue], expected: [] },
+    // Deferred does not excuse a concrete invalid value
+    { args: [DeferredValue, 'foo'], expected: [[1, 'foo']] },
+    { args: ['foo', DeferredValue], expected: [[0, 'foo']] },
+    // Divisor must be a number even when dividend is deferred
+    {
+      args: [DeferredValue, new Timedelta(1000)],
+      expected: [[1, new Timedelta(1000)]],
+    },
+    // Empty literals are rejected
+    { args: [null, 5], expected: [[0, null]] },
+    { args: [5, null], expected: [[1, null]] },
+    { args: ['', 5], expected: [[0, '']] },
+    { args: [5, ''], expected: [[1, '']] },
+    { args: [undefined, 5], expected: [[0, undefined]] },
+    { args: [5, undefined], expected: [[1, undefined]] },
+  ])(
+    'validates type of args with deferred or empty literal',
+    ({ args, expected }) => {
+      const formulaType = new RuntimeDivide()
+      const result = formulaType.validateTypeOfArgs(args)
+      expect(result).toStrictEqual(expected)
+    }
+  )
 })
 
 describe('RuntimeEqual', () => {
@@ -2454,88 +2571,6 @@ describe('RuntimeDurationFormat', () => {
     const formulaType = new RuntimeDurationFormat()
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toBe(expected)
-  })
-})
-
-describe('RuntimeAdd with datetime and timedelta', () => {
-  test.each([
-    {
-      args: [new Date(2025, 0, 1, 12, 0, 0), new Timedelta(86400000)],
-      expected: new Date(2025, 0, 2, 12, 0, 0),
-    },
-    {
-      args: [new Timedelta(86400000), new Date(2025, 0, 1, 12, 0, 0)],
-      expected: new Date(2025, 0, 2, 12, 0, 0),
-    },
-    {
-      args: [new Date(2025, 5, 15), new Timedelta(3 * 3600000)],
-      expected: new Date(2025, 5, 15, 3, 0, 0),
-    },
-  ])(
-    'execute returns expected value with datetime+timedelta',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeAdd()
-      const parsedArgs = formulaType.parseArgs(args)
-      const result = formulaType.execute({}, parsedArgs)
-      expect(result).toStrictEqual(expected)
-    }
-  )
-
-  test.each([
-    {
-      args: [new Date(2025, 0, 1), new Timedelta(86400000)],
-      expected: [],
-    },
-    {
-      args: [new Timedelta(86400000), new Date(2025, 0, 1)],
-      expected: [],
-    },
-    {
-      args: [new Timedelta(86400000), new Timedelta(86400000)],
-      expected: [],
-    },
-    { args: ['foo', new Timedelta(86400000)], expected: [[0, 'foo']] },
-  ])('validates type of args with timedelta', ({ args, expected }) => {
-    const formulaType = new RuntimeAdd()
-    const result = formulaType.validateTypeOfArgs(args)
-    expect(result).toStrictEqual(expected)
-  })
-})
-
-describe('RuntimeMinus with datetime and timedelta', () => {
-  test.each([
-    {
-      args: [new Date(2025, 0, 2, 12, 0, 0), new Timedelta(86400000)],
-      expected: new Date(2025, 0, 1, 12, 0, 0),
-    },
-    {
-      args: [new Date(2025, 5, 15, 3, 0, 0), new Timedelta(3 * 3600000)],
-      expected: new Date(2025, 5, 15, 0, 0, 0),
-    },
-  ])(
-    'execute returns expected value with datetime-timedelta',
-    ({ args, expected }) => {
-      const formulaType = new RuntimeMinus()
-      const parsedArgs = formulaType.parseArgs(args)
-      const result = formulaType.execute({}, parsedArgs)
-      expect(result).toStrictEqual(expected)
-    }
-  )
-
-  test.each([
-    {
-      args: [new Date(2025, 0, 2), new Timedelta(86400000)],
-      expected: [],
-    },
-    {
-      args: [new Timedelta(86400000), new Date(2025, 0, 1)],
-      expected: [[1, new Date(2025, 0, 1)]],
-    },
-    { args: ['foo', new Timedelta(86400000)], expected: [[0, 'foo']] },
-  ])('validates type of args with timedelta', ({ args, expected }) => {
-    const formulaType = new RuntimeMinus()
-    const result = formulaType.validateTypeOfArgs(args)
-    expect(result).toStrictEqual(expected)
   })
 })
 

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -2063,15 +2063,40 @@ describe('RuntimeNumberFormat', () => {
 })
 
 describe('RuntimeToDuration', () => {
+  const MS_IN_SEC = 1000
+  const MS_IN_MIN = 60 * MS_IN_SEC
+  const MS_IN_HOUR = 60 * MS_IN_MIN
+  const MS_IN_DAY = 24 * MS_IN_HOUR
+
   test.each([
-    { args: ['1 day'], expected: new Timedelta(86400000) },
-    { args: ['2 days'], expected: new Timedelta(2 * 86400000) },
-    { args: ['3 weeks'], expected: new Timedelta(3 * 7 * 86400000) },
-    { args: ['4 hours'], expected: new Timedelta(4 * 3600000) },
-    { args: ['30 minutes'], expected: new Timedelta(30 * 60000) },
-    { args: ['45 seconds'], expected: new Timedelta(45 * 1000) },
-    { args: ['1 year'], expected: new Timedelta(365 * 86400000) },
-    { args: ['1 month'], expected: new Timedelta(30 * 86400000) },
+    // Single-arg form
+    { args: ['1 day'], expected: new Timedelta(MS_IN_DAY) },
+    { args: ['2 days'], expected: new Timedelta(2 * MS_IN_DAY) },
+    { args: ['3 weeks'], expected: new Timedelta(3 * 7 * MS_IN_DAY) },
+    { args: ['4 hours'], expected: new Timedelta(4 * MS_IN_HOUR) },
+    { args: ['30 minutes'], expected: new Timedelta(30 * MS_IN_MIN) },
+    { args: ['45 seconds'], expected: new Timedelta(45 * MS_IN_SEC) },
+    { args: ['1 year'], expected: new Timedelta(365 * MS_IN_DAY) },
+    { args: ['1 month'], expected: new Timedelta(30 * MS_IN_DAY) },
+    // Two-arg form: value + format
+    {
+      args: ['1:30', 'h:mm'],
+      expected: new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN),
+    },
+    {
+      args: ['1:23:45', 'h:mm:ss'],
+      expected: new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC),
+    },
+    {
+      args: ['2 3:04:05', 'd h:mm:ss'],
+      expected: new Timedelta(
+        2 * MS_IN_DAY + 3 * MS_IN_HOUR + 4 * MS_IN_MIN + 5 * MS_IN_SEC
+      ),
+    },
+    {
+      args: ['-1:30', 'h:mm'],
+      expected: new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)),
+    },
   ])('execute returns expected value', ({ args, expected }) => {
     const formulaType = new RuntimeToDuration()
     const parsedArgs = formulaType.parseArgs(args)
@@ -2079,15 +2104,41 @@ describe('RuntimeToDuration', () => {
     expect(result).toStrictEqual(expected)
   })
 
+  test('execute throws when value is a Timedelta and format is provided', () => {
+    // At runtime, arg 0 may resolve to a Timedelta (e.g. from a get() on a
+    // duration field), in which case applying a format doesn't make sense.
+    const formulaType = new RuntimeToDuration()
+    const parsedArgs = formulaType.parseArgs([new Timedelta(3600000), 'h:mm'])
+    expect(() => formulaType.execute({}, parsedArgs)).toThrow(
+      'A duration format cannot be applied to a timedelta value.'
+    )
+  })
+
+  test('execute throws when value does not match format', () => {
+    const formulaType = new RuntimeToDuration()
+    const parsedArgs = formulaType.parseArgs(['not a duration', 'h:mm'])
+    expect(() => formulaType.execute({}, parsedArgs)).toThrow(
+      "'not a duration' could not be parsed using format 'h:mm'."
+    )
+  })
+
   test.each([
-    // Valid duration strings — arg passes
+    // Single-arg form
     { args: ['1 day'], expected: [] },
     { args: ['2 days'], expected: [] },
-    // Invalid strings and types — arg is returned as invalid
     { args: [''], expected: [[0, '']] },
     { args: ['not valid'], expected: [[0, 'not valid']] },
     { args: [1], expected: [] },
     { args: [null], expected: [[0, null]] },
+    // Two-arg form: arg 0 check is deferred to validateArgs(), so any
+    // arg 0 is accepted at this stage when the format is valid.
+    { args: ['1:30', 'h:mm'], expected: [] },
+    { args: ['whatever', 'h:mm'], expected: [] },
+    // Invalid format strings → arg 1 reported as invalid
+    { args: ['1:30', ':::'], expected: [[1, ':::']] },
+    { args: ['1:30', 'h h'], expected: [[1, 'h h']] },
+    { args: ['1:30', ''], expected: [[1, '']] },
+    { args: ['1:30', 123], expected: [[1, 123]] },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeToDuration()
     const result = formulaType.validateTypeOfArgs(args)
@@ -2097,11 +2148,26 @@ describe('RuntimeToDuration', () => {
   test.each([
     { args: [], expected: false },
     { args: ['1 day'], expected: true },
-    { args: ['1 day', 'extra'], expected: false },
+    { args: ['1 day', 'h:mm'], expected: true },
+    { args: ['1 day', 'h:mm', 'extra'], expected: false },
   ])('validates number of args', ({ args, expected }) => {
     const formulaType = new RuntimeToDuration()
     const result = formulaType.validateNumberOfArgs(args)
     expect(result).toBe(expected)
+  })
+
+  test('validateArgs throws when value is a Timedelta and format is provided', () => {
+    const formulaType = new RuntimeToDuration()
+    expect(() =>
+      formulaType.validateArgs([new Timedelta(3600000), 'h:mm'])
+    ).toThrow('A duration format cannot be applied to a timedelta value.')
+  })
+
+  test('validateArgs throws when value does not match format', () => {
+    const formulaType = new RuntimeToDuration()
+    expect(() => formulaType.validateArgs(['not a duration', 'h:mm'])).toThrow(
+      "'not a duration' could not be parsed using format 'h:mm'."
+    )
   })
 })
 

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -107,6 +107,44 @@ describe('RuntimeAdd', () => {
   })
 
   test.each([
+    // timedelta + timedelta
+    {
+      args: [new Timedelta(3600 * 1000), new Timedelta(1800 * 1000)],
+      expected: new Timedelta(5400 * 1000),
+    },
+    // timedelta + number (seconds)
+    {
+      args: [new Timedelta(3600 * 1000), 60],
+      expected: new Timedelta(3660 * 1000),
+    },
+    // number + timedelta (seconds)
+    {
+      args: [60, new Timedelta(3600 * 1000)],
+      expected: new Timedelta(3660 * 1000),
+    },
+    // fractional seconds
+    {
+      args: [new Timedelta(1000), 1.5],
+      expected: new Timedelta(2500),
+    },
+    // Date + timedelta
+    {
+      args: [new Date(2025, 0, 1, 12, 0, 0), new Timedelta(86400 * 1000)],
+      expected: new Date(2025, 0, 2, 12, 0, 0),
+    },
+    // timedelta + Date
+    {
+      args: [new Timedelta(86400 * 1000), new Date(2025, 0, 1, 12, 0, 0)],
+      expected: new Date(2025, 0, 2, 12, 0, 0),
+    },
+  ])('execute returns expected value with timedelta', ({ args, expected }) => {
+    const formulaType = new RuntimeAdd()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toStrictEqual(expected)
+  })
+
+  test.each([
     // These are invalid
     { args: ['foo'], expected: [[0, 'foo']] },
     { args: [true], expected: [[0, true]] },
@@ -122,6 +160,30 @@ describe('RuntimeAdd', () => {
     { args: [3.14], expected: [] },
     { args: ['23'], expected: [] },
     { args: ['23.23'], expected: [] },
+    // Timedelta combinations are valid
+    {
+      args: [new Timedelta(1000), new Timedelta(2000)],
+      expected: [],
+    },
+    { args: [new Timedelta(1000), 60], expected: [] },
+    { args: [60, new Timedelta(1000)], expected: [] },
+    {
+      args: [new Date(2025, 0, 1), new Timedelta(1000)],
+      expected: [],
+    },
+    {
+      args: [new Timedelta(1000), new Date(2025, 0, 1)],
+      expected: [],
+    },
+    // Invalid combinations
+    {
+      args: ['foo', new Timedelta(1000)],
+      expected: [[0, 'foo']],
+    },
+    {
+      args: [new Timedelta(1000), 'foo'],
+      expected: [[1, 'foo']],
+    },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeAdd()
     const result = formulaType.validateTypeOfArgs(args)
@@ -153,6 +215,34 @@ describe('RuntimeMinus', () => {
   })
 
   test.each([
+    // timedelta - timedelta
+    {
+      args: [new Timedelta(3600 * 1000), new Timedelta(1800 * 1000)],
+      expected: new Timedelta(1800 * 1000),
+    },
+    // timedelta - number (seconds)
+    {
+      args: [new Timedelta(30 * 1000), 1],
+      expected: new Timedelta(29 * 1000),
+    },
+    // number - timedelta (seconds)
+    {
+      args: [90, new Timedelta(30 * 1000)],
+      expected: new Timedelta(60 * 1000),
+    },
+    // Date - timedelta
+    {
+      args: [new Date(2025, 0, 2, 12, 0, 0), new Timedelta(86400 * 1000)],
+      expected: new Date(2025, 0, 1, 12, 0, 0),
+    },
+  ])('execute returns expected value with timedelta', ({ args, expected }) => {
+    const formulaType = new RuntimeMinus()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toStrictEqual(expected)
+  })
+
+  test.each([
     // These are invalid
     { args: ['foo'], expected: [[0, 'foo']] },
     { args: [true], expected: [[0, true]] },
@@ -168,6 +258,22 @@ describe('RuntimeMinus', () => {
     { args: [3.14], expected: [] },
     { args: ['23'], expected: [] },
     { args: ['23.23'], expected: [] },
+    // Timedelta combinations are valid
+    {
+      args: [new Timedelta(2000), new Timedelta(1000)],
+      expected: [],
+    },
+    { args: [new Timedelta(1000), 1], expected: [] },
+    { args: [90, new Timedelta(1000)], expected: [] },
+    {
+      args: [new Date(2025, 0, 2), new Timedelta(1000)],
+      expected: [],
+    },
+    // Invalid: timedelta - Date
+    {
+      args: [new Timedelta(1000), new Date(2025, 0, 1)],
+      expected: [[1, new Date(2025, 0, 1)]],
+    },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeMinus()
     const result = formulaType.validateTypeOfArgs(args)
@@ -199,6 +305,29 @@ describe('RuntimeMultiply', () => {
   })
 
   test.each([
+    // timedelta * number
+    {
+      args: [new Timedelta(3600 * 1000), 2],
+      expected: new Timedelta(7200 * 1000),
+    },
+    // number * timedelta
+    {
+      args: [2, new Timedelta(3600 * 1000)],
+      expected: new Timedelta(7200 * 1000),
+    },
+    // fractional scaling
+    {
+      args: [new Timedelta(10000), 0.5],
+      expected: new Timedelta(5000),
+    },
+  ])('execute returns expected value with timedelta', ({ args, expected }) => {
+    const formulaType = new RuntimeMultiply()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toStrictEqual(expected)
+  })
+
+  test.each([
     // These are invalid
     { args: ['foo'], expected: [[0, 'foo']] },
     { args: [true], expected: [[0, true]] },
@@ -214,6 +343,22 @@ describe('RuntimeMultiply', () => {
     { args: [3.14], expected: [] },
     { args: ['23'], expected: [] },
     { args: ['23.23'], expected: [] },
+    // Timedelta * number combinations are valid
+    { args: [new Timedelta(1000), 2], expected: [] },
+    { args: [2, new Timedelta(1000)], expected: [] },
+    // timedelta * timedelta is invalid
+    {
+      args: [new Timedelta(1000), new Timedelta(2000)],
+      expected: [[1, new Timedelta(2000)]],
+    },
+    {
+      args: ['foo', new Timedelta(1000)],
+      expected: [[0, 'foo']],
+    },
+    {
+      args: [new Timedelta(1000), 'foo'],
+      expected: [[1, 'foo']],
+    },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeMultiply()
     const result = formulaType.validateTypeOfArgs(args)
@@ -245,6 +390,23 @@ describe('RuntimeDivide', () => {
   })
 
   test.each([
+    // timedelta / number
+    {
+      args: [new Timedelta(3600 * 1000), 2],
+      expected: new Timedelta(1800 * 1000),
+    },
+    {
+      args: [new Timedelta(30 * 1000), 2],
+      expected: new Timedelta(15 * 1000),
+    },
+  ])('execute returns expected value with timedelta', ({ args, expected }) => {
+    const formulaType = new RuntimeDivide()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toStrictEqual(expected)
+  })
+
+  test.each([
     // These are invalid
     { args: ['foo'], expected: [[0, 'foo']] },
     { args: [true], expected: [[0, true]] },
@@ -260,6 +422,26 @@ describe('RuntimeDivide', () => {
     { args: [3.14], expected: [] },
     { args: ['23'], expected: [] },
     { args: ['23.23'], expected: [] },
+    // timedelta / number is valid
+    { args: [new Timedelta(1000), 2], expected: [] },
+    // number / timedelta is invalid
+    {
+      args: [2, new Timedelta(1000)],
+      expected: [[1, new Timedelta(1000)]],
+    },
+    // timedelta / timedelta is invalid
+    {
+      args: [new Timedelta(1000), new Timedelta(2000)],
+      expected: [[1, new Timedelta(2000)]],
+    },
+    {
+      args: ['foo', new Timedelta(1000)],
+      expected: [[0, 'foo']],
+    },
+    {
+      args: [new Timedelta(1000), 'foo'],
+      expected: [[1, 'foo']],
+    },
   ])('validates type of args', ({ args, expected }) => {
     const formulaType = new RuntimeDivide()
     const result = formulaType.validateTypeOfArgs(args)
@@ -2310,7 +2492,7 @@ describe('RuntimeAdd with datetime and timedelta', () => {
     },
     {
       args: [new Timedelta(86400000), new Timedelta(86400000)],
-      expected: [[1, new Timedelta(86400000)]],
+      expected: [],
     },
     { args: ['foo', new Timedelta(86400000)], expected: [[0, 'foo']] },
   ])('validates type of args with timedelta', ({ args, expected }) => {
@@ -2347,7 +2529,7 @@ describe('RuntimeMinus with datetime and timedelta', () => {
     },
     {
       args: [new Timedelta(86400000), new Date(2025, 0, 1)],
-      expected: [[0, new Timedelta(86400000)]],
+      expected: [[1, new Date(2025, 0, 1)]],
     },
     { args: ['foo', new Timedelta(86400000)], expected: [[0, 'foo']] },
   ])('validates type of args with timedelta', ({ args, expected }) => {

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -5,6 +5,7 @@ import {
   RuntimeCapitalize,
   RuntimeConcat,
   RuntimeToDuration,
+  RuntimeDurationFormat,
   RuntimeDateTimeFormat,
   RuntimeDay,
   RuntimeDivide,
@@ -2168,6 +2169,109 @@ describe('RuntimeToDuration', () => {
     expect(() => formulaType.validateArgs(['not a duration', 'h:mm'])).toThrow(
       "'not a duration' could not be parsed using format 'h:mm'."
     )
+  })
+})
+
+describe('RuntimeDurationFormat', () => {
+  const MS_IN_SEC = 1000
+  const MS_IN_MIN = 60 * MS_IN_SEC
+  const MS_IN_HOUR = 60 * MS_IN_MIN
+  const MS_IN_DAY = 24 * MS_IN_HOUR
+
+  test.each([
+    {
+      args: [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm'],
+      expected: '1:30',
+    },
+    {
+      args: [
+        new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC),
+        'h:mm:ss',
+      ],
+      expected: '1:23:45',
+    },
+    {
+      args: [
+        new Timedelta(
+          2 * MS_IN_DAY + 3 * MS_IN_HOUR + 4 * MS_IN_MIN + 5 * MS_IN_SEC
+        ),
+        'd h:mm:ss',
+      ],
+      expected: '2 3:04:05',
+    },
+    // rollup variations
+    {
+      args: [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'mm:ss'],
+      expected: '90:00',
+    },
+    {
+      args: [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm'],
+      expected: '25:30',
+    },
+    {
+      args: [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'd h:mm'],
+      expected: '1 1:30',
+    },
+    // negative durations
+    {
+      args: [new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)), 'h:mm'],
+      expected: '-1:30',
+    },
+    // zero
+    { args: [new Timedelta(0), 'h:mm'], expected: '0:00' },
+  ])('execute returns expected value', ({ args, expected }) => {
+    const formulaType = new RuntimeDurationFormat()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toBe(expected)
+  })
+
+  test('execute returns null for null duration', () => {
+    // The Duration argument type's parse() would reject null, but if a null
+    // value ever reaches execute() (e.g. via direct invocation) we expect null.
+    const formulaType = new RuntimeDurationFormat()
+    const result = formulaType.execute({}, [null, 'h:mm'])
+    expect(result).toBeNull()
+  })
+
+  test.each([
+    { args: [new Timedelta(MS_IN_HOUR), 'h:mm'], expected: [] },
+    { args: [new Timedelta(0), 'd h:mm:ss'], expected: [] },
+    // arg 0 invalid: not a duration-coercible value
+    {
+      args: ['not a duration', 'h:mm'],
+      expected: [[0, 'not a duration']],
+    },
+    { args: [null, 'h:mm'], expected: [[0, null]] },
+    // arg 1 invalid: bad format string
+    {
+      args: [new Timedelta(MS_IN_HOUR), ':::'],
+      expected: [[1, ':::']],
+    },
+    {
+      args: [new Timedelta(MS_IN_HOUR), 'h h'],
+      expected: [[1, 'h h']],
+    },
+    { args: [new Timedelta(MS_IN_HOUR), ''], expected: [[1, '']] },
+    { args: [new Timedelta(MS_IN_HOUR), 123], expected: [[1, 123]] },
+  ])('validates type of args', ({ args, expected }) => {
+    const formulaType = new RuntimeDurationFormat()
+    const result = formulaType.validateTypeOfArgs(args)
+    expect(result).toStrictEqual(expected)
+  })
+
+  test.each([
+    { args: [], expected: false },
+    { args: [new Timedelta(MS_IN_HOUR)], expected: false },
+    { args: [new Timedelta(MS_IN_HOUR), 'h:mm'], expected: true },
+    {
+      args: [new Timedelta(MS_IN_HOUR), 'h:mm', 'extra'],
+      expected: false,
+    },
+  ])('validates number of args', ({ args, expected }) => {
+    const formulaType = new RuntimeDurationFormat()
+    const result = formulaType.validateNumberOfArgs(args)
+    expect(result).toBe(expected)
   })
 })
 

--- a/web-frontend/test/unit/core/utils/duration.spec.js
+++ b/web-frontend/test/unit/core/utils/duration.spec.js
@@ -1,5 +1,6 @@
 import {
   Timedelta,
+  formatValueWithDurationFormat,
   isValidDurationFormat,
   parseValueWithDurationFormat,
   tokenizeDurationFormat,
@@ -163,6 +164,102 @@ describe('parseValueWithDurationFormat', () => {
     ]
     test.each(cases)('value %p with format %p', (value, formatStr) => {
       expect(parseValueWithDurationFormat(value, formatStr)).toBeNull()
+    })
+  })
+})
+
+describe('formatValueWithDurationFormat', () => {
+  describe('valid durations', () => {
+    const cases = [
+      [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm', '1:30'],
+      [
+        new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC),
+        'h:mm:ss',
+        '1:23:45',
+      ],
+      [
+        new Timedelta(
+          2 * MS_IN_DAY + 3 * MS_IN_HOUR + 4 * MS_IN_MIN + 5 * MS_IN_SEC
+        ),
+        'd h:mm:ss',
+        '2 3:04:05',
+      ],
+      [new Timedelta(3 * MS_IN_DAY + 4 * MS_IN_HOUR), 'd h', '3 4'],
+      // h-only rollup: 1d 2h → 26 total hours
+      [new Timedelta(MS_IN_DAY + 2 * MS_IN_HOUR), 'h', '26'],
+      // mm-only rollup: 1h 30m → 90 total minutes
+      [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'mm', '90'],
+      // mm:ss rollup: 1h 30m → 90 minutes, 0 seconds
+      [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'mm:ss', '90:00'],
+      // ss-only rollup: 5m → 300 total seconds
+      [new Timedelta(5 * MS_IN_MIN), 'ss', '300'],
+      // within-day hours when d is present: 25h → 1d 1h
+      [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'd h:mm', '1 1:30'],
+      // without d, hours roll up: 25h → 25 total hours
+      [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm', '25:30'],
+      // negative values get a leading minus
+      [new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)), 'h:mm', '-1:30'],
+      [new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)), 'mm:ss', '-90:00'],
+      // zero
+      [new Timedelta(0), 'h:mm', '0:00'],
+      [new Timedelta(0), 'd h:mm:ss', '0 0:00:00'],
+      // two-char tokens are zero-padded; one-char are not
+      [new Timedelta(MS_IN_HOUR + 5 * MS_IN_MIN), 'h:mm', '1:05'],
+      [new Timedelta(MS_IN_HOUR + 5 * MS_IN_MIN), 'hh:mm', '01:05'],
+      // arbitrary literal chars are preserved
+      [new Timedelta(2 * MS_IN_DAY + 5 * MS_IN_HOUR), 'd|h.', '2|5.'],
+      // sub-second precision is truncated
+      [new Timedelta(1500), 's', '1'],
+    ]
+    test.each(cases)(
+      'formats %p with format %s as %s',
+      (value, formatStr, expected) => {
+        expect(formatValueWithDurationFormat(value, formatStr)).toBe(expected)
+      }
+    )
+  })
+
+  describe('invalid input returns null', () => {
+    const cases = [
+      // non-Timedelta values
+      [null, 'h:mm'],
+      [undefined, 'h:mm'],
+      [1, 'h:mm'],
+      [1.5, 'h:mm'],
+      ['1:30', 'h:mm'],
+      [[], 'h:mm'],
+      [{}, 'h:mm'],
+      // invalid format strings
+      [new Timedelta(MS_IN_HOUR), null],
+      [new Timedelta(MS_IN_HOUR), undefined],
+      [new Timedelta(MS_IN_HOUR), ''],
+      [new Timedelta(MS_IN_HOUR), 'h:h'],
+      [new Timedelta(MS_IN_HOUR), 123],
+      [new Timedelta(MS_IN_HOUR), ':::'],
+    ]
+    test.each(cases)('value %p with format %p', (value, formatStr) => {
+      expect(formatValueWithDurationFormat(value, formatStr)).toBeNull()
+    })
+  })
+
+  describe('parsed format returns correct duration', () => {
+    const cases = [
+      [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm'],
+      [new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC), 'h:mm:ss'],
+      [
+        new Timedelta(
+          2 * MS_IN_DAY + 3 * MS_IN_HOUR + 4 * MS_IN_MIN + 5 * MS_IN_SEC
+        ),
+        'd h:mm:ss',
+      ],
+      [new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)), 'h:mm'],
+      [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm'],
+      [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'mm:ss'],
+    ]
+    test.each(cases)('%p with %s', (duration, formatStr) => {
+      const formatted = formatValueWithDurationFormat(duration, formatStr)
+      const reparsed = parseValueWithDurationFormat(formatted, formatStr)
+      expect(reparsed).toStrictEqual(duration)
     })
   })
 })

--- a/web-frontend/test/unit/core/utils/duration.spec.js
+++ b/web-frontend/test/unit/core/utils/duration.spec.js
@@ -35,6 +35,23 @@ describe('tokenizeDurationFormat', () => {
       ['d|h.', '2|5.', ['days', 'hours'], ['2', '5']],
       // leading minus is optional
       ['h:mm', '-1:30', ['hours', 'minutes'], ['1', '30']],
+      // fractional-seconds run with a dot separator
+      [
+        'h:mm:ss.fff',
+        '1:23:45.678',
+        ['hours', 'minutes', 'seconds', 'fraction'],
+        ['1', '23', '45', '678'],
+      ],
+      // single `f` accepts a single fractional digit
+      ['ss.f', '45.6', ['seconds', 'fraction'], ['45', '6']],
+      // the separator before `f` is a literal, so non-dot delimiters work
+      ['s fff', '1 234', ['seconds', 'fraction'], ['1', '234']],
+      [
+        'mm:ss,ff',
+        '01:02,34',
+        ['minutes', 'seconds', 'fraction'],
+        ['01', '02', '34'],
+      ],
     ]
     test.each(cases)(
       'format %s matches %s into fields %j with groups %j',
@@ -74,6 +91,8 @@ describe('tokenizeDurationFormat', () => {
       'mm mm', // mm repeated
       'h hh', // h then hh — both map to "hours"
       'ss s', // ss then s — both map to "seconds"
+      'ss.f.f', // fraction run appears twice
+      'f.fff', // fraction run appears twice
     ]
     test.each(repeatedTokens)('repeated token in %s', (formatStr) => {
       expect(tokenizeDurationFormat(formatStr)).toBeNull()
@@ -96,7 +115,18 @@ describe('tokenizeDurationFormat', () => {
 })
 
 describe('isValidDurationFormat', () => {
-  const valid = ['h:mm', 'h:mm:ss', 'd h:mm:ss', 'd h mm ss', 'd', 'hh:mm:ss']
+  const valid = [
+    'h:mm',
+    'h:mm:ss',
+    'd h:mm:ss',
+    'd h mm ss',
+    'd',
+    'hh:mm:ss',
+    'h:mm:ss.f',
+    'h:mm:ss.ff',
+    'h:mm:ss.fff',
+    's fff',
+  ]
   test.each(valid)('returns true for %s', (formatStr) => {
     expect(isValidDurationFormat(formatStr)).toBe(true)
   })
@@ -129,6 +159,20 @@ describe('parseValueWithDurationFormat', () => {
       ['12:34', 'hh:mm', 12 * MS_IN_HOUR + 34 * MS_IN_MIN],
       // 25 hours fits into the resulting Timedelta as 1 day + 1 hour worth of ms
       ['25:00', 'h:mm', 25 * MS_IN_HOUR],
+      // fractional seconds: digits are a positional decimal
+      [
+        '1:23:45.678',
+        'h:mm:ss.fff',
+        1 * MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC + 678,
+      ],
+      // "5" at precision 1 is 0.5s, not 0.05s
+      ['0:00:00.5', 'h:mm:ss.f', 500],
+      // "05" is 0.05s
+      ['0:00:00.05', 'h:mm:ss.ff', 50],
+      // non-dot separator before the fraction
+      ['1 234', 's fff', MS_IN_SEC + 234],
+      // negative carries the sub-second component
+      ['-0:00:01.250', 'h:mm:ss.fff', -(MS_IN_SEC + 250)],
     ]
     test.each(cases)(
       'parses %s with format %s',
@@ -208,8 +252,33 @@ describe('formatValueWithDurationFormat', () => {
       [new Timedelta(MS_IN_HOUR + 5 * MS_IN_MIN), 'hh:mm', '01:05'],
       // arbitrary literal chars are preserved
       [new Timedelta(2 * MS_IN_DAY + 5 * MS_IN_HOUR), 'd|h.', '2|5.'],
-      // sub-second precision is truncated
+      // sub-second precision is truncated when there's no fraction token
       [new Timedelta(1500), 's', '1'],
+      // fractional seconds rendered zero-padded to the format precision
+      [
+        new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC + 678),
+        'h:mm:ss.fff',
+        '1:23:45.678',
+      ],
+      // 0.5s at precision 1 → "5"; at precision 3 → "500"
+      [new Timedelta(500), 'ss.f', '00.5'],
+      [new Timedelta(500), 'ss.fff', '00.500'],
+      // 0.05s → "05" at precision 2
+      [new Timedelta(50), 'ss.ff', '00.05'],
+      // non-dot separator preserved on output
+      [new Timedelta(MS_IN_SEC + 234), 's fff', '1 234'],
+      // rounding up carries across fields: 59.9996 → 1:00.000
+      [new Timedelta(59999.6), 'mm:ss.fff', '01:00.000'],
+      // carry that rolls all the way over: 59:59.9996 → 1:00:00.000
+      [
+        new Timedelta(59 * MS_IN_MIN + 59 * MS_IN_SEC + 999.6),
+        'h:mm:ss.fff',
+        '1:00:00.000',
+      ],
+      // values beyond the precision are rounded, not truncated
+      [new Timedelta(MS_IN_SEC + 236), 'ss.ff', '01.24'],
+      // negative fractional value keeps the sign
+      [new Timedelta(-(MS_IN_SEC + 250)), 'ss.fff', '-01.250'],
     ]
     test.each(cases)(
       'formats %p with format %s as %s',
@@ -255,6 +324,14 @@ describe('formatValueWithDurationFormat', () => {
       [new Timedelta(-(MS_IN_HOUR + 30 * MS_IN_MIN)), 'h:mm'],
       [new Timedelta(25 * MS_IN_HOUR + 30 * MS_IN_MIN), 'h:mm'],
       [new Timedelta(MS_IN_HOUR + 30 * MS_IN_MIN), 'mm:ss'],
+      // fractional formats round-trip when the value fits the precision
+      [
+        new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC + 678),
+        'h:mm:ss.fff',
+      ],
+      [new Timedelta(MS_IN_SEC + 500), 'ss.f'],
+      [new Timedelta(MS_IN_SEC + 234), 's fff'],
+      [new Timedelta(-(MS_IN_SEC + 250)), 'ss.fff'],
     ]
     test.each(cases)('%p with %s', (duration, formatStr) => {
       const formatted = formatValueWithDurationFormat(duration, formatStr)

--- a/web-frontend/test/unit/core/utils/duration.spec.js
+++ b/web-frontend/test/unit/core/utils/duration.spec.js
@@ -1,0 +1,168 @@
+import {
+  Timedelta,
+  isValidDurationFormat,
+  parseValueWithDurationFormat,
+  tokenizeDurationFormat,
+} from '@baserow/modules/core/utils/duration'
+
+const MS_IN_SEC = 1000
+const MS_IN_MIN = 60 * MS_IN_SEC
+const MS_IN_HOUR = 60 * MS_IN_MIN
+const MS_IN_DAY = 24 * MS_IN_HOUR
+
+describe('tokenizeDurationFormat', () => {
+  describe('valid formats', () => {
+    const cases = [
+      ['h:mm', '1:30', ['hours', 'minutes'], ['1', '30']],
+      // literal `:` separators are escaped
+      [
+        'h:mm:ss',
+        '1:23:45',
+        ['hours', 'minutes', 'seconds'],
+        ['1', '23', '45'],
+      ],
+      // space-separated tokens
+      [
+        'd h mm ss',
+        '2 3 04 05',
+        ['days', 'hours', 'minutes', 'seconds'],
+        ['2', '3', '04', '05'],
+      ],
+      // two-char tokens take precedence over one-char (hh, not h+h)
+      ['hh:mm', '12:34', ['hours', 'minutes'], ['12', '34']],
+      // arbitrary literal chars (avoid d/h/m/s, which are token letters)
+      ['d|h.', '2|5.', ['days', 'hours'], ['2', '5']],
+      // leading minus is optional
+      ['h:mm', '-1:30', ['hours', 'minutes'], ['1', '30']],
+    ]
+    test.each(cases)(
+      'format %s matches %s into fields %j with groups %j',
+      (formatStr, value, expectedFields, expectedGroups) => {
+        const result = tokenizeDurationFormat(formatStr)
+
+        expect(result).not.toBeNull()
+        expect(result.pattern).toBeInstanceOf(RegExp)
+        expect(result.fields).toStrictEqual(expectedFields)
+        const match = value.match(result.pattern)
+        expect(match).not.toBeNull()
+        // match[0] is the full string; capture groups start at index 1.
+        expect(match.slice(1)).toStrictEqual(expectedGroups)
+      }
+    )
+  })
+
+  describe('values that do not match the compiled pattern', () => {
+    const cases = [
+      // anchored to start of string
+      ['h:mm', 'prefix 1:30'],
+      // anchored to end of string
+      ['h:mm', '1:30 trailing'],
+      // literal mismatch (`|` in format, `/` in value)
+      ['d|h.', '2/5.'],
+    ]
+    test.each(cases)('format %s does not match %s', (formatStr, value) => {
+      const { pattern } = tokenizeDurationFormat(formatStr)
+
+      expect(value.match(pattern)).toBeNull()
+    })
+  })
+
+  describe('invalid formats return null', () => {
+    const repeatedTokens = [
+      'h:mm:h', // h repeated
+      'mm mm', // mm repeated
+      'h hh', // h then hh — both map to "hours"
+      'ss s', // ss then s — both map to "seconds"
+    ]
+    test.each(repeatedTokens)('repeated token in %s', (formatStr) => {
+      expect(tokenizeDurationFormat(formatStr)).toBeNull()
+    })
+
+    const noTokens = [
+      '',
+      ':::', // only literals
+      '   ', // only whitespace
+    ]
+    test.each(noTokens)('no duration token in %j', (formatStr) => {
+      expect(tokenizeDurationFormat(formatStr)).toBeNull()
+    })
+
+    const nonStrings = [null, undefined, 1, 1.5, [], {}, true]
+    test.each(nonStrings)('non-string input %p', (value) => {
+      expect(tokenizeDurationFormat(value)).toBeNull()
+    })
+  })
+})
+
+describe('isValidDurationFormat', () => {
+  const valid = ['h:mm', 'h:mm:ss', 'd h:mm:ss', 'd h mm ss', 'd', 'hh:mm:ss']
+  test.each(valid)('returns true for %s', (formatStr) => {
+    expect(isValidDurationFormat(formatStr)).toBe(true)
+  })
+
+  const invalid = ['', 'h:h', ':::', null, undefined, 123, [], {}]
+  test.each(invalid)('returns false for %p', (value) => {
+    expect(isValidDurationFormat(value)).toBe(false)
+  })
+})
+
+describe('parseValueWithDurationFormat', () => {
+  describe('valid values', () => {
+    const cases = [
+      ['1:30', 'h:mm', 1 * MS_IN_HOUR + 30 * MS_IN_MIN],
+      ['1:23:45', 'h:mm:ss', 1 * MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC],
+      [
+        '2 3:04:05',
+        'd h:mm:ss',
+        2 * MS_IN_DAY + 3 * MS_IN_HOUR + 4 * MS_IN_MIN + 5 * MS_IN_SEC,
+      ],
+      ['3 4', 'd h', 3 * MS_IN_DAY + 4 * MS_IN_HOUR],
+      ['-1:30', 'h:mm', -(1 * MS_IN_HOUR + 30 * MS_IN_MIN)],
+      // surrounding whitespace is stripped
+      ['  1:30  ', 'h:mm', 1 * MS_IN_HOUR + 30 * MS_IN_MIN],
+      ['0:00', 'h:mm', 0],
+      // the generated regex uses \d+ for every field, so single-digit
+      // values are accepted even where the format suggests two digits
+      ['1:5', 'h:mm', 1 * MS_IN_HOUR + 5 * MS_IN_MIN],
+      // "hh:mm" tokenizes as hh + mm, not h + h + mm
+      ['12:34', 'hh:mm', 12 * MS_IN_HOUR + 34 * MS_IN_MIN],
+      // 25 hours fits into the resulting Timedelta as 1 day + 1 hour worth of ms
+      ['25:00', 'h:mm', 25 * MS_IN_HOUR],
+    ]
+    test.each(cases)(
+      'parses %s with format %s',
+      (value, formatStr, expectedMs) => {
+        const result = parseValueWithDurationFormat(value, formatStr)
+
+        expect(result).toBeInstanceOf(Timedelta)
+        expect(result.ms).toBe(expectedMs)
+      }
+    )
+  })
+
+  describe('invalid input returns null', () => {
+    const cases = [
+      // value doesn't match the format's literal separator
+      ['1.30', 'h:mm'],
+      // value has trailing garbage
+      ['1:30 extra', 'h:mm'],
+      // non-string values
+      [null, 'h:mm'],
+      [undefined, 'h:mm'],
+      [1, 'h:mm'],
+      [1.5, 'h:mm'],
+      [[], 'h:mm'],
+      [{}, 'h:mm'],
+      // invalid format strings
+      ['1:30', null],
+      ['1:30', undefined],
+      ['1:30', ''],
+      ['1:30', 'h:h'],
+      ['1:30', 123],
+      ['1:30', ':::'],
+    ]
+    test.each(cases)('value %p with format %p', (value, formatStr) => {
+      expect(parseValueWithDurationFormat(value, formatStr)).toBeNull()
+    })
+  })
+})

--- a/web-frontend/test/unit/core/utils/duration.spec.js
+++ b/web-frontend/test/unit/core/utils/duration.spec.js
@@ -252,8 +252,21 @@ describe('formatValueWithDurationFormat', () => {
       [new Timedelta(MS_IN_HOUR + 5 * MS_IN_MIN), 'hh:mm', '01:05'],
       // arbitrary literal chars are preserved
       [new Timedelta(2 * MS_IN_DAY + 5 * MS_IN_HOUR), 'd|h.', '2|5.'],
-      // sub-second precision is truncated when there's no fraction token
-      [new Timedelta(1500), 's', '1'],
+      // integer-second formats (no fraction token) round to whole seconds
+      // rather than truncating: 1.5s → "2", 1.4s → "1"
+      [new Timedelta(1500), 's', '2'],
+      [new Timedelta(1400), 's', '1'],
+      // rounding is half up, so 0.5s → "1"
+      [new Timedelta(500), 's', '1'],
+      [new Timedelta(-500), 's', '-1'],
+      // integer rounding carries across fields: 59.6s → 1:00
+      [new Timedelta(59600), 'mm:ss', '01:00'],
+      // 59m 59.6s → 1:00:00
+      [
+        new Timedelta(59 * MS_IN_MIN + 59 * MS_IN_SEC + 600),
+        'h:mm:ss',
+        '1:00:00',
+      ],
       // fractional seconds rendered zero-padded to the format precision
       [
         new Timedelta(MS_IN_HOUR + 23 * MS_IN_MIN + 45 * MS_IN_SEC + 678),

--- a/web-frontend/test/unit/core/utils/duration.spec.js
+++ b/web-frontend/test/unit/core/utils/duration.spec.js
@@ -52,6 +52,20 @@ describe('tokenizeDurationFormat', () => {
         ['minutes', 'seconds', 'fraction'],
         ['01', '02', '34'],
       ],
+      // backslash escapes a token letter so it becomes a literal suffix:
+      // `d\d h\h` matches "1d 2h" (the d/h after the backslash are literal)
+      ['d\\d h\\h', '1d 2h', ['days', 'hours'], ['1', '2']],
+      [
+        'd\\d h\\h mm\\m ss\\s',
+        '1d 2h 03m 04s',
+        ['days', 'hours', 'minutes', 'seconds'],
+        ['1', '2', '03', '04'],
+      ],
+      // an escaped backslash is a literal backslash
+      ['h\\\\mm', '1\\23', ['hours', 'minutes'], ['1', '23']],
+      // an escaped `f` is a literal `f`, not the fraction token, so a real
+      // fraction can still follow — and its precision is read correctly
+      ['\\f ss.ff', 'f 01.50', ['seconds', 'fraction'], ['01', '50']],
     ]
     test.each(cases)(
       'format %s matches %s into fields %j with groups %j',
@@ -104,6 +118,14 @@ describe('tokenizeDurationFormat', () => {
       '   ', // only whitespace
     ]
     test.each(noTokens)('no duration token in %j', (formatStr) => {
+      expect(tokenizeDurationFormat(formatStr)).toBeNull()
+    })
+
+    const trailingBackslash = [
+      'h:mm\\', // trailing backslash has nothing to escape
+      '\\', // lone backslash
+    ]
+    test.each(trailingBackslash)('trailing backslash in %j', (formatStr) => {
       expect(tokenizeDurationFormat(formatStr)).toBeNull()
     })
 
@@ -292,6 +314,24 @@ describe('formatValueWithDurationFormat', () => {
       [new Timedelta(MS_IN_SEC + 236), 'ss.ff', '01.24'],
       // negative fractional value keeps the sign
       [new Timedelta(-(MS_IN_SEC + 250)), 'ss.fff', '-01.250'],
+      // escaped token letters are emitted as literal unit suffixes
+      [new Timedelta(MS_IN_DAY + 2 * MS_IN_HOUR), 'd\\d h\\h', '1d 2h'],
+      [
+        new Timedelta(
+          MS_IN_DAY + 2 * MS_IN_HOUR + 3 * MS_IN_MIN + 4 * MS_IN_SEC
+        ),
+        'd\\d h\\h mm\\m ss\\s',
+        '1d 2h 03m 04s',
+      ],
+      [
+        new Timedelta(MS_IN_DAY + 2 * MS_IN_HOUR + 34 * MS_IN_MIN),
+        'd\\d h:mm',
+        '1d 2:34',
+      ],
+      // escaped backslash renders as a literal backslash
+      [new Timedelta(MS_IN_HOUR + 5 * MS_IN_MIN), 'h\\\\mm', '1\\05'],
+      // escaped `f` literal alongside a real fraction (precision read as 2)
+      [new Timedelta(MS_IN_SEC + 500), '\\f ss.ff', 'f 01.50'],
     ]
     test.each(cases)(
       'formats %p with format %s as %s',
@@ -345,6 +385,14 @@ describe('formatValueWithDurationFormat', () => {
       [new Timedelta(MS_IN_SEC + 500), 'ss.f'],
       [new Timedelta(MS_IN_SEC + 234), 's fff'],
       [new Timedelta(-(MS_IN_SEC + 250)), 'ss.fff'],
+      // escaped literal unit suffixes round-trip
+      [new Timedelta(MS_IN_DAY + 2 * MS_IN_HOUR), 'd\\d h\\h'],
+      [
+        new Timedelta(
+          MS_IN_DAY + 2 * MS_IN_HOUR + 3 * MS_IN_MIN + 4 * MS_IN_SEC
+        ),
+        'd\\d h\\h mm\\m ss\\s',
+      ],
     ]
     test.each(cases)('%p with %s', (duration, formatStr) => {
       const formatted = formatValueWithDurationFormat(duration, formatStr)


### PR DESCRIPTION
# What is in this PR
This PR improves the support for durations (timedelta) in advanced formulas. It also makes a small change to the categorization of formula functions.

[In a follow-up](https://github.com/baserow/baserow/issues/5442) PR, I'll be improving how we display the formula examples. Currently, we only show the 1st example in `getExamples()`. We should ideally show the first 2-3 examples, or perhaps show the examples in a modal.

Closes https://github.com/baserow/baserow/issues/5420
Closes https://github.com/baserow/baserow/issues/4423
Closes https://github.com/baserow/baserow/pull/4474

### 1. `duration_format()`
A new `duration_format()` formula function has been introduced. This allows you to pass in a duration (e.g. via a `to_duration()` result), and returns a string representation of the duration. It has two arguments: the duration and the format, e.g.: `duration_format(to_duration('1:30', 'h:mm'), 'h:mm')` which returns the string `1:30`.

### 2. Arithmetic on `duration`
We can now perform arithmetic operations on `duration`, e.g. `to_duration('1 minute') + to_duration('10 seconds')` returns a `90` second duration.

### 3. `to_duration()` format arg
The `to_duration()` function now accepts an optional format argument. E.g. `to_duration('1:30', 'm:s')` returns a `90` second duration.

For the format, I went with a token based format parser. I think this makes for a more flexible parser as opposed to using regex. The downside is that there is a small inconsistency, explain next.

The first argument to `to_duration()` can be of two formats: a helpful format similar to what is available in the DB side, or the token based format introduced in this PR, i.e. both of these are valid and return the same result:
- `to_duration('1m30s')`
- `to_duration('1:30', 'm:s')`

(just doing `to_duration('1')` returns a `1` second duration)

We could just disallow the first format, i.e. don't allow `'1m30s'`, but I think this small inconsistency is acceptable. The user can use the short-cut of `to_duration('1m30s')` or choose the more verbose version for explictness.

### 4. Formula categories
This PR also introduces a new category named Utility, and moves some existing formulas into this category.

Previously, we had some formulas that didn't cleanly fit into an existing category. E.g. the following were all categorized as `TEXT`:
- `concat()` also works for arrays.
- `get()` could return a variety of results.
- `length()` could operate on arrays, etc.

These (and others) are now recategorized to be more accurate.

# How to test this PR
To test the changes, in Builder, create a Heading element and enable expert mode.

### 1. `to_duration()` format
Use the `to_duration()` formula and:
- For the first arg (required), try either the short-hand form, e.g. `1 hour` or `1hr`.
- For the second arg (optional), try the format try a format like `h` or `d:h:m:s` in combination with the 1st arg.

### 2. duration arithmetic
Try doing arithmetic operations on durations, e.g. `to_duration('1h') + to_duration('1h')`. Try other operators, e.g. `+`, `*`, etc.

Try invalid operations, e.g. `now() - to_duration('1h')` should work, but `now() - now()` shouldn't (returns null, since both args are deferred).

### 3. `duration_format()`
Test the function with various args, e.g. `duration_format(to_duration('1 2:3:4', 'd h:m:s'), 'd:h:m:s')`

### 4. Formula categories
Check that the formulas in the Utility category make sense:
> <img width="199" height="287" alt="image" src="https://github.com/user-attachments/assets/2bf95710-22dd-451f-8fba-064a19e3e64b" />

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
