### PR TITLE
chore: Add crud table body slot

### DIFF
--- a/web-frontend/modules/core/components/crudTable/CrudTable.vue
+++ b/web-frontend/modules/core/components/crudTable/CrudTable.vue
@@ -156,6 +156,7 @@ import isObject from 'lodash/isObject'
  *          Two slot props are provided `updateRow` and `deleteRow` which are functions
  *          called when your menu has changed the row state which trigger the CrudTable
  *          to rerender the rows with the new data.
+ *  #rows: Can optionally replace the rows in the table.
  */
 export default {
   name: 'CrudTable',

--- a/web-frontend/modules/core/components/crudTable/CrudTable.vue
+++ b/web-frontend/modules/core/components/crudTable/CrudTable.vue
@@ -77,36 +77,47 @@
             </tr>
           </thead>
           <tbody>
-            <tr
-              v-for="row in rows"
-              :key="'row-' + row.id"
-              class="data-table__table-row"
+            <slot
+              name="rows"
+              :rows="rows"
+              :columns="columns"
+              :update-row="updateRow"
+              :delete-row="deleteRow"
+              :refresh="refresh"
             >
-              <td
-                v-for="col in columns"
-                :key="'col-' + col.key"
-                class="data-table__table-cell"
-                :class="{
-                  'data-table__table-cell--sticky-left': col.stickyLeft,
-                  'data-table__table-cell--sticky-right': col.stickyRight,
-                  [`data-table__table-cell--${col.key}`]: true,
-                }"
-                @contextmenu="$emit('row-context', { col, row, event: $event })"
+              <tr
+                v-for="row in rows"
+                :key="'row-' + row.id"
+                class="data-table__table-row"
               >
-                <div class="data-table__table-cell-content">
-                  <component
-                    :is="col.cellComponent"
-                    :row="row"
-                    :column="col"
-                    v-on="$attrs"
-                    @row-context="(payload) => $emit('row-context', payload)"
-                    @row-update="updateRow"
-                    @row-delete="deleteRow"
-                    @refresh="refresh"
-                  />
-                </div>
-              </td>
-            </tr>
+                <td
+                  v-for="col in columns"
+                  :key="'col-' + col.key"
+                  class="data-table__table-cell"
+                  :class="{
+                    'data-table__table-cell--sticky-left': col.stickyLeft,
+                    'data-table__table-cell--sticky-right': col.stickyRight,
+                    [`data-table__table-cell--${col.key}`]: true,
+                  }"
+                  @contextmenu="
+                    $emit('row-context', { col, row, event: $event })
+                  "
+                >
+                  <div class="data-table__table-cell-content">
+                    <component
+                      :is="col.cellComponent"
+                      :row="row"
+                      :column="col"
+                      v-on="$attrs"
+                      @row-context="(payload) => $emit('row-context', payload)"
+                      @row-update="updateRow"
+                      @row-delete="deleteRow"
+                      @refresh="refresh"
+                    />
+                  </div>
+                </td>
+              </tr>
+            </slot>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
### What is in this PR

Tiny PR needed for https://gitlab.com/baserow/baserow-saas/-/merge_requests/610/. Just adds a slot to the CrudTable.vue component body, so that it can be overwritten.

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
