### PR TITLE
fix(backend): allow negative numbers in rollup field filter input

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -6234,6 +6234,14 @@ class RollupFieldType(FormulaFieldType):
         "target_field_id",
         "rollup_function",
         "formula_type",
+        # `number_negative` is added explicitly so the frontend can correctly
+        # handle negative numbers in rollup fields (the user-visible symptom in
+        # issue #3925 is the grid view filter input swallowing the "-" key, but
+        # the same flag also gates negative-sign parsing/formatting). Unlike
+        # regular number fields, formula-backed number fields have no storage
+        # for this flag and no "no negatives" restriction, so the serializer
+        # override below returns a constant `True`.
+        "number_negative",
     ]
     serializer_field_overrides = {
         "through_field_id": serializers.IntegerField(
@@ -6250,6 +6258,9 @@ class RollupFieldType(FormulaFieldType):
             "through_field to rollup.",
         ),
         "nullable": serializers.BooleanField(required=False, read_only=True),
+        "number_negative": serializers.BooleanField(
+            required=False, read_only=True, default=True
+        ),
     }
 
     @property

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -6229,21 +6229,22 @@ class RollupFieldType(FormulaFieldType):
         "target_field_id",
         "rollup_function",
     ]
-    serializer_field_names = BASEROW_FORMULA_TYPE_ALLOWED_FIELDS + [
+    request_serializer_field_names = (
+        BASEROW_FORMULA_TYPE_REQUEST_SERIALIZER_FIELD_NAMES
+        + [
+            "through_field_id",
+            "target_field_id",
+            "rollup_function",
+            "formula_type",
+        ]
+    )
+    serializer_field_names = BASEROW_FORMULA_TYPE_SERIALIZER_FIELD_NAMES + [
         "through_field_id",
         "target_field_id",
         "rollup_function",
         "formula_type",
-        # `number_negative` is added explicitly so the frontend can correctly
-        # handle negative numbers in rollup fields (the user-visible symptom in
-        # issue #3925 is the grid view filter input swallowing the "-" key, but
-        # the same flag also gates negative-sign parsing/formatting). Unlike
-        # regular number fields, formula-backed number fields have no storage
-        # for this flag and no "no negatives" restriction, so the serializer
-        # override below returns a constant `True`.
-        "number_negative",
     ]
-    serializer_field_overrides = {
+    request_serializer_field_overrides = {
         "through_field_id": serializers.IntegerField(
             required=False,
             allow_null=True,
@@ -6258,18 +6259,7 @@ class RollupFieldType(FormulaFieldType):
             "through_field to rollup.",
         ),
         "nullable": serializers.BooleanField(required=False, read_only=True),
-        "number_negative": serializers.BooleanField(
-            required=False, read_only=True, default=True
-        ),
     }
-
-    @property
-    def request_serializer_field_names(self):
-        return self.serializer_field_names
-
-    @property
-    def request_serializer_field_overrides(self):
-        return self.serializer_field_overrides
 
     def before_create(
         self, table, primary, allowed_field_values, order, user, field_kwargs

--- a/backend/tests/baserow/contrib/database/field/test_rollup_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_rollup_field_type.py
@@ -738,9 +738,6 @@ def test_remove_dependent_count_rollup_field_through_field(
     assert test_field.error == "references the deleted or unknown field "
 
 
-# Regression test for https://github.com/baserow/baserow/issues/3925
-# The rollup field's API response must include `number_negative` so the
-# frontend filter input allows typing negative numbers.
 @pytest.mark.django_db
 def test_rollup_field_api_response_includes_number_negative(data_fixture, api_client):
     user, token = data_fixture.create_user_and_token()
@@ -776,6 +773,4 @@ def test_rollup_field_api_response_includes_number_negative(data_fixture, api_cl
     assert response.status_code == HTTP_200_OK
     response_json = response.json()
     assert response_json["type"] == "rollup"
-    # Rollup fields are formula-backed and never enforce a "no negatives"
-    # restriction, so they must always serialize as `number_negative: True`.
     assert response_json["number_negative"] is True

--- a/backend/tests/baserow/contrib/database/field/test_rollup_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_rollup_field_type.py
@@ -736,3 +736,46 @@ def test_remove_dependent_count_rollup_field_through_field(
     test_field.refresh_from_db()
     assert test_field.through_field_id is None
     assert test_field.error == "references the deleted or unknown field "
+
+
+# Regression test for https://github.com/baserow/baserow/issues/3925
+# The rollup field's API response must include `number_negative` so the
+# frontend filter input allows typing negative numbers.
+@pytest.mark.django_db
+def test_rollup_field_api_response_includes_number_negative(data_fixture, api_client):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    table2 = data_fixture.create_database_table(user=user, database=table.database)
+    data_fixture.create_text_field(name="tableprimary", table=table, primary=True)
+    data_fixture.create_text_field(name="table2primary", table=table2, primary=True)
+    rolled_up_field = data_fixture.create_number_field(
+        name="number", table=table2, number_negative=True
+    )
+    link_row_field = FieldHandler().create_field(
+        user,
+        table,
+        "link_row",
+        name="linkrowfield",
+        link_row_table=table2,
+    )
+    rollup_field = FieldHandler().create_field(
+        user,
+        table,
+        "rollup",
+        name="rollup_field",
+        through_field_id=link_row_field.id,
+        target_field_id=rolled_up_field.id,
+        rollup_function="sum",
+    )
+
+    response = api_client.get(
+        reverse("api:database:fields:item", kwargs={"field_id": rollup_field.id}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json["type"] == "rollup"
+    # Rollup fields are formula-backed and never enforce a "no negatives"
+    # restriction, so they must always serialize as `number_negative: True`.
+    assert response_json["number_negative"] is True

--- a/changelog/entries/unreleased/bug/lets_you_type_negative_numbers_when_filtering_by_rollup.json
+++ b/changelog/entries/unreleased/bug/lets_you_type_negative_numbers_when_filtering_by_rollup.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Lets you type negative numbers when filtering by rollup field",
+  "issue_origin": "github",
+  "issue_number": 3925,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-05-28"
+}


### PR DESCRIPTION
Closes #3925

### What is in this PR

Fixes a bug where the filter input for a **Rollup** field silently dropped the `-` keypress, making it impossible to type negative numbers (e.g. `-1` would appear as `1`).

#### Root cause

The frontend filter input (`web-frontend/modules/database/mixins/numberField.js → isValidChar`) only allows `-` when `field.number_negative` is truthy. The Rollup field's API response was missing the `number_negative` key entirely, so the check failed and `-` was blocked.

Why was it missing? `FormulaFieldType` exposes formula-type overrides (including `number_negative` from `BaserowFormulaNumberType`) via a `serializer_field_overrides` **property**. `RollupFieldType` defined `serializer_field_overrides` as a plain class attribute, which **silently shadowed** that property — so the merge never ran for Rollup. Additionally, `serializer_field_names` was built from `BASEROW_FORMULA_TYPE_ALLOWED_FIELDS` (which excludes `number_negative`) rather than `BASEROW_FORMULA_TYPE_SERIALIZER_FIELD_NAMES` (which includes it). `LookupFieldType` doesn't have either issue, which is why the same bug doesn't surface on Lookup.


#### Fix

Align `RollupFieldType` with the `LookupFieldType` pattern:

- Switch `serializer_field_names` from `BASEROW_FORMULA_TYPE_ALLOWED_FIELDS` to `BASEROW_FORMULA_TYPE_SERIALIZER_FIELD_NAMES`, so `number_negative` is declared on the response.
- Add `request_serializer_field_names` based on `BASEROW_FORMULA_TYPE_REQUEST_SERIALIZER_FIELD_NAMES`, which correctly excludes `number_negative` from the write API (it's read-only and not a `RollupField` column).
- Rename the Rollup-specific overrides dict from `serializer_field_overrides` to `request_serializer_field_overrides`. This removes the silent shadow and lets the parent's `serializer_field_overrides` property merge in formula-type overrides automatically — `number_negative: BooleanField(default=True)` now flows in from `BaserowFormulaNumberType.get_serializer_field_overrides()` without duplication.
- Drop the previously declared per-field overrides for things the parent already provides.

The Rollup response now matches the shape of `formula` and `lookup` fields. `select_options` and `available_collaborators` become empty values in the response — consistent with how Lookup behaves, and forward-compatible if a future rollup function ever targets single-select or collaborator fields.

#### Out of scope

`CountFieldType` has the same shadowing pattern but the bug is latent — `count` results are always `>= 0`, so the `number_negative` flag never affects the frontend. Left untouched to keep this PR scoped to the reported bug.

### How to test this PR

**Steps to reproduce the bug (on `develop`):**

1. Create **Table A** and **Table B** in a database.
2. In Table B, add a **Number** field `amount` with "Allow negative" enabled. Add rows with values like `-5`, `10`, `-3`.
3. In Table A, add a **Link to table** field pointing to Table B and link a row to one or more items.
4. In Table A, add a **Rollup** field: through = the link field, target = `amount`, function = `sum` (or any numeric aggregation).
5. In Table A's grid view, click **Filter** → **+ Add filter**, select the Rollup field, pick any numeric operator (e.g. `equals`, `lower than`).
6. Click the filter value input and try to type `-1`.

**Expected:** the input shows `-1`.
**Before this fix:** the `-` is swallowed; the input shows `1`.
**After this fix:** the input correctly shows `-1` and the filter behaves as expected.


### Checklist

- [x] A changelog entry has been added to \`changelog/entries/unreleased\` using \`changelog/src/changelog.py\`
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] Security impact of change has been considered