### PR TITLE
refactor: add a test plan and extract grid view helpers in preparation for collapsible group-by

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     services:
       db:
         image: pgvector/pgvector:pg14
@@ -877,7 +877,7 @@ jobs:
           CI: 1
         run: |
           cd e2e-tests
-          npx playwright test --timeout=30000 --grep-invert=@slow --shard=${{ matrix.shard }}/2 --project=firefox
+          npx playwright test --timeout=30000 --grep-invert=@slow --shard=${{ matrix.shard }}/4 --project=firefox
 
       - name: Upload E2E test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,6 +675,8 @@ jobs:
       packages: read
       checks: write
       pull-requests: write
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
     strategy:
       fail-fast: false
       matrix:
@@ -827,22 +829,8 @@ jobs:
           cd e2e-tests
           yarn install
 
-      - name: Get Playwright version
-        id: playwright-version
-        run: echo "version=$(cd e2e-tests && yarn list @playwright/test --depth=0 | grep @playwright/test | sed 's/.*@//')" >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          cd e2e-tests
-          npx playwright install --with-deps firefox
+      - name: Verify Google Chrome
+        run: google-chrome --version
 
       - name: Wait for services
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,7 +877,7 @@ jobs:
           CI: 1
         run: |
           cd e2e-tests
-          npx playwright test --timeout=30000 --grep-invert=@slow --shard=${{ matrix.shard }}/4 --project=firefox
+          npx playwright test --timeout=30000 --grep-invert=@slow --shard=${{ matrix.shard }}/4 --project=chrome
 
       - name: Upload E2E test results
         uses: actions/upload-artifact@v4

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -57,8 +57,8 @@ without waiting for the backend.
 
 **Deferred (✗):** at least one active constraint involves a formula field the
 frontend cannot evaluate — warnings and row changes for that constraint are
-deferred until the backend responds. Escape before the backend responds is `—`
-because no warning has appeared yet for the deferred constraint.
+deferred until the backend responds. Pressing Escape key before the backend
+responds is `—` because no warning has appeared yet for the deferred constraint.
 
 **Backend error column:** the backend returns a 5xx error. The optimistic value
 (always applied immediately for field edits) must be rolled back. For optimistic

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -1,8 +1,9 @@
-# Grid View Flat Test Plan
+# Grid View Test Plan
 
-Browser coverage for the flat (non-grouped) grid view lives in
-`e2e-tests/tests/database/grid/`. Grouped grid and collapsible group-by behavior
-are intentionally out of scope for this plan.
+Browser coverage for the grid view lives in `e2e-tests/tests/database/grid/`.
+
+This plan defines the expected visible behavior and maps it to e2e coverage,
+organized by numbering rules, a coverage matrix, and scenario expectations.
 
 Expected sequences are intentionally repetitive. Use the same sentence for the
 same visible side effect whenever a test is added or changed.
@@ -11,18 +12,104 @@ same visible side effect whenever a test is added or changed.
 verify. Keep those details in the plan so future tests know the intended
 behavior.
 
+## Numbering Convention
+
+Test IDs use `bucket.group.scenario` plus an optional letter suffix for closely
+related variants, for example `1.2.1b`.
+
+The first number identifies the domain:
+
+| Bucket | Domain |
+|---|---|
+| 1 | Row creation |
+| 2 | Row updates |
+| 3 | Row deletion |
+| 4 | Clipboard and multi-cell edits |
+| 5 | Filters |
+| 6 | Sorts |
+| 7 | Search |
+| 8 | View display options |
+| 9 | Cell selection |
+| 10 | Keyboard navigation |
+| 11 | Row hover and context menus |
+| 12 | Checkbox selection and bulk actions |
+| 13 | Row expand modal |
+| 14 | Public shared grid |
+| 15 | Realtime row events |
+| 16 | Realtime metadata and presence |
+| 17 | Data-sync read-only mode |
+
+Within each bucket, groups start at `.1` and increase by topic. In covered
+create, update, and clipboard sections, `.2` is filter-affecting behavior and
+`.3` is sort-affecting behavior. Specs may group setup-heavy blocks out of
+numeric order when that keeps related fixtures together. Uncovered group-by
+paths are listed in TODO coverage instead of reserving empty groups. Letter
+suffixes (`a`, `b`, `c`) are timing or selection variants of the same scenario.
+
+## Coverage Matrix
+
+Maps `operation × active constraints × timing` to the test section that covers
+it. `TODO` = uncovered. `—` = not applicable.
+
+**Optimistic (✓):** every active constraint is on a regular field the frontend
+can evaluate locally — warnings appear immediately and the row moves or hides
+without waiting for the backend.
+
+**Deferred (✗):** at least one active constraint involves a formula field the
+frontend cannot evaluate — warnings and row changes for that constraint are
+deferred until the backend responds. Escape before the backend responds is `—`
+because no warning has appeared yet for the deferred constraint.
+
+**Backend error column:** the backend returns a 5xx error. The optimistic value
+(always applied immediately for field edits) must be rolled back. For optimistic
+constraints the warning also disappears on rollback; for deferred constraints no
+warning appeared so only the value rollback matters. Error toasts are asserted
+for covered row CRUD backend-error cases.
+
+When multiple constraints are active and only some involve formula fields, the
+row can show an immediate warning for the optimistic constraints while still
+waiting on the deferred ones. The "Constraint fields" column records which
+constraint fields are regular vs. formula; for combined rows "all regular" and
+"any formula" are used since every combined cell is TODO and the specific
+field-type breakdown belongs in the scenario description when the test is
+written.
+
+| Operation | Constraint | Constraint field | Optimistic | Keep selected | Deselect after confirm | Deselect before confirm | Backend error | Escape |
+|---|---|---|:---:|---|---|---|---|---|
+| Create | — | — | ✓ | [1.1.1](#111-backend-confirmation-for-a-new-row) | — | — | [1.1.3](#113-failed-create-is-rolled-back-and-the-optimistic-row-disappears) | — |
+| Create | filter | regular | ✓ | [1.2.1a](#121a-add-row-that-does-not-match-an-active-simple-field-filter-and-keep-it-selected) | [1.2.1a](#121a-add-row-that-does-not-match-an-active-simple-field-filter-and-keep-it-selected) | [1.2.1b](#121b-deselect-newly-added-filter-mismatched-row-before-backend-confirmation) | [1.2.1d](#121d-backend-returns-500-on-filter-affected-create) | — |
+| Create | filter | formula | ✗ | [1.2.2a](#122a-create-row-with-formula-field-filter-active--no-warning-until-backend-responds) | [1.2.2a](#122a-create-row-with-formula-field-filter-active--no-warning-until-backend-responds) | [1.2.2b](#122b-deselect-newly-added-formula-filtered-row-before-backend-confirmation) | [1.2.2c](#122c-backend-returns-500-on-formula-filter-affected-create) | — |
+| Create | sort | regular | ✓ | [1.3.1a](#131a-add-row-with-simple-field-sort-asc-and-keep-it-selected) | [1.3.1a](#131a-add-row-with-simple-field-sort-asc-and-keep-it-selected) | [1.3.1b](#131b-add-row-with-simple-field-sort-asc-then-deselect-before-backend-confirmation) | [1.3.1c](#131c-backend-returns-500-on-sort-affected-create) | — |
+| Create | sort | formula | ✗ | [1.3.2a](#132a-add-row-with-formula-field-sort-active--no-move-warning-until-backend-responds) | [1.3.2a](#132a-add-row-with-formula-field-sort-active--no-move-warning-until-backend-responds) | [1.3.2b](#132b-add-row-with-formula-field-sort-active-then-deselect-before-backend-confirmation) | [1.3.2c](#132c-backend-returns-500-on-formula-sort-affected-create) | — |
+| Create | group-by | regular | ✓ | TODO | TODO | TODO | TODO | — |
+| Create | group-by | formula | ✗ | TODO | TODO | TODO | TODO | — |
+| Update | — | — | ✓ | [2.1.1](#211-edit-primary-field-and-press-enter) | — | — | [2.1.3](#213-backend-returns-500-on-update) | [2.1.4](#214-press-escape-while-editing) |
+| Update | filter | regular | ✓ | [2.2.1a](#221a-edit-filtered-row-to-non-matching-value-and-keep-it-selected) | [2.2.1a](#221a-edit-filtered-row-to-non-matching-value-and-keep-it-selected) | [2.2.1b](#221b-deselect-filter-mismatched-row-before-backend-confirmation) | [2.2.2](#222-backend-returns-500-on-filter-affecting-update) | [2.2.4](#224-press-escape-during-filter-mismatched-edit) |
+| Update | filter | formula | ✗ | [2.2.5a](#225a-edit-with-formula-field-filter-active--no-warning-until-backend-responds) | [2.2.5b](#225b-deselect-formula-filtered-row-after-backend-confirmation) | [2.2.5c](#225c-deselect-formula-filtered-row-before-backend-confirmation) | [2.2.5d](#225d-backend-returns-500-on-formula-filter-affecting-update) | — |
+| Update | sort | regular | ✓ | [2.3.1a](#231a-edit-sorted-row-so-it-should-move-and-keep-it-selected) | [2.3.1a](#231a-edit-sorted-row-so-it-should-move-and-keep-it-selected) | [2.3.1b](#231b-deselect-sort-mismatched-row-before-backend-confirmation) | [2.3.2](#232-backend-returns-500-on-sort-affecting-update) | [2.3.3](#233-press-escape-during-sort-mismatched-edit) |
+| Update | sort | formula | ✗ | [2.3.4a](#234a-edit-with-formula-field-sort-active--no-move-warning-until-backend-responds) | [2.3.4a](#234a-edit-with-formula-field-sort-active--no-move-warning-until-backend-responds) | [2.3.4b](#234b-deselect-formula-sorted-row-before-backend-confirmation) | [2.3.4c](#234c-backend-returns-500-on-formula-sort-affecting-update) | — |
+| Update | group-by | regular | ✓ | TODO | TODO | TODO | TODO | TODO |
+| Update | group-by | formula | ✗ | TODO | TODO | TODO | TODO | — |
+| Paste | — | — | ✓ | TODO | — | — | TODO | — |
+| Paste | filter | regular | ✓ | [4.2.1a](#421a-paste-value-that-breaks-active-filter-then-deselect) | [4.2.1a](#421a-paste-value-that-breaks-active-filter-then-deselect) | [4.2.1b](#421b-filter-breaking-paste-deselected-before-backend-confirmation) | TODO | — |
+| Paste | filter | formula | ✗ | TODO | TODO | TODO | TODO | — |
+| Paste | sort | regular | ✓ | [4.3.1a](#431a-sort-affecting-paste-shows-row-has-moved-warning-then-moves-row-on-deselect) | [4.3.1a](#431a-sort-affecting-paste-shows-row-has-moved-warning-then-moves-row-on-deselect) | [4.3.1b](#431b-sort-affecting-paste-deselected-before-backend-confirmation-moves-row-immediately) | TODO | — |
+| Paste | sort | formula | ✗ | TODO | TODO | TODO | TODO | — |
+| Paste | group-by | regular | ✓ | TODO | TODO | TODO | TODO | — |
+| Paste | group-by | formula | ✗ | TODO | TODO | TODO | TODO | — |
+
+### Combined constraints (TODO)
+
+All combinations of two or more active constraints (filter + sort, filter +
+group-by, sort + group-by, filter + sort + group-by) are uncovered for every
+operation and timing variant. Each combination should be tested in both the
+all-regular (fully optimistic) and any-formula (partially or fully deferred)
+configurations. When added, expand this section into a table following the same
+structure as the single-constraint table above.
+
 ## Row Creation
 
-### 1.1.1 Click "+ Add row" with no filters/sorts
-
-- Empty row is appended at the bottom.
-- Empty primary and field cells are visible immediately.
-- Row count increments.
-- Row loading spinner is visible while the create request is pending.
-  Covered by 1.1.2.
-- Row loading spinner is hidden after backend confirmation.
-
-### 1.1.2 Backend confirmation for a new row
+### 1.1.1 Backend confirmation for a new row
 
 - Empty row is appended at the bottom.
 - Empty primary and field cells are visible immediately.
@@ -31,71 +118,22 @@ behavior.
 - Empty row stays at the bottom after backend confirmation.
 - Row loading spinner is hidden after backend confirmation.
 
-### 1.2.1a Add row with simple-field sort ASC and keep it selected
+### 1.1.2 Primary field is selected after adding a row
 
 - Empty row is appended at the bottom.
-- Empty primary and field cells are visible immediately.
-- Row loading spinner is visible while the create request is pending.
-- "Row has moved" is visible immediately because the frontend can evaluate the
-  simple-field sort.
-- Row loading spinner is hidden after backend confirmation.
-- "Row has moved" remains visible while the row is selected.
-- After deselect, the row moves to the first sorted position.
-- After deselect, "Row has moved" is hidden.
+- Row count increments.
+- New row primary cell is selected after backend confirmation.
 
-### 1.2.1b Add row with simple-field sort ASC, then deselect before backend confirmation
+### 1.1.3 Failed create is rolled back and the optimistic row disappears
 
 - Empty row is appended at the bottom.
-- Empty primary and field cells are visible immediately.
 - Row loading spinner is visible while the create request is pending.
-- "Row has moved" is visible immediately because the frontend can evaluate the
-  simple-field sort.
-- After deselect while the create request is pending, the row moves to the first
-  sorted position.
-- Row loading spinner is visible while the create request is pending.
-- After deselect, "Row has moved" is hidden.
-- Empty row stays in the first sorted position after backend confirmation.
-- Row loading spinner is hidden after backend confirmation.
-- No warning is visible after backend confirmation.
+- POST request returns 500.
+- Optimistic row is removed from the visible grid after the error.
+- Row count returns to its original value.
+- Error toast is visible.
 
-### 1.2.2a Edit Name under simple-field sort ASC and keep it selected
-
-- Typed value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
-- "Row has moved" is visible immediately because the frontend can evaluate the
-  simple-field sort.
-- Row stays in its current visible position while selected.
-- "Row has moved" remains visible while the row is selected after backend
-  confirmation.
-- After deselect, the row moves to its sorted position.
-- After deselect, "Row has moved" is hidden.
-
-### 1.2.2b Edit Name under simple-field sort ASC, then deselect before backend confirmation
-
-- Typed value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
-- "Row has moved" is visible immediately because the frontend can evaluate the
-  simple-field sort.
-- After deselect while the update request is pending, the row moves to its sorted
-  position.
-- After deselect, "Row has moved" is hidden.
-- Row stays in its sorted position after backend confirmation.
-- No warning is visible after backend confirmation.
-
-### 1.2.3 Deselect the sort-mismatched row after backend confirmation
-
-- "Row has moved" is visible before deselect.
-- After deselect, the row moves to its sorted position.
-- After deselect, "Row has moved" is hidden.
-
-### 1.2.4 Press Escape during sort mismatch
-
-- Typed draft is discarded.
-- Original value is visible again.
-- "Row has moved" is hidden.
-- Row stays in its original position.
-
-### 1.3.1a Add row that does not match an active simple-field filter and keep it selected
+### 1.2.1a Add row that does not match an active simple-field filter and keep it selected
 
 - Empty row is appended at the bottom.
 - Empty primary and field cells are visible immediately.
@@ -110,7 +148,7 @@ behavior.
 - After deselect, the row is removed from the visible grid.
 - After deselect, "Row does not match filters" is hidden.
 
-### 1.3.1b Deselect newly added filter-mismatched row before backend confirmation
+### 1.2.1b Deselect newly added filter-mismatched row before backend confirmation
 
 - Empty row is appended at the bottom.
 - Empty primary and field cells are visible immediately.
@@ -122,7 +160,7 @@ behavior.
 - After deselect, "Row does not match filters" is hidden.
 - Row stays hidden after backend confirmation.
 
-### 1.3.1c Enter a value that makes the newly added row match the active filter
+### 1.2.1c Enter a value that makes the newly added row match the active filter
 
 - With a filter such as "Name is not empty", empty row is appended at the bottom.
 - Empty primary and field cells are visible immediately.
@@ -131,53 +169,143 @@ behavior.
 - Typed value is visible immediately.
 - "Row does not match filters" is hidden after the value matches the filter.
 - Row remains visible.
-- This exact newly-created-row correction path is TODO.
 
-### 1.3.1d Edit existing row to keep matching active filter
+### 1.2.1d Backend returns 500 on filter-affected create
 
-- Typed value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
-- Row remains visible.
-- No warning is visible.
-- Row count is unchanged.
-
-### 1.3.2a Type value that does not match a simple-field filter and keep it selected
-
-- Typed value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
 - "Row does not match filters" is visible immediately because the frontend can
   evaluate the simple-field filter.
-- Row remains visible while selected.
-- "Row does not match filters" remains visible while the row is selected after
-  backend confirmation.
+- POST request returns 500.
+- Optimistic row is removed from the visible grid after the error.
+- "Row does not match filters" is hidden after the error.
+- Row count returns to its original value.
+- Error toast is visible.
 
-### 1.3.2b Type value that does not match a simple-field filter, then deselect before backend confirmation
+### 1.2.2a Create row with formula-field filter active — no warning until backend responds
 
-- Typed value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
-- "Row does not match filters" is visible immediately because the frontend can
-  evaluate the simple-field filter.
-- After deselect while the update request is pending, the row is removed from the
-  visible grid.
-- After deselect, "Row does not match filters" is hidden.
-- Row stays hidden after backend confirmation.
-
-### 1.3.3 Deselect filter-mismatched row after backend confirmation
-
-- "Row does not match filters" is visible before deselect.
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row does not match filters" is hidden while the create request is pending
+  because the frontend cannot evaluate the formula filter.
+- Row loading spinner is hidden after backend confirmation.
+- "Row does not match filters" is visible after backend confirmation while the
+  row is selected.
 - After deselect, the row is removed from the visible grid.
 - After deselect, "Row does not match filters" is hidden.
-- Row count decrements.
 
-### 1.3.4 Press Escape during filter mismatch
+### 1.2.2b Deselect newly added formula-filtered row before backend confirmation
 
-- Typed draft is discarded.
-- Original matching value is visible again.
-- "Row does not match filters" is hidden.
-- Row remains visible.
-- Row count is unchanged.
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- "Row does not match filters" is hidden while the create request is pending.
+- After deselect while the create request is pending, the row remains visible
+  because the frontend has not yet received the formula result from the backend.
+- After the create request completes, the row is removed from the visible grid.
 
-## Row Editing
+### 1.2.2c Backend returns 500 on formula-filter-affected create
+
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- "Row does not match filters" is hidden while the create request is pending
+  because the frontend cannot evaluate the formula filter.
+- POST request returns 500.
+- Optimistic row is removed from the visible grid after the error.
+- Row count returns to its original value.
+- Error toast is visible.
+
+### 1.3.1a Add row with simple-field sort ASC and keep it selected
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- Row loading spinner is hidden after backend confirmation.
+- "Row has moved" remains visible while the row is selected.
+- After deselect, the row moves to the first sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 1.3.1b Add row with simple-field sort ASC, then deselect before backend confirmation
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- After deselect while the create request is pending, the row moves to the first
+  sorted position.
+- Row loading spinner is visible while the create request is pending.
+- After deselect, "Row has moved" is hidden.
+- Empty row stays in the first sorted position after backend confirmation.
+- Row loading spinner is hidden after backend confirmation.
+- No warning is visible after backend confirmation.
+
+### 1.3.1c Backend returns 500 on sort-affected create
+
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- POST request returns 500.
+- Optimistic row is removed from the visible grid after the error.
+- "Row has moved" is hidden after the error.
+- Row count returns to its original value.
+- Remaining rows are visible in their original sorted order.
+- Error toast is visible.
+
+### 1.3.2a Add row with formula-field sort active — no move warning until backend responds
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is hidden while the create request is pending because the
+  frontend cannot evaluate the formula sort.
+- Row loading spinner is hidden after backend confirmation.
+- "Row has moved" is visible after backend confirmation while the row is selected.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 1.3.2b Add row with formula-field sort active, then deselect before backend confirmation
+
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is hidden while the create request is pending.
+- After deselect while the create request is pending, the row stays at the bottom
+  because the frontend has not yet received the backend-computed sort value.
+- After the create request completes, the row moves to its sorted position.
+- No warning is visible after the row moves.
+
+### 1.3.2c Backend returns 500 on formula-sort-affected create
+
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is hidden while the create request is pending because the
+  frontend cannot evaluate the formula sort.
+- POST request returns 500.
+- Optimistic row is removed from the visible grid after the error.
+- Row count returns to its original value.
+- Error toast is visible.
+
+### 1.4.1 Edit a field while create is pending
+
+- Empty row is appended at the bottom.
+- Row loading spinner is visible while the create request is pending.
+- Typed value in a field of the pending row is visible immediately.
+- After the create request completes, the queued PATCH fires and the value is
+  confirmed.
+- No error is shown.
+
+### 1.4.2 PATCH is not sent to the network until the create request completes
+
+- Empty row is appended at the bottom.
+- Field in the pending row is edited and confirmed.
+- No PATCH request reaches the network while the POST is still in-flight.
+- After the POST completes, the queued PATCH fires with the real row ID.
+- Field value is saved correctly.
+
+## Row Updates
 
 ### 2.1.1 Edit primary field and press Enter
 
@@ -186,41 +314,51 @@ behavior.
 - Original value is no longer visible.
 - No row loading spinner is shown for this optimistic text update.
 
-### 2.1.2 Press Escape while editing
+### 2.1.4 Press Escape while editing
 
 - Typed draft is discarded.
 - Original value is visible again.
 - No save transition is shown.
 
-### 2.1.3 Click outside edited cell
+### 2.1.2 Click outside edited cell
 
 - Typed value is visible immediately.
 - Typed value is submitted by blur.
 - No row loading spinner is shown for this optimistic text update.
 
-### 2.1.4 Backend returns 500 on update
+### 2.1.3 Backend returns 500 on update
 
 - Typed value is submitted.
 - PATCH request returns 500.
 - Grid remains rendered with both rows.
-- Full rollback value and error-toast assertions are TODO.
+- Typed value is rolled back to the original value.
+- Error toast is visible.
 
-### 2.3.1 Edit filtered row to non-matching value
+### 2.1.5 Invalid email value shows validation UI
+
+- Invalid typed value is visible in the editor.
+- Field validation error is visible.
+- Pressing Enter keeps the editor open.
+- Field validation error remains visible.
+
+### 2.2.1a Edit filtered row to non-matching value and keep it selected
 
 - Typed value is visible immediately.
 - No row loading spinner is shown for this optimistic text update.
 - "Row does not match filters" is visible immediately for simple-field filters.
 - Row remains visible while selected.
-- Readonly/formula-filter deferral is TODO.
+- "Row does not match filters" remains visible after backend confirmation.
 
-### 2.3.1b Deselect filter-mismatched row
+### 2.2.1b Deselect filter-mismatched row before backend confirmation
 
 - "Row does not match filters" is visible before deselect.
-- After deselect, the row is removed from the visible grid.
+- After deselect while the update request is pending, the row is removed from the
+  visible grid.
 - After deselect, "Row does not match filters" is hidden.
 - Row count decrements.
+- Row stays hidden after backend confirmation.
 
-### 2.3.2 Press Escape during filter-mismatched edit
+### 2.2.4 Press Escape during filter-mismatched edit
 
 - Typed draft is discarded.
 - Original matching value is visible again.
@@ -228,7 +366,7 @@ behavior.
 - Row remains visible.
 - Row count is unchanged.
 
-### 2.3.3 Save the same matching value
+### 2.2.3 Save the same matching value
 
 - Typed value is visible immediately.
 - Row remains visible.
@@ -237,29 +375,114 @@ behavior.
 - No row loading spinner is expected because no visible value transition is
   needed.
 
-### 2.3.4 Backend returns 500 on filter-affecting update
+### 2.2.2 Backend returns 500 on filter-affecting update
 
 - Typed value is submitted.
 - PATCH request returns 500.
 - Filtered grid remains rendered.
-- Full rollback value and error-toast assertions are TODO.
+- Typed value is rolled back to the original value.
+- "Row does not match filters" is hidden after rollback.
+- Error toast is visible.
 
-### 2.5.1 Edit sorted row so it should move
+### 2.2.5a Edit with formula-field filter active — no warning until backend responds
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row does not match filters" is hidden while the update request is pending
+  because the frontend cannot evaluate the formula filter.
+- "Row does not match filters" is visible after backend confirmation.
+- Row remains visible while selected.
+
+### 2.2.5b Deselect formula-filtered row after backend confirmation
+
+- "Row does not match filters" is visible while the row is selected.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row count decrements.
+
+### 2.2.5c Deselect formula-filtered row before backend confirmation
+
+- Typed value is visible immediately.
+- "Row does not match filters" is hidden while the update request is pending.
+- After deselect while the update request is pending, the row remains visible
+  because the frontend has not yet received the formula result from the backend.
+- After the update request completes, the row is removed from the visible grid.
+
+### 2.2.5d Backend returns 500 on formula-filter-affecting update
+
+- Typed value is visible immediately.
+- "Row does not match filters" is hidden while the update request is pending
+  because the frontend cannot evaluate the formula filter.
+- PATCH request returns 500.
+- Typed value is rolled back to the original value.
+- Row remains visible.
+- Error toast is visible.
+
+### 2.3.1a Edit sorted row so it should move and keep it selected
 
 - Typed value is visible immediately.
 - No row loading spinner is shown for this optimistic text update.
 - "Row has moved" is visible immediately for simple-field sorts.
 - Row stays in its current visible position while selected.
-- After deselect, the row moves to its sorted position.
-- After deselect, "Row has moved" is hidden.
-- Readonly/formula-sort deferral is TODO.
+- "Row has moved" remains visible after backend confirmation.
 
-### 2.5.2 Press Escape during sort-mismatched edit
+### 2.3.1b Deselect sort-mismatched row before backend confirmation
+
+- "Row has moved" is visible before deselect.
+- After deselect while the update request is pending, the row moves to its sorted
+  position.
+- After deselect, "Row has moved" is hidden.
+- Row stays in its sorted position after backend confirmation.
+- No warning is visible after backend confirmation.
+
+### 2.3.2 Backend returns 500 on sort-affecting update
+
+- Typed value is visible immediately.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- PATCH request returns 500.
+- Typed value is rolled back to the original value.
+- "Row has moved" is hidden after rollback.
+- Row stays in its original position.
+- Error toast is visible.
+
+### 2.3.3 Press Escape during sort-mismatched edit
 
 - Typed draft is discarded.
 - Original value is visible again.
 - "Row has moved" is hidden.
 - Row stays in its original position.
+
+### 2.3.4a Edit with formula-field sort active — no move warning until backend responds
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row has moved" is hidden while the update request is pending because the
+  frontend cannot evaluate the formula sort.
+- "Row has moved" is visible after backend confirmation.
+- Row stays in its current visible position while selected.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 2.3.4b Deselect formula-sorted row before backend confirmation
+
+- Typed value is visible immediately.
+- "Row has moved" is hidden while the update request is pending.
+- After deselect while the update request is pending, the row stays in its
+  current position because the frontend has not yet received the
+  backend-computed sort value.
+- After the update request completes, the row moves to its sorted position
+  without showing a warning.
+
+### 2.3.4c Backend returns 500 on formula-sort-affecting update
+
+- Typed value is visible immediately.
+- "Row has moved" is hidden while the update request is pending because the
+  frontend cannot evaluate the formula sort.
+- PATCH request returns 500.
+- Typed value is rolled back to the original value.
+- Row stays in its current position.
+- Error toast is visible.
 
 ## Row Deletion
 
@@ -275,39 +498,103 @@ behavior.
 - DELETE request returns 500.
 - Deleted row is restored after rollback.
 - Grid remains rendered with both rows.
-- Error-toast assertion is TODO.
+- Error toast is visible.
 
-## View Options
+## Clipboard And Multi-Cell Edits
 
-### 4.1.1 Load view with API-created filter
+### 4.1.1 Copy one cell and paste into another
+
+- Clipboard receives copied value.
+- Pasted value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+
+### 4.1.2 Paste beyond the last row
+
+- Existing last row is updated.
+- Overflow row is created.
+- Pasted values are visible immediately.
+- Pasted field values are visible in both the updated row and overflow row.
+- Create and update spinners are TODO.
+
+### 4.2.1a Paste value that breaks active filter, then deselect
+
+- Pasted value is visible immediately.
+- "Row does not match filters" is visible immediately for simple-field filters.
+- Row remains visible while selected.
+- Row remains selected while warning is visible.
+- "Row does not match filters" is visible before deselect.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row count decrements.
+
+### 4.2.1b Filter-breaking paste deselected before backend confirmation
+
+- Pasted value is visible immediately.
+- "Row does not match filters" is visible immediately for simple-field filters.
+- After deselect while the update request is pending, the row is removed from the
+  visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row stays hidden after backend confirmation.
+
+### 4.3.1a Sort-affecting paste shows Row has moved warning then moves row on deselect
+
+- Pasted value is visible immediately.
+- "Row has moved" is visible immediately for simple-field sorts.
+- Row stays in its current visible position while selected.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 4.3.1b Sort-affecting paste deselected before backend confirmation moves row immediately
+
+- Pasted value is visible immediately.
+- "Row has moved" is visible immediately for simple-field sorts.
+- After deselect while the update request is pending, the row moves to its sorted
+  position.
+- After deselect, "Row has moved" is hidden.
+- Row stays in its sorted position after backend confirmation.
+- No warning is visible after backend confirmation.
+
+### 4.4.1 Delete clears selected cell range
+
+- Rectangular multi-select range is visible.
+- Pressing Delete clears every selected cell value.
+- Non-selected cells are unchanged.
+
+## Filters
+
+### 5.1.1 Load view with API-created filter
 
 - Grid opens with only matching rows visible.
 - Non-matching rows are absent from the visible grid.
 
-### 4.1.3 Load view with two AND filters
+### 5.1.2 Load view with two AND filters
 
 - Grid opens with only rows matching both filters visible.
 - Rows matching only one condition are absent from the visible grid.
 
-### 4.2.2 Use text contains filter
+### 5.2.1 Use text contains filter
 
 - Grid opens with every row containing the substring visible.
 - Non-matching rows are absent from the visible grid.
 
-### 5.1.1 Sort ASC
+## Sorts
+
+### 6.1.1 Sort ASC
 
 - Grid opens with rows visible in ascending order.
 
-### 5.1.2 Sort DESC
+### 6.1.2 Sort DESC
 
 - Grid opens with rows visible in descending order.
 
-### 5.1.3 Sort by Name ASC and Score DESC
+### 6.1.3 Sort by Name ASC and Score DESC
 
 - Grid opens with primary sort applied first.
 - Rows tied on Name are ordered by Score descending.
 
-### 6.1.1 Search in highlight mode
+## Search
+
+### 7.1.1 Search in highlight mode
 
 - Search panel is open.
 - Search is idle.
@@ -315,34 +602,36 @@ behavior.
 - Non-matching rows remain visible.
 - Non-matching cells are not highlighted.
 
-### 6.1.2 Search with no matches in highlight mode
+### 7.1.2 Search with no matches in highlight mode
 
 - Search panel is open.
 - Search is idle.
 - No cells are highlighted.
 - All rows remain visible.
 
-### 6.1.3 Clear search
+### 7.1.3 Clear search
 
 - Existing highlights are hidden.
 - All rows remain visible.
 
-### 6.1.4 Search matches a non-primary field
+### 7.1.4 Search matches a non-primary field
 
 - Matching non-primary cell is highlighted.
 - Primary plus non-primary multi-field highlight in the same row is TODO.
 
-### 6.2.1 Search in hide-not-matching mode
+### 7.2.1 Search in hide-not-matching mode
 
 - Typing search hides non-matching rows.
 - Matching rows remain visible.
 
-### 6.2.2 Toggle hide-not-matching mode off
+### 7.2.2 Toggle hide-not-matching mode off
 
 - Hidden rows become visible again.
 - Matching cells remain highlighted.
 
-### 7.1.1 Row coloring from single-select color
+## View Display Options
+
+### 8.1.1 Row coloring from single-select color
 
 - Grid opens with all rows loaded.
 - Selected single-select values are visible.
@@ -351,17 +640,19 @@ behavior.
 - No row loading spinner is shown because row coloring is loaded from the saved
   view decoration.
 
-### 7.2.1 Hide and show a non-primary field
+### 8.2.1 Hide and show a non-primary field
 
 - Field header is initially visible.
 - Field cells are initially visible.
 - Hiding the field removes the field header immediately.
 - Hiding the field removes the field cells immediately.
+- Hidden state persists after reload.
 - Row count is unchanged.
 - Showing the field restores the field header.
 - Showing the field restores the field cells with their values.
+- Shown state persists after reload.
 
-### 7.3.1 Change row height
+### 8.3.1 Change row height
 
 - Grid opens at small row height.
 - Values are visible.
@@ -369,226 +660,198 @@ behavior.
 - Values remain visible after changing row height.
 - Selecting Large changes visible rows to 99px.
 - Values remain visible after changing row height.
+- Large row height persists after reload.
 - No row loading spinner is shown.
 
-### 7.7.1 Count mode shows sequential row positions
+### 8.4.1 Load view with frozen columns
+
+- Saved frozen column count moves the first non-primary field into the frozen-left
+  section.
+- Frozen field header is absent from the scrollable-right section.
+- Next non-primary field remains visible in the scrollable-right section.
+- Frozen column layout persists after reload.
+
+### 8.5.1 Count mode shows sequential row positions
 
 - Row count column shows "1" for the first row, "2" for the second, and so on.
 - Note: the backend default for a new view is `row_identifier_type = "id"`. Tests
   that verify count mode must explicitly set the view to count mode via API before
   navigating.
 
-### 7.7.2 Switch to Row identifier shows actual row IDs
+### 8.5.2 Switch to Row identifier and back to Count
 
 - Clicking the dropdown icon in the row count header opens the identifier picker.
 - Selecting "Row identifier" changes the count column to show actual backend row IDs.
 - Sequential position values are no longer visible.
-
-### 7.7.3 Switch back to Count restores sequential positions
-
+- Row identifier values persist after reload.
 - Selecting "Count" restores sequential position values.
 - Row identifier values are no longer visible.
+- Count values persist after reload.
 
-## Row Hover Actions
+## Cell Selection
 
-### 10.1.1 Hover shows checkbox and hides row count
-
-- Row count is visible before hover.
-- Hovering the row reveals the checkbox.
-- Row count is hidden while the row is hovered.
-
-### 10.1.2 Mouse-out restores row count and hides checkbox
-
-- Checkbox is visible while hovering.
-- Moving the mouse away hides the checkbox.
-- Row count is visible again after unhover.
-
-### 10.1.3 Drag handle present in unsorted view, absent when sort is active
-
-- Drag handle element is present in a view with no active sort.
-- Drag handle element is absent in a view where a sort controls row order.
-
-## Selection, Paste, And Keyboard
-
-### 8.1.1 Click a cell
+### 9.1.1 Click a cell
 
 - Clicked cell becomes selected.
 - No multi-select range is shown.
 
-### 8.1.2 Shift-click another cell
+### 9.1.2 Shift-click another cell
 
 - First selected cell remains the anchor.
 - Rectangular multi-select range is shown between the anchor cell and clicked
   cell.
 
-### 8.1.3 Drag across cells
+### 9.1.3 Drag across cells
 
 - Rectangular multi-select range is shown during drag.
 - Rectangular multi-select range remains visible after mouseup.
 
-### 8.1.4 Press Escape
+### 9.1.4 Press Escape
 
 - Existing multi-select range is hidden.
 
-### 8.1.5 Click outside the grid
+### 9.1.5 Click outside the grid
 
 - Existing multi-select range is hidden.
 
-### 8.3.1 Copy one cell and paste into another
+### 9.2.1 Shift+Arrow expands selected range
 
-- Clipboard receives copied value.
-- Pasted value is visible immediately.
-- No row loading spinner is shown for this optimistic text update.
+- Starting from one selected cell, Shift+ArrowRight expands the selected range
+  to two cells.
+- Shift+ArrowDown expands the selected range to a 2x2 area.
 
-### 8.3.4 Paste beyond the last row
+## Keyboard Navigation
 
-- Existing last row is updated.
-- Overflow row is created.
-- Pasted values are visible immediately.
-- Create and update spinners are TODO.
-
-### 8.3.6 Paste value that breaks active filter
-
-- Pasted value is visible immediately.
-- "Row does not match filters" is visible immediately for simple-field filters.
-- Row remains visible while selected.
-- Pending update timing is TODO.
-
-### 8.3.7 Deselect after filter-mismatching paste
-
-- "Row does not match filters" is visible before deselect.
-- After deselect, the row is removed from the visible grid.
-- After deselect, "Row does not match filters" is hidden.
-- Row count decrements.
-- Deselecting before backend confirmation is TODO.
-
-### 9.1 Press Tab
+### 10.1.1 Press Tab
 
 - Selection moves to the next cell.
 - Typing starts editing that cell.
 - Typed value is visible immediately.
 
-### 9.3 Press Enter on selected cell
+### 10.1.2 Press Enter on selected cell
 
 - Editor appears in the selected cell.
 
-### 9.4 Press Enter while editing
+### 10.1.3 Press Enter while editing
 
 - Typed value is visible immediately.
 - Selection moves down.
 - Typing starts editing the row below.
 - Second typed value is visible immediately.
 
-### 9.5 Press Escape while editing
+### 10.1.4 Press Escape while editing
 
 - Typed draft is discarded.
 - Original value is visible again.
+- Editor is closed.
 
-### 9.6 Use arrow keys
+### 10.1.5 Use arrow keys
 
 - Selection moves to the target cell.
 - No editor appears.
 
-### 9.7 Type while a cell is selected
+### 10.1.6 Type while a cell is selected
 
 - Editor appears in the selected cell.
 - Editor contains the typed characters.
 
+## Row Hover Actions
+
+### 11.1.1 Hover and unhover toggles checkbox and row count
+
+- Row count is visible before hover.
+- Hovering the row reveals the checkbox.
+- Row count is hidden while the row is hovered.
+- Checkbox is visible while hovering.
+- Moving the mouse away hides the checkbox.
+- Row count is visible again after unhover.
+
+### 11.1.2 Drag handle present in unsorted view, absent when sort is active
+
+- Drag handle element is present in a view with no active sort.
+- Drag handle element is absent in a view where a sort controls row order.
+
+### 11.2.1 Insert row below from context menu
+
+- Context menu opens for a row.
+- Selecting "Insert row below" creates an empty row directly below the selected
+  row.
+- Existing rows keep their relative order.
+
+### 11.2.2 Duplicate row from context menu
+
+- Context menu opens for a row.
+- Selecting "Duplicate row" creates a copied row directly below the selected row.
+- Duplicated row contains the copied primary and field values.
+
+## Checkbox Selection
+
+### 12.1.1 Checkbox selection clears active area selection
+
+- Rectangular multi-select range is visible.
+- Hovering a row reveals its checkbox.
+- Clicking the row checkbox selects the row.
+- Existing multi-select range is hidden.
+
+## Row Expand Modal
+
+### 13.1.1 Open row expand modal from context menu
+
+- Context menu opens for a row.
+- Selecting "Enlarge row" opens the row edit modal.
+- Modal contains the selected row value.
+- Closing the modal hides it.
+
+## Public Shared Grid
+
+### 14.1.1 Public grid renders rows without edit controls
+
+- Public shared grid route renders without an authenticated session.
+- Visible rows are loaded.
+- Add row control is hidden.
+- Row mutation context-menu actions are hidden.
+
 ## TODO Coverage
 
-- 1.1.3: Full rollback assertions for failed row creation.
-- 1.1.4: Primary field is selected immediately after adding a row.
-- 1.2.x: Sorted add where the correct destination is outside the current buffer.
-- 1.2.x: Sorted add on a readonly/formula field.
-    - Empty row is appended at the bottom.
-    - Row loading spinner is visible while the create request is pending.
-    - "Row has moved" is hidden while the create request is pending because the
-      frontend must wait for the backend-computed sort value.
-    - After backend confirmation, "Row has moved" is visible while the row is
-      selected.
-    - If already deselected after backend confirmation, the row moves to its final
-      position without showing the warning.
-- 1.4.x: Create with an active formula-field filter.
-- 2.1.5: Field validation error UI for invalid typed values.
-- 2.2.x: Editing fields that participate in formulas.
-- 2.4.x: Editing fields while a formula filter is active.
-- 2.4.x: Editing a row where a readonly/formula-field filter cannot be evaluated
-  by the frontend.
-    - Typed value is visible immediately.
-    - No row loading spinner is shown for this optimistic text update.
-    - "Row does not match filters" is hidden while the update request is pending.
-    - "Row does not match filters" is visible after backend confirmation.
-    - Row is removed from the visible grid after backend confirmation if the row is
-      not selected.
-- 2.5.3: Failed sort-affecting update rollback.
-- 2.5.4: Sort relocation outside the current buffer.
-- 2.5.x: Editing a row where a readonly/formula-field sort cannot be evaluated
-  by the frontend.
-    - Typed value is visible immediately.
-    - No row loading spinner is shown for this optimistic text update.
-    - "Row has moved" is hidden while the update request is pending.
-    - "Row has moved" is visible after backend confirmation if the row is still
-      selected.
-    - Row moves to its sorted position after backend confirmation if the row is not
-      selected.
-- 4.4.x: OR filter combinations and filter groups.
-- 7.4.x: Drag-and-drop rows when no sort is applied.
-    - Drop target is visible while dragging.
-    - Dropped row moves to the new visual position.
-    - Row order persists after reload.
-- 7.5.x: Drag-and-drop fields.
-    - Field-drag preview is visible while dragging a field header.
-    - Target position is visible while dragging a field header.
-    - Dropping reorders field headers.
-    - Dropping reorders row cells to match the field headers.
-    - Field order persists after reload.
-- 7.6.x: Freeze columns.
+- 1.3.x: Sorted add where the correct destination is outside the current buffer.
+- 1.5.x: Create rows with active group-by constraints.
+- 2.3.5: Sort relocation outside the current buffer.
+- 2.4.x: Update rows with active group-by constraints.
+- 2.5.x: Editing fields that participate in formulas.
+- 4.2.x: Filter-affecting paste with formula-field filter (deferred warning path).
+- 4.3.x: Sort-affecting paste with formula-field sort (deferred move path).
+- 4.4.x: Backspace clears all selected cell values while an area selection is active.
+- 4.5.x: Larger multi-cell paste matrix.
+- 4.6.x: Copy selected cells with column headers via the context menu option.
+- 4.7.x: Paste with active group-by constraints.
+- 5.3.x: OR filter combinations and filter groups.
+- 8.1.x: Row coloring from a formula-based decoration (section 8.1 covers
+  single-select only).
+- 8.4.x: Freeze columns drag UI and limits.
     - Freeze handle is visible when there is enough horizontal space.
-    - Freezing 1 column moves 1 column into the frozen-left section.
-    - Freezing 2 columns moves 2 columns into the frozen-left section.
     - Freezing 3 columns moves 3 columns into the frozen-left section.
     - Freezing 4 columns moves 4 columns into the frozen-left section.
     - The scrollable-right section scrolls independently.
     - The UI does not allow freezing more than 4 columns.
     - The UI does not allow freezing more columns than can fit in the available
       width.
-- 7.8.x: Row coloring from a formula-based decoration (section 7.1 covers
-  single-select only).
-- 8.2.x: Shift+Arrow expands the multi-select area from the keyboard.
-- 8.4.x: Larger multi-cell paste matrix.
-- 8.5.x: Filter-affecting paste where the row is deselected before backend
-  confirmation.
-    - For simple-field filters, pasted value is visible immediately.
-    - For simple-field filters, "Row does not match filters" is visible
-      immediately.
-    - For simple-field filters, after deselect, the row is removed from the visible
-      grid while the update request is pending.
-    - For readonly/formula-field filters, pasted value is visible immediately.
-    - For readonly/formula-field filters, "Row does not match filters" is hidden
-      while the update request is pending.
-    - For readonly/formula-field filters, row is removed from the visible grid
-      after backend confirmation if the row is not selected.
-- 8.6.x: Delete/Backspace clears all selected cell values while an area selection
-  is active.
-- 8.7.x: Copy selected cells with column headers via the context menu option.
-- 10.2.x: Full single-row context menu matrix beyond deletion (insert above, insert
-  below, duplicate, copy row URL).
-- 11.1.x: Checkbox row selection mechanism (selecting rows via the checkbox column,
-  mutual exclusivity with area selection).
-- 11.2.x: Multi-row bulk actions on checkbox-selected rows.
-- 12.x: Realtime multi-user row events.
-- 13.x: Realtime metadata and presence.
-- 14.x: Row expand modal — open via double-click or context menu "Enlarge row",
-  navigate prev/next rows, edit fields from inside the modal, filter re-check on
-  modal close.
-- 15.x: Data-sync read-only mode — add row button and delete row option are hidden
+- 8.6.x: Drag-and-drop rows when no sort is applied.
+    - Drop target is visible while dragging.
+    - Dropped row moves to the new visual position.
+    - Row order persists after reload.
+- 8.7.x: Drag-and-drop fields.
+    - Field-drag preview is visible while dragging a field header.
+    - Target position is visible while dragging a field header.
+    - Dropping reorders field headers.
+    - Dropping reorders row cells to match the field headers.
+    - Field order persists after reload.
+- 11.2.x: Remaining single-row context menu actions beyond deletion, insert below,
+  and duplicate (insert above, copy row URL).
+- 12.2.x: Multi-row bulk actions on checkbox-selected rows.
+- 13.2.x: Row expand modal deeper coverage — open via double-click, navigate
+  prev/next rows, edit fields from inside the modal, filter re-check on modal
+  close.
+- 15.x: Realtime multi-user row events.
+- 16.x: Realtime metadata and presence.
+- 17.x: Data-sync read-only mode — add row button and delete row option are hidden
   when the table has a data sync without two-way sync enabled.
-- 16.x: Public shared grid view coverage.
-
-## Robustness Rules
-
-- Prefer locator assertions and Playwright polling over fixed sleeps.
-- Seed state through API fixtures so tests do not depend on previous test order.
-- Drive cells by visual row and field indices; use text only for assertions.
-- Intercept or pause network requests when verifying failed or pending backend
-  paths.

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -103,9 +103,8 @@ written.
 All combinations of two or more active constraints (filter + sort, filter +
 group-by, sort + group-by, filter + sort + group-by) are uncovered for every
 operation and timing variant. Each combination should be tested in both the
-all-regular (fully optimistic) and any-formula (partially or fully deferred)
-configurations. When added, expand this section into a table following the same
-structure as the single-constraint table above.
+all-regular (fully optimistic) and any-formula (deferred)
+configurations.
 
 ## Row Creation
 
@@ -287,6 +286,20 @@ structure as the single-constraint table above.
 - Optimistic row is removed from the visible grid after the error.
 - Row count returns to its original value.
 - Error toast is visible.
+
+### 1.3.3 Add row with simple-field sort and destination outside current buffer
+
+- Grid is scrolled so the current buffer does not contain the row's correct
+  sorted destination.
+- Empty row is appended to the visible bottom buffer.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is hidden while the create request is pending.
+- Row loading spinner is hidden after backend confirmation.
+- "Row has moved" is visible after backend confirmation while the row is
+  selected.
+- After deselect, the row leaves the current rendered buffer.
+- After deselect, "Row has moved" is hidden.
+- After scrolling to the row's sorted destination, the row is visible there.
 
 ### 1.4.1 Edit a field while create is pending
 
@@ -483,6 +496,21 @@ structure as the single-constraint table above.
 - Typed value is rolled back to the original value.
 - Row stays in its current position.
 - Error toast is visible.
+
+### 2.3.5 Sort relocation outside the current buffer
+
+- Grid is scrolled so the current buffer does not contain the row's correct
+  sorted destination after edit.
+- Typed value is visible immediately.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort against the current buffer.
+- Row stays in its current visible position while selected.
+- After deselect while the update request is pending, the row leaves the current
+  rendered buffer.
+- After deselect, "Row has moved" is hidden.
+- Row stays outside the current rendered buffer after backend confirmation.
+- After scrolling to the row's sorted destination, the updated row is visible
+  there.
 
 ## Row Deletion
 
@@ -813,11 +841,12 @@ structure as the single-constraint table above.
 
 ## TODO Coverage
 
-- 1.3.x: Sorted add where the correct destination is outside the current buffer.
 - 1.5.x: Create rows with active group-by constraints.
-- 2.3.5: Sort relocation outside the current buffer.
 - 2.4.x: Update rows with active group-by constraints.
-- 2.5.x: Editing fields that participate in formulas.
+- 2.5.x: Editing source fields for visible formula fields that are not active
+  filter/sort/group-by constraints; verify formula-cell loading, refresh, and
+  rollback. Formula-backed filter/sort constraints are covered by 2.2.5 and
+  2.3.4.
 - 4.2.x: Filter-affecting paste with formula-field filter (deferred warning path).
 - 4.3.x: Sort-affecting paste with formula-field sort (deferred move path).
 - 4.4.x: Backspace clears all selected cell values while an area selection is active.

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -1,0 +1,594 @@
+# Grid View Flat Test Plan
+
+Browser coverage for the flat (non-grouped) grid view lives in
+`e2e-tests/tests/database/grid/`. Grouped grid and collapsible group-by behavior
+are intentionally out of scope for this plan.
+
+Expected sequences are intentionally repetitive. Use the same sentence for the
+same visible side effect whenever a test is added or changed.
+
+`TODO` marks an expected visible detail that the current e2e tests do not
+verify. Keep those details in the plan so future tests know the intended
+behavior.
+
+## Row Creation
+
+### 1.1.1 Click "+ Add row" with no filters/sorts
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row count increments.
+- Row loading spinner is visible while the create request is pending.
+  Covered by 1.1.2.
+- Row loading spinner is hidden after backend confirmation.
+
+### 1.1.2 Backend confirmation for a new row
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- Row count increments.
+- Empty row stays at the bottom after backend confirmation.
+- Row loading spinner is hidden after backend confirmation.
+
+### 1.2.1a Add row with simple-field sort ASC and keep it selected
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- Row loading spinner is hidden after backend confirmation.
+- "Row has moved" remains visible while the row is selected.
+- After deselect, the row moves to the first sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 1.2.1b Add row with simple-field sort ASC, then deselect before backend confirmation
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- After deselect while the create request is pending, the row moves to the first
+  sorted position.
+- Row loading spinner is visible while the create request is pending.
+- After deselect, "Row has moved" is hidden.
+- Empty row stays in the first sorted position after backend confirmation.
+- Row loading spinner is hidden after backend confirmation.
+- No warning is visible after backend confirmation.
+
+### 1.2.2a Edit Name under simple-field sort ASC and keep it selected
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- Row stays in its current visible position while selected.
+- "Row has moved" remains visible while the row is selected after backend
+  confirmation.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 1.2.2b Edit Name under simple-field sort ASC, then deselect before backend confirmation
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row has moved" is visible immediately because the frontend can evaluate the
+  simple-field sort.
+- After deselect while the update request is pending, the row moves to its sorted
+  position.
+- After deselect, "Row has moved" is hidden.
+- Row stays in its sorted position after backend confirmation.
+- No warning is visible after backend confirmation.
+
+### 1.2.3 Deselect the sort-mismatched row after backend confirmation
+
+- "Row has moved" is visible before deselect.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+
+### 1.2.4 Press Escape during sort mismatch
+
+- Typed draft is discarded.
+- Original value is visible again.
+- "Row has moved" is hidden.
+- Row stays in its original position.
+
+### 1.3.1a Add row that does not match an active simple-field filter and keep it selected
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row does not match filters" is visible immediately because the frontend can
+  evaluate the simple-field filter.
+- Row remains visible while selected.
+- "Row does not match filters" remains visible while the row is selected.
+- Row loading spinner is hidden after backend confirmation.
+- "Row does not match filters" remains visible while the row is selected after
+  backend confirmation.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+
+### 1.3.1b Deselect newly added filter-mismatched row before backend confirmation
+
+- Empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- Row loading spinner is visible while the create request is pending.
+- "Row does not match filters" is visible immediately because the frontend can
+  evaluate the simple-field filter.
+- After deselect while the create request is pending, the row is removed from the
+  visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row stays hidden after backend confirmation.
+
+### 1.3.1c Enter a value that makes the newly added row match the active filter
+
+- With a filter such as "Name is not empty", empty row is appended at the bottom.
+- Empty primary and field cells are visible immediately.
+- "Row does not match filters" is visible immediately because the frontend can
+  evaluate the simple-field filter.
+- Typed value is visible immediately.
+- "Row does not match filters" is hidden after the value matches the filter.
+- Row remains visible.
+- This exact newly-created-row correction path is TODO.
+
+### 1.3.1d Edit existing row to keep matching active filter
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- Row remains visible.
+- No warning is visible.
+- Row count is unchanged.
+
+### 1.3.2a Type value that does not match a simple-field filter and keep it selected
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row does not match filters" is visible immediately because the frontend can
+  evaluate the simple-field filter.
+- Row remains visible while selected.
+- "Row does not match filters" remains visible while the row is selected after
+  backend confirmation.
+
+### 1.3.2b Type value that does not match a simple-field filter, then deselect before backend confirmation
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row does not match filters" is visible immediately because the frontend can
+  evaluate the simple-field filter.
+- After deselect while the update request is pending, the row is removed from the
+  visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row stays hidden after backend confirmation.
+
+### 1.3.3 Deselect filter-mismatched row after backend confirmation
+
+- "Row does not match filters" is visible before deselect.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row count decrements.
+
+### 1.3.4 Press Escape during filter mismatch
+
+- Typed draft is discarded.
+- Original matching value is visible again.
+- "Row does not match filters" is hidden.
+- Row remains visible.
+- Row count is unchanged.
+
+## Row Editing
+
+### 2.1.1 Edit primary field and press Enter
+
+- Typed value is visible immediately.
+- Typed value is submitted.
+- Original value is no longer visible.
+- No row loading spinner is shown for this optimistic text update.
+
+### 2.1.2 Press Escape while editing
+
+- Typed draft is discarded.
+- Original value is visible again.
+- No save transition is shown.
+
+### 2.1.3 Click outside edited cell
+
+- Typed value is visible immediately.
+- Typed value is submitted by blur.
+- No row loading spinner is shown for this optimistic text update.
+
+### 2.1.4 Backend returns 500 on update
+
+- Typed value is submitted.
+- PATCH request returns 500.
+- Grid remains rendered with both rows.
+- Full rollback value and error-toast assertions are TODO.
+
+### 2.3.1 Edit filtered row to non-matching value
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row does not match filters" is visible immediately for simple-field filters.
+- Row remains visible while selected.
+- Readonly/formula-filter deferral is TODO.
+
+### 2.3.1b Deselect filter-mismatched row
+
+- "Row does not match filters" is visible before deselect.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row count decrements.
+
+### 2.3.2 Press Escape during filter-mismatched edit
+
+- Typed draft is discarded.
+- Original matching value is visible again.
+- "Row does not match filters" is hidden.
+- Row remains visible.
+- Row count is unchanged.
+
+### 2.3.3 Save the same matching value
+
+- Typed value is visible immediately.
+- Row remains visible.
+- No warning is visible.
+- Row count is unchanged.
+- No row loading spinner is expected because no visible value transition is
+  needed.
+
+### 2.3.4 Backend returns 500 on filter-affecting update
+
+- Typed value is submitted.
+- PATCH request returns 500.
+- Filtered grid remains rendered.
+- Full rollback value and error-toast assertions are TODO.
+
+### 2.5.1 Edit sorted row so it should move
+
+- Typed value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+- "Row has moved" is visible immediately for simple-field sorts.
+- Row stays in its current visible position while selected.
+- After deselect, the row moves to its sorted position.
+- After deselect, "Row has moved" is hidden.
+- Readonly/formula-sort deferral is TODO.
+
+### 2.5.2 Press Escape during sort-mismatched edit
+
+- Typed draft is discarded.
+- Original value is visible again.
+- "Row has moved" is hidden.
+- Row stays in its original position.
+
+## Row Deletion
+
+### 3.1.1 Right-click row and choose "Delete row"
+
+- Row is removed from the visible grid immediately.
+- Row count decrements.
+- The next row remains visible.
+- Pending DELETE spinner is TODO.
+
+### 3.1.2 Backend returns 500 on delete
+
+- DELETE request returns 500.
+- Deleted row is restored after rollback.
+- Grid remains rendered with both rows.
+- Error-toast assertion is TODO.
+
+## View Options
+
+### 4.1.1 Load view with API-created filter
+
+- Grid opens with only matching rows visible.
+- Non-matching rows are absent from the visible grid.
+
+### 4.1.3 Load view with two AND filters
+
+- Grid opens with only rows matching both filters visible.
+- Rows matching only one condition are absent from the visible grid.
+
+### 4.2.2 Use text contains filter
+
+- Grid opens with every row containing the substring visible.
+- Non-matching rows are absent from the visible grid.
+
+### 5.1.1 Sort ASC
+
+- Grid opens with rows visible in ascending order.
+
+### 5.1.2 Sort DESC
+
+- Grid opens with rows visible in descending order.
+
+### 5.1.3 Sort by Name ASC and Score DESC
+
+- Grid opens with primary sort applied first.
+- Rows tied on Name are ordered by Score descending.
+
+### 6.1.1 Search in highlight mode
+
+- Search panel is open.
+- Search is idle.
+- Matching cells are highlighted.
+- Non-matching rows remain visible.
+- Non-matching cells are not highlighted.
+
+### 6.1.2 Search with no matches in highlight mode
+
+- Search panel is open.
+- Search is idle.
+- No cells are highlighted.
+- All rows remain visible.
+
+### 6.1.3 Clear search
+
+- Existing highlights are hidden.
+- All rows remain visible.
+
+### 6.1.4 Search matches a non-primary field
+
+- Matching non-primary cell is highlighted.
+- Primary plus non-primary multi-field highlight in the same row is TODO.
+
+### 6.2.1 Search in hide-not-matching mode
+
+- Typing search hides non-matching rows.
+- Matching rows remain visible.
+
+### 6.2.2 Toggle hide-not-matching mode off
+
+- Hidden rows become visible again.
+- Matching cells remain highlighted.
+
+### 7.1.1 Row coloring from single-select color
+
+- Grid opens with all rows loaded.
+- Selected single-select values are visible.
+- Row background uses the selected option color in the frozen-left section.
+- Row background uses the selected option color in the scrollable-right section.
+- No row loading spinner is shown because row coloring is loaded from the saved
+  view decoration.
+
+### 7.2.1 Hide and show a non-primary field
+
+- Field header is initially visible.
+- Field cells are initially visible.
+- Hiding the field removes the field header immediately.
+- Hiding the field removes the field cells immediately.
+- Row count is unchanged.
+- Showing the field restores the field header.
+- Showing the field restores the field cells with their values.
+
+### 7.3.1 Change row height
+
+- Grid opens at small row height.
+- Values are visible.
+- Selecting Medium changes visible rows to 55px.
+- Values remain visible after changing row height.
+- Selecting Large changes visible rows to 99px.
+- Values remain visible after changing row height.
+- No row loading spinner is shown.
+
+### 7.7.1 Count mode shows sequential row positions
+
+- Row count column shows "1" for the first row, "2" for the second, and so on.
+- Note: the backend default for a new view is `row_identifier_type = "id"`. Tests
+  that verify count mode must explicitly set the view to count mode via API before
+  navigating.
+
+### 7.7.2 Switch to Row identifier shows actual row IDs
+
+- Clicking the dropdown icon in the row count header opens the identifier picker.
+- Selecting "Row identifier" changes the count column to show actual backend row IDs.
+- Sequential position values are no longer visible.
+
+### 7.7.3 Switch back to Count restores sequential positions
+
+- Selecting "Count" restores sequential position values.
+- Row identifier values are no longer visible.
+
+## Row Hover Actions
+
+### 10.1.1 Hover shows checkbox and hides row count
+
+- Row count is visible before hover.
+- Hovering the row reveals the checkbox.
+- Row count is hidden while the row is hovered.
+
+### 10.1.2 Mouse-out restores row count and hides checkbox
+
+- Checkbox is visible while hovering.
+- Moving the mouse away hides the checkbox.
+- Row count is visible again after unhover.
+
+### 10.1.3 Drag handle present in unsorted view, absent when sort is active
+
+- Drag handle element is present in a view with no active sort.
+- Drag handle element is absent in a view where a sort controls row order.
+
+## Selection, Paste, And Keyboard
+
+### 8.1.1 Click a cell
+
+- Clicked cell becomes selected.
+- No multi-select range is shown.
+
+### 8.1.2 Shift-click another cell
+
+- First selected cell remains the anchor.
+- Rectangular multi-select range is shown between the anchor cell and clicked
+  cell.
+
+### 8.1.3 Drag across cells
+
+- Rectangular multi-select range is shown during drag.
+- Rectangular multi-select range remains visible after mouseup.
+
+### 8.1.4 Press Escape
+
+- Existing multi-select range is hidden.
+
+### 8.1.5 Click outside the grid
+
+- Existing multi-select range is hidden.
+
+### 8.3.1 Copy one cell and paste into another
+
+- Clipboard receives copied value.
+- Pasted value is visible immediately.
+- No row loading spinner is shown for this optimistic text update.
+
+### 8.3.4 Paste beyond the last row
+
+- Existing last row is updated.
+- Overflow row is created.
+- Pasted values are visible immediately.
+- Create and update spinners are TODO.
+
+### 8.3.6 Paste value that breaks active filter
+
+- Pasted value is visible immediately.
+- "Row does not match filters" is visible immediately for simple-field filters.
+- Row remains visible while selected.
+- Pending update timing is TODO.
+
+### 8.3.7 Deselect after filter-mismatching paste
+
+- "Row does not match filters" is visible before deselect.
+- After deselect, the row is removed from the visible grid.
+- After deselect, "Row does not match filters" is hidden.
+- Row count decrements.
+- Deselecting before backend confirmation is TODO.
+
+### 9.1 Press Tab
+
+- Selection moves to the next cell.
+- Typing starts editing that cell.
+- Typed value is visible immediately.
+
+### 9.3 Press Enter on selected cell
+
+- Editor appears in the selected cell.
+
+### 9.4 Press Enter while editing
+
+- Typed value is visible immediately.
+- Selection moves down.
+- Typing starts editing the row below.
+- Second typed value is visible immediately.
+
+### 9.5 Press Escape while editing
+
+- Typed draft is discarded.
+- Original value is visible again.
+
+### 9.6 Use arrow keys
+
+- Selection moves to the target cell.
+- No editor appears.
+
+### 9.7 Type while a cell is selected
+
+- Editor appears in the selected cell.
+- Editor contains the typed characters.
+
+## TODO Coverage
+
+- 1.1.3: Full rollback assertions for failed row creation.
+- 1.1.4: Primary field is selected immediately after adding a row.
+- 1.2.x: Sorted add where the correct destination is outside the current buffer.
+- 1.2.x: Sorted add on a readonly/formula field.
+    - Empty row is appended at the bottom.
+    - Row loading spinner is visible while the create request is pending.
+    - "Row has moved" is hidden while the create request is pending because the
+      frontend must wait for the backend-computed sort value.
+    - After backend confirmation, "Row has moved" is visible while the row is
+      selected.
+    - If already deselected after backend confirmation, the row moves to its final
+      position without showing the warning.
+- 1.4.x: Create with an active formula-field filter.
+- 2.1.5: Field validation error UI for invalid typed values.
+- 2.2.x: Editing fields that participate in formulas.
+- 2.4.x: Editing fields while a formula filter is active.
+- 2.4.x: Editing a row where a readonly/formula-field filter cannot be evaluated
+  by the frontend.
+    - Typed value is visible immediately.
+    - No row loading spinner is shown for this optimistic text update.
+    - "Row does not match filters" is hidden while the update request is pending.
+    - "Row does not match filters" is visible after backend confirmation.
+    - Row is removed from the visible grid after backend confirmation if the row is
+      not selected.
+- 2.5.3: Failed sort-affecting update rollback.
+- 2.5.4: Sort relocation outside the current buffer.
+- 2.5.x: Editing a row where a readonly/formula-field sort cannot be evaluated
+  by the frontend.
+    - Typed value is visible immediately.
+    - No row loading spinner is shown for this optimistic text update.
+    - "Row has moved" is hidden while the update request is pending.
+    - "Row has moved" is visible after backend confirmation if the row is still
+      selected.
+    - Row moves to its sorted position after backend confirmation if the row is not
+      selected.
+- 4.4.x: OR filter combinations and filter groups.
+- 7.4.x: Drag-and-drop rows when no sort is applied.
+    - Drop target is visible while dragging.
+    - Dropped row moves to the new visual position.
+    - Row order persists after reload.
+- 7.5.x: Drag-and-drop fields.
+    - Field-drag preview is visible while dragging a field header.
+    - Target position is visible while dragging a field header.
+    - Dropping reorders field headers.
+    - Dropping reorders row cells to match the field headers.
+    - Field order persists after reload.
+- 7.6.x: Freeze columns.
+    - Freeze handle is visible when there is enough horizontal space.
+    - Freezing 1 column moves 1 column into the frozen-left section.
+    - Freezing 2 columns moves 2 columns into the frozen-left section.
+    - Freezing 3 columns moves 3 columns into the frozen-left section.
+    - Freezing 4 columns moves 4 columns into the frozen-left section.
+    - The scrollable-right section scrolls independently.
+    - The UI does not allow freezing more than 4 columns.
+    - The UI does not allow freezing more columns than can fit in the available
+      width.
+- 7.8.x: Row coloring from a formula-based decoration (section 7.1 covers
+  single-select only).
+- 8.2.x: Shift+Arrow expands the multi-select area from the keyboard.
+- 8.4.x: Larger multi-cell paste matrix.
+- 8.5.x: Filter-affecting paste where the row is deselected before backend
+  confirmation.
+    - For simple-field filters, pasted value is visible immediately.
+    - For simple-field filters, "Row does not match filters" is visible
+      immediately.
+    - For simple-field filters, after deselect, the row is removed from the visible
+      grid while the update request is pending.
+    - For readonly/formula-field filters, pasted value is visible immediately.
+    - For readonly/formula-field filters, "Row does not match filters" is hidden
+      while the update request is pending.
+    - For readonly/formula-field filters, row is removed from the visible grid
+      after backend confirmation if the row is not selected.
+- 8.6.x: Delete/Backspace clears all selected cell values while an area selection
+  is active.
+- 8.7.x: Copy selected cells with column headers via the context menu option.
+- 10.2.x: Full single-row context menu matrix beyond deletion (insert above, insert
+  below, duplicate, copy row URL).
+- 11.1.x: Checkbox row selection mechanism (selecting rows via the checkbox column,
+  mutual exclusivity with area selection).
+- 11.2.x: Multi-row bulk actions on checkbox-selected rows.
+- 12.x: Realtime multi-user row events.
+- 13.x: Realtime metadata and presence.
+- 14.x: Row expand modal — open via double-click or context menu "Enlarge row",
+  navigate prev/next rows, edit fields from inside the modal, filter re-check on
+  modal close.
+- 15.x: Data-sync read-only mode — add row button and delete row option are hidden
+  when the table has a data sync without two-way sync enabled.
+- 16.x: Public shared grid view coverage.
+
+## Robustness Rules
+
+- Prefer locator assertions and Playwright polling over fixed sleeps.
+- Seed state through API fixtures so tests do not depend on previous test order.
+- Drive cells by visual row and field indices; use text only for assertions.
+- Intercept or pause network requests when verifying failed or pending backend
+  paths.

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -758,7 +758,7 @@ configurations.
 
 ### 10.1.2 Press Enter on selected cell
 
-- Editor appears in the selected cell.
+- The selected cell enters edit mode.
 
 ### 10.1.3 Press Enter while editing
 
@@ -780,8 +780,8 @@ configurations.
 
 ### 10.1.6 Type while a cell is selected
 
-- Editor appears in the selected cell.
-- Editor contains the typed characters.
+- The selected cell enters edit mode.
+- The edit field contains the typed characters.
 
 ## Row Hover Actions
 
@@ -847,6 +847,20 @@ configurations.
   filter/sort/group-by constraints; verify formula-cell loading, refresh, and
   rollback. Formula-backed filter/sort constraints are covered by 2.2.5 and
   2.3.4.
+- 1.6.x: Create rows in a field with a unique / unique-with-empty constraint.
+    - Adding a row whose value duplicates an existing non-empty value in a field
+      with a unique constraint is rejected: the backend validation error is
+      surfaced (error toast) and the optimistic row is rolled back.
+    - With a unique-with-empty constraint, adding multiple rows that leave the
+      field empty is accepted, while duplicate non-empty values are still
+      rejected.
+- 2.6.x: Edit rows in a field with a unique / unique-with-empty constraint.
+    - Editing a cell to a value that duplicates another row's non-empty value in
+      a field with a unique constraint is rejected: the backend validation error
+      is surfaced and the typed value is rolled back to the previous value.
+    - With a unique-with-empty constraint, clearing a cell is accepted even when
+      other rows are already empty, while duplicate non-empty values are
+      rejected.
 - 4.2.x: Filter-affecting paste with formula-field filter (deferred warning path).
 - 4.3.x: Sort-affecting paste with formula-field sort (deferred move path).
 - 4.4.x: Backspace clears all selected cell values while an area selection is active.

--- a/e2e-tests/fixtures/database/field.ts
+++ b/e2e-tests/fixtures/database/field.ts
@@ -90,7 +90,10 @@ export async function deleteAllNonPrimaryFieldsFromTable(
   user: User,
   table: Table
 ): Promise<void> {
-  (await getFieldsForTable(user, table))
-    .filter((f) => !f.primary)
-    .forEach((f) => deleteField(user, f));
+  const fields = (await getFieldsForTable(user, table)).filter(
+    (f) => !f.primary
+  );
+  // Await every delete before returning so a subsequent createField
+  // doesn't race with an in-flight delete (409 conflict).
+  await Promise.all(fields.map((f) => deleteField(user, f)));
 }

--- a/e2e-tests/fixtures/database/field.ts
+++ b/e2e-tests/fixtures/database/field.ts
@@ -93,7 +93,5 @@ export async function deleteAllNonPrimaryFieldsFromTable(
   const fields = (await getFieldsForTable(user, table)).filter(
     (f) => !f.primary
   );
-  // Await every delete before returning so a subsequent createField
-  // doesn't race with an in-flight delete (409 conflict).
   await Promise.all(fields.map((f) => deleteField(user, f)));
 }

--- a/e2e-tests/fixtures/database/gridSetup.ts
+++ b/e2e-tests/fixtures/database/gridSetup.ts
@@ -1,5 +1,5 @@
 import { User, createUser } from "../user";
-import { Workspace, createWorkspace } from "../workspace";
+import { createWorkspace } from "../workspace";
 import { Database, createDatabase } from "./database";
 import { Table, createTable } from "./table";
 import {

--- a/e2e-tests/fixtures/database/gridSetup.ts
+++ b/e2e-tests/fixtures/database/gridSetup.ts
@@ -1,0 +1,332 @@
+import { User, createUser } from "../user";
+import { Workspace, createWorkspace } from "../workspace";
+import { Database, createDatabase } from "./database";
+import { Table, createTable } from "./table";
+import {
+  View,
+  getDefaultGridView,
+  createViewFilter,
+  createViewSort,
+} from "./view";
+import {
+  Field,
+  createField,
+  getFieldsForTable,
+  deleteAllNonPrimaryFieldsFromTable,
+} from "./field";
+import { createRows, deleteRows, listRows } from "./rows";
+
+// Field spec
+
+export type FieldType =
+  | "text"
+  | "number"
+  | "boolean"
+  | "date"
+  | "single_select"
+  | "long_text";
+
+export type SelectOptionSpec =
+  | string
+  | {
+      value: string;
+      color?: string;
+    };
+
+export interface FieldSpec {
+  name: string;
+  type: FieldType;
+  /** For single_select: option labels or explicit value/color pairs. */
+  options?: SelectOptionSpec[];
+  /** Any extra field-type-specific settings passed directly to the API */
+  settings?: Record<string, unknown>;
+}
+
+// Filter / sort spec
+
+export interface FilterSpec {
+  /** Field name matching a key in `fields` */
+  fieldName: string;
+  /** Baserow filter type, e.g. "equal", "contains", "higher_than", "single_select_equal" */
+  type: string;
+  value: string;
+}
+
+export interface SortSpec {
+  fieldName: string;
+  order?: "ASC" | "DESC";
+}
+
+// Setup options
+
+export interface GridSetupOptions {
+  /** Human-readable database name (defaults to "TestDb") */
+  dbName?: string;
+  /** Human-readable table name (defaults to "Test") */
+  tableName?: string;
+  /** Non-primary fields to create (the primary Name field is always created by Baserow) */
+  fields: FieldSpec[];
+  /**
+   * Seed rows. Keys are field names (matching `fields[].name` or the primary field
+   * name "Name"). For single_select fields you can pass the option label string; it will be
+   * resolved to the option id automatically.
+   */
+  rows?: Record<string, unknown>[];
+  /** View-level filters applied via the API before the test starts */
+  filters?: FilterSpec[];
+  /** View-level sorts applied via the API before the test starts */
+  sorts?: SortSpec[];
+}
+
+// Setup result
+
+export interface GridSetupResult {
+  /** The isolated user created for this test suite - pass to GridPage */
+  user: User;
+  database: Database;
+  table: Table;
+  view: View;
+  /** Fields by name - includes both the primary field ("Name") and all created fields */
+  fieldByName: Record<string, Field>;
+  /** Ids of the seeded rows in creation order */
+  rowIds: number[];
+  /**
+   * Resolve a single_select option label to its BE-assigned integer id.
+   * Throws if the field or option is not found.
+   */
+  getOptionId(fieldName: string, optionLabel: string): number;
+}
+
+// Main helper
+
+function normalizeSelectOption(option: SelectOptionSpec): {
+  value: string;
+  color: string;
+} {
+  if (typeof option === "string") {
+    return { value: option, color: "blue" };
+  }
+
+  return { value: option.value, color: option.color ?? "blue" };
+}
+
+/**
+ * Creates a complete, isolated grid environment for a test suite.
+ *
+ * Creates its own user and workspace so `beforeAll` needs no Playwright
+ * fixtures. `page` and `context` are test-scoped and cannot be used in
+ * `beforeAll`. Navigation is done in `beforeEach` using the returned `user`.
+ *
+ * Example:
+ * ```typescript
+ * let g: GridSetupResult
+ *
+ * test.beforeAll(async () => {
+ *   g = await setupGrid({
+ *     fields: [
+ *       { name: "Score", type: "number" },
+ *       { name: "Status", type: "single_select", options: ["Done", "In Progress"] },
+ *     ],
+ *     rows: [
+ *       { Name: "Alice", Score: 10, Status: "Done" },
+ *       { Name: "Bob",   Score: 20, Status: "In Progress" },
+ *     ],
+ *   })
+ * })
+ *
+ * test.beforeEach(async ({ page }) => {
+ *   const grid = new GridPage(page, g.user)
+ *   await grid.goTo(g.database, g.table)
+ * })
+ * ```
+ */
+export async function setupGrid(
+  options: GridSetupOptions,
+): Promise<GridSetupResult> {
+  const user = await createUser();
+  const workspace = await createWorkspace(user);
+  // 1. Create isolated database + table
+  const database = await createDatabase(
+    user,
+    options.dbName ?? "TestDb",
+    workspace,
+  );
+  const table = await createTable(user, options.tableName ?? "Test", database);
+
+  // Remove the extra fields Baserow creates by default (keeps only the primary field)
+  await deleteAllNonPrimaryFieldsFromTable(user, table);
+
+  // Remove the two default empty rows Baserow inserts on table creation
+  const defaultRows = await listRows(user, table);
+  if (defaultRows.length > 0) {
+    await deleteRows(
+      user,
+      table,
+      defaultRows.map((r) => r.id),
+    );
+  }
+
+  // 2. Create the requested fields
+  const fieldByName: Record<string, Field> = {};
+
+  // Fetch the primary field so callers can reference it by name
+  const existingFields = await getFieldsForTable(user, table);
+  for (const f of existingFields) {
+    fieldByName[f.name] = f;
+  }
+
+  for (const spec of options.fields) {
+    const apiSettings: Record<string, unknown> = { ...(spec.settings ?? {}) };
+
+    if (spec.type === "single_select" && spec.options) {
+      apiSettings.select_options = spec.options.map(normalizeSelectOption);
+    }
+
+    fieldByName[spec.name] = await createField(
+      user,
+      spec.name,
+      spec.type,
+      apiSettings,
+      table,
+    );
+  }
+
+  // 3. Refresh to get BE-assigned select option IDs
+  const optionIdMap: Record<string, Record<string, number>> = {};
+  const refreshedFields = await getFieldsForTable(user, table);
+
+  for (const spec of options.fields) {
+    if (spec.type === "single_select" && spec.options) {
+      const refreshed = refreshedFields.find(
+        (f) => f.id === fieldByName[spec.name].id,
+      );
+      const opts = refreshed?.fieldSettings?.select_options ?? [];
+      optionIdMap[spec.name] = Object.fromEntries(
+        opts.map((o: { value: string; id: number }) => [o.value, o.id]),
+      );
+    }
+  }
+
+  const getOptionId = (fieldName: string, optionLabel: string): number => {
+    const id = optionIdMap[fieldName]?.[optionLabel];
+    if (id === undefined) {
+      throw new Error(
+        `Option "${optionLabel}" not found in field "${fieldName}". ` +
+          `Available: ${Object.keys(optionIdMap[fieldName] ?? {}).join(", ")}`,
+      );
+    }
+    return id;
+  };
+
+  // 4. Seed rows - resolve single_select labels to option ids automatically
+  const rowIds: number[] = [];
+
+  if (options.rows?.length) {
+    const fieldSpecByName = Object.fromEntries(
+      options.fields.map((s) => [s.name, s]),
+    );
+
+    const resolved = options.rows.map((row) => {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(row)) {
+        const spec = fieldSpecByName[key];
+        if (spec?.type === "single_select" && typeof value === "string") {
+          out[key] = getOptionId(key, value);
+        } else {
+          out[key] = value;
+        }
+      }
+      return out;
+    });
+
+    const created = await createRows(user, table, resolved);
+    rowIds.push(...created.map((r) => r.id));
+  }
+
+  // 5. Get the default grid view
+  const view = await getDefaultGridView(user, table);
+
+  // 6. Apply view-level filters
+  for (const f of options.filters ?? []) {
+    const fieldSpec = options.fields.find((s) => s.name === f.fieldName);
+    const value =
+      fieldSpec?.type === "single_select" && typeof f.value === "string"
+        ? String(getOptionId(f.fieldName, f.value))
+        : f.value;
+
+    await createViewFilter(user, view, fieldByName[f.fieldName], f.type, value);
+  }
+
+  // 7. Apply view-level sorts
+  for (const s of options.sorts ?? []) {
+    await createViewSort(
+      user,
+      view,
+      fieldByName[s.fieldName],
+      s.order ?? "ASC",
+    );
+  }
+
+  return { user, database, table, view, fieldByName, rowIds, getOptionId };
+}
+
+// Row reset helper
+
+/**
+ * Delete all existing rows in the table and recreate them from `newRows`.
+ * Call in `beforeEach` for tests that mutate row data so each test starts
+ * from a clean, known state.
+ *
+ * Resolves single_select labels to option IDs automatically using the
+ * `getOptionId` function from the setup result.
+ *
+ * Example:
+ * ```typescript
+ * test.beforeEach(async ({ page }) => {
+ *   await resetRows(g, [
+ *     { Name: "Alice", Score: 10 },
+ *     { Name: "Bob",   Score: 20 },
+ *   ])
+ *   const grid = new GridPage(page, g.user)
+ *   await grid.goTo(g.database, g.table)
+ * })
+ * ```
+ */
+export async function resetRows(
+  g: GridSetupResult,
+  newRows: Record<string, unknown>[],
+): Promise<void> {
+  const existing = await listRows(g.user, g.table);
+  if (existing.length > 0) {
+    await deleteRows(
+      g.user,
+      g.table,
+      existing.map((r) => r.id),
+    );
+  }
+
+  if (newRows.length === 0) return;
+
+  // Resolve single_select labels to option IDs
+  const resolved = newRows.map((row) => {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (
+        typeof value === "string" &&
+        key !== "Name" // Name is the primary text field, no resolution needed
+      ) {
+        // Try to resolve as a single_select option (silently keep string if not found)
+        try {
+          out[key] = g.getOptionId(key, value);
+        } catch {
+          out[key] = value;
+        }
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  });
+
+  await createRows(g.user, g.table, resolved);
+}

--- a/e2e-tests/fixtures/database/gridSetup.ts
+++ b/e2e-tests/fixtures/database/gridSetup.ts
@@ -5,6 +5,7 @@ import { Table, createTable } from "./table";
 import {
   View,
   getDefaultGridView,
+  ensureViewFieldOptions,
   createViewFilter,
   createViewSort,
 } from "./view";
@@ -21,10 +22,12 @@ import { createRows, deleteRows, listRows } from "./rows";
 export type FieldType =
   | "text"
   | "number"
+  | "email"
   | "boolean"
   | "date"
   | "single_select"
-  | "long_text";
+  | "long_text"
+  | "formula";
 
 export type SelectOptionSpec =
   | string
@@ -245,6 +248,7 @@ export async function setupGrid(
 
   // 5. Get the default grid view
   const view = await getDefaultGridView(user, table);
+  await ensureViewFieldOptions(user, view);
 
   // 6. Apply view-level filters
   for (const f of options.filters ?? []) {
@@ -311,16 +315,8 @@ export async function resetRows(
   const resolved = newRows.map((row) => {
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(row)) {
-      if (
-        typeof value === "string" &&
-        key !== "Name" // Name is the primary text field, no resolution needed
-      ) {
-        // Try to resolve as a single_select option (silently keep string if not found)
-        try {
-          out[key] = g.getOptionId(key, value);
-        } catch {
-          out[key] = value;
-        }
+      if (g.fieldByName[key]?.type === "single_select" && typeof value === "string") {
+        out[key] = g.getOptionId(key, value);
       } else {
         out[key] = value;
       }

--- a/e2e-tests/fixtures/database/rows.ts
+++ b/e2e-tests/fixtures/database/rows.ts
@@ -32,15 +32,22 @@ export async function createRows(
   );
 }
 
-/**
- * Fetches a table's rows keyed by field name, used to read back row ids.
- */
-export async function getRows(
+export async function deleteRows(
   user: User,
-  table: { id: number },
-): Promise<any[]> {
-  const response: any = await getClient(user).get(
-    `database/rows/table/${table.id}/?user_field_names=true`,
+  table: Table,
+  rowIds: number[],
+): Promise<void> {
+  await getClient(user).post(`database/rows/table/${table.id}/batch-delete/`, {
+    items: rowIds,
+  });
+}
+
+export async function listRows(
+  user: User,
+  table: Table,
+): Promise<{ id: number; [k: string]: any }[]> {
+  const response = await getClient(user).get(
+    `database/rows/table/${table.id}/?user_field_names=true&size=200`,
   );
   return response.data.results;
 }

--- a/e2e-tests/fixtures/database/rows.ts
+++ b/e2e-tests/fixtures/database/rows.ts
@@ -25,11 +25,12 @@ export async function createRows(
   user: User,
   table: Table,
   rowValues: any,
-): Promise<void> {
-  await getClient(user).post(
+): Promise<{ id: number; [k: string]: any }[]> {
+  const response = await getClient(user).post(
     `database/rows/table/${table.id}/batch/?user_field_names=true`,
     { items: rowValues },
   );
+  return response.data.items;
 }
 
 export async function deleteRows(

--- a/e2e-tests/fixtures/database/view.ts
+++ b/e2e-tests/fixtures/database/view.ts
@@ -112,6 +112,13 @@ export async function getDefaultGridView(
   );
 }
 
+export async function ensureViewFieldOptions(
+  user: User,
+  view: View,
+): Promise<void> {
+  await getClient(user).get(`database/views/${view.id}/field-options/`);
+}
+
 export async function createViewFilter(
   user: User,
   view: View,

--- a/e2e-tests/fixtures/database/view.ts
+++ b/e2e-tests/fixtures/database/view.ts
@@ -1,6 +1,7 @@
 import { getClient } from "../../client";
 import { User } from "../user";
 import { Table } from "./table";
+import { Field } from "./field";
 
 export class View {
   constructor(
@@ -92,4 +93,70 @@ export async function updateFormFieldOptions(
   await getClient(user).patch(`database/views/${view.id}/field-options/`, {
     field_options: payload,
   });
+}
+
+export async function getDefaultGridView(
+  user: User,
+  table: Table,
+): Promise<View> {
+  const response: any = await getClient(user).get(
+    `database/views/table/${table.id}/`,
+  );
+  const gridView = response.data.find((view: any) => view.type === "grid");
+  return new View(
+    gridView.id,
+    gridView.name,
+    gridView.type,
+    gridView.slug,
+    table,
+  );
+}
+
+export async function createViewFilter(
+  user: User,
+  view: View,
+  field: Field,
+  type: string,
+  value: string,
+): Promise<void> {
+  await getClient(user).post(`database/views/${view.id}/filters/`, {
+    field: field.id,
+    type,
+    value,
+  });
+}
+
+export async function createViewSort(
+  user: User,
+  view: View,
+  field: Field,
+  order: "ASC" | "DESC" = "ASC",
+): Promise<void> {
+  await getClient(user).post(`database/views/${view.id}/sortings/`, {
+    field: field.id,
+    order,
+  });
+}
+
+export interface ViewDecorationPayload {
+  type: string;
+  value_provider_type?: string;
+  value_provider_conf?: Record<string, unknown>;
+  order?: number;
+}
+
+export async function patchView(
+  user: User,
+  view: View,
+  values: Record<string, unknown>,
+): Promise<void> {
+  await getClient(user).patch(`database/views/${view.id}/`, values);
+}
+
+export async function createViewDecoration(
+  user: User,
+  view: View,
+  values: ViewDecorationPayload,
+): Promise<void> {
+  await getClient(user).post(`database/views/${view.id}/decorations/`, values);
 }

--- a/e2e-tests/fixtures/network.ts
+++ b/e2e-tests/fixtures/network.ts
@@ -1,0 +1,121 @@
+import { Page, Route } from "@playwright/test";
+
+export interface RouteOptions {
+  /**
+   * Only intercept requests with this HTTP method (e.g. "POST", "PATCH").
+   * Requests with other methods continue normally.
+   * If omitted, all methods are intercepted.
+   */
+  method?: string;
+}
+
+export interface PausedRequest {
+  release: () => void;
+  intercepted: Promise<void>;
+}
+
+/**
+ * Arms a one-shot route intercept that fulfills the NEXT matching request
+ * with HTTP 500. Returns a promise that resolves once the 500 has been
+ * delivered, so callers can `await` it before asserting rollback state.
+ *
+ * Pass `{ method: "POST" }` to only intercept POST requests and let GETs
+ * through - important for the flat grid which fires background GETs.
+ *
+ * Usage:
+ *   const failed = failNextRequest(page, `**\/rows\/table\/${id}\/`, { method: "POST" })
+ *   await grid.addRow()
+ *   await failed
+ *   await grid.expectRowCount(1)   // optimistic row was rolled back
+ */
+export function failNextRequest(
+  page: Page,
+  urlPattern: string,
+  options: RouteOptions = {},
+): Promise<void> {
+  return new Promise((resolve) => {
+    const handler = async (route: Route) => {
+      if (options.method && route.request().method() !== options.method) {
+        // Wrong method - let it through and keep the handler registered
+        await route.continue();
+        return;
+      }
+      // Correct method (or no method filter) - fail it and unregister.
+      // Use a Baserow-structured body so the client-side ErrorHandler fires the
+      // toast notification. An empty {} body is parsed as an object by axios,
+      // causing hasBaserowAPIError() to return false and the toast to be suppressed.
+      await page.unroute(urlPattern, handler);
+      await route.fulfill({ status: 500, body: "{}" });
+      resolve();
+    };
+    page.route(urlPattern, handler);
+  });
+}
+
+/**
+ * Arms a route intercept that PAUSES matching requests until the returned
+ * `release` function is called.
+ *
+ * Pass `{ method: "POST" }` to only pause POST requests.
+ *
+ * Usage:
+ *   const release = await pauseNextRequest(page, pattern, { method: "POST" })
+ *   await grid.addRow()
+ *   // Optimistic state visible - network paused
+ *   await grid.expectRowCount(2)
+ *   release()
+ *   await grid.expectRowCount(2)   // BE confirmed
+ */
+export async function pauseNextRequest(
+  page: Page,
+  urlPattern: string,
+  options: RouteOptions = {},
+): Promise<() => void> {
+  const paused = await pauseNextRequestWithSignal(page, urlPattern, options);
+  return paused.release;
+}
+
+export async function pauseNextRequestWithSignal(
+  page: Page,
+  urlPattern: string,
+  options: RouteOptions = {},
+): Promise<PausedRequest> {
+  let release!: () => void;
+  let releaseGate!: () => void;
+  let markIntercepted!: () => void;
+  let handler!: (route: Route) => Promise<void>;
+  let interceptedResolved = false;
+  let released = false;
+  const gate = new Promise<void>((r) => {
+    releaseGate = r;
+  });
+  const intercepted = new Promise<void>((r) => {
+    markIntercepted = r;
+  });
+
+  release = () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    releaseGate();
+    void page.unroute(urlPattern, handler);
+  };
+
+  handler = async (route: Route) => {
+    if (options.method && route.request().method() !== options.method) {
+      await route.continue();
+      return;
+    }
+    if (!interceptedResolved) {
+      interceptedResolved = true;
+      markIntercepted();
+    }
+    await gate;
+    await route.continue();
+  };
+
+  await page.route(urlPattern, handler);
+
+  return { release, intercepted };
+}

--- a/e2e-tests/fixtures/network.ts
+++ b/e2e-tests/fixtures/network.ts
@@ -17,48 +17,59 @@ export interface PausedRequest {
   intercepted: Promise<void>;
 }
 
+export interface FailedRequest {
+  /** Resolves once the forced HTTP 500 has been delivered. */
+  done: Promise<void>;
+}
+
 /**
  * Arms a one-shot route intercept that fulfills the NEXT matching request
- * with HTTP 500. Returns a promise that resolves once the 500 has been
- * delivered, so callers can `await` it before asserting rollback state.
+ * with HTTP 500. Awaits route registration before returning, then exposes a
+ * `done` promise that resolves once the 500 has been delivered, so callers can
+ * `await` it before asserting rollback state.
  *
  * Pass `{ method: "POST" }` to only intercept POST requests and let GETs
  * through - important for the flat grid which fires background GETs.
  *
  * Usage:
- *   const failed = failNextRequest(page, `**\/rows\/table\/${id}\/`, { method: "POST" })
+ *   const { done } = await failNextRequest(page, `**\/rows\/table\/${id}\/`, { method: "POST" })
  *   await grid.addRow()
- *   await failed
+ *   await done                     // 500 delivered
  *   await grid.expectRowCount(1)   // optimistic row was rolled back
  */
-export function failNextRequest(
+export async function failNextRequest(
   page: Page,
   urlPattern: string,
   options: RouteOptions = {},
-): Promise<void> {
-  return new Promise((resolve) => {
-    const handler = async (route: Route) => {
-      if (options.method && route.request().method() !== options.method) {
-        // Wrong method - let it through and keep the handler registered
-        await route.continue();
-        return;
-      }
-      // Correct method (or no method filter) - fail it and unregister.
-      // Use a Baserow-structured body so hasBaserowAPIError() returns true and
-      // the standard error toast fires.
-      await route.fulfill({
-        status: 500,
-        contentType: "application/json",
-        body: JSON.stringify({
-          error: "ERROR_E2E_FORCED_FAILURE",
-          detail: "Forced e2e failure.",
-        }),
-      });
-      await page.unroute(urlPattern, handler);
-      resolve();
-    };
-    page.route(urlPattern, handler);
+): Promise<FailedRequest> {
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
   });
+  const handler = async (route: Route) => {
+    if (options.method && route.request().method() !== options.method) {
+      // Wrong method - let it through and keep the handler registered
+      await route.continue();
+      return;
+    }
+    // Correct method (or no method filter) - fail it and unregister.
+    // Use a Baserow-structured body so hasBaserowAPIError() returns true and
+    // the standard error toast fires.
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error: "ERROR_E2E_FORCED_FAILURE",
+        detail: "Forced e2e failure.",
+      }),
+    });
+    await page.unroute(urlPattern, handler);
+    resolveDone();
+  };
+  // Await registration so the intercept is armed before the caller triggers
+  // the request (mirrors pauseNextRequestWithSignal).
+  await page.route(urlPattern, handler);
+  return { done };
 }
 
 export async function pauseNextRequestWithSignal(

--- a/e2e-tests/fixtures/network.ts
+++ b/e2e-tests/fixtures/network.ts
@@ -10,7 +10,10 @@ export interface RouteOptions {
 }
 
 export interface PausedRequest {
+  /** Let the intercepted request proceed normally. */
   release: () => void;
+  /** Fulfill the intercepted request with HTTP 500 instead of continuing it. */
+  fail: () => void;
   intercepted: Promise<void>;
 }
 
@@ -41,11 +44,17 @@ export function failNextRequest(
         return;
       }
       // Correct method (or no method filter) - fail it and unregister.
-      // Use a Baserow-structured body so the client-side ErrorHandler fires the
-      // toast notification. An empty {} body is parsed as an object by axios,
-      // causing hasBaserowAPIError() to return false and the toast to be suppressed.
+      // Use a Baserow-structured body so hasBaserowAPIError() returns true and
+      // the standard error toast fires.
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "ERROR_E2E_FORCED_FAILURE",
+          detail: "Forced e2e failure.",
+        }),
+      });
       await page.unroute(urlPattern, handler);
-      await route.fulfill({ status: 500, body: "{}" });
       resolve();
     };
     page.route(urlPattern, handler);
@@ -53,8 +62,9 @@ export function failNextRequest(
 }
 
 /**
- * Arms a route intercept that PAUSES matching requests until the returned
- * `release` function is called.
+ * Arms a route intercept that PAUSES the next matching request until the
+ * returned `release` function is called. Later matching requests continue
+ * normally.
  *
  * Pass `{ method: "POST" }` to only pause POST requests.
  *
@@ -81,11 +91,14 @@ export async function pauseNextRequestWithSignal(
   options: RouteOptions = {},
 ): Promise<PausedRequest> {
   let release!: () => void;
+  let fail!: () => void;
   let releaseGate!: () => void;
   let markIntercepted!: () => void;
   let handler!: (route: Route) => Promise<void>;
   let interceptedResolved = false;
   let released = false;
+  let failMode = false;
+  let routed = true;
   const gate = new Promise<void>((r) => {
     releaseGate = r;
   });
@@ -93,13 +106,30 @@ export async function pauseNextRequestWithSignal(
     markIntercepted = r;
   });
 
+  const unrouteOnce = async () => {
+    if (!routed) {
+      return;
+    }
+    routed = false;
+    await page.unroute(urlPattern, handler);
+  };
+
   release = () => {
     if (released) {
       return;
     }
     released = true;
+    failMode = false;
     releaseGate();
-    void page.unroute(urlPattern, handler);
+  };
+
+  fail = () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    failMode = true;
+    releaseGate();
   };
 
   handler = async (route: Route) => {
@@ -107,15 +137,29 @@ export async function pauseNextRequestWithSignal(
       await route.continue();
       return;
     }
-    if (!interceptedResolved) {
-      interceptedResolved = true;
-      markIntercepted();
+    if (interceptedResolved) {
+      await route.continue();
+      return;
     }
+    interceptedResolved = true;
+    markIntercepted();
     await gate;
-    await route.continue();
+    if (failMode) {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "ERROR_E2E_FORCED_FAILURE",
+          detail: "Forced e2e failure.",
+        }),
+      });
+    } else {
+      await route.continue();
+    }
+    await unrouteOnce();
   };
 
   await page.route(urlPattern, handler);
 
-  return { release, intercepted };
+  return { release, fail, intercepted };
 }

--- a/e2e-tests/fixtures/network.ts
+++ b/e2e-tests/fixtures/network.ts
@@ -61,30 +61,6 @@ export function failNextRequest(
   });
 }
 
-/**
- * Arms a route intercept that PAUSES the next matching request until the
- * returned `release` function is called. Later matching requests continue
- * normally.
- *
- * Pass `{ method: "POST" }` to only pause POST requests.
- *
- * Usage:
- *   const release = await pauseNextRequest(page, pattern, { method: "POST" })
- *   await grid.addRow()
- *   // Optimistic state visible - network paused
- *   await grid.expectRowCount(2)
- *   release()
- *   await grid.expectRowCount(2)   // BE confirmed
- */
-export async function pauseNextRequest(
-  page: Page,
-  urlPattern: string,
-  options: RouteOptions = {},
-): Promise<() => void> {
-  const paused = await pauseNextRequestWithSignal(page, urlPattern, options);
-  return paused.release;
-}
-
 export async function pauseNextRequestWithSignal(
   page: Page,
   urlPattern: string,

--- a/e2e-tests/justfile
+++ b/e2e-tests/justfile
@@ -146,12 +146,31 @@ up: _ensure-images
 
     # Wait for PostgreSQL to be ready
     echo "Waiting for PostgreSQL..."
+    POSTGRES_READY=false
     for i in {1..30}; do
         if docker exec e2e-db pg_isready -U baserow > /dev/null 2>&1; then
+            POSTGRES_READY=true
             break
         fi
         sleep 1
     done
+    if [ "$POSTGRES_READY" != true ]; then
+        echo "Timed out waiting for PostgreSQL to accept connections."
+        exit 1
+    fi
+
+    BASEROW_DB_CREATED=false
+    for i in {1..30}; do
+        if docker exec e2e-db psql -U baserow -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='baserow'" | grep -q 1; then
+            BASEROW_DB_CREATED=true
+            break
+        fi
+        sleep 1
+    done
+    if [ "$BASEROW_DB_CREATED" != true ]; then
+        echo "Timed out waiting for PostgreSQL to create the baserow database."
+        exit 1
+    fi
 
     # Restore database from dump (fast - migrations pre-applied)
     echo "Restoring database from dump..."

--- a/e2e-tests/pages/database/gridPage.ts
+++ b/e2e-tests/pages/database/gridPage.ts
@@ -438,35 +438,6 @@ export class GridPage {
     await expect(this.rowEditModal()).toHaveCount(0, { timeout: 10_000 });
   }
 
-  // -- Search / toolbar --------------------------------------------------------
-
-  async openSearch(): Promise<void> {
-    await this.page.locator(".header__search .header__filter-link").click();
-    await this.page
-      .locator("[placeholder='Search in all rows']")
-      .waitFor({ state: "visible" });
-  }
-
-  async typeInSearch(term: string): Promise<void> {
-    const input = this.page.locator("[placeholder='Search in all rows']");
-    // Must use pressSequentially (not fill) because the search input listens to
-    // @keyup events to trigger `searchIfChanged`. fill() only fires `input` events,
-    // not keyboard events, so the search would never run.
-    await input.clear();
-    await input.pressSequentially(term);
-  }
-
-  async clearSearch(): Promise<void> {
-    // The FormInput clear button is .form-input__clear inside the search context
-    await this.page.locator(".form-input__clear").click();
-  }
-
-  async toggleHideNotMatchingRows(): Promise<void> {
-    await this.page
-      .getByText("hide not matching rows", { exact: false })
-      .click();
-  }
-
   private escapeRegex(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   }

--- a/e2e-tests/pages/database/gridPage.ts
+++ b/e2e-tests/pages/database/gridPage.ts
@@ -1,0 +1,735 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { Database } from "../../fixtures/database/database";
+import { Table } from "../../fixtures/database/table";
+import { User } from "../../fixtures/user";
+
+/**
+ * Page object for the flat (no group-by) Baserow grid view.
+ *
+ * ## Left / right section model
+ *
+ * Baserow renders the grid in two separate sections:
+ *   - LEFT  - primary field cell (Name) + row controls (ID, checkbox, warning)
+ *   - RIGHT - all non-primary field cells (Score, Notes, ...)
+ *
+ * Both sections render the same number of rows at the same visual positions.
+ * Row index 0 is the topmost visible row in both sections simultaneously.
+ *
+ * ## Cell addressing
+ *
+ * All interaction methods use numeric row/field indices:
+ *   - `rowIndex`   - 0-based visual position (depends on current sort)
+ *   - `fieldIndex` - 0-based index into non-primary fields (right section)
+ *
+ * Text-based methods (expectPrimaryText, expectPrimaryVisible, ...) are provided
+ * only for ASSERTIONS - not for driving clicks. Tests know the row order from
+ * their own data setup, so positional access is unambiguous.
+ */
+export class GridPage {
+  private readonly baseUrl: string;
+
+  constructor(
+    readonly page: Page,
+    private readonly user: User,
+  ) {
+    this.baseUrl =
+      process.env.PUBLIC_WEB_FRONTEND_URL ?? "http://localhost:3000";
+  }
+
+  // -- Navigation --------------------------------------------------------------
+
+  async goTo(database: Database, table: Table): Promise<void> {
+    await this.page.context().addCookies([
+      {
+        name: "jwt_token",
+        value: this.user.refreshToken,
+        url: this.baseUrl,
+      },
+    ]);
+    await this.page.goto(
+      `${this.baseUrl}/database/${database.id}/table/${table.id}`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await this.page.waitForFunction(
+      "window.useNuxtApp?.().isHydrating === false",
+    );
+    const grid = this.page.locator(".grid-view__right");
+    await expect(grid).toBeVisible({ timeout: 15_000 });
+  }
+
+  // -- Row locators -------------------------------------------------------------
+
+  gridRoot(): Locator {
+    return this.page.locator(".grid-view").first();
+  }
+
+  /** All rows in the LEFT section (primary field + row controls) */
+  leftRows(): Locator {
+    return this.page.locator(
+      ".grid-view__left .grid-view__rows .grid-view__row",
+    );
+  }
+
+  /** All rows in the RIGHT section (non-primary fields) */
+  rightRows(): Locator {
+    return this.page.locator(
+      ".grid-view__right .grid-view__rows .grid-view__row",
+    );
+  }
+
+  /** nth row in the LEFT section (0-based) */
+  leftRowAt(index: number): Locator {
+    return this.leftRows().nth(index);
+  }
+
+  /** nth row in the RIGHT section (0-based) */
+  rightRowAt(index: number): Locator {
+    return this.rightRows().nth(index);
+  }
+
+  // -- Cell locators -------------------------------------------------------------
+
+  /**
+   * Primary field cell for the row at `rowIndex`.
+   * This is the LAST column in the left section row (after the row-details column).
+   */
+  primaryCellAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__column").last();
+  }
+
+  /**
+   * Non-primary field cell at `rowIndex`, `fieldIndex` (both 0-based).
+   * `fieldIndex 0` = first non-primary field (right section, first column).
+   */
+  fieldCellAt(rowIndex: number, fieldIndex: number): Locator {
+    return this.rightRowAt(rowIndex)
+      .locator(".grid-view__column")
+      .nth(fieldIndex);
+  }
+
+  nonPrimaryFieldHeadersByName(fieldName: string): Locator {
+    return this.page.locator(
+      ".grid-view__right .grid-view__head .grid-view__description-name",
+      { hasText: new RegExp(`^\\s*${this.escapeRegex(fieldName)}\\s*$`) },
+    );
+  }
+
+  /** The active cell editor input/textarea (visible while a cell is in edit mode) */
+  activeEditor(): Locator {
+    return this.page
+      .locator(
+        ".grid-view__cell.active input, .grid-view__cell.active textarea",
+      )
+      .first();
+  }
+
+  /** The selected primary field cell content for the row at `rowIndex`. */
+  selectedPrimaryCellAt(rowIndex: number): Locator {
+    return this.primaryCellAt(rowIndex).locator(".grid-view__cell.active");
+  }
+
+  /** The selected non-primary field cell content at `rowIndex`, `fieldIndex`. */
+  selectedFieldCellAt(rowIndex: number, fieldIndex: number): Locator {
+    return this.fieldCellAt(rowIndex, fieldIndex).locator(
+      ".grid-view__cell.active",
+    );
+  }
+
+  // -- Row-level locators (warning, checkbox) ------------------------------------
+
+  /**
+   * The warning banner (`grid-view__row-warning`) for the row at `rowIndex`.
+   * The warning lives in the LEFT section row.
+   */
+  rowWarningAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__row-warning");
+  }
+
+  checkboxAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__row-checkbox");
+  }
+
+  // -- Grid actions ------------------------------------------------------------
+
+  /** Click "+ Add row" at the bottom of the right section */
+  async addRow(): Promise<void> {
+    const addRow = this.page.locator(".grid-view__right .grid-view__add-row");
+    await expect(addRow).toBeVisible({ timeout: 10_000 });
+    await addRow.click();
+  }
+
+  /** Single-click a non-primary cell to select it without entering edit mode */
+  async selectFieldCell(rowIndex: number, fieldIndex: number): Promise<void> {
+    const cell = this.fieldCellAt(rowIndex, fieldIndex);
+    const selected = this.selectedFieldCellAt(rowIndex, fieldIndex);
+    await expect(async () => {
+      await cell.click();
+      if (await selected.isVisible()) {
+        return;
+      }
+      await cell.locator(".grid-view__cell").click();
+      if (!(await selected.isVisible())) {
+        throw new Error("Expected field cell to be selected.");
+      }
+    }).toPass({
+      timeout: 5_000,
+    });
+  }
+
+  /** Single-click the primary cell to select it without entering edit mode */
+  async selectPrimaryCell(rowIndex: number): Promise<void> {
+    const cell = this.primaryCellAt(rowIndex);
+    const selected = this.selectedPrimaryCellAt(rowIndex);
+    await expect(async () => {
+      await cell.click();
+      if (await selected.isVisible()) {
+        return;
+      }
+      await cell.locator(".grid-view__cell").click();
+      if (!(await selected.isVisible())) {
+        throw new Error("Expected primary cell to be selected.");
+      }
+    }).toPass({
+      timeout: 5_000,
+    });
+  }
+
+  /**
+   * Select a non-primary cell and press Enter to enter edit mode.
+   * Waits for the editor input/textarea to appear.
+   */
+  async startEditingField(rowIndex: number, fieldIndex: number): Promise<void> {
+    await this.selectFieldCell(rowIndex, fieldIndex);
+    await this.page.keyboard.press("Enter");
+    await expect(this.activeEditor()).toBeVisible({ timeout: 10_000 });
+  }
+
+  /**
+   * Select the primary cell and press Enter to enter edit mode.
+   */
+  async startEditingPrimary(rowIndex: number): Promise<void> {
+    await this.selectPrimaryCell(rowIndex);
+    await this.page.keyboard.press("Enter");
+    await expect(this.activeEditor()).toBeVisible({ timeout: 10_000 });
+  }
+
+  /** Type into the currently active editor (replaces existing content) */
+  async type(text: string): Promise<void> {
+    await this.activeEditor().fill(text);
+  }
+
+  /** Press Enter: saves the value and moves selection to the cell below */
+  async confirmWithEnter(): Promise<void> {
+    await this.page.keyboard.press("Enter");
+  }
+
+  /**
+   * Press Tab: saves the value and moves selection to the next cell in the
+   * same row, keeping the row selected (the warning remains visible).
+   */
+  async confirmWithTab(): Promise<void> {
+    await this.page.keyboard.press("Tab");
+  }
+
+  /** Press Escape: cancels the edit and reverts to the original value */
+  async cancelEdit(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+
+  private shortcut(key: string): string {
+    return `${process.platform === "darwin" ? "Meta" : "Control"}+${key}`;
+  }
+
+  async copyShortcut(): Promise<void> {
+    await this.page.keyboard.press(this.shortcut("C"));
+  }
+
+  async pasteShortcut(): Promise<void> {
+    await this.page.keyboard.press(this.shortcut("V"));
+  }
+
+  async writeClipboard(text: string): Promise<void> {
+    await this.page
+      .context()
+      .grantPermissions(["clipboard-read", "clipboard-write"], {
+        origin: this.baseUrl,
+      });
+    await this.page.evaluate(
+      (value) => navigator.clipboard.writeText(value),
+      text,
+    );
+  }
+
+  /**
+   * Click the grid column header area (RIGHT section) to deselect any
+   * selected cell without triggering any row operation. Uses the right
+   * section specifically because both sections have a `.grid-view__head`
+   * element and strict mode requires a unique match.
+   */
+  async clickAway(): Promise<void> {
+    await this.page
+      .locator(".grid-view__right .grid-view__head")
+      .click({ position: { x: 5, y: 5 } });
+  }
+
+  /**
+   * Right-click a row to open its context menu.
+   * We right-click the RIGHT section row (field cell area) because the left
+   * section's row-controls area does not reliably trigger the context menu.
+   */
+  async rightClickRow(rowIndex: number): Promise<void> {
+    const row = this.rightRowAt(rowIndex);
+    await row.waitFor({ state: "visible", timeout: 10_000 });
+    const deleteRow = this.contextItem("Delete row");
+    await expect(async () => {
+      await row.click({
+        button: "right",
+        position: { x: 10, y: 10 },
+      });
+      if (!(await deleteRow.isVisible())) {
+        throw new Error("Expected row context menu to open.");
+      }
+    }).toPass({
+      timeout: 5_000,
+    });
+  }
+
+  contextMenu(): Locator {
+    return this.page.locator(".context__menu:visible").first();
+  }
+
+  contextItem(label: string): Locator {
+    return this.page
+      .locator(".context__menu:visible .context__menu-item-link", {
+        hasText: label,
+      })
+      .first();
+  }
+
+  async clickContextItem(label: string): Promise<void> {
+    await this.contextItem(label).click();
+  }
+
+  // -- Search / toolbar --------------------------------------------------------
+
+  async openSearch(): Promise<void> {
+    await this.page.locator(".header__search .header__filter-link").click();
+    await this.page
+      .locator("[placeholder='Search in all rows']")
+      .waitFor({ state: "visible" });
+  }
+
+  async typeInSearch(term: string): Promise<void> {
+    const input = this.page.locator("[placeholder='Search in all rows']");
+    // Must use pressSequentially (not fill) because the search input listens to
+    // @keyup events to trigger `searchIfChanged`. fill() only fires `input` events,
+    // not keyboard events, so the search would never run.
+    await input.clear();
+    await input.pressSequentially(term);
+  }
+
+  async clearSearch(): Promise<void> {
+    // The FormInput clear button is .form-input__clear inside the search context
+    await this.page.locator(".form-input__clear").click();
+  }
+
+  async toggleHideNotMatchingRows(): Promise<void> {
+    await this.page
+      .getByText("hide not matching rows", { exact: false })
+      .click();
+  }
+
+  private escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  private fieldVisibilityLink(): Locator {
+    return this.page
+      .locator(".header__filter-link", {
+        has: this.page.locator(".header__filter-icon.iconoir-eye-off"),
+      })
+      .first();
+  }
+
+  private fieldVisibilityContext(): Locator {
+    return this.page.locator(".hidings:visible").first();
+  }
+
+  private fieldVisibilitySwitch(fieldName: string): Locator {
+    const context = this.fieldVisibilityContext();
+
+    return context
+      .locator(".hidings__item", {
+        hasText: new RegExp(`\\b${this.escapeRegex(fieldName)}\\b`),
+      })
+      .locator(".switch")
+      .first();
+  }
+
+  async openFieldVisibilityContext(): Promise<void> {
+    await expect(this.fieldVisibilityLink()).toBeVisible({ timeout: 10_000 });
+    await this.fieldVisibilityLink().click();
+    await expect(this.fieldVisibilityContext()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  async setFieldVisibility(fieldName: string, visible: boolean): Promise<void> {
+    const fieldSwitch = this.fieldVisibilitySwitch(fieldName);
+    await expect(fieldSwitch).toBeVisible({ timeout: 10_000 });
+
+    const isVisible = await fieldSwitch.evaluate((element) =>
+      element.classList.contains("switch--active"),
+    );
+    if (isVisible !== visible) {
+      await fieldSwitch.click();
+    }
+
+    if (visible) {
+      await expect(fieldSwitch).toHaveClass(/switch--active/, {
+        timeout: 10_000,
+      });
+    } else {
+      await expect(fieldSwitch).not.toHaveClass(/switch--active/, {
+        timeout: 10_000,
+      });
+    }
+  }
+
+  private rowIdentifierDropdownIcon(): Locator {
+    return this.page.locator(
+      ".grid-view__left .grid-view__head-row-identifier-dropdown",
+    );
+  }
+
+  async selectRowIdentifierType(type: "id" | "count"): Promise<void> {
+    await this.rowIdentifierDropdownIcon().click();
+    const label = type === "id" ? "Row identifier" : "Count";
+    await this.page
+      .locator(".select__item-link", { hasText: new RegExp(`^\\s*${label}\\s*$`) })
+      .first()
+      .click();
+  }
+
+  rowIdentifierContentAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__row-count-content");
+  }
+
+  rowCountWrapperAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__row-count");
+  }
+
+  rowDragHandleAt(rowIndex: number): Locator {
+    return this.leftRowAt(rowIndex).locator(".grid-view__row-drag");
+  }
+
+  async hoverRow(rowIndex: number): Promise<void> {
+    await this.leftRowAt(rowIndex).hover();
+  }
+
+  async unhoverRow(): Promise<void> {
+    await this.page
+      .locator(".grid-view__left .grid-view__head")
+      .hover({ position: { x: 5, y: 5 } });
+  }
+
+  private rowHeightLink(): Locator {
+    return this.page
+      .locator(".header__filter-link", {
+        has: this.page.locator(".header__filter-icon.iconoir-table-rows"),
+      })
+      .first();
+  }
+
+  async selectRowHeight(label: "Small" | "Medium" | "Large"): Promise<void> {
+    await expect(this.rowHeightLink()).toBeVisible({ timeout: 10_000 });
+    await this.rowHeightLink().click();
+
+    const item = this.page
+      .locator(".select__items:visible .select__item", {
+        hasText: new RegExp(`^\\s*${label}\\s*$`),
+      })
+      .first();
+    await expect(item).toBeVisible({ timeout: 10_000 });
+    await item.locator(".select__item-link").click();
+  }
+
+  // -- Assertions --------------------------------------------------------------
+
+  /** Assert that exactly `count` rows are visible in the right section */
+  async expectRowCount(count: number): Promise<void> {
+    await expect(this.rightRows()).toHaveCount(count, { timeout: 10_000 });
+  }
+
+  async expectRowNotLoading(rowIndex: number): Promise<void> {
+    await expect(this.leftRowAt(rowIndex)).not.toHaveClass(
+      /grid-view__row--loading/,
+      { timeout: 10_000 },
+    );
+    await expect(this.rightRowAt(rowIndex)).not.toHaveClass(
+      /grid-view__row--loading/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectRowLoading(rowIndex: number): Promise<void> {
+    // The visible spinner is rendered in the left row-details cell via the row
+    // count, so the left row is the stable user-visible loading signal.
+    await expect(this.leftRowAt(rowIndex)).toHaveClass(
+      /grid-view__row--loading/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectNoRowsLoading(): Promise<void> {
+    await expect(this.page.locator(".grid-view__row--loading")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Assert the visible text of the primary field cell at `rowIndex`.
+   * Searches the LEFT section.
+   */
+  async expectPrimaryText(rowIndex: number, text: string): Promise<void> {
+    await expect(this.primaryCellAt(rowIndex)).toContainText(text, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectPrimaryEmpty(rowIndex: number): Promise<void> {
+    await expect(this.primaryCellAt(rowIndex)).toBeEmpty({
+      timeout: 10_000,
+    });
+  }
+
+  /**
+   * Assert that the LEFT section contains a row whose primary field text
+   * includes `text`. Use this to check existence, not for interaction.
+   */
+  async expectPrimaryVisible(text: string): Promise<void> {
+    await expect(this.leftRows().filter({ hasText: text })).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  async expectPrimaryNotVisible(text: string): Promise<void> {
+    await expect(this.leftRows().filter({ hasText: text })).not.toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  /** Assert the visible text of a non-primary field cell */
+  async expectFieldText(
+    rowIndex: number,
+    fieldIndex: number,
+    text: string,
+  ): Promise<void> {
+    await expect(this.fieldCellAt(rowIndex, fieldIndex)).toContainText(text, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectFieldEmpty(rowIndex: number, fieldIndex: number): Promise<void> {
+    await expect(this.fieldCellAt(rowIndex, fieldIndex)).toBeEmpty({
+      timeout: 5_000,
+    });
+  }
+
+  async expectNonPrimaryFieldHeaderVisible(fieldName: string): Promise<void> {
+    await expect(
+      this.nonPrimaryFieldHeadersByName(fieldName).first(),
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  async expectNonPrimaryFieldHeaderHidden(fieldName: string): Promise<void> {
+    await expect(this.nonPrimaryFieldHeadersByName(fieldName)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectVisibleNonPrimaryFieldCount(count: number): Promise<void> {
+    await expect(
+      this.page.locator(
+        ".grid-view__right .grid-view__head .grid-view__description-name",
+      ),
+    ).toHaveCount(count, { timeout: 10_000 });
+    await expect(this.rightRowAt(0).locator(".grid-view__column")).toHaveCount(
+      count,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectPrimarySelected(rowIndex: number): Promise<void> {
+    await expect(this.selectedPrimaryCellAt(rowIndex)).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  async expectFieldSelected(
+    rowIndex: number,
+    fieldIndex: number,
+  ): Promise<void> {
+    await expect(this.selectedFieldCellAt(rowIndex, fieldIndex)).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  /**
+   * Assert that the row at `rowIndex` has the warning class
+   * (shown when matchFilters, matchSortings, or matchSearch is false
+   * while the row is still selected).
+   */
+  async expectRowHasWarning(rowIndex: number): Promise<void> {
+    await expect(this.leftRowAt(rowIndex)).toHaveClass(
+      /grid-view__row--warning/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectRowWarningText(rowIndex: number, text: string): Promise<void> {
+    await expect(this.rowWarningAt(rowIndex)).toContainText(text, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectRowNoWarning(rowIndex: number): Promise<void> {
+    await expect(this.leftRowAt(rowIndex)).not.toHaveClass(
+      /grid-view__row--warning/,
+      { timeout: 10_000 },
+    );
+  }
+
+  /** Assert that the nth cell (right section) has the search-match highlight */
+  async expectCellHighlighted(
+    rowIndex: number,
+    fieldIndex: number,
+  ): Promise<void> {
+    await expect(this.fieldCellAt(rowIndex, fieldIndex)).toHaveClass(
+      /grid-view__column--matches-search/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectCellNotHighlighted(
+    rowIndex: number,
+    fieldIndex: number,
+  ): Promise<void> {
+    await expect(this.fieldCellAt(rowIndex, fieldIndex)).not.toHaveClass(
+      /grid-view__column--matches-search/,
+      { timeout: 10_000 },
+    );
+  }
+
+  /** Assert that the primary (Name) cell at rowIndex has the search-match highlight */
+  async expectPrimaryHighlighted(rowIndex: number): Promise<void> {
+    await expect(this.primaryCellAt(rowIndex)).toHaveClass(
+      /grid-view__column--matches-search/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectPrimaryNotHighlighted(rowIndex: number): Promise<void> {
+    await expect(this.primaryCellAt(rowIndex)).not.toHaveClass(
+      /grid-view__column--matches-search/,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectRowHeight(
+    size: "small" | "medium" | "large",
+    expectedPx: number,
+    rowIndex = 0,
+  ): Promise<void> {
+    await expect(this.gridRoot()).toHaveClass(
+      new RegExp(`grid-view--row-height-${size}`),
+      { timeout: 10_000 },
+    );
+    await expect(this.leftRowAt(rowIndex)).toHaveCSS(
+      "height",
+      `${expectedPx}px`,
+      { timeout: 10_000 },
+    );
+    await expect(this.rightRowAt(rowIndex)).toHaveCSS(
+      "height",
+      `${expectedPx}px`,
+      { timeout: 10_000 },
+    );
+  }
+
+  async expectRowIdentifierText(rowIndex: number, text: string): Promise<void> {
+    await expect(this.rowIdentifierContentAt(rowIndex)).toHaveText(text, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectRowCountVisible(rowIndex: number): Promise<void> {
+    await expect(this.rowCountWrapperAt(rowIndex)).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  async expectRowCountHidden(rowIndex: number): Promise<void> {
+    await expect(this.rowCountWrapperAt(rowIndex)).not.toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  async expectRowCheckboxVisible(rowIndex: number): Promise<void> {
+    await expect(this.checkboxAt(rowIndex)).toBeVisible({ timeout: 5_000 });
+  }
+
+  async expectRowCheckboxHidden(rowIndex: number): Promise<void> {
+    await expect(this.checkboxAt(rowIndex)).not.toBeVisible({ timeout: 5_000 });
+  }
+
+  async expectRowDragHandlePresent(rowIndex: number): Promise<void> {
+    await expect(this.rowDragHandleAt(rowIndex)).toHaveCount(1, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectRowDragHandleAbsent(rowIndex: number): Promise<void> {
+    await expect(this.rowDragHandleAt(rowIndex)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectRowBackgroundColor(
+    rowIndex: number,
+    color: string,
+  ): Promise<void> {
+    const colorClass = new RegExp(
+      `background-color--${this.escapeRegex(color)}`,
+    );
+    await expect(
+      this.page
+        .locator(".grid-view__left .grid-view__row-background-wrapper")
+        .nth(rowIndex),
+    ).toHaveClass(colorClass, { timeout: 10_000 });
+    await expect(
+      this.page
+        .locator(".grid-view__right .grid-view__row-background-wrapper")
+        .nth(rowIndex),
+    ).toHaveClass(colorClass, { timeout: 10_000 });
+  }
+
+  /**
+   * Assert that an error toast is visible.
+   *
+   * Baserow toasts render as:
+   *   <div class="toast">
+   *     <div class="toast__icon toast__icon--error">...</div>
+   *   </div>
+   *
+   * The type modifier is on the icon child, not the root element, so we
+   * target `.toast__icon--error` rather than a non-existent `.toast--error`.
+   */
+  async expectErrorToast(): Promise<void> {
+    await expect(this.page.locator(".toast__icon--error").first()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+}

--- a/e2e-tests/pages/database/gridPage.ts
+++ b/e2e-tests/pages/database/gridPage.ts
@@ -50,9 +50,19 @@ export class GridPage {
       `${this.baseUrl}/database/${database.id}/table/${table.id}`,
       { waitUntil: "domcontentloaded" },
     );
-    await this.page.waitForFunction(
-      "window.useNuxtApp?.().isHydrating === false",
-    );
+    // Wait until Nuxt finishes hydrating. Falls back gracefully if the dev
+    // server CSP blocks the function evaluation.
+    await this.page
+      .waitForFunction(
+        () =>
+          typeof (window as any).useNuxtApp === "function" &&
+          !(window as any).useNuxtApp().isHydrating,
+        { timeout: 15_000 },
+      )
+      .catch(() => {
+        // CSP may block the evaluation on the dev server; the grid visibility
+        // assertion below provides sufficient confirmation of hydration.
+      });
     const grid = this.page.locator(".grid-view__right");
     await expect(grid).toBeVisible({ timeout: 15_000 });
   }
@@ -114,6 +124,13 @@ export class GridPage {
     );
   }
 
+  frozenFieldHeadersByName(fieldName: string): Locator {
+    return this.page.locator(
+      ".grid-view__left .grid-view__head .grid-view__description-name",
+      { hasText: new RegExp(`^\\s*${this.escapeRegex(fieldName)}\\s*$`) },
+    );
+  }
+
   /** The active cell editor input/textarea (visible while a cell is in edit mode) */
   activeEditor(): Locator {
     return this.page
@@ -121,6 +138,10 @@ export class GridPage {
         ".grid-view__cell.active input, .grid-view__cell.active textarea",
       )
       .first();
+  }
+
+  activeCellError(): Locator {
+    return this.page.locator(".grid-view__cell.active .grid-view__cell-error");
   }
 
   /** The selected primary field cell content for the row at `rowIndex`. */
@@ -147,6 +168,27 @@ export class GridPage {
 
   checkboxAt(rowIndex: number): Locator {
     return this.leftRowAt(rowIndex).locator(".grid-view__row-checkbox");
+  }
+
+  checkboxNativeAt(rowIndex: number): Locator {
+    return this.checkboxAt(rowIndex).locator(".checkbox__native");
+  }
+
+  multiSelectedCells(): Locator {
+    return this.page.locator(
+      [
+        ".grid-view__column--multi-select-top",
+        ".grid-view__column--multi-select-right",
+        ".grid-view__column--multi-select-bottom",
+        ".grid-view__column--multi-select-left",
+      ].join(", "),
+    );
+  }
+
+  rowEditModal(): Locator {
+    return this.page.locator(".modal__box", {
+      has: this.page.locator(".row-modal__title"),
+    });
   }
 
   // -- Grid actions ------------------------------------------------------------
@@ -310,6 +352,17 @@ export class GridPage {
     await this.contextItem(label).click();
   }
 
+  async openRowModalFromContext(rowIndex: number): Promise<void> {
+    await this.rightClickRow(rowIndex);
+    await this.clickContextItem("Enlarge row");
+    await expect(this.rowEditModal()).toBeVisible({ timeout: 10_000 });
+  }
+
+  async closeRowModal(): Promise<void> {
+    await this.rowEditModal().locator(".modal__close").click();
+    await expect(this.rowEditModal()).toHaveCount(0, { timeout: 10_000 });
+  }
+
   // -- Search / toolbar --------------------------------------------------------
 
   async openSearch(): Promise<void> {
@@ -341,6 +394,10 @@ export class GridPage {
 
   private escapeRegex(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  private exactTextRegex(value: string): RegExp {
+    return new RegExp(`^\\s*${this.escapeRegex(value)}\\s*$`);
   }
 
   private fieldVisibilityLink(): Locator {
@@ -406,7 +463,9 @@ export class GridPage {
     await this.rowIdentifierDropdownIcon().click();
     const label = type === "id" ? "Row identifier" : "Count";
     await this.page
-      .locator(".select__item-link", { hasText: new RegExp(`^\\s*${label}\\s*$`) })
+      .locator(".select__item-link", {
+        hasText: new RegExp(`^\\s*${label}\\s*$`),
+      })
       .first()
       .click();
   }
@@ -492,9 +551,25 @@ export class GridPage {
    * Searches the LEFT section.
    */
   async expectPrimaryText(rowIndex: number, text: string): Promise<void> {
-    await expect(this.primaryCellAt(rowIndex)).toContainText(text, {
-      timeout: 10_000,
-    });
+    await expect(this.primaryCellAt(rowIndex)).toHaveText(
+      this.exactTextRegex(text),
+      {
+        timeout: 10_000,
+      },
+    );
+  }
+
+  async expectFieldText(
+    rowIndex: number,
+    fieldIndex: number,
+    text: string,
+  ): Promise<void> {
+    await expect(this.fieldCellAt(rowIndex, fieldIndex)).toHaveText(
+      this.exactTextRegex(text),
+      {
+        timeout: 10_000,
+      },
+    );
   }
 
   async expectPrimaryEmpty(rowIndex: number): Promise<void> {
@@ -519,17 +594,6 @@ export class GridPage {
     });
   }
 
-  /** Assert the visible text of a non-primary field cell */
-  async expectFieldText(
-    rowIndex: number,
-    fieldIndex: number,
-    text: string,
-  ): Promise<void> {
-    await expect(this.fieldCellAt(rowIndex, fieldIndex)).toContainText(text, {
-      timeout: 10_000,
-    });
-  }
-
   async expectFieldEmpty(rowIndex: number, fieldIndex: number): Promise<void> {
     await expect(this.fieldCellAt(rowIndex, fieldIndex)).toBeEmpty({
       timeout: 5_000,
@@ -545,6 +609,18 @@ export class GridPage {
   }
 
   async expectNonPrimaryFieldHeaderHidden(fieldName: string): Promise<void> {
+    await expect(this.nonPrimaryFieldHeadersByName(fieldName)).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectFrozenFieldHeaderVisible(fieldName: string): Promise<void> {
+    await expect(this.frozenFieldHeadersByName(fieldName).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  }
+
+  async expectScrollableFieldHeaderHidden(fieldName: string): Promise<void> {
     await expect(this.nonPrimaryFieldHeadersByName(fieldName)).toHaveCount(0, {
       timeout: 10_000,
     });
@@ -574,6 +650,35 @@ export class GridPage {
   ): Promise<void> {
     await expect(this.selectedFieldCellAt(rowIndex, fieldIndex)).toBeVisible({
       timeout: 5_000,
+    });
+  }
+
+  async expectActiveCellError(text: string): Promise<void> {
+    await expect(this.activeCellError()).toContainText(text, {
+      timeout: 10_000,
+    });
+  }
+
+  async expectActiveEditorValue(value: string): Promise<void> {
+    await expect(this.activeEditor()).toHaveValue(value, { timeout: 5_000 });
+  }
+
+  async expectMultiSelectedCellCount(count: number): Promise<void> {
+    await expect(this.multiSelectedCells()).toHaveCount(count, {
+      timeout: 5_000,
+    });
+  }
+
+  async expectRowCheckboxChecked(rowIndex: number): Promise<void> {
+    await expect(this.checkboxNativeAt(rowIndex)).toBeChecked({
+      timeout: 5_000,
+    });
+  }
+
+  async expectRowModalVisibleFor(primaryValue: string): Promise<void> {
+    await expect(this.rowEditModal()).toBeVisible({ timeout: 10_000 });
+    await expect(this.rowEditModal()).toContainText(primaryValue, {
+      timeout: 10_000,
     });
   }
 
@@ -660,6 +765,7 @@ export class GridPage {
   }
 
   async expectRowIdentifierText(rowIndex: number, text: string): Promise<void> {
+    await this.page.mouse.move(0, 0);
     await expect(this.rowIdentifierContentAt(rowIndex)).toHaveText(text, {
       timeout: 10_000,
     });

--- a/e2e-tests/pages/database/gridPage.ts
+++ b/e2e-tests/pages/database/gridPage.ts
@@ -314,6 +314,81 @@ export class GridPage {
       .click({ position: { x: 5, y: 5 } });
   }
 
+  async renderedRowCount(): Promise<number> {
+    return await this.rightRows().count();
+  }
+
+  async reduceCurrentBufferToSlice(
+    startIndex: number,
+    limit: number,
+    viewportAlign: "start" | "end" = "start",
+  ): Promise<void> {
+    await this.page.evaluate(
+      async ({ start, rowLimit, align }) => {
+        const nuxtWindow = window as unknown as {
+          useNuxtApp?: () => { $store: any };
+        };
+        const store = nuxtWindow.useNuxtApp?.().$store;
+        if (!store) {
+          throw new Error("Expected Nuxt store to be available.");
+        }
+
+        const gridStore = ["page/view/grid", "view/grid"].find((namespace) =>
+          Object.prototype.hasOwnProperty.call(
+            store.getters,
+            `${namespace}/getAllRows`,
+          ),
+        );
+        if (!gridStore) {
+          throw new Error("Expected grid Vuex module to be registered.");
+        }
+
+        const rows = store.getters[`${gridStore}/getAllRows`];
+        if (rows.length < start + rowLimit) {
+          throw new Error(
+            `Expected at least ${start + rowLimit} buffered rows, got ${
+              rows.length
+            }.`,
+          );
+        }
+
+        const rowsInSlice = rows.slice(start, start + rowLimit);
+        const count = store.getters[`${gridStore}/getCount`];
+        const rowHeight = store.getters[`${gridStore}/getRowHeight`];
+        store.commit(`${gridStore}/ADD_ROWS`, {
+          rows: [],
+          prependToRows: -rows.length,
+          appendToRows: 0,
+          count,
+          bufferStartIndex: start,
+          bufferLimit: 0,
+        });
+        store.commit(`${gridStore}/ADD_ROWS`, {
+          rows: rowsInSlice,
+          prependToRows: 0,
+          appendToRows: rowsInSlice.length,
+          count,
+          bufferStartIndex: start,
+          bufferLimit: rowsInSlice.length,
+        });
+        if (align === "end") {
+          await store.dispatch(
+            `${gridStore}/visibleByScrollTop`,
+            count * rowHeight,
+          );
+        } else {
+          store.commit(`${gridStore}/SET_ROWS_INDEX`, {
+            startIndex: 0,
+            endIndex: rowsInSlice.length,
+            top: start * rowHeight,
+          });
+          store.commit(`${gridStore}/SET_SCROLL_TOP`, start * rowHeight);
+        }
+      },
+      { start: startIndex, rowLimit: limit, align: viewportAlign },
+    );
+  }
+
   /**
    * Right-click a row to open its context menu.
    * We right-click the RIGHT section row (field cell area) because the left
@@ -698,6 +773,20 @@ export class GridPage {
     await expect(this.rowWarningAt(rowIndex)).toContainText(text, {
       timeout: 10_000,
     });
+  }
+
+  async expectPrimaryRowHasWarning(
+    primaryText: string,
+    warningText: string,
+  ): Promise<void> {
+    const row = this.leftRows().filter({ hasText: primaryText });
+    await expect(row).toHaveClass(/grid-view__row--warning/, {
+      timeout: 10_000,
+    });
+    await expect(row.locator(".grid-view__row-warning")).toContainText(
+      warningText,
+      { timeout: 10_000 },
+    );
   }
 
   async expectRowNoWarning(rowIndex: number): Promise<void> {

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -56,6 +56,7 @@ const config: PlaywrightTestConfig = {
       name: "chrome",
       use: {
         ...devices["Desktop Chrome"],
+        ...(process.env.CI ? { channel: "chrome" } : {}),
       },
     },
     {

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -1,7 +1,10 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
+import path from "path";
 
-require("dotenv").config();
+// Resolve relative to this file so paths are correct regardless of cwd
+// (VS Code Playwright extension runs from the workspace root, not e2e-tests/).
+require("dotenv").config({ path: path.join(__dirname, ".env") });
 
 export const baserowConfig = {
   PUBLIC_WEB_FRONTEND_URL: process.env.PUBLIC_WEB_FRONTEND_URL
@@ -17,7 +20,7 @@ export const baserowConfig = {
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
-  testDir: "./tests",
+  testDir: path.join(__dirname, "tests"),
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -44,6 +47,8 @@ const config: PlaywrightTestConfig = {
     video: "on-first-retry",
     nuxt: {
       host: baserowConfig.PUBLIC_WEB_FRONTEND_URL,
+      // Disable fixture loading - test against running server, not local Nuxt app
+      fixture: false,
     },
   },
   projects: [

--- a/e2e-tests/tests/database/form_view_link_row.spec.ts
+++ b/e2e-tests/tests/database/form_view_link_row.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from "../baserowTest";
 import { createDatabase } from "../../fixtures/database/database";
 import { createTable, Table } from "../../fixtures/database/table";
 import { createField, Field } from "../../fixtures/database/field";
-import { getRows } from "../../fixtures/database/rows";
+import { listRows } from "../../fixtures/database/rows";
 import {
   createFormView,
   updateFormFieldOptions,
@@ -38,7 +38,7 @@ async function buildScenario(
     [namedRowName],
     [""],
   ]);
-  const linkedRows = await getRows(user, linkedTable);
+  const linkedRows = await listRows(user, linkedTable);
   const emptyRow = linkedRows.find((r) => !r.Name);
   if (!emptyRow) {
     throw new Error("Expected an empty-primary row in the linked table.");

--- a/e2e-tests/tests/database/grid/grid_interaction.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_interaction.spec.ts
@@ -23,8 +23,6 @@ import { pauseNextRequestWithSignal } from "../../../fixtures/network";
 
 type Setup = GridSetupResult;
 
-test.describe.configure({ mode: "serial" });
-
 async function pasteText(page: Page, text: string) {
   await page.evaluate((clipboardText) => {
     const data = new DataTransfer();
@@ -47,6 +45,7 @@ function multiSelectedFieldCells(page: Page) {
 // -----------------------------------------------------------------------------
 
 test.describe("9.1 Selection mechanics", () => {
+  test.describe.configure({ mode: "serial" });
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -172,6 +171,7 @@ test.describe("9.1 Selection mechanics", () => {
 // -----------------------------------------------------------------------------
 
 test.describe("9.2 Keyboard multi-cell selection", () => {
+  test.describe.configure({ mode: "serial" });
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -211,6 +211,7 @@ test.describe("9.2 Keyboard multi-cell selection", () => {
 // -----------------------------------------------------------------------------
 
 test.describe("4 Clipboard operations", () => {
+  test.describe.configure({ mode: "serial" });
   let g: Setup;
   let pasteFilter: Setup;
   let pasteSort: Setup;
@@ -456,6 +457,7 @@ test.describe("4 Clipboard operations", () => {
 // -----------------------------------------------------------------------------
 
 test.describe("10.1 Keyboard navigation", () => {
+  test.describe.configure({ mode: "serial" });
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -572,6 +574,7 @@ test.describe("10.1 Keyboard navigation", () => {
 // -----------------------------------------------------------------------------
 
 test.describe("11.1 Row hover actions", () => {
+  test.describe.configure({ mode: "serial" });
   let gUnsorted: Setup;
   let gSorted: Setup;
 
@@ -700,6 +703,7 @@ test.describe("11.2 Row context menu actions", () => {
 // -----------------------------------------------------------------------------
 
 test.describe("12.1 Checkbox row selection", () => {
+  test.describe.configure({ mode: "serial" });
   let g: Setup;
 
   test.beforeAll(async () => {

--- a/e2e-tests/tests/database/grid/grid_interaction.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_interaction.spec.ts
@@ -1,0 +1,477 @@
+/**
+ * Grid view - multi-cell selection, keyboard navigation, copy/paste, row hover.
+ *
+ * Catalogue sections covered:
+ *   section 8   Multi-cell selection (mechanics, copy/paste including overflow-create)
+ *   section 9   Keyboard navigation
+ *   section 10  Row hover actions
+ *
+ * Anti-flakiness:
+ *   - Keyboard navigation tests prove where selection moved by typing into
+ *     the newly selected cell and asserting the saved value.
+ *   - All count/visibility assertions use Playwright's built-in polling.
+ */
+
+import type { Page } from "@playwright/test";
+import { test, expect } from "../../baserowTest";
+import { GridPage } from "../../../pages/database/gridPage";
+import {
+  GridSetupResult,
+  resetRows,
+  setupGrid,
+} from "../../../fixtures/database/gridSetup";
+
+type Setup = GridSetupResult;
+
+test.describe.configure({ mode: "serial" });
+
+async function pasteText(page: Page, text: string) {
+  await page.evaluate((clipboardText) => {
+    const data = new DataTransfer();
+    data.setData("text/plain", clipboardText);
+    const event = new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: data,
+    });
+    document.dispatchEvent(event);
+  }, text);
+}
+
+function multiSelectedFieldCells(page: Page) {
+  return page.locator(".grid-view__right .grid-view__column--multi-select");
+}
+
+// -----------------------------------------------------------------------------
+// section 8.1  Selection mechanics
+// -----------------------------------------------------------------------------
+
+test.describe("8.1 Selection mechanics", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "SelectionDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Notes: "note A" },
+        { Name: "Bob", Score: 20, Notes: "note B" },
+        { Name: "Carol", Score: 30, Notes: "note C" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("8.1.1 clicking one field cell selects it and leaves no multi-select range visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.selectFieldCell(0, 0);
+
+    await grid.expectFieldSelected(0, 0);
+    await expect(page.locator(".grid-view__column--multi-select")).toHaveCount(
+      0,
+    );
+  });
+
+  test("8.1.2 shift-clicking another cell keeps the anchor selected and shows the rectangular range", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0); // head (Alice, Score)
+    await grid.expectFieldSelected(0, 0);
+    await grid.fieldCellAt(1, 1).click({ modifiers: ["Shift"] }); // tail (Bob, Notes)
+
+    // Both cells should be in the multi-select range
+    await expect(multiSelectedFieldCells(page)).toHaveCount(4, {
+      timeout: 5_000,
+    }); // 2 rows x 2 cols
+  });
+
+  test("8.1.3 dragging across cells shows a rectangular range that remains visible after mouseup", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    const fromCell = grid.fieldCellAt(0, 0); // Alice / Score
+    const toCell = grid.fieldCellAt(1, 1); // Bob   / Notes
+
+    const fromBox = await fromCell.boundingBox();
+    const toBox = await toCell.boundingBox();
+
+    if (!fromBox || !toBox)
+      throw new Error("Could not measure cell bounding boxes");
+
+    const cx = (box: { x: number; width: number }) => box.x + box.width / 2;
+    const cy = (box: { y: number; height: number }) => box.y + box.height / 2;
+
+    // Simulate a real drag: mousedown on the first cell, move to the last,
+    // then release. The { steps } option fires intermediate mousemove events
+    // so the grid's mouseover handler extends the selection incrementally.
+    await page.mouse.move(cx(fromBox), cy(fromBox));
+    await page.mouse.down();
+    await page.mouse.move(cx(toBox), cy(toBox), { steps: 5 });
+    await page.mouse.up();
+
+    // The selection must still be present after mouseup.
+    // This specifically tests the regression where mouseup clears
+    // the selection instead of just releasing the hold.
+    await expect(multiSelectedFieldCells(page)).toHaveCount(4, {
+      timeout: 5_000,
+    }); // 2 rows x 2 cols
+  });
+
+  test("8.1.4 Escape removes the visible multi-select range", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0);
+    await grid.expectFieldSelected(0, 0);
+    await grid.fieldCellAt(1, 1).click({ modifiers: ["Shift"] });
+    await expect(
+      page.locator(".grid-view__column--multi-select").first(),
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(page.locator(".grid-view__column--multi-select")).toHaveCount(
+      0,
+      { timeout: 5_000 },
+    );
+  });
+
+  test("8.1.5 clicking outside the grid removes the visible multi-select range", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0);
+    await grid.expectFieldSelected(0, 0);
+    await grid.fieldCellAt(1, 0).click({ modifiers: ["Shift"] });
+
+    await grid.clickAway();
+
+    await expect(page.locator(".grid-view__column--multi-select")).toHaveCount(
+      0,
+      { timeout: 5_000 },
+    );
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 8.3  Copy and paste
+// -----------------------------------------------------------------------------
+
+test.describe("8.3 Copy and paste", () => {
+  let g: Setup;
+  let pasteFilter: Setup;
+  let pasteFilterRemove: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "PasteDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Row1", Score: 10, Notes: "note1" },
+        { Name: "Row2", Score: 20, Notes: "note2" },
+        { Name: "Row3", Score: 30, Notes: "note3" },
+      ],
+    });
+    pasteFilter = await setupGrid({
+      dbName: "PasteFilterDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Keep", Score: 10 },
+        { Name: "Keep", Score: 20 },
+      ],
+      filters: [{ fieldName: "Name", type: "equal", value: "Keep" }],
+    });
+    pasteFilterRemove = await setupGrid({
+      dbName: "PasteFilterRemoveDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [{ Name: "Keep", Score: 10 }],
+      filters: [{ fieldName: "Name", type: "equal", value: "Keep" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await page
+      .context()
+      .grantPermissions(["clipboard-read", "clipboard-write"], {
+        origin: process.env.PUBLIC_WEB_FRONTEND_URL ?? "http://localhost:3000",
+      });
+  });
+
+  test("8.3.1 copy stores selected value in clipboard and paste immediately shows it in target cell", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    // Select Score cell of Row1 and copy
+    await grid.selectFieldCell(0, 0); // Row1 / Score
+    await grid.expectFieldSelected(0, 0);
+    await grid.copyShortcut();
+    await expect
+      .poll(async () =>
+        (await page.evaluate(() => navigator.clipboard.readText())).trim(),
+      )
+      .toBe("10");
+    const copiedText = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+
+    // Select Score cell of Row3 and paste
+    await grid.selectFieldCell(2, 0); // Row3 / Score
+    await pasteText(page, copiedText);
+
+    // Row3's Score should now be 10 (same as Row1)
+    await grid.expectFieldText(2, 0, "10");
+  });
+
+  test("8.3.4 pasting two lines on last row updates last row and immediately creates visible overflow row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    // Select the last row's primary field (Row3 / Name) and paste two rows
+    // across Name and Score.
+    await grid.selectPrimaryCell(2);
+    await pasteText(page, "OverflowA\t99\nOverflowB\t88");
+
+    // New rows should have been created for the overflow lines
+    await grid.expectRowCount(4); // 3 original + 1 new (Row3 updated + 1 new)
+    await grid.expectPrimaryVisible("OverflowA");
+    await grid.expectPrimaryVisible("OverflowB");
+  });
+
+  test("8.3.6 filter-breaking paste immediately shows pasted value with warning while row remains selected", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, pasteFilter.user);
+    await grid.goTo(pasteFilter.database, pasteFilter.table);
+    await grid.expectRowCount(2);
+
+    // Paste a value that breaks the filter - "Keep" -> "Gone"
+    await grid.selectPrimaryCell(0); // first Keep row / Name
+    await pasteText(page, "Gone");
+
+    // The pasted row should show a filter-mismatch warning while still selected
+    await grid.expectRowHasWarning(0);
+  });
+
+  test("8.3.7 deselecting after filter-breaking paste removes the pasted value from visible grid", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, pasteFilterRemove.user);
+    await grid.goTo(pasteFilterRemove.database, pasteFilterRemove.table);
+
+    await grid.selectPrimaryCell(0); // Keep / Name
+    await pasteText(page, "Gone");
+    await grid.expectRowHasWarning(0);
+
+    await grid.clickAway();
+
+    await grid.expectPrimaryNotVisible("Gone");
+    await grid.expectRowCount(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 9  Keyboard navigation
+// -----------------------------------------------------------------------------
+
+test.describe("9. Keyboard navigation", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "KeyboardDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Row1", Score: 10, Notes: "n1" },
+        { Name: "Row2", Score: 20, Notes: "n2" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Row1", Score: 10, Notes: "n1" },
+      { Name: "Row2", Score: 20, Notes: "n2" },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("9.1 Tab moves selection to next cell, typing opens editor there, and Enter saves visible value", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0); // Row1 / Score cell
+    await grid.expectFieldSelected(0, 0);
+    await page.keyboard.press("Tab");
+
+    await grid.expectFieldSelected(0, 1);
+    await page.keyboard.type("tabbed");
+    await expect(grid.activeEditor()).toHaveValue("tabbed", { timeout: 5_000 });
+    await grid.confirmWithEnter();
+    await grid.expectFieldText(0, 1, "tabbed");
+  });
+
+  test("9.3 pressing Enter on a selected cell shows the editor in that cell", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.startEditingField(0, 0); // Row1 / Score
+  });
+
+  test("9.4 Enter while editing saves visible value, moves focus down, and allows editing next row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.startEditingField(0, 1); // Row1 / Notes
+    await grid.type("Row1Updated");
+    await grid.confirmWithEnter();
+
+    await grid.expectFieldText(0, 1, "Row1Updated");
+
+    await page.keyboard.type("Row2Updated");
+    await expect(grid.activeEditor()).toHaveValue("Row2Updated", {
+      timeout: 5_000,
+    });
+    await grid.confirmWithEnter();
+    await grid.expectFieldText(1, 1, "Row2Updated");
+  });
+
+  test("9.5 Escape while editing discards typed draft and keeps original row visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.startEditingField(0, 0); // Row1 / Score
+    await grid.type("ShouldNotSave");
+    await grid.cancelEdit();
+
+    await grid.expectPrimaryVisible("Row1");
+    await grid.expectPrimaryNotVisible("ShouldNotSave");
+  });
+
+  test("9.6 arrow key moves selection to adjacent row without showing an editor", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0); // Row1 / Score
+    await grid.expectFieldSelected(0, 0);
+    await page.keyboard.press("ArrowDown");
+
+    // Row2's first cell should now be active and ready to edit - no editor opened
+    // until the user starts typing.
+    await expect(grid.activeEditor()).toHaveCount(0);
+    await grid.expectFieldSelected(1, 0);
+  });
+
+  test("9.7 typing while a cell is selected shows editor containing the typed characters", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 1); // Row1 / Notes cell (fieldIndex 1)
+    await grid.expectFieldSelected(0, 1);
+    await page.keyboard.type("42");
+
+    const editor = grid.activeEditor();
+    await expect(editor).toBeVisible({ timeout: 5_000 });
+    await expect(editor).toHaveValue("42");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 10.1  Row hover actions
+// -----------------------------------------------------------------------------
+
+test.describe("10.1 Row hover actions", () => {
+  let gUnsorted: Setup;
+  let gSorted: Setup;
+
+  test.beforeAll(async () => {
+    [gUnsorted, gSorted] = await Promise.all([
+      setupGrid({
+        dbName: "HoverDb",
+        fields: [{ name: "Score", type: "number" }],
+        rows: [
+          { Name: "Alice", Score: 10 },
+          { Name: "Bob", Score: 20 },
+        ],
+      }),
+      setupGrid({
+        dbName: "HoverSortedDb",
+        fields: [{ name: "Score", type: "number" }],
+        rows: [{ Name: "Alice", Score: 10 }],
+        sorts: [{ fieldName: "Name", order: "ASC" }],
+      }),
+    ]);
+  });
+
+  test("10.1.1 hovering a row shows the checkbox and hides the row count", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, gUnsorted.user);
+    await grid.goTo(gUnsorted.database, gUnsorted.table);
+
+    await grid.expectRowCountVisible(0);
+    await grid.expectRowCheckboxHidden(0);
+
+    await grid.hoverRow(0);
+
+    await grid.expectRowCheckboxVisible(0);
+    await grid.expectRowCountHidden(0);
+  });
+
+  test("10.1.2 moving the mouse away restores the row count and hides the checkbox", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, gUnsorted.user);
+    await grid.goTo(gUnsorted.database, gUnsorted.table);
+
+    await grid.hoverRow(0);
+    await grid.expectRowCheckboxVisible(0);
+
+    await grid.unhoverRow();
+
+    await grid.expectRowCountVisible(0);
+    await grid.expectRowCheckboxHidden(0);
+  });
+
+  test("10.1.3 drag handle is present in an unsorted view and absent when a sort is active", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, gUnsorted.user);
+    await grid.goTo(gUnsorted.database, gUnsorted.table);
+    await grid.expectRowDragHandlePresent(0);
+
+    const sortedGrid = new GridPage(page, gSorted.user);
+    await sortedGrid.goTo(gSorted.database, gSorted.table);
+    await sortedGrid.expectRowDragHandleAbsent(0);
+  });
+});

--- a/e2e-tests/tests/database/grid/grid_interaction.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_interaction.spec.ts
@@ -2,14 +2,13 @@
  * Grid view - multi-cell selection, keyboard navigation, copy/paste, row hover.
  *
  * Catalogue sections covered:
- *   section 8   Multi-cell selection (mechanics, copy/paste including overflow-create)
- *   section 9   Keyboard navigation
- *   section 10  Row hover actions
+ *   section 4   Clipboard operations
+ *   section 9   Multi-cell selection
+ *   section 10  Keyboard navigation
+ *   section 11  Row hover/context actions
+ *   section 12  Checkbox row selection
+ *   section 13  Row expand modal smoke coverage
  *
- * Anti-flakiness:
- *   - Keyboard navigation tests prove where selection moved by typing into
- *     the newly selected cell and asserting the saved value.
- *   - All count/visibility assertions use Playwright's built-in polling.
  */
 
 import type { Page } from "@playwright/test";
@@ -20,6 +19,7 @@ import {
   resetRows,
   setupGrid,
 } from "../../../fixtures/database/gridSetup";
+import { pauseNextRequestWithSignal } from "../../../fixtures/network";
 
 type Setup = GridSetupResult;
 
@@ -43,10 +43,10 @@ function multiSelectedFieldCells(page: Page) {
 }
 
 // -----------------------------------------------------------------------------
-// section 8.1  Selection mechanics
+// section 9.1  Selection mechanics
 // -----------------------------------------------------------------------------
 
-test.describe("8.1 Selection mechanics", () => {
+test.describe("9.1 Selection mechanics", () => {
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -69,7 +69,7 @@ test.describe("8.1 Selection mechanics", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("8.1.1 clicking one field cell selects it and leaves no multi-select range visible", async ({
+  test("9.1.1 clicking one field cell selects it and leaves no multi-select range visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -81,7 +81,7 @@ test.describe("8.1 Selection mechanics", () => {
     );
   });
 
-  test("8.1.2 shift-clicking another cell keeps the anchor selected and shows the rectangular range", async ({
+  test("9.1.2 shift-clicking another cell keeps the anchor selected and shows the rectangular range", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -96,7 +96,7 @@ test.describe("8.1 Selection mechanics", () => {
     }); // 2 rows x 2 cols
   });
 
-  test("8.1.3 dragging across cells shows a rectangular range that remains visible after mouseup", async ({
+  test("9.1.3 dragging across cells shows a rectangular range that remains visible after mouseup", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -129,7 +129,7 @@ test.describe("8.1 Selection mechanics", () => {
     }); // 2 rows x 2 cols
   });
 
-  test("8.1.4 Escape removes the visible multi-select range", async ({
+  test("9.1.4 Escape removes the visible multi-select range", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -149,7 +149,7 @@ test.describe("8.1 Selection mechanics", () => {
     );
   });
 
-  test("8.1.5 clicking outside the grid removes the visible multi-select range", async ({
+  test("9.1.5 clicking outside the grid removes the visible multi-select range", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -168,13 +168,52 @@ test.describe("8.1 Selection mechanics", () => {
 });
 
 // -----------------------------------------------------------------------------
-// section 8.3  Copy and paste
+// section 9.2  Keyboard multi-cell selection
 // -----------------------------------------------------------------------------
 
-test.describe("8.3 Copy and paste", () => {
+test.describe("9.2 Keyboard multi-cell selection", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "KeyboardSelectionDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Notes: "note A" },
+        { Name: "Bob", Score: 20, Notes: "note B" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("9.2.1 Shift+Arrow expands the selected range from one cell to a 2x2 area", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0);
+    await page.keyboard.press("Shift+ArrowRight");
+    await grid.expectMultiSelectedCellCount(2);
+    await page.keyboard.press("Shift+ArrowDown");
+    await grid.expectMultiSelectedCellCount(4);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 4  Clipboard operations
+// -----------------------------------------------------------------------------
+
+test.describe("4 Clipboard operations", () => {
   let g: Setup;
   let pasteFilter: Setup;
-  let pasteFilterRemove: Setup;
+  let pasteSort: Setup;
 
   test.beforeAll(async () => {
     g = await setupGrid({
@@ -198,27 +237,40 @@ test.describe("8.3 Copy and paste", () => {
       ],
       filters: [{ fieldName: "Name", type: "equal", value: "Keep" }],
     });
-    pasteFilterRemove = await setupGrid({
-      dbName: "PasteFilterRemoveDb",
+    pasteSort = await setupGrid({
+      dbName: "PasteSortDb",
       fields: [{ name: "Score", type: "number" }],
-      rows: [{ Name: "Keep", Score: 10 }],
-      filters: [{ fieldName: "Name", type: "equal", value: "Keep" }],
+      sorts: [{ fieldName: "Name", order: "ASC" }],
     });
   });
 
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
+    await resetRows(g, [
+      { Name: "Row1", Score: 10, Notes: "note1" },
+      { Name: "Row2", Score: 20, Notes: "note2" },
+      { Name: "Row3", Score: 30, Notes: "note3" },
+    ]);
     const grid = new GridPage(page, g.user);
     await grid.goTo(g.database, g.table);
-    await page
-      .context()
-      .grantPermissions(["clipboard-read", "clipboard-write"], {
-        origin: process.env.PUBLIC_WEB_FRONTEND_URL ?? "http://localhost:3000",
-      });
+    if (browserName === "chromium") {
+      await page
+        .context()
+        .grantPermissions(["clipboard-read", "clipboard-write"], {
+          origin:
+            process.env.PUBLIC_WEB_FRONTEND_URL ?? "http://localhost:3000",
+        });
+    }
   });
 
-  test("8.3.1 copy stores selected value in clipboard and paste immediately shows it in target cell", async ({
+  test("4.1.1 copy stores selected value in clipboard and paste immediately shows it in target cell", async ({
+    browserName,
     page,
   }) => {
+    test.skip(
+      browserName !== "chromium",
+      "Playwright cannot grant clipboard-read permission in Firefox.",
+    );
+
     const grid = new GridPage(page, g.user);
 
     // Select Score cell of Row1 and copy
@@ -238,11 +290,13 @@ test.describe("8.3 Copy and paste", () => {
     await grid.selectFieldCell(2, 0); // Row3 / Score
     await pasteText(page, copiedText);
 
-    // Row3's Score should now be 10 (same as Row1)
+    // Row3's Score should now be 10 (same as Row1); no loading spinner since
+    // the cell update is optimistic.
     await grid.expectFieldText(2, 0, "10");
+    await grid.expectNoRowsLoading();
   });
 
-  test("8.3.4 pasting two lines on last row updates last row and immediately creates visible overflow row", async ({
+  test("4.1.2 pasting two lines on last row updates last row and immediately creates visible overflow row", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -254,47 +308,154 @@ test.describe("8.3 Copy and paste", () => {
 
     // New rows should have been created for the overflow lines
     await grid.expectRowCount(4); // 3 original + 1 new (Row3 updated + 1 new)
-    await grid.expectPrimaryVisible("OverflowA");
-    await grid.expectPrimaryVisible("OverflowB");
+    await grid.expectPrimaryText(2, "OverflowA");
+    await grid.expectFieldText(2, 0, "99");
+    await grid.expectPrimaryText(3, "OverflowB");
+    await grid.expectFieldText(3, 0, "88");
   });
 
-  test("8.3.6 filter-breaking paste immediately shows pasted value with warning while row remains selected", async ({
+  test("4.2.1a filter-breaking paste shows warning, keeps selection, then removes row on deselect", async ({
     page,
   }) => {
+    await resetRows(pasteFilter, [{ Name: "Keep", Score: 10 }]);
     const grid = new GridPage(page, pasteFilter.user);
     await grid.goTo(pasteFilter.database, pasteFilter.table);
-    await grid.expectRowCount(2);
+    await grid.expectRowCount(1);
 
     // Paste a value that breaks the filter - "Keep" -> "Gone"
     await grid.selectPrimaryCell(0); // first Keep row / Name
     await pasteText(page, "Gone");
 
     // The pasted row should show a filter-mismatch warning while still selected
+    await grid.expectPrimaryText(0, "Gone");
+    await grid.expectPrimarySelected(0);
     await grid.expectRowHasWarning(0);
-  });
-
-  test("8.3.7 deselecting after filter-breaking paste removes the pasted value from visible grid", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, pasteFilterRemove.user);
-    await grid.goTo(pasteFilterRemove.database, pasteFilterRemove.table);
-
-    await grid.selectPrimaryCell(0); // Keep / Name
-    await pasteText(page, "Gone");
-    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
 
     await grid.clickAway();
 
     await grid.expectPrimaryNotVisible("Gone");
     await grid.expectRowCount(0);
   });
+
+  test("4.2.1b filter-breaking paste deselected before backend confirmation removes the row immediately", async ({
+    page,
+  }) => {
+    await resetRows(pasteFilter, [{ Name: "Keep", Score: 10 }]);
+    const grid = new GridPage(page, pasteFilter.user);
+    await grid.goTo(pasteFilter.database, pasteFilter.table);
+    await grid.expectRowCount(1);
+
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${pasteFilter.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await grid.selectPrimaryCell(0);
+    await pasteText(page, "Gone");
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Gone");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+
+    await grid.clickAway();
+    await grid.expectRowCount(0);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectRowCount(0);
+  });
+
+  test("4.3.1a sort-affecting paste shows Row has moved warning while selected then moves row on deselect", async ({
+    page,
+  }) => {
+    await resetRows(pasteSort, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, pasteSort.user);
+    await grid.goTo(pasteSort.database, pasteSort.table);
+    await grid.expectRowCount(2);
+
+    await grid.selectPrimaryCell(0); // Alice, sorts to position 1 after "Zara" replaces it
+    await pasteText(page, "Zara"); // Zara > Bob alphabetically
+
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+    await grid.expectPrimaryText(1, "Bob");
+
+    await grid.clickAway();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("4.3.1b sort-affecting paste deselected before backend confirmation moves row immediately on deselect", async ({
+    page,
+  }) => {
+    await resetRows(pasteSort, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, pasteSort.user);
+    await grid.goTo(pasteSort.database, pasteSort.table);
+    await grid.expectRowCount(2);
+
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${pasteSort.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await grid.selectPrimaryCell(0); // Alice
+    await pasteText(page, "Zara");
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+
+    await grid.clickAway();
+    // Warning was visible so row moves to sorted position immediately
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(0);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("4.4.1 Delete clears every value in the selected cell range", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0);
+    await grid.fieldCellAt(1, 1).click({ modifiers: ["Shift"] });
+    await grid.expectMultiSelectedCellCount(4);
+
+    await page.keyboard.press("Delete");
+
+    await grid.expectFieldEmpty(0, 0);
+    await grid.expectFieldEmpty(0, 1);
+    await grid.expectFieldEmpty(1, 0);
+    await grid.expectFieldEmpty(1, 1);
+    await grid.expectPrimaryText(0, "Row1");
+    await grid.expectFieldText(2, 0, "30");
+  });
 });
 
 // -----------------------------------------------------------------------------
-// section 9  Keyboard navigation
+// section 10.1  Keyboard navigation
 // -----------------------------------------------------------------------------
 
-test.describe("9. Keyboard navigation", () => {
+test.describe("10.1 Keyboard navigation", () => {
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -320,7 +481,7 @@ test.describe("9. Keyboard navigation", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("9.1 Tab moves selection to next cell, typing opens editor there, and Enter saves visible value", async ({
+  test("10.1.1 Tab moves selection to next cell, typing opens editor there, and Enter saves visible value", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -336,7 +497,7 @@ test.describe("9. Keyboard navigation", () => {
     await grid.expectFieldText(0, 1, "tabbed");
   });
 
-  test("9.3 pressing Enter on a selected cell shows the editor in that cell", async ({
+  test("10.1.2 pressing Enter on a selected cell shows the editor in that cell", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -344,7 +505,7 @@ test.describe("9. Keyboard navigation", () => {
     await grid.startEditingField(0, 0); // Row1 / Score
   });
 
-  test("9.4 Enter while editing saves visible value, moves focus down, and allows editing next row", async ({
+  test("10.1.3 Enter while editing saves visible value, moves focus down, and allows editing next row", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -363,20 +524,20 @@ test.describe("9. Keyboard navigation", () => {
     await grid.expectFieldText(1, 1, "Row2Updated");
   });
 
-  test("9.5 Escape while editing discards typed draft and keeps original row visible", async ({
+  test("10.1.4 Escape while editing discards typed draft and keeps original row visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
 
-    await grid.startEditingField(0, 0); // Row1 / Score
+    await grid.startEditingField(0, 1); // Row1 / Notes
     await grid.type("ShouldNotSave");
     await grid.cancelEdit();
 
-    await grid.expectPrimaryVisible("Row1");
-    await grid.expectPrimaryNotVisible("ShouldNotSave");
+    await expect(grid.activeEditor()).toHaveCount(0);
+    await grid.expectFieldText(0, 1, "n1");
   });
 
-  test("9.6 arrow key moves selection to adjacent row without showing an editor", async ({
+  test("10.1.5 arrow key moves selection to adjacent row without showing an editor", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -391,7 +552,7 @@ test.describe("9. Keyboard navigation", () => {
     await grid.expectFieldSelected(1, 0);
   });
 
-  test("9.7 typing while a cell is selected shows editor containing the typed characters", async ({
+  test("10.1.6 typing while a cell is selected shows editor containing the typed characters", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -407,10 +568,10 @@ test.describe("9. Keyboard navigation", () => {
 });
 
 // -----------------------------------------------------------------------------
-// section 10.1  Row hover actions
+// section 11.1  Row hover actions
 // -----------------------------------------------------------------------------
 
-test.describe("10.1 Row hover actions", () => {
+test.describe("11.1 Row hover actions", () => {
   let gUnsorted: Setup;
   let gSorted: Setup;
 
@@ -433,7 +594,7 @@ test.describe("10.1 Row hover actions", () => {
     ]);
   });
 
-  test("10.1.1 hovering a row shows the checkbox and hides the row count", async ({
+  test("11.1.1 hovering and unhovering a row toggles the checkbox and row count", async ({
     page,
   }) => {
     const grid = new GridPage(page, gUnsorted.user);
@@ -446,16 +607,6 @@ test.describe("10.1 Row hover actions", () => {
 
     await grid.expectRowCheckboxVisible(0);
     await grid.expectRowCountHidden(0);
-  });
-
-  test("10.1.2 moving the mouse away restores the row count and hides the checkbox", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, gUnsorted.user);
-    await grid.goTo(gUnsorted.database, gUnsorted.table);
-
-    await grid.hoverRow(0);
-    await grid.expectRowCheckboxVisible(0);
 
     await grid.unhoverRow();
 
@@ -463,7 +614,7 @@ test.describe("10.1 Row hover actions", () => {
     await grid.expectRowCheckboxHidden(0);
   });
 
-  test("10.1.3 drag handle is present in an unsorted view and absent when a sort is active", async ({
+  test("11.1.2 drag handle is present in an unsorted view and absent when a sort is active", async ({
     page,
   }) => {
     const grid = new GridPage(page, gUnsorted.user);
@@ -473,5 +624,116 @@ test.describe("10.1 Row hover actions", () => {
     const sortedGrid = new GridPage(page, gSorted.user);
     await sortedGrid.goTo(gSorted.database, gSorted.table);
     await sortedGrid.expectRowDragHandleAbsent(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 11.2 / 13.1  Row context menu and row modal
+// -----------------------------------------------------------------------------
+
+test.describe("11.2 Row context menu actions", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "ContextMenuDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 20 },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("11.2.1 context-menu insert below creates an empty row below the selected row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.rightClickRow(0);
+    await grid.clickContextItem("Insert row below");
+
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectPrimaryText(2, "Bob");
+  });
+
+  test("11.2.2 context-menu duplicate creates a copied row directly below the selected row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.rightClickRow(0);
+    await grid.clickContextItem("Duplicate row");
+
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectFieldText(1, 0, "10");
+    await grid.expectPrimaryText(2, "Bob");
+  });
+
+  test("13.1.1 context-menu enlarge opens and closes the row edit modal", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.openRowModalFromContext(0);
+    await grid.expectRowModalVisibleFor("Alice");
+    await grid.closeRowModal();
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 12.1  Checkbox row selection
+// -----------------------------------------------------------------------------
+
+test.describe("12.1 Checkbox row selection", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CheckboxSelectionDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Notes: "note A" },
+        { Name: "Bob", Score: 20, Notes: "note B" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("12.1.1 selecting a row checkbox clears an active multi-cell selection", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.selectFieldCell(0, 0);
+    await grid.fieldCellAt(1, 1).click({ modifiers: ["Shift"] });
+    await grid.expectMultiSelectedCellCount(4);
+
+    await grid.hoverRow(0);
+    await grid.checkboxAt(0).click();
+
+    await grid.expectRowCheckboxChecked(0);
+    await grid.expectMultiSelectedCellCount(0);
   });
 });

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -850,7 +850,7 @@ test.describe("2.1 Simple field edit", () => {
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
+    const { done } = await failNextRequest(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
       { method: "PATCH" },
@@ -858,7 +858,7 @@ test.describe("2.1 Simple field edit", () => {
     await startEditingPrimary(grid, 0);
     await grid.type("WillFail");
     await grid.confirmWithEnter();
-    await failed;
+    await done;
     await grid.expectErrorToast();
     await grid.expectRowCount(2);
     await grid.expectPrimaryText(0, "Alice");
@@ -983,7 +983,7 @@ test.describe("2.2 Edit with active filter on the edited field", () => {
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
+    const { done } = await failNextRequest(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
       { method: "PATCH" },
@@ -991,7 +991,7 @@ test.describe("2.2 Edit with active filter on the edited field", () => {
     await startEditingPrimary(grid, 0);
     await grid.type("Charlie");
     await grid.confirmWithEnter();
-    await failed;
+    await done;
     await grid.expectErrorToast();
     await grid.expectRowCount(1);
     await grid.expectPrimaryText(0, "Alice");
@@ -1486,13 +1486,13 @@ test.describe("3.1 Row deletion", () => {
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
+    const { done } = await failNextRequest(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
       { method: "DELETE" },
     );
     await deleteRowThroughContextMenu(grid, 1);
-    await failed;
+    await done;
     await grid.expectErrorToast();
     await grid.expectRowCount(2);
     await grid.expectPrimaryVisible("Alice");

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -3,17 +3,7 @@
  *
  * Catalogue sections: section 1 Row creation, section 2 Row update, section 3 Row deletion.
  *
- * ## Data isolation
- * Each describe block creates an isolated database in `beforeAll` (fields,
- * view config) and resets rows in `beforeEach` (row content). Tests within
- * each describe run serially so `resetRows` always fires before each test.
  *
- * ## Anti-flakiness
- * - All assertions use Playwright polling — no arbitrary timeouts.
- * - Network failures delivered via `failNextRequest` resolve only after the
- *   request has been intercepted, removing all timing races.
- * - Warning tests use Tab (not Enter) so the row stays selected long enough
- *   to assert the warning before deselect triggers removal.
  */
 
 import { test } from "../../baserowTest";
@@ -59,6 +49,13 @@ async function deleteRowThroughContextMenu(
 ): Promise<void> {
   await grid.rightClickRow(rowIndex);
   await grid.clickContextItem("Delete row");
+}
+
+function numberedRows(count: number): Record<string, unknown>[] {
+  return Array.from({ length: count }, (_, index) => ({
+    Name: `Row ${String(index + 1).padStart(3, "0")}`,
+    Score: index + 1,
+  }));
 }
 
 // -----------------------------------------------------------------------------
@@ -372,6 +369,68 @@ test.describe("1.3.2 Create with active formula-field sort (deferred)", () => {
     await grid.expectRowCount(1);
     await grid.expectPrimaryText(0, "Alice");
     await grid.expectRowNoWarning(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.3.3  Create with active sort where destination is outside buffer
+// -----------------------------------------------------------------------------
+
+test.describe("1.3.3 Create with active sort outside the current buffer", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudSortCreateOutsideBufferDb",
+      fields: [{ name: "Score", type: "number" }],
+      sorts: [{ fieldName: "Name", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, numberedRows(50));
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectPrimaryText(0, "Row 001");
+  });
+
+  test("1.3.3 sorted add at bottom moves to a destination above the current buffer after deselect", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.reduceCurrentBufferToSlice(20, 30, "end");
+    let lastRowIndex = (await grid.renderedRowCount()) - 1;
+    await grid.expectPrimaryText(lastRowIndex, "Row 050");
+
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    const newRowIndex = (await grid.renderedRowCount()) - 1;
+    await grid.expectPrimaryEmpty(newRowIndex);
+    await grid.expectRowLoading(newRowIndex);
+    await grid.expectRowNoWarning(newRowIndex);
+
+    pausedCreate.release();
+    await grid.expectRowNotLoading(newRowIndex);
+    await grid.expectRowHasWarning(newRowIndex);
+    await grid.expectRowWarningText(newRowIndex, "Row has moved");
+
+    await grid.clickAway();
+    lastRowIndex = (await grid.renderedRowCount()) - 1;
+    await grid.expectPrimaryText(lastRowIndex, "Row 050");
+    await grid.expectRowNoWarning(lastRowIndex);
+
+    await grid.goTo(g.database, g.table);
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Row 001");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
   });
 });
 
@@ -1326,6 +1385,65 @@ test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
     await grid.expectPrimaryText(1, "Alice");
     await grid.expectRowNoWarning(0);
     await grid.expectRowNoWarning(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.3.5  Edit with active sort where destination is outside buffer
+// -----------------------------------------------------------------------------
+
+test.describe("2.3.5 Edit with active sort outside the current buffer", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudSortUpdateOutsideBufferDb",
+      fields: [{ name: "Score", type: "number" }],
+      sorts: [{ fieldName: "Name", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, numberedRows(50));
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectPrimaryText(0, "Row 001");
+  });
+
+  test("2.3.5 sort-affecting edit moves the row outside the current buffer after deselect", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.reduceCurrentBufferToSlice(20, 30, "end");
+    await grid.expectPrimaryVisible("Row 050");
+
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Row 000");
+    await grid.expectActiveEditorValue("Row 000");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryVisible("Row 000");
+    await grid.expectPrimaryRowHasWarning("Row 000", "Row has moved");
+
+    await grid.clickAway();
+    await grid.expectPrimaryNotVisible("Row 000");
+    await grid.expectRowNoWarning(0);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectPrimaryNotVisible("Row 000");
+
+    await grid.goTo(g.database, g.table);
+    await grid.expectPrimaryText(0, "Row 000");
+    await grid.expectPrimaryText(1, "Row 001");
+    await grid.expectRowNoWarning(0);
   });
 });
 

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -985,10 +985,10 @@ test.describe("2.2.5 Edit with formula-field filter (deferred)", () => {
     await grid.confirmWithTab();
     await pausedUpdate.intercepted;
 
-    // Typed value visible immediately (field edit is optimistic); no loading
-    // spinner because the row update is optimistic.
+    // Typed value is visible immediately, but formula-derived filter results
+    // need the backend response, so the row remains loading while pending.
     await grid.expectPrimaryText(0, "Al");
-    await grid.expectRowNotLoading(0);
+    await grid.expectRowLoading(0);
     // No warning while pending — formula filter cannot be evaluated locally
     await grid.expectRowNoWarning(0);
     await grid.expectRowCount(1);
@@ -997,6 +997,7 @@ test.describe("2.2.5 Edit with formula-field filter (deferred)", () => {
     // Warning appears only after the backend responds with the formula result
     await grid.expectRowHasWarning(0);
     await grid.expectRowWarningText(0, "Row does not match filters");
+    await grid.expectRowNotLoading(0);
     await grid.expectRowCount(1);
   });
 
@@ -1162,7 +1163,7 @@ test.describe("2.3 Edit with active sort on the edited field", () => {
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
+    const pausedUpdate = await pauseNextRequestWithSignal(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
       { method: "PATCH" },
@@ -1170,11 +1171,13 @@ test.describe("2.3 Edit with active sort on the edited field", () => {
     await startEditingPrimary(grid, 0);
     await grid.type("Zara");
     await grid.confirmWithEnter();
-    // Optimistic state: typed value and sort warning visible before the PATCH resolves.
-    await grid.expectPrimaryText(0, "Zara");
-    await grid.expectRowHasWarning(0);
-    await grid.expectRowWarningText(0, "Row has moved");
-    await failed;
+    await pausedUpdate.intercepted;
+    // Enter commits and clears the selection, so the locally-sortable row moves
+    // immediately while the PATCH is still pending.
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(1);
+    pausedUpdate.fail();
     await grid.expectErrorToast();
     await grid.expectRowCount(2);
     await grid.expectPrimaryText(0, "Alice");
@@ -1243,10 +1246,10 @@ test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
     await grid.confirmWithTab();
     await pausedUpdate.intercepted;
 
-    // Typed value visible immediately (field edit is optimistic); no loading
-    // spinner because the row update is optimistic.
+    // Typed value is visible immediately, but formula-derived sort results
+    // need the backend response, so the row remains loading while pending.
     await grid.expectPrimaryText(0, "Alexander");
-    await grid.expectRowNotLoading(0);
+    await grid.expectRowLoading(0);
     // No move warning while pending — formula sort cannot be evaluated locally
     await grid.expectRowNoWarning(0);
     await grid.expectRowCount(2);
@@ -1255,6 +1258,7 @@ test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
     // Warning appears only after the backend responds with the formula result
     await grid.expectRowHasWarning(0);
     await grid.expectRowWarningText(0, "Row has moved");
+    await grid.expectRowNotLoading(0);
     await grid.expectPrimaryText(0, "Alexander");
     await grid.expectRowCount(2);
 
@@ -1301,7 +1305,7 @@ test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
+    const pausedUpdate = await pauseNextRequestWithSignal(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
       { method: "PATCH" },
@@ -1309,11 +1313,13 @@ test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
     await startEditingPrimary(grid, 0);
     await grid.type("Alexander");
     await grid.confirmWithEnter();
+    await pausedUpdate.intercepted;
     // Optimistic state: typed value visible immediately; no warning because the
     // frontend cannot evaluate the formula sort locally.
     await grid.expectPrimaryText(0, "Alexander");
+    await grid.expectRowLoading(0);
     await grid.expectRowNoWarning(0);
-    await failed;
+    pausedUpdate.fail();
     await grid.expectErrorToast();
     await grid.expectRowCount(2);
     await grid.expectPrimaryText(0, "Al");

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Grid view - row CRUD and mismatch warning tests.
  *
- * Catalogue sections: section 1 Row creation, section 2 Row update, section 3 Row deletion, section 14 Warning.
+ * Catalogue sections: section 1 Row creation, section 2 Row update, section 3 Row deletion.
  *
  * ## Data isolation
  * Each describe block creates an isolated database in `beforeAll` (fields,
@@ -9,18 +9,11 @@
  * each describe run serially so `resetRows` always fires before each test.
  *
  * ## Anti-flakiness
- * - All assertions use Playwright polling - no arbitrary timeouts.
+ * - All assertions use Playwright polling — no arbitrary timeouts.
  * - Network failures delivered via `failNextRequest` resolve only after the
  *   request has been intercepted, removing all timing races.
  * - Warning tests use Tab (not Enter) so the row stays selected long enough
  *   to assert the warning before deselect triggers removal.
- *
- * ## Known issue: section 1.1.3 and section 2.3.4 (BE-500 rollback)
- * `createNewRow` in the flat grid is dispatched twice when both the left
- * and right sections have @add-row handlers. The second dispatch fires a
- * second batchCreate that `failNextRequest` does not intercept (one-shot).
- * These tests are marked `@skip-rollback` and tracked in the catalogue as
- * needing a grid fix to prevent the double-dispatch.
  */
 
 import { test } from "../../baserowTest";
@@ -90,16 +83,7 @@ test.describe("1.1 Basic add row", () => {
     await waitForInitialRows(grid, 1);
   });
 
-  test("1.1.1 add row without sort/filter appends an empty row and clears loading after confirmation", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await addRowAndWaitForCreatedRow(grid, 2);
-    await grid.expectPrimaryEmpty(1);
-    await grid.expectFieldEmpty(1, 0);
-  });
-
-  test("1.1.2 paused create shows the empty optimistic row with row loading spinner, then clears loading in place", async ({
+  test("1.1.1 paused create shows the empty optimistic row with row loading spinner, then clears loading in place", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -121,13 +105,42 @@ test.describe("1.1 Basic add row", () => {
     await grid.expectPrimaryText(0, "Alice");
     await grid.expectPrimaryEmpty(1);
   });
+
+  test("1.1.3 failed create is rolled back and the optimistic row disappears", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    // Optimistic row is visible with loading spinner while the POST is in-flight.
+    await grid.expectRowCount(2);
+    await grid.expectRowLoading(1);
+    pausedCreate.fail();
+    await grid.expectErrorToast();
+    // Poll until the optimistic row is gone after rollback.
+    // If a second POST fires and succeeds (double-dispatch), count stays at 2
+    // and this assertion times out — making the bug immediately visible.
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+  });
+
+  test("1.1.2 adding a row selects the new primary cell", async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await addRowAndWaitForCreatedRow(grid, 2);
+    await grid.expectPrimarySelected(1);
+  });
 });
 
 // -----------------------------------------------------------------------------
-// section 1.2  Create with active sort - mismatch warning + move
+// section 1.3  Create with active sort - mismatch warning + move
 // -----------------------------------------------------------------------------
 
-test.describe("1.2 Create with active sort", () => {
+test.describe("1.3 Create with active sort", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -149,7 +162,7 @@ test.describe("1.2 Create with active sort", () => {
     await waitForInitialRows(grid, 2);
   });
 
-  test("1.2.1a paused simple-sorted add kept selected immediately shows Row has moved until deselect", async ({
+  test("1.3.1a paused simple-sorted add kept selected immediately shows Row has moved until deselect", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -182,7 +195,7 @@ test.describe("1.2 Create with active sort", () => {
     await grid.expectRowNoWarning(0);
   });
 
-  test("1.2.1b paused simple-sorted add deselected before confirmation moves immediately and finalizes without warning", async ({
+  test("1.3.1b paused simple-sorted add deselected before confirmation moves immediately and finalizes without warning", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -218,93 +231,155 @@ test.describe("1.2 Create with active sort", () => {
     await grid.expectRowNoWarning(0);
   });
 
-  test("1.2.2a paused simple-sorted edit kept selected immediately shows Row has moved", async ({
+  test("1.3.1c failed sort-affected create rolls back the optimistic row and restores row order", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    const pausedUpdate = await pauseNextRequestWithSignal(
+    const pausedCreate = await pauseNextRequestWithSignal(
       page,
       `**/api/database/rows/table/${g.table.id}/**`,
-      { method: "PATCH" },
+      { method: "POST" },
     );
-
-    await startEditingPrimary(grid, 0);
-    await grid.type("Zara");
-    await grid.confirmWithTab();
-    await pausedUpdate.intercepted;
-    await grid.expectPrimaryText(0, "Zara");
-    await grid.expectRowHasWarning(0);
-    await grid.expectRowWarningText(0, "Row has moved");
-    await grid.expectRowNotLoading(0);
-
-    pausedUpdate.release();
-    await grid.expectRowHasWarning(0);
-    await grid.expectRowWarningText(0, "Row has moved");
-  });
-
-  test("1.2.2b paused simple-sorted edit deselected before confirmation moves immediately without warning", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    const pausedUpdate = await pauseNextRequestWithSignal(
-      page,
-      `**/api/database/rows/table/${g.table.id}/**`,
-      { method: "PATCH" },
-    );
-
-    await startEditingPrimary(grid, 0);
-    await grid.type("Zara");
-    await grid.confirmWithTab();
-    await pausedUpdate.intercepted;
-    await grid.expectPrimaryText(0, "Zara");
-    await grid.expectPrimaryText(1, "Bob");
-    await grid.expectRowHasWarning(0);
-    await grid.expectRowWarningText(0, "Row has moved");
-
-    await grid.clickAway();
-    await grid.expectPrimaryText(0, "Bob");
-    await grid.expectPrimaryText(1, "Zara");
-    await grid.expectRowNoWarning(1);
-
-    pausedUpdate.release();
-    await grid.expectNoRowsLoading();
-    await grid.expectPrimaryText(0, "Bob");
-    await grid.expectPrimaryText(1, "Zara");
-    await grid.expectRowNoWarning(1);
-  });
-
-  test("1.2.3 deselecting a sort-mismatched edited row moves the visible value to its sorted position and clears warning", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Zara");
-    await grid.confirmWithTab();
-    await grid.expectRowHasWarning(0);
-    await grid.selectFieldCell(1, 0);
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    // Optimistic row is appended at the bottom with loading spinner and immediate warning.
+    await grid.expectRowCount(3);
+    await grid.expectRowLoading(2);
+    await grid.expectRowHasWarning(2);
+    await grid.expectRowWarningText(2, "Row has moved");
+    pausedCreate.fail();
+    await grid.expectErrorToast();
     await grid.expectRowCount(2);
-    await grid.expectPrimaryVisible("Zara");
-    await grid.expectRowNoWarning(0);
-  });
-
-  test("1.2.4 Escape during sort-mismatched edit restores original value, clears warning, and leaves row in place", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Zara");
-    await grid.cancelEdit();
     await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
     await grid.expectRowNoWarning(0);
-    await grid.expectRowCount(2);
+    await grid.expectRowNoWarning(1);
   });
 });
 
 // -----------------------------------------------------------------------------
-// section 1.3  Create with active filter - mismatch warning + removal
+// section 1.3.2  Create with active formula-field sort — deferred move
 // -----------------------------------------------------------------------------
 
-test.describe("1.3 Create with active filter", () => {
+test.describe("1.3.2 Create with active formula-field sort (deferred)", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFormulaCreateSortDb",
+      fields: [
+        {
+          name: "NameLength",
+          type: "formula",
+          settings: { formula: "length(field('Name'))" },
+        },
+      ],
+      sorts: [{ fieldName: "NameLength", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice" }]); // length 5, sorts after an empty row
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("1.3.2a paused formula-sorted create shows no move warning while pending then shows warning after backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowLoading(1);
+    // No move warning while pending — formula sort cannot be evaluated locally
+    await grid.expectRowNoWarning(1);
+
+    pausedCreate.release();
+    await grid.expectRowNotLoading(1);
+    // Warning appears only after the backend responds with the formula result
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row has moved");
+    await grid.expectRowCount(2);
+
+    await grid.clickAway();
+    // Row moves to its sorted position (length 0 < length 5)
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("1.3.2b deselecting before the create request completes keeps the row in place then moves it after the backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectRowNoWarning(1);
+
+    await grid.clickAway();
+    // Row stays at the bottom because the frontend has not yet received the
+    // backend-computed sort value
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowLoading(1);
+
+    pausedCreate.release();
+    await grid.expectNoRowsLoading();
+    // Row moves to its sorted position after the backend responds
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("1.3.2c failed formula-sort-affected create rolls back the optimistic row and restores row order", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    // Optimistic row visible with spinner; no move warning because the frontend
+    // cannot evaluate the formula sort locally.
+    await grid.expectRowCount(2);
+    await grid.expectRowLoading(1);
+    await grid.expectRowNoWarning(1);
+    pausedCreate.fail();
+    await grid.expectErrorToast();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.2  Create with active filter - mismatch warning + removal
+// -----------------------------------------------------------------------------
+
+test.describe("1.2 Create with active filter", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -323,7 +398,7 @@ test.describe("1.3 Create with active filter", () => {
     await grid.expectRowCount(1);
   });
 
-  test("1.3.1a paused simple-filtered add kept selected immediately shows filter warning until deselect", async ({
+  test("1.2.1a paused simple-filtered add kept selected immediately shows filter warning until deselect", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -355,7 +430,7 @@ test.describe("1.3 Create with active filter", () => {
     await grid.expectRowNoWarning(0);
   });
 
-  test("1.3.1b paused simple-filtered add deselected before confirmation is removed immediately", async ({
+  test("1.2.1b paused simple-filtered add deselected before confirmation is removed immediately", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -386,18 +461,389 @@ test.describe("1.3 Create with active filter", () => {
     await grid.expectRowNoWarning(0);
   });
 
-  test("1.3.1d matching filtered edit keeps the typed value visible with no warning and no row removal", async ({
+  test("1.2.1d failed filter-affected create rolls back the optimistic row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    // Optimistic row visible with loading spinner and immediate filter warning.
+    await grid.expectRowCount(2);
+    await grid.expectRowLoading(1);
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+    pausedCreate.fail();
+    await grid.expectErrorToast();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.2.1c  Newly created row corrected to match active filter
+// -----------------------------------------------------------------------------
+
+test.describe("1.2.1c Newly created row corrected to match active filter", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFilter1c3Db",
+      fields: [{ name: "Score", type: "number" }],
+      filters: [{ fieldName: "Name", type: "not_empty", value: "" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("1.2.1c typing a value that matches the active filter into the new row clears the warning and keeps the row visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.addRow();
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+
+    await startEditingPrimary(grid, 1);
+    await grid.type("Bob");
+    await grid.confirmWithTab();
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectRowNoWarning(1);
+    await grid.expectRowCount(2);
+
+    await grid.clickAway();
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectRowNoWarning(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.2.2  Create with active formula-field filter — deferred warning
+// -----------------------------------------------------------------------------
+
+test.describe("1.2.2 Create with active formula-field filter (deferred)", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFormulaCreateFilterDb",
+      fields: [
+        {
+          name: "NameLength",
+          type: "formula",
+          settings: { formula: "length(field('Name'))" },
+        },
+      ],
+      filters: [{ fieldName: "NameLength", type: "higher_than", value: "3" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice" }]); // length 5, matches > 3
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("1.2.2a paused formula-filtered create shows no warning while pending then shows warning after backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowLoading(1);
+    // No warning while pending — formula filter cannot be evaluated locally
+    await grid.expectRowNoWarning(1);
+
+    pausedCreate.release();
+    await grid.expectRowNotLoading(1);
+    // Warning appears only after the backend responds with the formula result
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+    await grid.expectRowCount(2);
+
+    await grid.clickAway();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+  });
+
+  test("1.2.2b deselecting before the create request completes keeps the row visible until the backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectRowLoading(1);
+    await grid.expectRowNoWarning(1);
+
+    await grid.clickAway();
+    // Row stays visible because the frontend has not yet received the formula result
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryEmpty(1);
+
+    pausedCreate.release();
+    await grid.expectNoRowsLoading();
+    // Row is removed after the backend responds with the formula result
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+  });
+
+  test("1.2.2c failed formula-filter-affected create rolls back the optimistic row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    // Optimistic row visible with loading spinner; no warning because the
+    // frontend cannot evaluate the formula filter locally.
+    await grid.expectRowCount(2);
+    await grid.expectRowLoading(1);
+    await grid.expectRowNoWarning(1);
+    pausedCreate.fail();
+    await grid.expectErrorToast();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.4  Task queue — update during pending create
+// -----------------------------------------------------------------------------
+
+test.describe("1.4 Task queue — update during pending create", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "TaskQueueDb",
+      fields: [{ name: "Score", type: "number" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("1.4.1 typing in a field of a pending row shows the value immediately and saves after create completes", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowLoading(1);
+
+    await grid.startEditingField(1, 0);
+    await grid.type("99");
+    await grid.clickAway();
+    await grid.expectFieldText(1, 0, "99");
+
+    pausedCreate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectFieldText(1, 0, "99");
+  });
+
+  test("1.4.2 PATCH is not sent to the network until after the create request completes", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+
+    await grid.startEditingField(1, 0);
+    await grid.type("42");
+    await grid.clickAway();
+
+    // Register the PATCH interceptor now, after the POST is already held.
+    // If the queue did not exist the PATCH would have fired before this point
+    // and the intercepted promise below would never resolve.
+    const pausedPatch = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    pausedCreate.release();
+    await pausedPatch.intercepted;
+
+    pausedPatch.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectFieldText(1, 0, "42");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.1  Simple field edit
+// -----------------------------------------------------------------------------
+
+test.describe("2.1 Simple field edit", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "EditBasicDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Email", type: "email" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10, Email: "alice@example.com" },
+      { Name: "Bob", Score: 20, Email: "bob@example.com" },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 2);
+  });
+
+  test("2.1.1 Enter save makes the typed primary value visible and removes the original value from the grid", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
     await startEditingPrimary(grid, 0);
-    await grid.type("Alice");
-    await grid.confirmWithTab();
-    await grid.expectPrimaryVisible("Alice");
-    await grid.expectRowNoWarning(0);
+    await grid.type("Alicia");
+    await grid.confirmWithEnter();
+    await grid.expectPrimaryText(0, "Alicia");
+    await grid.expectPrimaryNotVisible("Alice");
+    await grid.expectRowNotLoading(0);
   });
 
-  test("1.3.2a paused non-matching simple-filtered edit kept selected immediately shows filter warning", async ({
+  test("2.1.4 Escape while editing discards the typed value and keeps the original value visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 1);
+    await grid.type("Changed");
+    await grid.cancelEdit();
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryNotVisible("Changed");
+    await grid.expectRowNotLoading(1);
+  });
+
+  test("2.1.2 blur save makes the typed value visible after clicking outside the cell", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alicia");
+    await grid.clickAway();
+    await grid.expectPrimaryVisible("Alicia");
+    await grid.expectNoRowsLoading();
+  });
+
+  test("2.1.3 failed PATCH rolls back the typed value and shows an error toast", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("WillFail");
+    await grid.confirmWithEnter();
+    await failed;
+    await grid.expectErrorToast();
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryNotVisible("WillFail");
+  });
+
+  test("2.1.5 invalid email edit shows validation error and keeps editor open", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.startEditingField(0, 1);
+    await grid.type("not-an-email");
+    await grid.expectActiveCellError("Invalid email");
+    await grid.confirmWithEnter();
+    await grid.expectActiveCellError("Invalid email");
+    await grid.expectActiveEditorValue("not-an-email");
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.2  Edit with active filter - mismatch warning + removal
+// -----------------------------------------------------------------------------
+
+test.describe("2.2 Edit with active filter on the edited field", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "EditFilterDb",
+      fields: [{ name: "Score", type: "number" }],
+      filters: [{ fieldName: "Name", type: "equal", value: "Alice" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.2.1a paused non-matching filtered edit shows warning while selected until confirmation", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -422,7 +868,7 @@ test.describe("1.3 Create with active filter", () => {
     await grid.expectRowCount(1);
   });
 
-  test("1.3.2b paused non-matching simple-filtered edit deselected before confirmation is removed immediately", async ({
+  test("2.2.1b paused non-matching filtered edit deselected before confirmation is removed immediately", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -450,157 +896,7 @@ test.describe("1.3 Create with active filter", () => {
     await grid.expectPrimaryNotVisible("Charlie");
   });
 
-  test("1.3.3 deselecting a filter-mismatched edited row removes the typed value from the visible grid", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Charlie");
-    await grid.confirmWithTab();
-    await grid.expectRowHasWarning(0);
-    await grid.clickAway();
-    await grid.expectRowCount(0);
-    await grid.expectPrimaryNotVisible("Charlie");
-  });
-
-  test("1.3.4 Escape during filter-mismatched edit restores matching value, clears warning, and keeps row visible", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Charlie");
-    await grid.cancelEdit();
-    await grid.expectPrimaryVisible("Alice");
-    await grid.expectRowNoWarning(0);
-    await grid.expectRowCount(1);
-  });
-});
-
-// -----------------------------------------------------------------------------
-// section 2.1  Simple field edit
-// -----------------------------------------------------------------------------
-
-test.describe("2.1 Simple field edit", () => {
-  test.describe.configure({ mode: "serial" });
-  let g: Setup;
-
-  test.beforeAll(async () => {
-    g = await setupGrid({
-      dbName: "EditBasicDb",
-      fields: [{ name: "Score", type: "number" }],
-    });
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await resetRows(g, [
-      { Name: "Alice", Score: 10 },
-      { Name: "Bob", Score: 20 },
-    ]);
-    const grid = new GridPage(page, g.user);
-    await grid.goTo(g.database, g.table);
-    await waitForInitialRows(grid, 2);
-  });
-
-  test("2.1.1 Enter save makes the typed primary value visible and removes the original value from the grid", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Alicia");
-    await grid.confirmWithEnter();
-    await grid.expectPrimaryText(0, "Alicia");
-    await grid.expectPrimaryNotVisible("Alice");
-  });
-
-  test("2.1.2 Escape while editing discards the typed value and keeps the original value visible", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 1);
-    await grid.type("Changed");
-    await grid.cancelEdit();
-    await grid.expectPrimaryText(1, "Bob");
-    await grid.expectPrimaryNotVisible("Changed");
-  });
-
-  test("2.1.3 blur save makes the typed value visible after clicking outside the cell", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Alicia");
-    await grid.clickAway();
-    await grid.expectPrimaryVisible("Alicia");
-  });
-
-  test("2.1.4 failed PATCH is intercepted after typed value is submitted and the grid remains rendered with both rows", async ({
-    page,
-  }) => {
-    // Verifies that `failNextRequest` correctly intercepts the PATCH and the grid
-    // does not crash. Full rollback verification belongs in unit tests where the
-    // task-queue timing is deterministic.
-    const grid = new GridPage(page, g.user);
-    const failed = failNextRequest(
-      page,
-      `**/api/database/rows/table/${g.table.id}/**`,
-      { method: "PATCH" },
-    );
-    await startEditingPrimary(grid, 0);
-    await grid.type("WillFail");
-    await grid.confirmWithEnter();
-    await failed; // 500 was delivered - test passes if this resolves
-    await grid.expectRowCount(2); // grid still has both rows (no crash)
-  });
-});
-
-// -----------------------------------------------------------------------------
-// section 2.3  Edit with active filter - mismatch warning + removal
-// -----------------------------------------------------------------------------
-
-test.describe("2.3 Edit with active filter on the edited field", () => {
-  test.describe.configure({ mode: "serial" });
-  let g: Setup;
-
-  test.beforeAll(async () => {
-    g = await setupGrid({
-      dbName: "EditFilterDb",
-      fields: [{ name: "Score", type: "number" }],
-      filters: [{ fieldName: "Name", type: "equal", value: "Alice" }],
-    });
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
-    const grid = new GridPage(page, g.user);
-    await grid.goTo(g.database, g.table);
-    await grid.expectRowCount(1);
-  });
-
-  test("2.3.1 non-matching filtered edit shows typed value and warning while selected, without removing row", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Charlie");
-    await grid.confirmWithTab();
-    await grid.expectRowHasWarning(0);
-    await grid.expectRowCount(1);
-  });
-
-  test("2.3.1b deselecting a filter-mismatched edit removes the typed value from the visible grid", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await startEditingPrimary(grid, 0);
-    await grid.type("Charlie");
-    await grid.confirmWithTab();
-    await grid.expectRowHasWarning(0);
-    await grid.clickAway();
-    await grid.expectRowCount(0);
-    await grid.expectPrimaryNotVisible("Charlie");
-  });
-
-  test("2.3.2 Escape during filter-mismatched edit restores matching value, clears warning, and keeps row visible", async ({
+  test("2.2.4 Escape during filter-mismatched edit restores matching value, clears warning, and keeps row visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -612,7 +908,7 @@ test.describe("2.3 Edit with active filter on the edited field", () => {
     await grid.expectRowCount(1);
   });
 
-  test("2.3.3 saving the same matching value keeps row visible and produces no warning", async ({
+  test("2.2.3 saving the same matching value keeps row visible and produces no warning", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -621,9 +917,10 @@ test.describe("2.3 Edit with active filter on the edited field", () => {
     await grid.confirmWithEnter();
     await grid.expectRowNoWarning(0);
     await grid.expectRowCount(1);
+    await grid.expectNoRowsLoading();
   });
 
-  test("2.3.4 failed filter-affecting PATCH is intercepted and the filtered grid remains rendered", async ({
+  test("2.2.2 failed filter-affecting PATCH rolls back the typed value and shows an error toast", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -636,15 +933,155 @@ test.describe("2.3 Edit with active filter on the edited field", () => {
     await grid.type("Charlie");
     await grid.confirmWithEnter();
     await failed;
-    await grid.expectRowCount(1); // filter still shows Alice's row (the grid didn't crash)
+    await grid.expectErrorToast();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryNotVisible("Charlie");
+    await grid.expectRowNoWarning(0);
   });
 });
 
 // -----------------------------------------------------------------------------
-// section 2.5  Edit with active sort - mismatch warning + move
+// section 2.2  Edit with formula-field filter (deferred) — deferred warning
 // -----------------------------------------------------------------------------
 
-test.describe("2.5 Edit with active sort on the edited field", () => {
+test.describe("2.2.5 Edit with formula-field filter (deferred)", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFormulaEditFilterDb",
+      fields: [
+        {
+          name: "NameLength",
+          type: "formula",
+          settings: { formula: "length(field('Name'))" },
+        },
+      ],
+      filters: [{ fieldName: "NameLength", type: "higher_than", value: "3" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice" }]); // length 5, matches > 3
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.2.5a paused formula-filtered edit shows typed value immediately but no warning until backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Al"); // length 2, does not match > 3
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+
+    // Typed value visible immediately (field edit is optimistic); no loading
+    // spinner because the row update is optimistic.
+    await grid.expectPrimaryText(0, "Al");
+    await grid.expectRowNotLoading(0);
+    // No warning while pending — formula filter cannot be evaluated locally
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(1);
+
+    pausedUpdate.release();
+    // Warning appears only after the backend responds with the formula result
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+    await grid.expectRowCount(1);
+  });
+
+  test("2.2.5b deselecting after backend confirmation removes the formula-filtered row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Al");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectRowNoWarning(0);
+
+    pausedUpdate.release();
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+
+    await grid.clickAway();
+    await grid.expectRowCount(0);
+  });
+
+  test("2.2.5c deselecting before backend confirmation keeps the row visible until the backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Al");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Al");
+    await grid.expectRowNoWarning(0);
+
+    await grid.clickAway();
+    // Row stays visible because the frontend has not yet received the formula result
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Al");
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    // Row is removed after the backend responds with the formula result
+    await grid.expectRowCount(0);
+  });
+
+  test("2.2.5d failed formula-filter-affecting PATCH restores the original row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("Al");
+    await grid.confirmWithEnter();
+    await pausedUpdate.intercepted;
+    // Typed value visible immediately; no warning because the frontend cannot
+    // evaluate the formula filter locally.
+    await grid.expectPrimaryText(0, "Al");
+    await grid.expectRowNoWarning(0);
+    pausedUpdate.fail();
+    await grid.expectErrorToast();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.3  Edit with active sort - mismatch warning + move
+// -----------------------------------------------------------------------------
+
+test.describe("2.3 Edit with active sort on the edited field", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -666,21 +1103,87 @@ test.describe("2.5 Edit with active sort on the edited field", () => {
     await waitForInitialRows(grid, 2);
   });
 
-  test("2.5.1 sorted edit immediately shows typed value with Row has moved warning, then moves after deselect", async ({
+  test("2.3.1a paused sorted edit kept selected shows Row has moved until confirmation", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
     await startEditingPrimary(grid, 0);
     await grid.type("Zara");
     await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Zara");
     await grid.expectRowHasWarning(0);
-    await grid.selectFieldCell(1, 0);
-    await grid.expectRowCount(2);
-    await grid.expectPrimaryVisible("Zara");
-    await grid.expectRowNoWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+    await grid.expectRowNotLoading(0);
+
+    pausedUpdate.release();
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
   });
 
-  test("2.5.2 Escape during sort-mismatched edit restores original value, clears warning, and leaves row in place", async ({
+  test("2.3.1b paused sorted edit deselected before confirmation moves immediately", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+
+    await grid.clickAway();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(1);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("2.3.2 failed sort-affecting PATCH restores the original row order", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithEnter();
+    // Optimistic state: typed value and sort warning visible before the PATCH resolves.
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+    await failed;
+    await grid.expectErrorToast();
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("2.3.3 Escape during sort-mismatched edit restores original value, clears warning, and leaves row in place", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -690,6 +1193,133 @@ test.describe("2.5 Edit with active sort on the edited field", () => {
     await grid.expectPrimaryText(0, "Alice");
     await grid.expectRowNoWarning(0);
     await grid.expectRowCount(2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.3  Edit with formula-field sort (deferred) — deferred move
+// -----------------------------------------------------------------------------
+
+test.describe("2.3.4 Edit with formula-field sort (deferred)", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFormulaSortDb",
+      fields: [
+        {
+          name: "NameLength",
+          type: "formula",
+          settings: { formula: "length(field('Name'))" },
+        },
+      ],
+      sorts: [{ fieldName: "NameLength", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Al" }, // length 2, sorts first
+      { Name: "Alice" }, // length 5, sorts second
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(2);
+  });
+
+  test("2.3.4a paused formula-sorted edit shows typed value immediately but no move warning until backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0); // edit "Al"
+    await grid.type("Alexander"); // length 9, should sort after "Alice" (5)
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+
+    // Typed value visible immediately (field edit is optimistic); no loading
+    // spinner because the row update is optimistic.
+    await grid.expectPrimaryText(0, "Alexander");
+    await grid.expectRowNotLoading(0);
+    // No move warning while pending — formula sort cannot be evaluated locally
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(2);
+
+    pausedUpdate.release();
+    // Warning appears only after the backend responds with the formula result
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+    await grid.expectPrimaryText(0, "Alexander");
+    await grid.expectRowCount(2);
+
+    await grid.clickAway();
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Alexander");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("2.3.4b deselecting before backend confirmation keeps the row in place then moves it after the backend responds", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alexander");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectRowNoWarning(0);
+
+    await grid.clickAway();
+    // Row stays in current position because the frontend has not yet received the
+    // backend-computed sort value
+    await grid.expectPrimaryText(0, "Alexander");
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectRowCount(2);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    // Row moves to its sorted position after backend responds
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Alexander");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("2.3.4c failed formula-sort-affecting PATCH restores the original row order", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alexander");
+    await grid.confirmWithEnter();
+    // Optimistic state: typed value visible immediately; no warning because the
+    // frontend cannot evaluate the formula sort locally.
+    await grid.expectPrimaryText(0, "Alexander");
+    await grid.expectRowNoWarning(0);
+    await failed;
+    await grid.expectErrorToast();
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Al");
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowNoWarning(1);
   });
 });
 
@@ -739,8 +1369,9 @@ test.describe("3.1 Row deletion", () => {
     );
     await deleteRowThroughContextMenu(grid, 1);
     await failed;
-    // The 500 was delivered. The grid should still have both rows
-    // (optimistic remove + rollback, or at minimum the grid hasn't crashed).
+    await grid.expectErrorToast();
     await grid.expectRowCount(2);
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectPrimaryVisible("Bob");
   });
 });

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -1,0 +1,746 @@
+/**
+ * Grid view - row CRUD and mismatch warning tests.
+ *
+ * Catalogue sections: section 1 Row creation, section 2 Row update, section 3 Row deletion, section 14 Warning.
+ *
+ * ## Data isolation
+ * Each describe block creates an isolated database in `beforeAll` (fields,
+ * view config) and resets rows in `beforeEach` (row content). Tests within
+ * each describe run serially so `resetRows` always fires before each test.
+ *
+ * ## Anti-flakiness
+ * - All assertions use Playwright polling - no arbitrary timeouts.
+ * - Network failures delivered via `failNextRequest` resolve only after the
+ *   request has been intercepted, removing all timing races.
+ * - Warning tests use Tab (not Enter) so the row stays selected long enough
+ *   to assert the warning before deselect triggers removal.
+ *
+ * ## Known issue: section 1.1.3 and section 2.3.4 (BE-500 rollback)
+ * `createNewRow` in the flat grid is dispatched twice when both the left
+ * and right sections have @add-row handlers. The second dispatch fires a
+ * second batchCreate that `failNextRequest` does not intercept (one-shot).
+ * These tests are marked `@skip-rollback` and tracked in the catalogue as
+ * needing a grid fix to prevent the double-dispatch.
+ */
+
+import { test } from "../../baserowTest";
+import { GridPage } from "../../../pages/database/gridPage";
+import {
+  GridSetupResult,
+  resetRows,
+  setupGrid,
+} from "../../../fixtures/database/gridSetup";
+import {
+  failNextRequest,
+  pauseNextRequestWithSignal,
+} from "../../../fixtures/network";
+
+type Setup = GridSetupResult;
+
+async function waitForInitialRows(
+  grid: GridPage,
+  count: number,
+): Promise<void> {
+  await grid.expectRowCount(count);
+}
+
+async function addRowAndWaitForCreatedRow(
+  grid: GridPage,
+  expectedCount: number,
+): Promise<void> {
+  await grid.addRow();
+  await grid.expectRowCount(expectedCount);
+  await grid.expectNoRowsLoading();
+}
+
+async function startEditingPrimary(
+  grid: GridPage,
+  rowIndex: number,
+): Promise<void> {
+  await grid.startEditingPrimary(rowIndex);
+}
+
+async function deleteRowThroughContextMenu(
+  grid: GridPage,
+  rowIndex: number,
+): Promise<void> {
+  await grid.rightClickRow(rowIndex);
+  await grid.clickContextItem("Delete row");
+}
+
+// -----------------------------------------------------------------------------
+// section 1.1  Basic add row
+// -----------------------------------------------------------------------------
+
+test.describe("1.1 Basic add row", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudBasicDb",
+      fields: [{ name: "Score", type: "number" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 1);
+  });
+
+  test("1.1.1 add row without sort/filter appends an empty row and clears loading after confirmation", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await addRowAndWaitForCreatedRow(grid, 2);
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectFieldEmpty(1, 0);
+  });
+
+  test("1.1.2 paused create shows the empty optimistic row with row loading spinner, then clears loading in place", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectFieldEmpty(1, 0);
+    await grid.expectRowLoading(1);
+    pausedCreate.release();
+    await grid.expectRowCount(2);
+    await grid.expectRowNotLoading(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.2  Create with active sort - mismatch warning + move
+// -----------------------------------------------------------------------------
+
+test.describe("1.2 Create with active sort", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudSortDb",
+      fields: [{ name: "Score", type: "number" }],
+      sorts: [{ fieldName: "Name", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 2);
+  });
+
+  test("1.2.1a paused simple-sorted add kept selected immediately shows Row has moved until deselect", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryEmpty(2);
+    await grid.expectRowLoading(2);
+    await grid.expectRowHasWarning(2);
+    await grid.expectRowWarningText(2, "Row has moved");
+
+    pausedCreate.release();
+    await grid.expectRowNotLoading(2);
+    await grid.expectRowHasWarning(2);
+    await grid.expectRowWarningText(2, "Row has moved");
+
+    await grid.clickAway();
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectPrimaryText(2, "Bob");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.2.1b paused simple-sorted add deselected before confirmation moves immediately and finalizes without warning", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryEmpty(2);
+    await grid.expectRowLoading(2);
+    await grid.expectRowHasWarning(2);
+    await grid.expectRowWarningText(2, "Row has moved");
+
+    await grid.clickAway();
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectPrimaryText(2, "Bob");
+    await grid.expectRowLoading(0);
+    await grid.expectRowNoWarning(0);
+
+    pausedCreate.release();
+    await grid.expectRowCount(3);
+    await grid.expectNoRowsLoading();
+    await grid.expectPrimaryEmpty(0);
+    await grid.expectPrimaryText(1, "Alice");
+    await grid.expectPrimaryText(2, "Bob");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.2.2a paused simple-sorted edit kept selected immediately shows Row has moved", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+    await grid.expectRowNotLoading(0);
+
+    pausedUpdate.release();
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+  });
+
+  test("1.2.2b paused simple-sorted edit deselected before confirmation moves immediately without warning", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Zara");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row has moved");
+
+    await grid.clickAway();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(1);
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectPrimaryText(0, "Bob");
+    await grid.expectPrimaryText(1, "Zara");
+    await grid.expectRowNoWarning(1);
+  });
+
+  test("1.2.3 deselecting a sort-mismatched edited row moves the visible value to its sorted position and clears warning", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithTab();
+    await grid.expectRowHasWarning(0);
+    await grid.selectFieldCell(1, 0);
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryVisible("Zara");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.2.4 Escape during sort-mismatched edit restores original value, clears warning, and leaves row in place", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.cancelEdit();
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 1.3  Create with active filter - mismatch warning + removal
+// -----------------------------------------------------------------------------
+
+test.describe("1.3 Create with active filter", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "CrudFilterDb",
+      fields: [{ name: "Score", type: "number" }],
+      filters: [{ fieldName: "Name", type: "equal", value: "Alice" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("1.3.1a paused simple-filtered add kept selected immediately shows filter warning until deselect", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowLoading(1);
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+
+    pausedCreate.release();
+    await grid.expectRowCount(2);
+    await grid.expectRowNotLoading(1);
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+
+    await grid.clickAway();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.3.1b paused simple-filtered add deselected before confirmation is removed immediately", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedCreate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "POST" },
+    );
+
+    await grid.addRow();
+    await pausedCreate.intercepted;
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryEmpty(1);
+    await grid.expectRowLoading(1);
+    await grid.expectRowHasWarning(1);
+    await grid.expectRowWarningText(1, "Row does not match filters");
+
+    await grid.clickAway();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+
+    pausedCreate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.3.1d matching filtered edit keeps the typed value visible with no warning and no row removal", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alice");
+    await grid.confirmWithTab();
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("1.3.2a paused non-matching simple-filtered edit kept selected immediately shows filter warning", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Charlie");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+    await grid.expectRowNotLoading(0);
+
+    pausedUpdate.release();
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+    await grid.expectRowCount(1);
+  });
+
+  test("1.3.2b paused non-matching simple-filtered edit deselected before confirmation is removed immediately", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const pausedUpdate = await pauseNextRequestWithSignal(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithTab();
+    await pausedUpdate.intercepted;
+    await grid.expectPrimaryText(0, "Charlie");
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowWarningText(0, "Row does not match filters");
+
+    await grid.clickAway();
+    await grid.expectRowCount(0);
+    await grid.expectPrimaryNotVisible("Charlie");
+
+    pausedUpdate.release();
+    await grid.expectNoRowsLoading();
+    await grid.expectRowCount(0);
+    await grid.expectPrimaryNotVisible("Charlie");
+  });
+
+  test("1.3.3 deselecting a filter-mismatched edited row removes the typed value from the visible grid", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithTab();
+    await grid.expectRowHasWarning(0);
+    await grid.clickAway();
+    await grid.expectRowCount(0);
+    await grid.expectPrimaryNotVisible("Charlie");
+  });
+
+  test("1.3.4 Escape during filter-mismatched edit restores matching value, clears warning, and keeps row visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.cancelEdit();
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(1);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.1  Simple field edit
+// -----------------------------------------------------------------------------
+
+test.describe("2.1 Simple field edit", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "EditBasicDb",
+      fields: [{ name: "Score", type: "number" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 2);
+  });
+
+  test("2.1.1 Enter save makes the typed primary value visible and removes the original value from the grid", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alicia");
+    await grid.confirmWithEnter();
+    await grid.expectPrimaryText(0, "Alicia");
+    await grid.expectPrimaryNotVisible("Alice");
+  });
+
+  test("2.1.2 Escape while editing discards the typed value and keeps the original value visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 1);
+    await grid.type("Changed");
+    await grid.cancelEdit();
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryNotVisible("Changed");
+  });
+
+  test("2.1.3 blur save makes the typed value visible after clicking outside the cell", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alicia");
+    await grid.clickAway();
+    await grid.expectPrimaryVisible("Alicia");
+  });
+
+  test("2.1.4 failed PATCH is intercepted after typed value is submitted and the grid remains rendered with both rows", async ({
+    page,
+  }) => {
+    // Verifies that `failNextRequest` correctly intercepts the PATCH and the grid
+    // does not crash. Full rollback verification belongs in unit tests where the
+    // task-queue timing is deterministic.
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("WillFail");
+    await grid.confirmWithEnter();
+    await failed; // 500 was delivered - test passes if this resolves
+    await grid.expectRowCount(2); // grid still has both rows (no crash)
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.3  Edit with active filter - mismatch warning + removal
+// -----------------------------------------------------------------------------
+
+test.describe("2.3 Edit with active filter on the edited field", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "EditFilterDb",
+      fields: [{ name: "Score", type: "number" }],
+      filters: [{ fieldName: "Name", type: "equal", value: "Alice" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [{ Name: "Alice", Score: 10 }]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.3.1 non-matching filtered edit shows typed value and warning while selected, without removing row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithTab();
+    await grid.expectRowHasWarning(0);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.3.1b deselecting a filter-mismatched edit removes the typed value from the visible grid", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithTab();
+    await grid.expectRowHasWarning(0);
+    await grid.clickAway();
+    await grid.expectRowCount(0);
+    await grid.expectPrimaryNotVisible("Charlie");
+  });
+
+  test("2.3.2 Escape during filter-mismatched edit restores matching value, clears warning, and keeps row visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.cancelEdit();
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.3.3 saving the same matching value keeps row visible and produces no warning", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Alice");
+    await grid.confirmWithEnter();
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(1);
+  });
+
+  test("2.3.4 failed filter-affecting PATCH is intercepted and the filtered grid remains rendered", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "PATCH" },
+    );
+    await startEditingPrimary(grid, 0);
+    await grid.type("Charlie");
+    await grid.confirmWithEnter();
+    await failed;
+    await grid.expectRowCount(1); // filter still shows Alice's row (the grid didn't crash)
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 2.5  Edit with active sort - mismatch warning + move
+// -----------------------------------------------------------------------------
+
+test.describe("2.5 Edit with active sort on the edited field", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "EditSortDb",
+      fields: [{ name: "Score", type: "number" }],
+      sorts: [{ fieldName: "Name", order: "ASC" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 2);
+  });
+
+  test("2.5.1 sorted edit immediately shows typed value with Row has moved warning, then moves after deselect", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.confirmWithTab();
+    await grid.expectRowHasWarning(0);
+    await grid.selectFieldCell(1, 0);
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryVisible("Zara");
+    await grid.expectRowNoWarning(0);
+  });
+
+  test("2.5.2 Escape during sort-mismatched edit restores original value, clears warning, and leaves row in place", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await startEditingPrimary(grid, 0);
+    await grid.type("Zara");
+    await grid.cancelEdit();
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectRowNoWarning(0);
+    await grid.expectRowCount(2);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 3.1  Row deletion
+// -----------------------------------------------------------------------------
+
+test.describe("3.1 Row deletion", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "DeleteDb",
+      fields: [{ name: "Score", type: "number" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Score: 10 },
+      { Name: "Bob", Score: 20 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await waitForInitialRows(grid, 2);
+  });
+
+  test("3.1.1 context-menu delete removes the row immediately and leaves the next row visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await deleteRowThroughContextMenu(grid, 0);
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryNotVisible("Alice");
+    await grid.expectPrimaryVisible("Bob");
+  });
+
+  test("3.1.2 failed delete request is intercepted and both rows remain visible after rollback/stability check", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    const failed = failNextRequest(
+      page,
+      `**/api/database/rows/table/${g.table.id}/**`,
+      { method: "DELETE" },
+    );
+    await deleteRowThroughContextMenu(grid, 1);
+    await failed;
+    // The 500 was delivered. The grid should still have both rows
+    // (optimistic remove + rollback, or at minimum the grid hasn't crashed).
+    await grid.expectRowCount(2);
+  });
+});

--- a/e2e-tests/tests/database/grid/grid_view_options.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_view_options.spec.ts
@@ -1,0 +1,669 @@
+/**
+ * Grid view - filters, sorts, and search.
+ *
+ * Catalogue sections covered:
+ *   section 4  Filters (add/remove, types, AND combination)
+ *   section 5  Sorts  (add, direction, multiple)
+ *   section 6  Search (highlight mode, hide-not-matching mode)
+ *   section 7  Presentation options (row coloring, fields, row height)
+ *
+ * Each describe block creates its own isolated database so a failing filter
+ * test cannot corrupt the sort seed data. All setups run once via beforeAll;
+ * each test re-navigates via beforeEach so it starts with a clean slate.
+ *
+ * Anti-flakiness:
+ *   - Filters and sorts are applied via the API in beforeAll (not via UI
+ *     configuration in beforeEach), so the view is already configured when
+ *     the test navigates to it. This removes any race between "panel open"
+ *     and "filter applied".
+ *   - For UI-driven operations (section 4/section 5 panel interactions) we wait for the
+ *     updated row count before asserting row content.
+ */
+
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "../../baserowTest";
+import { GridPage } from "../../../pages/database/gridPage";
+import {
+  GridSetupResult,
+  setupGrid,
+} from "../../../fixtures/database/gridSetup";
+import { createViewDecoration, patchView } from "../../../fixtures/database/view";
+import {
+  createLicense,
+  deleteLicense,
+  ENTERPRISE_LICENSE,
+  License,
+} from "../../../fixtures/licence";
+
+type Setup = GridSetupResult;
+
+const searchInputSelector = 'input[placeholder*="Search in"]';
+
+function gridSearchContext(page: Page): Locator {
+  return page
+    .locator(".context")
+    .filter({ has: page.locator(searchInputSelector) })
+    .last();
+}
+
+async function openGridSearch(page: Page): Promise<Locator> {
+  const input = page.locator(searchInputSelector).first();
+  const searchLink = page
+    .locator(".header__search .header__filter-link")
+    .first();
+
+  await expect(searchLink).toBeVisible({ timeout: 10_000 });
+  if (!(await input.isVisible())) {
+    await searchLink.click();
+  }
+  await expect(input).toBeVisible({ timeout: 10_000 });
+  return input;
+}
+
+async function waitForSearchContextIdle(page: Page): Promise<void> {
+  await expect(gridSearchContext(page)).not.toHaveClass(
+    /context--loading-overlay/,
+    { timeout: 10_000 },
+  );
+}
+
+async function typeInGridSearch(page: Page, term: string): Promise<void> {
+  const input = await openGridSearch(page);
+  await waitForSearchContextIdle(page);
+  await input.click();
+  await input.press("ControlOrMeta+A");
+  await input.pressSequentially(term);
+}
+
+async function clearGridSearch(page: Page): Promise<void> {
+  const input = await openGridSearch(page);
+  await waitForSearchContextIdle(page);
+  await input.click();
+  await input.press("ControlOrMeta+A");
+  await input.press("Backspace");
+}
+
+async function turnOffHideNotMatchingRows(page: Page): Promise<void> {
+  await openGridSearch(page);
+
+  const searchContext = gridSearchContext(page);
+  const hideSwitch = searchContext.locator(".switch", {
+    hasText: /hide not matching rows/i,
+  });
+
+  await expect(hideSwitch).toHaveClass(/switch--active/, { timeout: 5_000 });
+  await hideSwitch.click();
+  await expect(hideSwitch).not.toHaveClass(/switch--active/, {
+    timeout: 5_000,
+  });
+  await waitForSearchContextIdle(page);
+}
+
+// -----------------------------------------------------------------------------
+// section 4  Filters
+// -----------------------------------------------------------------------------
+
+test.describe("4.1 Filter applied via API - rows hidden on load", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    // Apply a Name = "Alice" filter before the tests start
+    g = await setupGrid({
+      dbName: "FilterApiDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 20 },
+        { Name: "Carol", Score: 30 },
+      ],
+      filters: [{ fieldName: "Name", type: "equal", value: "Alice" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("4.1.1 loading a filtered view shows only the matching row and hides non-matching rows", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectPrimaryNotVisible("Bob");
+    await grid.expectPrimaryNotVisible("Carol");
+  });
+});
+
+test.describe("4.2 Filter types - text contains", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "FilterContainsDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice Smith", Score: 10 },
+        { Name: "Alice Jones", Score: 20 },
+        { Name: "Bob Brown", Score: 30 },
+      ],
+      filters: [{ fieldName: "Name", type: "contains", value: "Alice" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("4.2.2 loading a contains-filtered view shows all substring matches and hides non-matches", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryVisible("Alice Smith");
+    await grid.expectPrimaryVisible("Alice Jones");
+    await grid.expectPrimaryNotVisible("Bob Brown");
+  });
+});
+
+test.describe("4.3 AND filter - two conditions must both match", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "FilterAndDb",
+      fields: [
+        { name: "Score", type: "number" },
+        {
+          name: "Status",
+          type: "single_select",
+          options: ["Done", "In Progress"],
+        },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Status: "Done" },
+        { Name: "Bob", Score: 20, Status: "Done" },
+        { Name: "Carol", Score: 30, Status: "In Progress" },
+      ],
+      filters: [
+        { fieldName: "Name", type: "equal", value: "Alice" },
+        { fieldName: "Status", type: "single_select_equal", value: "Done" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("4.1.3 loading an AND-filtered view shows only rows matching both conditions", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    // Only "Alice" matches Name=Alice AND Status=Done
+    await grid.expectRowCount(1);
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectPrimaryNotVisible("Bob"); // Bob matches Status but not Name
+    await grid.expectPrimaryNotVisible("Carol"); // Carol matches neither
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 5  Sorts
+// -----------------------------------------------------------------------------
+
+test.describe("5.1 Sort ASC / DESC", () => {
+  test.describe.configure({ mode: "serial" });
+  let gAsc: Setup;
+  let gDesc: Setup;
+
+  test.beforeAll(async () => {
+    // Two setups: same data, one ASC one DESC
+    [gAsc, gDesc] = await Promise.all([
+      setupGrid({
+        dbName: "SortAscDb",
+        fields: [{ name: "Score", type: "number" }],
+        rows: [
+          { Name: "Carol", Score: 30 },
+          { Name: "Alice", Score: 10 },
+          { Name: "Bob", Score: 20 },
+        ],
+        sorts: [{ fieldName: "Name", order: "ASC" }],
+      }),
+      setupGrid({
+        dbName: "SortDescDb",
+        fields: [{ name: "Score", type: "number" }],
+        rows: [
+          { Name: "Carol", Score: 30 },
+          { Name: "Alice", Score: 10 },
+          { Name: "Bob", Score: 20 },
+        ],
+        sorts: [{ fieldName: "Name", order: "DESC" }],
+      }),
+    ]);
+  });
+
+  test("5.1.1 loading an ASC-sorted view shows rows in alphabetical order", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, gAsc.user);
+    await grid.goTo(gAsc.database, gAsc.table);
+
+    // Names are in the LEFT section (primary field). Extract from primary cells.
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryText(2, "Carol");
+  });
+
+  test("5.1.2 loading a DESC-sorted view shows rows in reverse alphabetical order", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, gDesc.user);
+    await grid.goTo(gDesc.database, gDesc.table);
+
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryText(0, "Carol");
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectPrimaryText(2, "Alice");
+  });
+});
+
+test.describe("5.1.3 Multiple sorts - primary ASC, secondary DESC", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "MultiSortDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 50 },
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 30 },
+      ],
+      sorts: [
+        { fieldName: "Name", order: "ASC" },
+        { fieldName: "Score", order: "DESC" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("5.1.3 loading multi-sort view applies Name ASC first and Score DESC for tied names", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.expectRowCount(3);
+
+    // First two rows are the two Alices; Alice with Score 50 should be first (DESC on Score)
+    const firstScore = await grid.fieldCellAt(0, 0).innerText();
+    const secondScore = await grid.fieldCellAt(1, 0).innerText();
+    expect(Number(firstScore)).toBeGreaterThan(Number(secondScore));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 6  Search
+// -----------------------------------------------------------------------------
+
+test.describe("6.1 Search highlight mode", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "SearchDb",
+      fields: [{ name: "Notes", type: "text" }],
+      rows: [
+        { Name: "Alice", Notes: "Modernize the dashboard" },
+        { Name: "Bob", Notes: "Refactor the backend" },
+        { Name: "Carol", Notes: "Design the landing page" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    // The flat grid defaults hideRowsNotMatchingSearch=true (set in CLEAR_ROWS).
+    // For highlight-mode tests, we must turn it OFF first.
+    await turnOffHideNotMatchingRows(page);
+    // Leave the search panel open - typeInSearch will use it.
+  });
+
+  test("6.1.1 highlight-mode search highlights matching cell while all rows remain visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await typeInGridSearch(page, "Alice");
+
+    // Only Alice's Name cell is highlighted
+    await grid.expectPrimaryHighlighted(0);
+    // Non-matching rows are still visible
+    await grid.expectPrimaryVisible("Bob");
+    await grid.expectPrimaryVisible("Carol");
+    // Their Name cells are NOT highlighted
+    await grid.expectPrimaryNotHighlighted(1);
+  });
+
+  test("6.1.2 highlight-mode search with no matches shows no highlights and keeps all rows visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await typeInGridSearch(page, "XYZ_NO_MATCH");
+
+    await grid.expectRowCount(3);
+    await expect(
+      page.locator(".grid-view__column--matches-search"),
+    ).toHaveCount(0);
+  });
+
+  test("6.1.3 clearing search removes existing highlights and keeps all rows visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await typeInGridSearch(page, "Alice");
+    await grid.expectPrimaryHighlighted(0);
+
+    await clearGridSearch(page);
+    await grid.expectPrimaryNotHighlighted(0);
+    await grid.expectRowCount(3);
+  });
+
+  test("6.1.4 highlight-mode search marks the matching non-primary cell", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    // Search for "Modern" which matches Alice's Notes cell
+    await typeInGridSearch(page, "Modern");
+
+    await grid.expectCellHighlighted(0, 0); // Notes cell of Alice's row (row 0, first non-primary field)
+  });
+});
+
+test.describe("6.2 Search hide-not-matching mode", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "SearchHideDb",
+      fields: [{ name: "Notes", type: "text" }],
+      rows: [
+        // Only Alice and Carol have "found" in Notes; Bob does not.
+        { Name: "Alice", Notes: "Found it here" },
+        { Name: "Bob", Notes: "Unrelated note" },
+        { Name: "Carol", Notes: "Also found" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    // The grid defaults to hide mode ON. Open search and type - it will hide rows.
+    await openGridSearch(page);
+  });
+
+  test("6.2.1 hide-mode search hides non-matching rows and keeps matching rows visible", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    // Default is hide mode ON - typing immediately hides non-matching rows
+    await typeInGridSearch(page, "found");
+
+    // "Bob" ("Unrelated note") doesn't match -> disappears
+    await grid.expectPrimaryNotVisible("Bob");
+    await grid.expectPrimaryVisible("Alice");
+    await grid.expectPrimaryVisible("Carol");
+    await grid.expectRowCount(2);
+  });
+
+  test("6.2.2 turning hide mode off restores hidden rows while keeping matching cells highlighted", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await typeInGridSearch(page, "found");
+    await grid.expectRowCount(2);
+
+    // Toggle hide mode OFF - all rows reappear
+    await turnOffHideNotMatchingRows(page);
+
+    await grid.expectRowCount(3);
+    await grid.expectPrimaryVisible("Bob");
+    // Alice's Notes cell should still be highlighted (highlight mode now active)
+    await grid.expectCellHighlighted(0, 0); // Alice's Notes (row 0, first non-primary field)
+  });
+});
+
+// -----------------------------------------------------------------------------
+// section 7  Presentation options
+// -----------------------------------------------------------------------------
+
+test.describe("7.1 Row coloring", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+  let license: License;
+
+  test.beforeAll(async () => {
+    license = await createLicense(ENTERPRISE_LICENSE);
+    g = await setupGrid({
+      dbName: "RowColoringDb",
+      fields: [
+        {
+          name: "Status",
+          type: "single_select",
+          options: [
+            { value: "Blocked", color: "red" },
+            { value: "Ready", color: "green" },
+          ],
+        },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Status: "Blocked", Notes: "Investigate" },
+        { Name: "Bob", Status: "Ready", Notes: "Ship" },
+      ],
+    });
+    await createViewDecoration(g.user, g.view, {
+      type: "background_color",
+      value_provider_type: "single_select_color",
+      value_provider_conf: { field_id: g.fieldByName.Status.id },
+    });
+  });
+
+  test.afterAll(async () => {
+    if (license) {
+      await deleteLicense(license);
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("7.1.1 background row coloring uses the selected single-select option color on both grid sections", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(2);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "Blocked");
+    await grid.expectRowBackgroundColor(0, "red");
+
+    await grid.expectPrimaryText(1, "Bob");
+    await grid.expectFieldText(1, 0, "Ready");
+    await grid.expectRowBackgroundColor(1, "green");
+  });
+});
+
+test.describe("7.2 Field visibility", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "FieldVisibilityDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Notes: "Alpha" },
+        { Name: "Bob", Score: 20, Notes: "Beta" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("7.2.1 fields panel hides and shows a non-primary field without changing visible rows", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(2);
+    await grid.expectNonPrimaryFieldHeaderVisible("Score");
+    await grid.expectNonPrimaryFieldHeaderVisible("Notes");
+    await grid.expectVisibleNonPrimaryFieldCount(2);
+    await grid.expectFieldText(0, 1, "Alpha");
+
+    await grid.openFieldVisibilityContext();
+    await grid.setFieldVisibility("Notes", false);
+
+    await grid.expectRowCount(2);
+    await grid.expectNonPrimaryFieldHeaderVisible("Score");
+    await grid.expectNonPrimaryFieldHeaderHidden("Notes");
+    await grid.expectVisibleNonPrimaryFieldCount(1);
+    await grid.expectFieldText(0, 0, "10");
+
+    await grid.setFieldVisibility("Notes", true);
+
+    await grid.expectRowCount(2);
+    await grid.expectNonPrimaryFieldHeaderVisible("Score");
+    await grid.expectNonPrimaryFieldHeaderVisible("Notes");
+    await grid.expectVisibleNonPrimaryFieldCount(2);
+    await grid.expectFieldText(0, 1, "Alpha");
+  });
+});
+
+test.describe("7.7 Row identifier type", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "RowIdentifierDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 20 },
+        { Name: "Carol", Score: 30 },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await patchView(g.user, g.view, { row_identifier_type: "count" });
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("7.7.1 count mode shows sequential row position starting from 1", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.expectRowCount(3);
+    await grid.expectRowIdentifierText(0, "1");
+    await grid.expectRowIdentifierText(1, "2");
+    await grid.expectRowIdentifierText(2, "3");
+  });
+
+  test("7.7.2 switching to Row identifier shows the actual backend row ID for each row", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.selectRowIdentifierType("id");
+    await grid.expectRowIdentifierText(0, String(g.rowIds[0]));
+    await grid.expectRowIdentifierText(1, String(g.rowIds[1]));
+    await grid.expectRowIdentifierText(2, String(g.rowIds[2]));
+  });
+
+  test("7.7.3 switching back to Count restores sequential row positions", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.selectRowIdentifierType("id");
+    await grid.expectRowIdentifierText(0, String(g.rowIds[0]));
+    await grid.selectRowIdentifierType("count");
+    await grid.expectRowIdentifierText(0, "1");
+    await grid.expectRowIdentifierText(1, "2");
+    await grid.expectRowIdentifierText(2, "3");
+  });
+});
+
+test.describe("7.3 Row height", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "RowHeightDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 20 },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("7.3.1 height menu switches visible rows from small to medium and large", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(2);
+    await grid.expectRowHeight("small", 33);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+
+    await grid.selectRowHeight("Medium");
+    await grid.expectRowHeight("medium", 55);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+
+    await grid.selectRowHeight("Large");
+    await grid.expectRowHeight("large", 99);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+  });
+});

--- a/e2e-tests/tests/database/grid/grid_view_options.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_view_options.spec.ts
@@ -2,22 +2,12 @@
  * Grid view - filters, sorts, and search.
  *
  * Catalogue sections covered:
- *   section 4  Filters (add/remove, types, AND combination)
- *   section 5  Sorts  (add, direction, multiple)
- *   section 6  Search (highlight mode, hide-not-matching mode)
- *   section 7  Presentation options (row coloring, fields, row height)
+ *   section 5   Filters loaded from saved view configuration
+ *   section 6   Sorts loaded from saved view configuration
+ *   section 7   Search (highlight mode, hide-not-matching mode)
+ *   section 8   Presentation options (row coloring, fields, row height, freeze, identifiers)
+ *   section 14  Public shared grid view
  *
- * Each describe block creates its own isolated database so a failing filter
- * test cannot corrupt the sort seed data. All setups run once via beforeAll;
- * each test re-navigates via beforeEach so it starts with a clean slate.
- *
- * Anti-flakiness:
- *   - Filters and sorts are applied via the API in beforeAll (not via UI
- *     configuration in beforeEach), so the view is already configured when
- *     the test navigates to it. This removes any race between "panel open"
- *     and "filter applied".
- *   - For UI-driven operations (section 4/section 5 panel interactions) we wait for the
- *     updated row count before asserting row content.
  */
 
 import type { Locator, Page } from "@playwright/test";
@@ -27,7 +17,10 @@ import {
   GridSetupResult,
   setupGrid,
 } from "../../../fixtures/database/gridSetup";
-import { createViewDecoration, patchView } from "../../../fixtures/database/view";
+import {
+  createViewDecoration,
+  patchView,
+} from "../../../fixtures/database/view";
 import {
   createLicense,
   deleteLicense,
@@ -38,6 +31,44 @@ import {
 type Setup = GridSetupResult;
 
 const searchInputSelector = 'input[placeholder*="Search in"]';
+
+async function waitForApiPatch(
+  page: Page,
+  path: string,
+  action: () => Promise<void>,
+): Promise<void> {
+  const response = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.pathname.endsWith(path) &&
+      response.request().method() === "PATCH" &&
+      response.ok()
+    );
+  });
+
+  await action();
+  await response;
+}
+
+async function waitForViewPatch(
+  page: Page,
+  viewId: number,
+  action: () => Promise<void>,
+): Promise<void> {
+  await waitForApiPatch(page, `/api/database/views/${viewId}/`, action);
+}
+
+async function waitForFieldOptionsPatch(
+  page: Page,
+  viewId: number,
+  action: () => Promise<void>,
+): Promise<void> {
+  await waitForApiPatch(
+    page,
+    `/api/database/views/${viewId}/field-options/`,
+    action,
+  );
+}
 
 function gridSearchContext(page: Page): Locator {
   return page
@@ -100,10 +131,10 @@ async function turnOffHideNotMatchingRows(page: Page): Promise<void> {
 }
 
 // -----------------------------------------------------------------------------
-// section 4  Filters
+// section 5  Filters
 // -----------------------------------------------------------------------------
 
-test.describe("4.1 Filter applied via API - rows hidden on load", () => {
+test.describe("5.1 Filter applied via API - rows hidden on load", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -126,7 +157,7 @@ test.describe("4.1 Filter applied via API - rows hidden on load", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("4.1.1 loading a filtered view shows only the matching row and hides non-matching rows", async ({
+  test("5.1.1 loading a filtered view shows only the matching row and hides non-matching rows", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -138,7 +169,7 @@ test.describe("4.1 Filter applied via API - rows hidden on load", () => {
   });
 });
 
-test.describe("4.2 Filter types - text contains", () => {
+test.describe("5.2 Filter types - text contains", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -160,7 +191,7 @@ test.describe("4.2 Filter types - text contains", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("4.2.2 loading a contains-filtered view shows all substring matches and hides non-matches", async ({
+  test("5.2.1 loading a contains-filtered view shows all substring matches and hides non-matches", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -172,7 +203,7 @@ test.describe("4.2 Filter types - text contains", () => {
   });
 });
 
-test.describe("4.3 AND filter - two conditions must both match", () => {
+test.describe("5.1.2 AND filter - two conditions must both match", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -204,7 +235,7 @@ test.describe("4.3 AND filter - two conditions must both match", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("4.1.3 loading an AND-filtered view shows only rows matching both conditions", async ({
+  test("5.1.2 loading an AND-filtered view shows only rows matching both conditions", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -218,10 +249,10 @@ test.describe("4.3 AND filter - two conditions must both match", () => {
 });
 
 // -----------------------------------------------------------------------------
-// section 5  Sorts
+// section 6  Sorts
 // -----------------------------------------------------------------------------
 
-test.describe("5.1 Sort ASC / DESC", () => {
+test.describe("6.1 Sort ASC / DESC", () => {
   test.describe.configure({ mode: "serial" });
   let gAsc: Setup;
   let gDesc: Setup;
@@ -252,7 +283,7 @@ test.describe("5.1 Sort ASC / DESC", () => {
     ]);
   });
 
-  test("5.1.1 loading an ASC-sorted view shows rows in alphabetical order", async ({
+  test("6.1.1 loading an ASC-sorted view shows rows in alphabetical order", async ({
     page,
   }) => {
     const grid = new GridPage(page, gAsc.user);
@@ -265,7 +296,7 @@ test.describe("5.1 Sort ASC / DESC", () => {
     await grid.expectPrimaryText(2, "Carol");
   });
 
-  test("5.1.2 loading a DESC-sorted view shows rows in reverse alphabetical order", async ({
+  test("6.1.2 loading a DESC-sorted view shows rows in reverse alphabetical order", async ({
     page,
   }) => {
     const grid = new GridPage(page, gDesc.user);
@@ -278,7 +309,7 @@ test.describe("5.1 Sort ASC / DESC", () => {
   });
 });
 
-test.describe("5.1.3 Multiple sorts - primary ASC, secondary DESC", () => {
+test.describe("6.1.3 Multiple sorts - primary ASC, secondary DESC", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -303,7 +334,7 @@ test.describe("5.1.3 Multiple sorts - primary ASC, secondary DESC", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("5.1.3 loading multi-sort view applies Name ASC first and Score DESC for tied names", async ({
+  test("6.1.3 loading multi-sort view applies Name ASC first and Score DESC for tied names", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -317,10 +348,10 @@ test.describe("5.1.3 Multiple sorts - primary ASC, secondary DESC", () => {
 });
 
 // -----------------------------------------------------------------------------
-// section 6  Search
+// section 7  Search
 // -----------------------------------------------------------------------------
 
-test.describe("6.1 Search highlight mode", () => {
+test.describe("7.1 Search highlight mode", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -345,7 +376,7 @@ test.describe("6.1 Search highlight mode", () => {
     // Leave the search panel open - typeInSearch will use it.
   });
 
-  test("6.1.1 highlight-mode search highlights matching cell while all rows remain visible", async ({
+  test("7.1.1 highlight-mode search highlights matching cell while all rows remain visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -361,7 +392,7 @@ test.describe("6.1 Search highlight mode", () => {
     await grid.expectPrimaryNotHighlighted(1);
   });
 
-  test("6.1.2 highlight-mode search with no matches shows no highlights and keeps all rows visible", async ({
+  test("7.1.2 highlight-mode search with no matches shows no highlights and keeps all rows visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -374,7 +405,7 @@ test.describe("6.1 Search highlight mode", () => {
     ).toHaveCount(0);
   });
 
-  test("6.1.3 clearing search removes existing highlights and keeps all rows visible", async ({
+  test("7.1.3 clearing search removes existing highlights and keeps all rows visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -387,7 +418,7 @@ test.describe("6.1 Search highlight mode", () => {
     await grid.expectRowCount(3);
   });
 
-  test("6.1.4 highlight-mode search marks the matching non-primary cell", async ({
+  test("7.1.4 highlight-mode search marks the matching non-primary cell", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -399,7 +430,7 @@ test.describe("6.1 Search highlight mode", () => {
   });
 });
 
-test.describe("6.2 Search hide-not-matching mode", () => {
+test.describe("7.2 Search hide-not-matching mode", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -423,7 +454,7 @@ test.describe("6.2 Search hide-not-matching mode", () => {
     await openGridSearch(page);
   });
 
-  test("6.2.1 hide-mode search hides non-matching rows and keeps matching rows visible", async ({
+  test("7.2.1 hide-mode search hides non-matching rows and keeps matching rows visible", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -438,7 +469,7 @@ test.describe("6.2 Search hide-not-matching mode", () => {
     await grid.expectRowCount(2);
   });
 
-  test("6.2.2 turning hide mode off restores hidden rows while keeping matching cells highlighted", async ({
+  test("7.2.2 turning hide mode off restores hidden rows while keeping matching cells highlighted", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -457,10 +488,10 @@ test.describe("6.2 Search hide-not-matching mode", () => {
 });
 
 // -----------------------------------------------------------------------------
-// section 7  Presentation options
+// section 8  Presentation options
 // -----------------------------------------------------------------------------
 
-test.describe("7.1 Row coloring", () => {
+test.describe("8.1 Row coloring", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
   let license: License;
@@ -503,7 +534,7 @@ test.describe("7.1 Row coloring", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("7.1.1 background row coloring uses the selected single-select option color on both grid sections", async ({
+  test("8.1.1 background row coloring uses the selected single-select option color on both grid sections", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -516,10 +547,11 @@ test.describe("7.1 Row coloring", () => {
     await grid.expectPrimaryText(1, "Bob");
     await grid.expectFieldText(1, 0, "Ready");
     await grid.expectRowBackgroundColor(1, "green");
+    await grid.expectNoRowsLoading();
   });
 });
 
-test.describe("7.2 Field visibility", () => {
+test.describe("8.2 Field visibility", () => {
   test.describe.configure({ mode: "serial" });
   let g: Setup;
 
@@ -542,7 +574,7 @@ test.describe("7.2 Field visibility", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("7.2.1 fields panel hides and shows a non-primary field without changing visible rows", async ({
+  test("8.2.1 fields panel hides and shows a non-primary field and persists both states", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -554,7 +586,9 @@ test.describe("7.2 Field visibility", () => {
     await grid.expectFieldText(0, 1, "Alpha");
 
     await grid.openFieldVisibilityContext();
-    await grid.setFieldVisibility("Notes", false);
+    await waitForFieldOptionsPatch(page, g.view.id, () =>
+      grid.setFieldVisibility("Notes", false),
+    );
 
     await grid.expectRowCount(2);
     await grid.expectNonPrimaryFieldHeaderVisible("Score");
@@ -562,17 +596,121 @@ test.describe("7.2 Field visibility", () => {
     await grid.expectVisibleNonPrimaryFieldCount(1);
     await grid.expectFieldText(0, 0, "10");
 
-    await grid.setFieldVisibility("Notes", true);
+    await grid.goTo(g.database, g.table);
+    await grid.expectNonPrimaryFieldHeaderVisible("Score");
+    await grid.expectNonPrimaryFieldHeaderHidden("Notes");
+    await grid.expectVisibleNonPrimaryFieldCount(1);
+
+    await grid.openFieldVisibilityContext();
+    await waitForFieldOptionsPatch(page, g.view.id, () =>
+      grid.setFieldVisibility("Notes", true),
+    );
 
     await grid.expectRowCount(2);
     await grid.expectNonPrimaryFieldHeaderVisible("Score");
     await grid.expectNonPrimaryFieldHeaderVisible("Notes");
     await grid.expectVisibleNonPrimaryFieldCount(2);
     await grid.expectFieldText(0, 1, "Alpha");
+
+    await grid.goTo(g.database, g.table);
+    await grid.expectNonPrimaryFieldHeaderVisible("Score");
+    await grid.expectNonPrimaryFieldHeaderVisible("Notes");
+    await grid.expectVisibleNonPrimaryFieldCount(2);
   });
 });
 
-test.describe("7.7 Row identifier type", () => {
+test.describe("8.3 Row height", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "RowHeightDb",
+      fields: [{ name: "Score", type: "number" }],
+      rows: [
+        { Name: "Alice", Score: 10 },
+        { Name: "Bob", Score: 20 },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("8.3.1 height menu switches visible rows from small to medium and large", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectRowCount(2);
+    await grid.expectRowHeight("small", 33);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+
+    await waitForViewPatch(page, g.view.id, () =>
+      grid.selectRowHeight("Medium"),
+    );
+    await grid.expectRowHeight("medium", 55);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+
+    await waitForViewPatch(page, g.view.id, () =>
+      grid.selectRowHeight("Large"),
+    );
+    await grid.expectRowHeight("large", 99);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+
+    await grid.goTo(g.database, g.table);
+    await grid.expectRowHeight("large", 99);
+    await grid.expectPrimaryText(0, "Alice");
+    await grid.expectFieldText(0, 0, "10");
+    await grid.expectNoRowsLoading();
+  });
+});
+
+test.describe("8.4 Frozen columns", () => {
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "FrozenColumnsDb",
+      fields: [
+        { name: "Score", type: "number" },
+        { name: "Notes", type: "text" },
+      ],
+      rows: [
+        { Name: "Alice", Score: 10, Notes: "Alpha" },
+        { Name: "Bob", Score: 20, Notes: "Beta" },
+      ],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await patchView(g.user, g.view, { frozen_column_count: 2 });
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+  });
+
+  test("8.4.1 loading a view with two frozen columns keeps the first non-primary field frozen after reload", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+
+    await grid.expectFrozenFieldHeaderVisible("Score");
+    await grid.expectScrollableFieldHeaderHidden("Score");
+    await grid.expectNonPrimaryFieldHeaderVisible("Notes");
+
+    await grid.goTo(g.database, g.table);
+    await grid.expectFrozenFieldHeaderVisible("Score");
+    await grid.expectScrollableFieldHeaderHidden("Score");
+    await grid.expectNonPrimaryFieldHeaderVisible("Notes");
+  });
+});
+
+test.describe("8.5 Row identifier type", () => {
   let g: Setup;
 
   test.beforeAll(async () => {
@@ -593,7 +731,7 @@ test.describe("7.7 Row identifier type", () => {
     await grid.goTo(g.database, g.table);
   });
 
-  test("7.7.1 count mode shows sequential row position starting from 1", async ({
+  test("8.5.1 count mode shows sequential row position starting from 1", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
@@ -603,67 +741,99 @@ test.describe("7.7 Row identifier type", () => {
     await grid.expectRowIdentifierText(2, "3");
   });
 
-  test("7.7.2 switching to Row identifier shows the actual backend row ID for each row", async ({
+  test("8.5.2 row identifier menu switches to backend row IDs and back to count", async ({
     page,
   }) => {
     const grid = new GridPage(page, g.user);
-    await grid.selectRowIdentifierType("id");
+
+    await waitForViewPatch(page, g.view.id, () =>
+      grid.selectRowIdentifierType("id"),
+    );
+    // Backend row IDs are shown; sequential position values are no longer visible.
     await grid.expectRowIdentifierText(0, String(g.rowIds[0]));
     await grid.expectRowIdentifierText(1, String(g.rowIds[1]));
     await grid.expectRowIdentifierText(2, String(g.rowIds[2]));
-  });
+    await expect(grid.rowIdentifierContentAt(0)).not.toHaveText("1", {
+      timeout: 5_000,
+    });
+    await expect(grid.rowIdentifierContentAt(1)).not.toHaveText("2", {
+      timeout: 5_000,
+    });
 
-  test("7.7.3 switching back to Count restores sequential row positions", async ({
-    page,
-  }) => {
-    const grid = new GridPage(page, g.user);
-    await grid.selectRowIdentifierType("id");
+    await grid.goTo(g.database, g.table);
     await grid.expectRowIdentifierText(0, String(g.rowIds[0]));
-    await grid.selectRowIdentifierType("count");
+    await grid.expectRowIdentifierText(1, String(g.rowIds[1]));
+    await grid.expectRowIdentifierText(2, String(g.rowIds[2]));
+
+    await waitForViewPatch(page, g.view.id, () =>
+      grid.selectRowIdentifierType("count"),
+    );
+    await grid.expectRowIdentifierText(0, "1");
+    await grid.expectRowIdentifierText(1, "2");
+    await grid.expectRowIdentifierText(2, "3");
+
+    await grid.goTo(g.database, g.table);
     await grid.expectRowIdentifierText(0, "1");
     await grid.expectRowIdentifierText(1, "2");
     await grid.expectRowIdentifierText(2, "3");
   });
 });
 
-test.describe("7.3 Row height", () => {
-  test.describe.configure({ mode: "serial" });
+// -----------------------------------------------------------------------------
+// section 14  Public shared grid view
+// -----------------------------------------------------------------------------
+
+test.describe("14.1 Public shared grid", () => {
   let g: Setup;
 
   test.beforeAll(async () => {
     g = await setupGrid({
-      dbName: "RowHeightDb",
+      dbName: "PublicGridDb",
       fields: [{ name: "Score", type: "number" }],
       rows: [
         { Name: "Alice", Score: 10 },
         { Name: "Bob", Score: 20 },
       ],
     });
+    await patchView(g.user, g.view, { public: true });
   });
 
-  test.beforeEach(async ({ page }) => {
-    const grid = new GridPage(page, g.user);
-    await grid.goTo(g.database, g.table);
-  });
-
-  test("7.3.1 height menu switches visible rows from small to medium and large", async ({
+  test("14.1.1 public shared grid renders rows without edit controls", async ({
     page,
   }) => {
-    const grid = new GridPage(page, g.user);
+    const slug = g.view.slug;
+    if (!slug) {
+      throw new Error("Expected setup grid view to include a public slug.");
+    }
 
-    await grid.expectRowCount(2);
-    await grid.expectRowHeight("small", 33);
-    await grid.expectPrimaryText(0, "Alice");
-    await grid.expectFieldText(0, 0, "10");
+    const baseUrl =
+      process.env.PUBLIC_WEB_FRONTEND_URL ?? "http://localhost:3000";
+    await page.goto(`${baseUrl}/public/grid/${slug}`, {
+      waitUntil: "domcontentloaded",
+    });
 
-    await grid.selectRowHeight("Medium");
-    await grid.expectRowHeight("medium", 55);
-    await grid.expectPrimaryText(0, "Alice");
-    await grid.expectFieldText(0, 0, "10");
-
-    await grid.selectRowHeight("Large");
-    await grid.expectRowHeight("large", 99);
-    await grid.expectPrimaryText(0, "Alice");
-    await grid.expectFieldText(0, 0, "10");
+    await expect(page.locator(".grid-view__right")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.locator(".grid-view__left .grid-view__row", {
+        hasText: "Alice",
+      }),
+    ).toBeVisible();
+    await expect(
+      page.locator(".grid-view__left .grid-view__row", {
+        hasText: "Bob",
+      }),
+    ).toBeVisible();
+    await expect(page.locator(".grid-view__add-row")).toHaveCount(0);
+    await page
+      .locator(".grid-view__left .grid-view__row")
+      .first()
+      .click({ button: "right" });
+    await expect(
+      page.locator(".context__menu:visible .context__menu-item-link", {
+        hasText: /Delete row|Insert row|Duplicate row/,
+      }),
+    ).toHaveCount(0);
   });
 });

--- a/web-frontend/modules/database/components/view/grid/GridRowContextItems.vue
+++ b/web-frontend/modules/database/components/view/grid/GridRowContextItems.vue
@@ -1,0 +1,127 @@
+<template>
+  <ul class="context__menu">
+    <li v-if="canSelectRow" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'select-row', row)"
+      >
+        <i class="context__menu-item-icon iconoir-check-circle"></i>
+        {{ $t('gridView.selectRow') }}
+      </a>
+    </li>
+    <li v-if="canCreateRow" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'insert-above', row)"
+      >
+        <i class="context__menu-item-icon iconoir-arrow-up"></i>
+        {{ $t('gridView.insertRowAbove') }}
+      </a>
+    </li>
+    <li v-if="canCreateRow" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'insert-below', row)"
+      >
+        <i class="context__menu-item-icon iconoir-arrow-down"></i>
+        {{ $t('gridView.insertRowBelow') }}
+      </a>
+    </li>
+    <li v-if="canCreateRow" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'duplicate-row', row)"
+      >
+        <i class="context__menu-item-icon iconoir-copy"></i>
+        {{ $t('gridView.duplicateRow') }}
+      </a>
+    </li>
+    <li v-if="!readOnly" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'copy-row-url', row)"
+      >
+        <i class="context__menu-item-icon iconoir-link"></i>
+        {{ $t('gridView.copyRowURL') }}
+      </a>
+    </li>
+    <li v-if="row !== null && !row._.loading" class="context__menu-item">
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'open-row-modal', row)"
+      >
+        <i class="context__menu-item-icon iconoir-expand"></i>
+        {{ $t('gridView.enlargeRow') }}
+      </a>
+    </li>
+    <li
+      v-if="canDeleteRow"
+      class="context__menu-item context__menu-item--with-separator"
+    >
+      <a
+        class="context__menu-item-link"
+        @click="onItemClick($event, 'delete-row', row)"
+      >
+        <i class="context__menu-item-icon iconoir-bin"></i>
+        {{ $t('gridView.deleteRow') }}
+      </a>
+    </li>
+  </ul>
+</template>
+
+<script>
+/**
+ * Single-row context menu items for grid views. Stateless: emits a typed event
+ * per action; the parent component owns the wiring to its store and the
+ * Context wrapper that positions the menu next to the mouse.
+ *
+ * `canCreateRow`, `canDeleteRow`, `canSelectRow` are computed by the
+ * caller because they are permission/two-way-sync checks tied to the table,
+ * view, and workspace. This keeps the component presentational and the checks
+ * near the state they depend on.
+ */
+export default {
+  name: 'GridRowContextItems',
+  props: {
+    row: {
+      type: Object,
+      default: null,
+    },
+    readOnly: {
+      type: Boolean,
+      default: false,
+    },
+    canCreateRow: {
+      type: Boolean,
+      default: false,
+    },
+    canDeleteRow: {
+      type: Boolean,
+      default: false,
+    },
+    canSelectRow: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  emits: [
+    'select-row',
+    'insert-above',
+    'insert-below',
+    'duplicate-row',
+    'copy-row-url',
+    'open-row-modal',
+    'delete-row',
+  ],
+  methods: {
+    onItemClick(event, name, row) {
+      // The flat grid's `gridField` mixin uses this flag to keep an
+      // open editor from closing when the user clicks a menu item.
+      // Keep this in the presentational component so every context-menu user
+      // sends the same upstream event shape.
+      event.preventFieldCellUnselect = true
+      this.$emit(name, row)
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/components/view/grid/GridRowContextItems.vue
+++ b/web-frontend/modules/database/components/view/grid/GridRowContextItems.vue
@@ -115,10 +115,8 @@ export default {
   ],
   methods: {
     onItemClick(event, name, row) {
-      // The flat grid's `gridField` mixin uses this flag to keep an
-      // open editor from closing when the user clicks a menu item.
-      // Keep this in the presentational component so every context-menu user
-      // sends the same upstream event shape.
+      // The `gridField` mixin uses this flag to keep an open editor from closing when
+      // the user clicks a menu item.
       event.preventFieldCellUnselect = true
       this.$emit(name, row)
     },

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -258,135 +258,20 @@
           </a>
         </li>
       </ul>
-      <ul v-show="!isMultiSelectActive" class="context__menu">
-        <li class="context__menu-item">
-          <a
-            class="context__menu-item-link"
-            @click=";[selectRow($event, selectedRow), $refs.rowContext.hide()]"
-          >
-            <i class="context__menu-item-icon iconoir-check-circle"></i>
-            {{ $t('gridView.selectRow') }}
-          </a>
-        </li>
-        <li
-          v-if="
-            !readOnly &&
-            (!table.data_sync || table.data_sync.two_way_sync) &&
-            ($hasPermission(
-              'database.table.create_row',
-              table,
-              database.workspace.id
-            ) ||
-              $hasPermission(
-                'database.table.view.create_row',
-                view,
-                database.workspace.id
-              ))
-          "
-          class="context__menu-item"
-        >
-          <a
-            class="context__menu-item-link"
-            @click="addRowAboveSelectedRow($event, selectedRow)"
-          >
-            <i class="context__menu-item-icon iconoir-arrow-up"></i>
-            {{ $t('gridView.insertRowAbove') }}
-          </a>
-        </li>
-        <li
-          v-if="
-            !readOnly &&
-            (!table.data_sync || table.data_sync.two_way_sync) &&
-            ($hasPermission(
-              'database.table.create_row',
-              table,
-              database.workspace.id
-            ) ||
-              $hasPermission(
-                'database.table.view.create_row',
-                view,
-                database.workspace.id
-              ))
-          "
-          class="context__menu-item"
-        >
-          <a
-            class="context__menu-item-link"
-            @click="addRowBelowSelectedRow($event, selectedRow)"
-          >
-            <i class="context__menu-item-icon iconoir-arrow-down"></i>
-            {{ $t('gridView.insertRowBelow') }}
-          </a>
-        </li>
-        <li
-          v-if="
-            !readOnly &&
-            (!table.data_sync || table.data_sync.two_way_sync) &&
-            ($hasPermission(
-              'database.table.create_row',
-              table,
-              database.workspace.id
-            ) ||
-              $hasPermission(
-                'database.table.view.create_row',
-                view,
-                database.workspace.id
-              ))
-          "
-          class="context__menu-item"
-        >
-          <a
-            class="context__menu-item-link"
-            @click="duplicateSelectedRow($event, selectedRow)"
-          >
-            <i class="context__menu-item-icon iconoir-copy"></i>
-            {{ $t('gridView.duplicateRow') }}
-          </a>
-        </li>
-        <li v-if="!readOnly" class="context__menu-item">
-          <a
-            class="context__menu-item-link"
-            @click="copyLinkToSelectedRow($event, selectedRow)"
-          >
-            <i class="context__menu-item-icon iconoir-link"></i>
-            {{ $t('gridView.copyRowURL') }}
-          </a>
-        </li>
-        <li
-          v-if="selectedRow !== null && !selectedRow._.loading"
-          class="context__menu-item"
-        >
-          <a
-            class="context__menu-item-link"
-            @click=";[openRowEditModal(selectedRow), $refs.rowContext.hide()]"
-          >
-            <i class="context__menu-item-icon iconoir-expand"></i>
-            {{ $t('gridView.enlargeRow') }}
-          </a>
-        </li>
-        <li
-          v-if="
-            !readOnly &&
-            (!table.data_sync || table.data_sync.two_way_sync) &&
-            ($hasPermission(
-              'database.table.delete_row',
-              table,
-              database.workspace.id
-            ) ||
-              $hasPermission(
-                'database.table.view.delete_row',
-                view,
-                database.workspace.id
-              ))
-          "
-          class="context__menu-item context__menu-item--with-separator"
-        >
-          <a class="context__menu-item-link" @click="deleteRow(selectedRow)">
-            <i class="context__menu-item-icon iconoir-bin"></i>
-            {{ $t('gridView.deleteRow') }}
-          </a>
-        </li>
-      </ul>
+      <GridRowContextItems
+        v-show="!isMultiSelectActive"
+        :row="selectedRow"
+        :read-only="readOnly"
+        :can-create-row="canCreateRow"
+        :can-delete-row="canDeleteRow"
+        @select-row="onContextSelectRow"
+        @insert-above="onContextInsertAbove"
+        @insert-below="onContextInsertBelow"
+        @duplicate-row="onContextDuplicateRow"
+        @copy-row-url="copyLinkToSelectedRow({}, $event)"
+        @open-row-modal="onContextOpenRowModal"
+        @delete-row="deleteRow($event)"
+      />
     </Context>
     <RowEditModal
       ref="rowEditModal"
@@ -455,7 +340,10 @@ import GridViewFreezeHandle from '@baserow/modules/database/components/view/grid
 import GridViewRowDragging from '@baserow/modules/database/components/view/grid/GridViewRowDragging'
 import RowEditModal from '@baserow/modules/database/components/row/RowEditModal'
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
-import { sortFieldsByOrderAndIdFunction } from '@baserow/modules/database/utils/view'
+import {
+  canRowsBeOptimisticallyUpdatedInView,
+  sortFieldsByOrderAndIdFunction,
+} from '@baserow/modules/database/utils/view'
 import { filterGridViewVisibleFieldsFunction } from '@baserow/modules/database/components/view/grid/utils'
 import viewHelpers from '@baserow/modules/database/mixins/viewHelpers'
 import { isElement } from '@baserow/modules/core/utils/dom'
@@ -464,6 +352,7 @@ import { populateRow } from '@baserow/modules/database/store/view/grid'
 import { clone } from '@baserow/modules/core/utils/object'
 import copyPasteHelper from '@baserow/modules/database/mixins/copyPasteHelper'
 import GridViewRowsAddContext from '@baserow/modules/database/components/view/grid/fields/GridViewRowsAddContext'
+import GridRowContextItems from '@baserow/modules/database/components/view/grid/GridRowContextItems'
 import { copyToClipboard } from '@baserow/modules/database/utils/clipboard'
 import {
   GRID_VIEW_SIZE_TO_ROW_HEIGHT_MAPPING,
@@ -480,6 +369,7 @@ export default {
     GridViewRowsAddContext,
     GridViewSection,
     GridViewRowDragging,
+    GridRowContextItems,
     RowEditModal,
   },
   mixins: [viewHelpers, gridViewHelpers, viewDecoration, copyPasteHelper],
@@ -560,6 +450,46 @@ export default {
     },
     viewHasGroupBys() {
       return this.activeGroupBys.length > 0
+    },
+    canCreateRow() {
+      if (this.readOnly) {
+        return false
+      }
+      if (this.table?.data_sync && !this.table.data_sync.two_way_sync) {
+        return false
+      }
+      return (
+        this.$hasPermission(
+          'database.table.create_row',
+          this.table,
+          this.database.workspace.id
+        ) ||
+        this.$hasPermission(
+          'database.table.view.create_row',
+          this.view,
+          this.database.workspace.id
+        )
+      )
+    },
+    canDeleteRow() {
+      if (this.readOnly) {
+        return false
+      }
+      if (this.table?.data_sync && !this.table.data_sync.two_way_sync) {
+        return false
+      }
+      return (
+        this.$hasPermission(
+          'database.table.delete_row',
+          this.table,
+          this.database.workspace.id
+        ) ||
+        this.$hasPermission(
+          'database.table.view.delete_row',
+          this.view,
+          this.database.workspace.id
+        )
+      )
     },
     frozenColumnCount() {
       return this.view.frozen_column_count ?? 1
@@ -868,6 +798,26 @@ export default {
         }
       }
     },
+    onContextSelectRow(row) {
+      this.selectRow(this.stubMenuEvent(), row)
+      this.$refs.rowContext.hide()
+    },
+    onContextInsertAbove(row) {
+      this.addRowAboveSelectedRow(this.stubMenuEvent(), row)
+    },
+    onContextInsertBelow(row) {
+      this.addRowBelowSelectedRow(this.stubMenuEvent(), row)
+    },
+    onContextDuplicateRow(row) {
+      this.duplicateSelectedRow(this.stubMenuEvent(), row)
+    },
+    onContextOpenRowModal(row) {
+      this.openRowEditModal(row)
+      this.$refs.rowContext.hide()
+    },
+    stubMenuEvent() {
+      return { preventFieldCellUnselect: true, stopPropagation: () => {} }
+    },
     duplicateSelectedRow(event, selectedRow) {
       event.preventFieldCellUnselect = true
       const duplicatedRow = clone(selectedRow)
@@ -992,10 +942,21 @@ export default {
       }
     },
     /**
-     * Called when a value is edited, but not yet saved. Here we can do a preliminary
-     * check to see if the values matches the filters.
+     * Called when a value is edited, but not yet saved. Views that the frontend can
+     * safely evaluate show mismatch warnings immediately. Views that depend on
+     * backend-computed values wait for the confirmed update.
      */
     editValue({ field, row, value, oldValue }) {
+      if (
+        !canRowsBeOptimisticallyUpdatedInView(
+          this.$registry,
+          this.view,
+          this.fields,
+          this.activeSearchTerm
+        )
+      ) {
+        return
+      }
       const overrides = {}
       overrides[`field_${field.id}`] = value
       this.$store.dispatch(this.storePrefix + 'view/grid/onRowChange', {
@@ -1602,6 +1563,14 @@ export default {
       if (
         this.$store.getters[this.storePrefix + 'view/grid/isMultiSelectActive']
       ) {
+        if (key === 'Escape') {
+          event.preventDefault()
+          this.$store.dispatch(
+            this.storePrefix + 'view/grid/clearAndDisableMultiSelect'
+          )
+          return
+        }
+
         if (arrowKeys.includes(key) && !shiftKey) {
           this.$store.dispatch(
             this.storePrefix + 'view/grid/setSelectedCellCancelledMultiSelect',

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -547,7 +547,6 @@ export default {
       return (
         this.leftFieldsWidth +
         (this.viewHasGroupBys ? 0 : this.gridViewRowDetailsWidth) +
-        // 100 must be replaced with the dynamic width
         this.activeGroupByWidth
       )
     },
@@ -1338,6 +1337,17 @@ export default {
       }
 
       if (nextFieldId === -1 || nextRowId === -1) {
+        // For Tab navigation with no next cell (last field of last row), still
+        // unselect the current cell so the open editor saves its value.
+        // For Enter/arrow navigation with no target, just return — the editor
+        // was already closed by save() in the key handler.
+        if (direction === 'next' || direction === 'previous') {
+          this.$store.dispatch(this.storePrefix + 'view/grid/setSelectedCell', {
+            rowId: -1,
+            fieldId: -1,
+            fields: this.fields,
+          })
+        }
         return
       }
 

--- a/web-frontend/modules/database/components/view/grid/GridViewGroups.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroups.vue
@@ -30,8 +30,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
-
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
 import GridViewGroup from '@baserow/modules/database/components/view/grid/GridViewGroup'
 

--- a/web-frontend/modules/database/components/view/grid/GridViewPlaceholder.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewPlaceholder.vue
@@ -23,8 +23,6 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
-
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
 
 export default {
@@ -81,11 +79,6 @@ export default {
     placeholderHeight() {
       return this.$store.getters[
         this.storePrefix + 'view/grid/getPlaceholderHeight'
-      ]
-    },
-    activeGroupBys() {
-      return this.$store.getters[
-        this.storePrefix + 'view/grid/getActiveGroupBys'
       ]
     },
   },

--- a/web-frontend/modules/database/components/view/grid/GridViewRow.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewRow.vue
@@ -373,8 +373,6 @@ export default {
       const isAreaSelectionActive =
         selectionType === GRID_VIEW_MULTI_SELECT_AREA &&
         this.$store.getters[this.storePrefix + 'view/grid/isMultiSelectActive']
-      // Row/field indices and ranges are only needed when an area selection is
-      // active; skip the getter calls (and the allVisibleFields scan) otherwise.
       if (!isAreaSelectionActive) {
         return computeMultiSelectPosition({
           isAreaSelectionActive: false,

--- a/web-frontend/modules/database/components/view/grid/GridViewRow.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewRow.vue
@@ -146,6 +146,7 @@
 
 <script>
 import GridViewCell from '@baserow/modules/database/components/view/grid/GridViewCell'
+import { computeMultiSelectPosition } from '@baserow/modules/database/utils/row'
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
 import GridViewRowExpandButton from '@baserow/modules/database/components/view/grid/GridViewRowExpandButton'
 import RecursiveWrapper from '@baserow/modules/core/components/RecursiveWrapper'
@@ -367,62 +368,40 @@ export default {
     // Return an object that represents if a cell is selected,
     // and it's current position in the selection grid
     getMultiSelectPosition(rowId, field) {
-      const position = {
-        selected: false,
-        top: false,
-        right: false,
-        bottom: false,
-        left: false,
-      }
       const selectionType =
         this.$store.getters[this.storePrefix + 'view/grid/getSelectionType']
-      if (selectionType !== GRID_VIEW_MULTI_SELECT_AREA) {
-        if (this.isCheckboxSelected(rowId)) {
-          position.selected = true
-        }
-        return position
-      }
-
-      if (
+      const isAreaSelectionActive =
+        selectionType === GRID_VIEW_MULTI_SELECT_AREA &&
         this.$store.getters[this.storePrefix + 'view/grid/isMultiSelectActive']
-      ) {
-        const rowIndex =
+      // Row/field indices and ranges are only needed when an area selection is
+      // active; skip the getter calls (and the allVisibleFields scan) otherwise.
+      if (!isAreaSelectionActive) {
+        return computeMultiSelectPosition({
+          isAreaSelectionActive: false,
+          // Checkbox highlight only shows outside area-selection mode, preserving
+          // the original behaviour where entering area-select hides it.
+          isCheckboxSelected:
+            selectionType !== GRID_VIEW_MULTI_SELECT_AREA &&
+            this.isCheckboxSelected(rowId),
+        })
+      }
+      return computeMultiSelectPosition({
+        isAreaSelectionActive: true,
+        isCheckboxSelected: false,
+        rowIndex:
           this.$store.getters[this.storePrefix + 'view/grid/getRowIndexById'](
             rowId
-          )
-
-        const fieldIndex = this.allVisibleFields.findIndex(
-          (f) => f.id === field.id
-        )
-
-        const [minRow, maxRow] =
+          ),
+        fieldIndex: this.allVisibleFields.findIndex((f) => f.id === field.id),
+        rowIndexRange:
           this.$store.getters[
             this.storePrefix + 'view/grid/getMultiSelectRowIndexSorted'
-          ]
-        const [minField, maxField] =
+          ],
+        fieldIndexRange:
           this.$store.getters[
             this.storePrefix + 'view/grid/getMultiSelectFieldIndexSorted'
-          ]
-
-        if (rowIndex >= minRow && rowIndex <= maxRow) {
-          if (fieldIndex >= minField && fieldIndex <= maxField) {
-            position.selected = true
-            if (rowIndex === minRow) {
-              position.top = true
-            }
-            if (rowIndex === maxRow) {
-              position.bottom = true
-            }
-            if (fieldIndex === minField) {
-              position.left = true
-            }
-            if (fieldIndex === maxField) {
-              position.right = true
-            }
-          }
-        }
-      }
-      return position
+          ],
+      })
     },
     setState(value) {
       this.state = value

--- a/web-frontend/modules/database/components/view/grid/GridViewRows.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewRows.vue
@@ -122,7 +122,7 @@ export default {
     },
     rowsAtEndOfGroups: {
       type: Set,
-      required: true,
+      default: () => new Set(),
     },
     canDrag: {
       type: Boolean,

--- a/web-frontend/modules/database/components/view/grid/GridViewSection.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewSection.vue
@@ -299,6 +299,9 @@ export default {
       if (this.includeRowDetails) {
         width += this.gridViewRowDetailsWidth
       }
+      if (this.includeGroupBy) {
+        width += this.activeGroupByWidth
+      }
 
       // The add button has a width of 100 and we reserve 100 at the right side.
       if (this.includeAddField) {
@@ -496,8 +499,6 @@ export default {
           'view/grid/isMultiSelectHolding',
         count: this.$options.propsData.storePrefix + 'view/grid/getCount',
         allRows: this.$options.propsData.storePrefix + 'view/grid/getAllRows',
-        groupByMetadata:
-          this.$options.propsData.storePrefix + 'view/grid/getGroupByMetadata',
       }),
     }
   },*/

--- a/web-frontend/modules/database/pages/publicView.vue
+++ b/web-frontend/modules/database/pages/publicView.vue
@@ -117,7 +117,7 @@ const { data, error } = await useAsyncData(
         )
       )
 
-      return { success: true, database, table }
+      return { success: true, database, table, fields, view }
     } catch (e) {
       const statusCode = e.response?.status
       // password protected view requires authentication
@@ -159,8 +159,8 @@ if (data.value?.redirect) {
 
 const database = computed(() => data.value?.database)
 const table = computed(() => data.value?.table)
-const fields = computed(() => $store.getters['field/getAll'])
-const view = computed(() => $store.getters['view/getSelected'])
+const fields = computed(() => data.value?.fields || [])
+const view = computed(() => data.value?.view)
 
 useHead(() => {
   const head = { title: view.value?.name || 'View' }

--- a/web-frontend/modules/database/pages/publicView.vue
+++ b/web-frontend/modules/database/pages/publicView.vue
@@ -159,8 +159,8 @@ if (data.value?.redirect) {
 
 const database = computed(() => data.value?.database)
 const table = computed(() => data.value?.table)
-const fields = computed(() => data.value?.fields || [])
-const view = computed(() => data.value?.view)
+const fields = computed(() => $store.getters['field/getAll'])
+const view = computed(() => $store.getters['view/getSelected'])
 
 useHead(() => {
   const head = { title: view.value?.name || 'View' }

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -2355,7 +2355,7 @@ export const actions = {
       return
     }
 
-    const { $registry, $client } = this
+    const { $registry } = this
     const row = clone(values)
 
     if (populate) {
@@ -2371,9 +2371,7 @@ export const actions = {
 
     handleRowCreated({
       context: createRowLifecycleContext({
-        client: $client,
         registry: $registry,
-        table: { id: null },
         view,
         fields,
         groupBys: view.group_bys,
@@ -3000,7 +2998,7 @@ export const actions = {
     { commit, getters, dispatch },
     { view, fields, row, values, metadata, updatedFieldIds = [] }
   ) {
-    const { $registry, $client } = this
+    const { $registry } = this
     const oldRow = clone(row)
     const newRow = Object.assign(clone(row), values)
     populateRow(oldRow, metadata)
@@ -3206,9 +3204,7 @@ export const actions = {
 
     handleRowUpdated({
       context: createRowLifecycleContext({
-        client: $client,
         registry: $registry,
-        table: { id: null },
         view,
         fields,
         groupBys: view.group_bys,
@@ -3328,7 +3324,7 @@ export const actions = {
     { commit, getters, dispatch },
     { view, fields, row }
   ) {
-    const { $registry, $client } = this
+    const { $registry } = this
     row = clone(row)
     populateRow(row)
 
@@ -3341,9 +3337,7 @@ export const actions = {
 
     handleRowDeleted({
       context: createRowLifecycleContext({
-        client: $client,
         registry: $registry,
-        table: { id: null },
         view,
         fields,
         groupBys: view.group_bys,
@@ -3398,9 +3392,7 @@ export const actions = {
         : row
     reapplyMatchFlags({
       context: createRowLifecycleContext({
-        client: this.$client,
         registry: this.$registry,
-        table: { id: null },
         view,
         fields,
         groupBys: view.group_bys,

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -18,6 +18,7 @@ import {
   getGroupBy,
   getOrderBy,
   canRowsBeOptimisticallyUpdatedInView,
+  viewHasRulesThatCanMoveOrHideRows,
 } from '@baserow/modules/database/utils/view'
 import { RefreshCancelledError } from '@baserow/modules/core/errors'
 import {
@@ -26,6 +27,7 @@ import {
   updateRowMetadataType,
   getRowMetadata,
   extractChangedFields,
+  buildNewRowDefaults,
 } from '@baserow/modules/database/utils/row'
 import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 import { fieldValuesAreEqualInObjects } from '@baserow/modules/database/utils/groupBy'
@@ -2074,47 +2076,11 @@ export const actions = {
       `table_${table.id}`
     )
     const taskId = taskQueue.add(async () => {
-      // Create an object of default field values that can be used to fill the row. If
-      // the view has default row values configured, those take precedence over the
-      // field type's default value.
-      const defaultItems = view.default_row_values
-      const defaultsByFieldId = {}
-      for (const item of defaultItems) {
-        if (item.enabled && (item.value != null || item.function)) {
-          defaultsByFieldId[item.field] = item
-        }
-      }
-      const fieldNewRowValueMap = fields.reduce((map, field) => {
-        const name = `field_${field.id}`
-        const fieldType = $registry.get('field', field._.type.type)
-        const defaultViewItem = defaultsByFieldId[field.id]
-        const supportedFunctions = fieldType
-          .getSupportedDefaultValueFunctions()
-          .map((f) => f.name)
-        if (
-          defaultViewItem &&
-          defaultViewItem.function &&
-          supportedFunctions.includes(defaultViewItem.function)
-        ) {
-          map[name] = fieldType.resolveDefaultValueFunction(
-            defaultViewItem.function,
-            field
-          )
-        } else if (
-          defaultViewItem &&
-          defaultViewItem.value != null &&
-          (!defaultViewItem.field_type ||
-            defaultViewItem.field_type === field._.type.type)
-        ) {
-          map[name] = fieldType.parseDefaultRowValue(
-            field,
-            defaultViewItem.value
-          )
-        } else {
-          map[name] = fieldType.getNewRowValue(field)
-        }
-        return map
-      }, {})
+      const fieldNewRowValueMap = buildNewRowDefaults({
+        view,
+        fields,
+        registry: $registry,
+      })
 
       const step = before ? ORDER_STEP_BEFORE : ORDER_STEP
 
@@ -2237,6 +2203,18 @@ export const actions = {
         })
       }
 
+      if (
+        canUpdateOptimistically &&
+        isSingleRowInsertion &&
+        viewHasRulesThatCanMoveOrHideRows(view, getters.getActiveSearchTerm)
+      ) {
+        await dispatch('onRowChange', {
+          view,
+          row: rowsPopulated[0],
+          fields,
+        })
+      }
+
       // The backend expects slightly different values than what we have in the row
       // buffer. Therefore, we need to prepare the rows before we can send them to the
       // backend.
@@ -2296,20 +2274,18 @@ export const actions = {
           }
           dispatch('onRowChange', { view, row, fields })
           const rowId = row.id
-          setTimeout(() => {
-            // Get the latest row so that any changes that might have been made in the
-            // meantime are included. This is needed to pass the correct row into the
-            // `refreshRow` that shows/hide the row.
-            const row = getters.getRow(rowId)
-            if (row && !row._.selected) {
-              dispatch('refreshRow', {
-                grid: view,
-                row,
-                fields,
-                isRowOpenedInModal,
-              })
-            }
-          }, REFRESH_ROW_DELAY)
+          // Get the latest row so that any changes that might have been made in the
+          // meantime are included. This is needed to pass the correct row into the
+          // `refreshRow` that shows/hide the row.
+          const latestRow = getters.getRow(rowId)
+          if (latestRow && !latestRow._.selected) {
+            dispatch('refreshRow', {
+              grid: view,
+              row: latestRow,
+              fields,
+              isRowOpenedInModal,
+            })
+          }
         }
 
         await dispatch('fetchAllFieldAggregationData', {
@@ -2616,6 +2592,8 @@ export const actions = {
         fields,
         getters.getActiveSearchTerm
       )
+      const hasViewRulesThatCanMoveOrHideRows =
+        viewHasRulesThatCanMoveOrHideRows(view, getters.getActiveSearchTerm)
       if (!canUpdateOptimistically) {
         commit('SET_ROW_LOADING', { row, value: true })
       }
@@ -2667,9 +2645,13 @@ export const actions = {
           // If we can't optimistically update the row, refresh it to stop the loading
           // state, show proper messages, and update its position and state. Also, if the
           // backend changed other fields, we should refresh sorting/search/filtering.
-          if (!canUpdateOptimistically || otherFieldsChangedInBackend) {
+          if (
+            !canUpdateOptimistically ||
+            otherFieldsChangedInBackend ||
+            hasViewRulesThatCanMoveOrHideRows
+          ) {
             commit('SET_ROW_LOADING', { row: existing, value: false })
-            setTimeout(() => {
+            const refreshUnselectedRow = () => {
               // Get the latest row so that updated `readOnlyData` values are included,
               // and any other changes that might have been made in the meantime. This is
               // needed to pass the correct row into the `refreshRow` that shows/hide the
@@ -2683,7 +2665,13 @@ export const actions = {
                   isRowOpenedInModal,
                 })
               }
-            }, REFRESH_ROW_DELAY)
+            }
+
+            if (hasViewRulesThatCanMoveOrHideRows) {
+              refreshUnselectedRow()
+            } else {
+              setTimeout(refreshUnselectedRow, REFRESH_ROW_DELAY)
+            }
           }
         }
         dispatch('fetchAllFieldAggregationData', {
@@ -3466,8 +3454,7 @@ export const actions = {
     }
   ) {
     const { $registry, $client, $i18n, $config } = this
-    const rowShouldBeHidden =
-      (!row._.matchFilters || !row._.matchSearch) && !row._.loading
+    const rowShouldBeHidden = !row._.matchFilters || !row._.matchSearch
     const openedInModal =
       isRowOpenedInModal !== undefined ? isRowOpenedInModal(row) : false
     if (row._.selectedBy.length === 0 && rowShouldBeHidden && !openedInModal) {

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -2,6 +2,13 @@ import axios from 'axios'
 import _ from 'lodash'
 import BigNumber from 'bignumber.js'
 import { createNewUndoRedoActionGroupId } from '@baserow/modules/database/utils/action'
+import {
+  createRowLifecycleContext,
+  handleRowCreated,
+  handleRowDeleted,
+  handleRowUpdated,
+  reapplyMatchFlags,
+} from '@baserow/modules/database/utils/rowLifecycle'
 
 import { uuid } from '@baserow/modules/core/utils/string'
 import { clone } from '@baserow/modules/core/utils/object'
@@ -28,6 +35,8 @@ import {
   getRowMetadata,
   extractChangedFields,
   buildNewRowDefaults,
+  computeRowMatchFlags,
+  computeRowInsertPosition,
 } from '@baserow/modules/database/utils/row'
 import { getDefaultSearchModeFromEnv } from '@baserow/modules/database/utils/search'
 import { fieldValuesAreEqualInObjects } from '@baserow/modules/database/utils/groupBy'
@@ -1131,6 +1140,7 @@ export const actions = {
     })
     commit('REPLACE_ALL_FIELD_OPTIONS', data.field_options)
     commit('SET_GROUP_BY_METADATA', data.group_by_metadata || {})
+
     dispatch('updateSearch', { fields })
   },
   /**
@@ -1217,6 +1227,7 @@ export const actions = {
           bufferLimit: data.results.length,
         })
         commit('SET_GROUP_BY_METADATA', data.group_by_metadata || {})
+
         dispatch('updateSearch', { fields })
         if (includeFieldOptions) {
           if (rootGetters['page/view/public/getIsPublic']) {
@@ -2344,25 +2355,20 @@ export const actions = {
       return
     }
 
-    const { $registry, $client, $i18n, $config } = this
+    const { $registry, $client } = this
     const row = clone(values)
 
     if (populate) {
       populateRow(row, metadata)
     }
 
-    // Check if the row belongs into the current view by checking if it matches the
-    // filters and search.
-    await dispatch('updateMatchFilters', { view, row, fields })
+    // The lifecycle helper only evaluates filters/sortings, so the search match
+    // is still gated here against the active search term.
     await dispatch('updateSearchMatchesForRow', { row, fields })
-
-    // If the row does not match the filters or the search then we don't have to add
-    // it at all.
-    if (!row._.matchFilters || !row._.matchSearch) {
+    if (!row._.matchSearch) {
       return
     }
 
-    // Update the group by metadata if needed.
     commit('UPDATE_GROUP_BY_METADATA_COUNT', {
       fields,
       registry: $registry,
@@ -2371,40 +2377,41 @@ export const actions = {
       decrease: false,
     })
 
-    // Now that we know that the row applies to the filters, which means it belongs
-    // in this view, we need to estimate what position it has in the table.
-    const allRowsCopy = clone(getters.getAllRows)
-    allRowsCopy.push(row)
-    const sortFunction = getRowSortFunction(
-      $registry,
-      view.sortings,
-      fields,
-      view.group_bys
-    )
-    allRowsCopy.sort(sortFunction)
-    const index = allRowsCopy.findIndex((r) => r.id === row.id)
-
-    const isFirst = index === 0
-    const isLast = index === allRowsCopy.length - 1
-
-    if (
-      // All of these scenario's mean that the row belongs in the buffer that
-      // we have loaded currently.
-      (isFirst && getters.getBufferStartIndex === 0) ||
-      (isLast && getters.getBufferEndIndex === getters.getCount) ||
-      (index > 0 && index < allRowsCopy.length - 1)
-    ) {
-      commit('INSERT_NEW_ROWS_IN_BUFFER_AT_INDEX', { rows: [row], index })
-    } else {
-      if (isFirst) {
-        // Because the row has been added before the our buffer, we need know that the
-        // buffer start index has increased by one.
-        commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex + 1)
-      }
-      // The row has been added outside of the buffer, so we can safely increase the
-      // count.
-      commit('SET_COUNT', getters.getCount + 1)
-    }
+    handleRowCreated({
+      context: createRowLifecycleContext({
+        client: $client,
+        registry: $registry,
+        table: { id: null },
+        view,
+        fields,
+        groupBys: view.group_bys,
+      }),
+      mutations: {
+        insertAtPosition: (insertedRow, { sortedIndex, isFirst, isLast }) => {
+          const inBuffer =
+            (isFirst && getters.getBufferStartIndex === 0) ||
+            (isLast && getters.getBufferEndIndex === getters.getCount) ||
+            (!isFirst && !isLast)
+          if (inBuffer) {
+            commit('INSERT_NEW_ROWS_IN_BUFFER_AT_INDEX', {
+              rows: [insertedRow],
+              index: sortedIndex,
+            })
+          } else {
+            if (isFirst) {
+              commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex + 1)
+            }
+            commit('SET_COUNT', getters.getCount + 1)
+          }
+        },
+        applyMatchFlags: (rowId, { matchFilters, matchSortings }) => {
+          commit('SET_ROW_MATCH_FILTERS', { row, value: matchFilters })
+          commit('SET_ROW_MATCH_SORTINGS', { row, value: matchSortings })
+        },
+        rowsForMatchCheck: () => getters.getAllRows,
+      },
+      row,
+    })
   },
   /**
    * Moves an existing row to the position before the provided before row. It will
@@ -2514,12 +2521,26 @@ export const actions = {
     }
   ) {
     const { $registry, $client, $i18n, $config } = this
-    // Add the update actual update function to the queue so that the same row
-    // will never be updated concurrency, and so that the value won't be
-    // updated if the row hasn't been created yet
     const taskQueue = createAndUpdateRowQueue.getOrCreateQueue(
       `table_${table.id}`
     )
+
+    // Apply the changed field value immediately so the UI reflects the user's
+    // input even when a pending create is holding the persistentId lock.
+    // The PATCH and all other side-effects still run inside the task queue.
+    if (
+      canRowsBeOptimisticallyUpdatedInView(
+        $registry,
+        view,
+        fields,
+        getters.getActiveSearchTerm
+      )
+    ) {
+      const storeRow = getters.getRow(row.id)
+      if (storeRow !== undefined) {
+        commit('UPDATE_ROW_FIELD_VALUE', { row: storeRow, field, value })
+      }
+    }
 
     const taskId = taskQueue.add(async () => {
       /**
@@ -2533,27 +2554,11 @@ export const actions = {
           // If the row exists in the buffer, we can visually show to the user that
           // the values have changed, without immediately reflecting the change in
           // the buffer.
-          if (optimisticUpdate) {
-            commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-              fields,
-              registry: $registry,
-              row,
-              increase: false,
-              decrease: true,
-            })
-          }
           commit('UPDATE_ROW_VALUES', {
             row,
             values: { ...values },
           })
           if (optimisticUpdate) {
-            commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-              fields,
-              registry: $registry,
-              row,
-              increase: true,
-              decrease: false,
-            })
             await dispatch('onRowChange', { view, row, fields })
           }
         } else {
@@ -2682,6 +2687,15 @@ export const actions = {
           commit('SET_ROW_LOADING', { row, value: false })
         }
         await updateValues(row, oldRowValues, true)
+        const latestRow = getters.getRow(row.id)
+        if (latestRow && hasViewRulesThatCanMoveOrHideRows) {
+          await dispatch('refreshRow', {
+            grid: view,
+            row: latestRow,
+            fields,
+            isRowOpenedInModal,
+          })
+        }
         throw error
       }
     }, row._.persistentId)
@@ -2986,72 +3000,136 @@ export const actions = {
     { commit, getters, dispatch },
     { view, fields, row, values, metadata, updatedFieldIds = [] }
   ) {
-    const { $registry, $client, $i18n, $config } = this
+    const { $registry, $client } = this
     const oldRow = clone(row)
     const newRow = Object.assign(clone(row), values)
     populateRow(oldRow, metadata)
     populateRow(newRow, metadata)
 
-    await dispatch('updateMatchFilters', { view, row: oldRow, fields })
+    // The lifecycle helper only evaluates filters/sortings, so the search match
+    // is still gated here against the active search term. A row that fails the
+    // active search is effectively out of the view regardless of its filters.
     await dispatch('updateSearchMatchesForRow', { row: oldRow, fields })
-
-    await dispatch('updateMatchFilters', { view, row: newRow, fields })
     await dispatch('updateSearchMatchesForRow', { row: newRow, fields })
 
-    const oldRowExists = oldRow._.matchFilters && oldRow._.matchSearch
-    const newRowExists = newRow._.matchFilters && newRow._.matchSearch
+    const oldMatchesSearch = oldRow._.matchSearch
+    const newMatchesSearch = newRow._.matchSearch
+    const oldFlags = computeRowMatchFlags({
+      row: oldRow,
+      view,
+      fields,
+      registry: $registry,
+      rowsInSortingGroup: getters.getAllRows,
+      groupBys: view.group_bys,
+    })
+    const rowsExcludingNew = getters.getAllRows.filter(
+      (r) => r.id !== newRow.id
+    )
+    const newFlags = computeRowMatchFlags({
+      row: newRow,
+      view,
+      fields,
+      registry: $registry,
+      rowsInSortingGroup: rowsExcludingNew,
+      groupBys: view.group_bys,
+    })
+    const oldRowExists = oldMatchesSearch && oldFlags.matchFilters
+    const newRowExists = newMatchesSearch && newFlags.matchFilters
 
+    if (!oldRowExists && !newRowExists) {
+      return
+    }
+
+    // When the row crosses the view boundary, delegate to the create/delete paths
+    // so filter/search checks and group-by metadata updates stay aligned.
     if (oldRowExists && !newRowExists) {
-      await dispatch('deletedExistingRow', {
-        view,
-        fields,
-        row,
-      })
-    } else if (!oldRowExists && newRowExists) {
+      await dispatch('deletedExistingRow', { view, fields, row })
+      return
+    }
+    if (!oldRowExists && newRowExists) {
       await dispatch('createdNewRow', {
         view,
         fields,
         values: newRow,
         metadata,
       })
-    } else if (oldRowExists && newRowExists) {
-      // Instead of implementing a metadata updated mutation, we can easily just
-      // call the deleted and created mutation because that will have the same effect.
-      commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-        fields,
-        registry: $registry,
-        row: oldRow,
-        increase: false,
-        decrease: true,
-      })
-      commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-        fields,
-        registry: $registry,
-        row: newRow,
-        increase: true,
-        decrease: false,
-      })
+      return
+    }
 
-      // If the new order already exists in the buffer and is not the row that has
-      // been updated, we need to decrease all the other orders, otherwise we could
-      // have duplicate orders.
-      if (
-        getters.getAllRows.findIndex(
-          (r) => r.id !== newRow.id && r.order === newRow.order
-        ) > -1
-      ) {
-        commit('DECREASE_ORDERS_IN_BUFFER_LOWER_THAN', newRow.order)
+    commit('UPDATE_GROUP_BY_METADATA_COUNT', {
+      fields,
+      registry: $registry,
+      row: oldRow,
+      increase: false,
+      decrease: true,
+    })
+    commit('UPDATE_GROUP_BY_METADATA_COUNT', {
+      fields,
+      registry: $registry,
+      row: newRow,
+      increase: true,
+      decrease: false,
+    })
+
+    if (
+      getters.getAllRows.findIndex(
+        (r) => r.id !== newRow.id && r.order === newRow.order
+      ) > -1
+    ) {
+      commit('DECREASE_ORDERS_IN_BUFFER_LOWER_THAN', newRow.order)
+    }
+
+    const insertAtPosition = (
+      insertedRow,
+      { sortedIndex, isFirst, isLast }
+    ) => {
+      const inBuffer =
+        (isFirst && getters.getBufferStartIndex === 0) ||
+        (isLast && getters.getBufferEndIndex === getters.getCount) ||
+        (!isFirst && !isLast)
+      if (inBuffer) {
+        commit('INSERT_NEW_ROWS_IN_BUFFER_AT_INDEX', {
+          rows: [insertedRow],
+          index: sortedIndex,
+        })
+      } else {
+        if (isFirst) {
+          commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex + 1)
+        }
+        commit('SET_COUNT', getters.getCount + 1)
       }
+    }
 
-      // Figure out if the row is currently in the buffer.
-      const sortFunction = getRowSortFunction(
-        $registry,
+    const remove = (rowId) => {
+      const allRows = getters.getAllRows
+      const idx = allRows.findIndex((r) => r.id === rowId)
+      if (idx >= 0) {
+        commit('DELETE_ROW_IN_BUFFER', row)
+        dispatch('correctMultiSelect')
+        return
+      }
+      const position = computeRowInsertPosition(
+        oldRow,
+        allRows,
         view.sortings,
         fields,
+        $registry,
         view.group_bys
       )
+      if (position.isFirst) {
+        commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex - 1)
+      }
+      commit('SET_COUNT', getters.getCount - 1)
+      dispatch('correctMultiSelect')
+    }
+
+    const replaceAtPosition = (
+      rowId,
+      newRowValues,
+      { sortedIndex, isFirst, isLast }
+    ) => {
       const allRows = getters.getAllRows
-      const index = allRows.findIndex((r) => r.id === row.id)
+      const index = allRows.findIndex((r) => r.id === rowId)
       const oldIsFirst = index === 0
       const oldIsLast = index === allRows.length - 1
       const oldRowInBuffer =
@@ -3060,52 +3138,34 @@ export const actions = {
         (index > 0 && index < allRows.length - 1)
 
       if (oldRowInBuffer) {
-        // If the old row is inside the buffer at a known position.
         commit('UPDATE_ROW_IN_BUFFER', { row, values, metadata })
         commit('SET_BUFFER_LIMIT', getters.getBufferLimit - 1)
-      } else if (oldIsFirst) {
-        // If the old row exists in the buffer, but is at the before position.
-        commit('DELETE_ROW_IN_BUFFER_WITHOUT_UPDATE', row)
-        commit('SET_BUFFER_LIMIT', getters.getBufferLimit - 1)
-      } else if (oldIsLast) {
-        // If the old row exists in the buffer, bit is at the after position.
+      } else if (oldIsFirst || oldIsLast) {
         commit('DELETE_ROW_IN_BUFFER_WITHOUT_UPDATE', row)
         commit('SET_BUFFER_LIMIT', getters.getBufferLimit - 1)
       } else {
-        // The row does not exist in the buffer, so we need to check if it is before
-        // or after the buffer.
-        const allRowsCopy = clone(getters.getAllRows)
-        const oldRowIndex = allRowsCopy.findIndex((r) => r.id === oldRow.id)
-        if (oldRowIndex > -1) {
-          allRowsCopy.splice(oldRowIndex, 1)
-        }
-        allRowsCopy.push(oldRow)
-        allRowsCopy.sort(sortFunction)
-        const oldIndex = allRowsCopy.findIndex((r) => r.id === newRow.id)
-        if (oldIndex === 0) {
-          // If the old row is before the buffer.
+        const oldPosition = computeRowInsertPosition(
+          oldRow,
+          allRows.filter((r) => r.id !== oldRow.id),
+          view.sortings,
+          fields,
+          $registry,
+          view.group_bys
+        )
+        if (oldPosition.isFirst) {
           commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex - 1)
         }
       }
 
-      // Calculate what the new index should be.
-      const allRowsCopy = clone(getters.getAllRows)
-      const oldRowIndex = allRowsCopy.findIndex((r) => r.id === oldRow.id)
-      if (oldRowIndex > -1) {
-        allRowsCopy.splice(oldRowIndex, 1)
-      }
-      allRowsCopy.push(newRow)
-      allRowsCopy.sort(sortFunction)
-      const newIndex = allRowsCopy.findIndex((r) => r.id === newRow.id)
-      const newIsFirst = newIndex === 0
-      const newIsLast = newIndex === allRowsCopy.length - 1
+      const newIndex = sortedIndex
+      const newIsFirst = isFirst
+      const newIsLast = isLast
       const newRowInBuffer =
         (newIsFirst && getters.getBufferStartIndex === 0) ||
         (newIsLast && getters.getBufferEndIndex === getters.getCount - 1) ||
-        (newIndex > 0 && newIndex < allRowsCopy.length - 1)
+        (!newIsFirst && !newIsLast)
 
       if (oldRowInBuffer && newRowInBuffer) {
-        // If the old row and the new row are in the buffer.
         if (index !== newIndex) {
           commit('MOVE_EXISTING_ROW_IN_BUFFER', {
             row: oldRow,
@@ -3114,47 +3174,62 @@ export const actions = {
         }
         commit('SET_BUFFER_LIMIT', getters.getBufferLimit + 1)
       } else if (newRowInBuffer) {
-        // If the new row should be in the buffer, but wasn't.
         commit('INSERT_EXISTING_ROW_IN_BUFFER_AT_INDEX', {
-          row: newRow,
+          row: newRowValues,
           index: newIndex,
         })
         commit('SET_BUFFER_LIMIT', getters.getBufferLimit + 1)
       } else if (newIsFirst) {
-        // If the new row is before the buffer.
         commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex + 1)
       }
 
-      // Remove every pending AI field if a value is provided for it. This will make
-      // sure the loading state will stop if the value is updated. This is done even
-      // if the row is not found in the buffer because it could have been removed from
-      // the buffer when scrolling outside the buffer range.
-      const getFieldId = (key) => parseInt(key.split('_')[1])
-      const fieldIdsToClearPendingOperationsFor = Object.entries(values)
-        .filter(
-          ([key, value]) =>
-            key.startsWith('field_') &&
-            // Either the value has changed.
-            (_.isEqual(value, oldRow[key]) ||
-              // Or the backend has just recalculated the value, even if it hasn't
-              // actually changed.
-              updatedFieldIds.includes(getFieldId(key)))
-        )
-        .map(([key, value]) => getFieldId(key))
-
-      commit('CLEAR_PENDING_FIELD_OPERATIONS', {
-        fieldIds: fieldIdsToClearPendingOperationsFor,
-        rowId: row.id,
-      })
-
-      // If the row as in the old buffer, but ended up at the first/before or
-      // last/after position. This means that we can't know for sure the row should
-      // be in the buffer, so it is removed from it.
       if (oldRowInBuffer && !newRowInBuffer && (newIsFirst || newIsLast)) {
         commit('DELETE_ROW_IN_BUFFER_WITHOUT_UPDATE', row)
       }
-      await dispatch('correctMultiSelect')
+      dispatch('correctMultiSelect')
     }
+
+    const applyMatchFlags = (rowId, { matchFilters, matchSortings }) => {
+      commit('SET_ROW_MATCH_FILTERS', { row: newRow, value: matchFilters })
+      commit('SET_ROW_MATCH_SORTINGS', { row: newRow, value: matchSortings })
+    }
+
+    const rowsForMatchCheck = () => getters.getAllRows
+
+    handleRowUpdated({
+      context: createRowLifecycleContext({
+        client: $client,
+        registry: $registry,
+        table: { id: null },
+        view,
+        fields,
+        groupBys: view.group_bys,
+      }),
+      mutations: {
+        insertAtPosition,
+        remove,
+        replaceAtPosition,
+        applyMatchFlags,
+        rowsForMatchCheck,
+      },
+      oldRow,
+      newRow,
+    })
+
+    const getFieldId = (key) => parseInt(key.split('_')[1])
+    const fieldIdsToClearPendingOperationsFor = Object.entries(values)
+      .filter(
+        ([key, value]) =>
+          key.startsWith('field_') &&
+          (_.isEqual(value, oldRow[key]) ||
+            updatedFieldIds.includes(getFieldId(key)))
+      )
+      .map(([key, value]) => getFieldId(key))
+
+    commit('CLEAR_PENDING_FIELD_OPERATIONS', {
+      fieldIds: fieldIdsToClearPendingOperationsFor,
+      rowId: row.id,
+    })
   },
   /**
    * Called when the user wants to delete an existing row in the table.
@@ -3245,21 +3320,17 @@ export const actions = {
     { commit, getters, dispatch },
     { view, fields, row }
   ) {
-    const { $registry, $client, $i18n, $config } = this
+    const { $registry, $client } = this
     row = clone(row)
     populateRow(row)
 
-    // Check if that row was visible in the view.
-    await dispatch('updateMatchFilters', { view, row, fields })
+    // The lifecycle helper only evaluates filters/sortings, so the search match
+    // is still gated here against the active search term.
     await dispatch('updateSearchMatchesForRow', { row, fields })
-
-    // If the row does not match the filters or the search then did not exist in the
-    // view, so we don't have to do anything.
-    if (!row._.matchFilters || !row._.matchSearch) {
+    if (!row._.matchSearch) {
       return
     }
 
-    // Decrease the count in the group by metadata if an entry exists.
     commit('UPDATE_GROUP_BY_METADATA_COUNT', {
       fields,
       registry: $registry,
@@ -3268,48 +3339,73 @@ export const actions = {
       decrease: true,
     })
 
-    // Now that we know for sure that the row belongs in the view, we need to figure
-    // out if is before, inside or after the buffered results.
-    const allRowsCopy = clone(getters.getAllRows)
-    const exists = allRowsCopy.findIndex((r) => r.id === row.id) > -1
-
-    // If the row is already in the buffer, it can be removed via the
-    // `DELETE_ROW_IN_BUFFER` commit, which removes it and changes the buffer state
-    // accordingly.
-    if (exists) {
-      commit('DELETE_ROW_IN_BUFFER', row)
-      await dispatch('correctMultiSelect')
-      return
-    }
-
-    // Otherwise we have to calculate was before or after the current buffer.
-    allRowsCopy.push(row)
-    const sortFunction = getRowSortFunction(
-      $registry,
-      view.sortings,
-      fields,
-      view.group_bys
-    )
-    allRowsCopy.sort(sortFunction)
-    const index = allRowsCopy.findIndex((r) => r.id === row.id)
-
-    // If the row is at position 0, it means that the row existed before the buffer,
-    // which means the buffer start index has decreased.
-    if (index === 0) {
-      commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex - 1)
-    }
-
-    // Regardless of where the
-    commit('SET_COUNT', getters.getCount - 1)
-    await dispatch('correctMultiSelect')
+    handleRowDeleted({
+      context: createRowLifecycleContext({
+        client: $client,
+        registry: $registry,
+        table: { id: null },
+        view,
+        fields,
+        groupBys: view.group_bys,
+      }),
+      mutations: {
+        remove: (rowId) => {
+          const allRows = getters.getAllRows
+          const idx = allRows.findIndex((r) => r.id === rowId)
+          if (idx >= 0) {
+            commit('DELETE_ROW_IN_BUFFER', row)
+            dispatch('correctMultiSelect')
+            return
+          }
+          const position = computeRowInsertPosition(
+            row,
+            allRows,
+            view.sortings,
+            fields,
+            $registry,
+            view.group_bys
+          )
+          if (position.isFirst) {
+            commit('SET_BUFFER_START_INDEX', getters.getBufferStartIndex - 1)
+          }
+          commit('SET_COUNT', getters.getCount - 1)
+          dispatch('correctMultiSelect')
+        },
+        rowsForMatchCheck: () => getters.getAllRows,
+      },
+      row,
+    })
   },
   /**
    * Triggered when a row has been changed, or has a pending change in the provided
    * overrides.
    */
-  onRowChange({ dispatch }, { view, row, fields, overrides = {} }) {
-    dispatch('updateMatchFilters', { view, row, fields, overrides })
-    dispatch('updateMatchSortings', { view, row, fields, overrides })
+  onRowChange(
+    { dispatch, commit, getters },
+    { view, row, fields, overrides = {} }
+  ) {
+    const lifecycleRow =
+      Object.keys(overrides).length > 0
+        ? Object.assign({}, row, overrides)
+        : row
+    reapplyMatchFlags({
+      context: createRowLifecycleContext({
+        client: this.$client,
+        registry: this.$registry,
+        table: { id: null },
+        view,
+        fields,
+        groupBys: view.group_bys,
+      }),
+      mutations: {
+        applyMatchFlags: (rowId, { matchFilters, matchSortings }) => {
+          commit('SET_ROW_MATCH_FILTERS', { row, value: matchFilters })
+          commit('SET_ROW_MATCH_SORTINGS', { row, value: matchSortings })
+        },
+        rowsForMatchCheck: () => getters.getAllRows,
+      },
+      row: lifecycleRow,
+    })
     dispatch('updateSearchMatchesForRow', { row, fields, overrides })
   },
   /**
@@ -3318,21 +3414,18 @@ export const actions = {
    * override values that not actually belong to the row to do some preliminary checks.
    */
   updateMatchFilters({ commit }, { view, row, fields, overrides = {} }) {
-    const values = JSON.parse(JSON.stringify(row))
-    Object.assign(values, overrides)
-
-    // The value is always valid if the filters are disabled.
-    const matches = view.filters_disabled
-      ? true
-      : matchSearchFilters(
-          this.$registry,
-          view.filter_type,
-          view.filters,
-          view.filter_groups,
-          fields,
-          values
-        )
-    commit('SET_ROW_MATCH_FILTERS', { row, value: matches })
+    const rowWithOverrides = Object.assign(
+      JSON.parse(JSON.stringify(row)),
+      overrides
+    )
+    const { matchFilters } = computeRowMatchFlags({
+      row: rowWithOverrides,
+      view,
+      fields,
+      registry: this.$registry,
+      rowsInSortingGroup: [],
+    })
+    commit('SET_ROW_MATCH_FILTERS', { row, value: matchFilters })
   },
   /**
    * Changes the current search parameters if provided and optionally refreshes which
@@ -3394,20 +3487,16 @@ export const actions = {
     { commit, getters },
     { view, row, fields, overrides = {} }
   ) {
-    const { $registry, $client, $i18n, $config } = this
-    const values = clone(row)
-    Object.assign(values, overrides)
-
-    const allRows = getters.getAllRows
-    const currentIndex = getters.getAllRows.findIndex((r) => r.id === row.id)
-    const sortedRows = clone(allRows)
-    sortedRows[currentIndex] = values
-    sortedRows.sort(
-      getRowSortFunction($registry, view.sortings, fields, view.group_bys)
-    )
-    const newIndex = sortedRows.findIndex((r) => r.id === row.id)
-
-    commit('SET_ROW_MATCH_SORTINGS', { row, value: currentIndex === newIndex })
+    const rowWithOverrides = Object.assign(clone(row), overrides)
+    const { matchSortings } = computeRowMatchFlags({
+      row: rowWithOverrides,
+      view,
+      fields,
+      registry: this.$registry,
+      rowsInSortingGroup: getters.getAllRows,
+      groupBys: view.group_bys,
+    })
+    commit('SET_ROW_MATCH_SORTINGS', { row, value: matchSortings })
   },
   /**
    * Refreshes the row in the store if the given rowId exists. If the row
@@ -3854,16 +3943,16 @@ export const getters = {
   getAllFieldAggregationData(state) {
     return state.fieldAggregationData
   },
-  hasSelectedCell(state) {
-    return state.rows.some((row) => {
-      return row._.selected && row._.selectedFieldId !== -1
-    })
-  },
   getActiveGroupBys(state) {
     return state.activeGroupBys
   },
   getGroupByMetadata(state) {
     return state.groupByMetadata
+  },
+  hasSelectedCell(state) {
+    return state.rows.some((row) => {
+      return row._.selected && row._.selectedFieldId !== -1
+    })
   },
   getAdhocFiltering(state) {
     return state.adhocFiltering

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -3409,25 +3409,6 @@ export const actions = {
     dispatch('updateSearchMatchesForRow', { row, fields, overrides })
   },
   /**
-   * Checks if the given row still matches the given view filters. The row's
-   * matchFilters value is updated accordingly. It is also possible to provide some
-   * override values that not actually belong to the row to do some preliminary checks.
-   */
-  updateMatchFilters({ commit }, { view, row, fields, overrides = {} }) {
-    const rowWithOverrides = Object.assign(
-      JSON.parse(JSON.stringify(row)),
-      overrides
-    )
-    const { matchFilters } = computeRowMatchFlags({
-      row: rowWithOverrides,
-      view,
-      fields,
-      registry: this.$registry,
-      rowsInSortingGroup: [],
-    })
-    commit('SET_ROW_MATCH_FILTERS', { row, value: matchFilters })
-  },
-  /**
    * Changes the current search parameters if provided and optionally refreshes which
    * cells match the new search parameters by updating every rows row._.matchSearch and
    * row._.fieldSearchMatches attributes.
@@ -3477,26 +3458,6 @@ export const actions = {
 
       commit('SET_ROW_SEARCH_MATCHES', rowSearchMatches)
     }
-  },
-  /**
-   * Checks if the given row index is still the same. The row's matchSortings value is
-   * updated accordingly. It is also possible to provide some override values that not
-   * actually belong to the row to do some preliminary checks.
-   */
-  updateMatchSortings(
-    { commit, getters },
-    { view, row, fields, overrides = {} }
-  ) {
-    const rowWithOverrides = Object.assign(clone(row), overrides)
-    const { matchSortings } = computeRowMatchFlags({
-      row: rowWithOverrides,
-      view,
-      fields,
-      registry: this.$registry,
-      rowsInSortingGroup: getters.getAllRows,
-      groupBys: view.group_bys,
-    })
-    commit('SET_ROW_MATCH_SORTINGS', { row, value: matchSortings })
   },
   /**
    * Refreshes the row in the store if the given rowId exists. If the row

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -2369,14 +2369,6 @@ export const actions = {
       return
     }
 
-    commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-      fields,
-      registry: $registry,
-      row,
-      increase: true,
-      decrease: false,
-    })
-
     handleRowCreated({
       context: createRowLifecycleContext({
         client: $client,
@@ -2388,6 +2380,14 @@ export const actions = {
       }),
       mutations: {
         insertAtPosition: (insertedRow, { sortedIndex, isFirst, isLast }) => {
+          commit('UPDATE_GROUP_BY_METADATA_COUNT', {
+            fields,
+            registry: $registry,
+            row: insertedRow,
+            increase: true,
+            decrease: false,
+          })
+
           const inBuffer =
             (isFirst && getters.getBufferStartIndex === 0) ||
             (isLast && getters.getBufferEndIndex === getters.getCount) ||
@@ -3190,8 +3190,16 @@ export const actions = {
     }
 
     const applyMatchFlags = (rowId, { matchFilters, matchSortings }) => {
-      commit('SET_ROW_MATCH_FILTERS', { row: newRow, value: matchFilters })
-      commit('SET_ROW_MATCH_SORTINGS', { row: newRow, value: matchSortings })
+      const targetRow = getters.getAllRows.find((row) => row.id === rowId)
+      if (!targetRow?._) {
+        return
+      }
+
+      commit('SET_ROW_MATCH_FILTERS', { row: targetRow, value: matchFilters })
+      commit('SET_ROW_MATCH_SORTINGS', {
+        row: targetRow,
+        value: matchSortings,
+      })
     }
 
     const rowsForMatchCheck = () => getters.getAllRows
@@ -3331,14 +3339,6 @@ export const actions = {
       return
     }
 
-    commit('UPDATE_GROUP_BY_METADATA_COUNT', {
-      fields,
-      registry: $registry,
-      row,
-      increase: false,
-      decrease: true,
-    })
-
     handleRowDeleted({
       context: createRowLifecycleContext({
         client: $client,
@@ -3350,6 +3350,14 @@ export const actions = {
       }),
       mutations: {
         remove: (rowId) => {
+          commit('UPDATE_GROUP_BY_METADATA_COUNT', {
+            fields,
+            registry: $registry,
+            row,
+            increase: false,
+            decrease: true,
+          })
+
           const allRows = getters.getAllRows
           const idx = allRows.findIndex((r) => r.id === rowId)
           if (idx >= 0) {

--- a/web-frontend/modules/database/utils/row.js
+++ b/web-frontend/modules/database/utils/row.js
@@ -1,5 +1,9 @@
 //import Vue from 'vue'
 import { clone } from '@baserow/modules/core/utils/object'
+import {
+  getRowSortFunction,
+  matchSearchFilters,
+} from '@baserow/modules/database/utils/view'
 
 /**
  * Serializes a row to make sure that the values are according to what the API expects.
@@ -84,6 +88,221 @@ export function prepareNewOldAndUpdateRequestValues(
   updateRequestValues[`field_${field.id}`] = updateValue
 
   return { newRowValues, oldRowValues, updateRequestValues }
+}
+
+/**
+ * Multi-field variant of `prepareNewOldAndUpdateRequestValues`. Given a single
+ * row and multiple `(field, value, oldValue)` triples, return one combined
+ * `{newRowValues, oldRowValues, updateRequestValues}` so the row can be patched
+ * once with every field change at the same time. Side-effect optimistic values
+ * (`onRowChange`) are still computed for unedited fields against a virtual row
+ * that already reflects every new value.
+ */
+export function prepareRowMultiFieldUpdate(
+  row,
+  allFields,
+  fieldValuePairs,
+  registry
+) {
+  const newRowValues = { id: row.id }
+  const oldRowValues = { id: row.id }
+  const updateRequestValues = { id: row.id }
+  const editedFieldIds = new Set(fieldValuePairs.map((p) => p.field.id))
+
+  for (const { field, value, oldValue } of fieldValuePairs) {
+    const fieldKey = `field_${field.id}`
+    newRowValues[fieldKey] = value
+    oldRowValues[fieldKey] = oldValue
+    const fieldType = registry.get('field', field.type)
+    updateRequestValues[fieldKey] = fieldType.prepareValueForUpdate(
+      field,
+      value
+    )
+  }
+
+  const virtualRow = { ...row, ...newRowValues }
+  for (const otherField of allFields) {
+    if (editedFieldIds.has(otherField.id)) {
+      continue
+    }
+    const fieldType = registry.get('field', otherField.type)
+    const fieldKey = `field_${otherField.id}`
+    const currentFieldValue = row[fieldKey]
+    const optimisticFieldValue = fieldType.onRowChange(
+      virtualRow,
+      otherField,
+      currentFieldValue
+    )
+    if (currentFieldValue !== optimisticFieldValue) {
+      newRowValues[fieldKey] = optimisticFieldValue
+      oldRowValues[fieldKey] = currentFieldValue
+    }
+  }
+
+  return { newRowValues, oldRowValues, updateRequestValues }
+}
+
+/**
+ * Compute the row-form values a brand-new row should start with,
+ * combining: explicit caller-supplied values (highest priority),
+ * view-level default_row_values, and each field type's own default
+ * (`getNewRowValue`). Returns a `{ field_X: rowFormValue, ... }` map
+ * suitable for an optimistic insert; pass each value through the
+ * field type's `prepareValueForUpdate` separately to build the BE
+ * payload.
+ *
+ * This is the same computation the flat-grid create flow previously did
+ * inline; extracting it keeps row default handling reusable by other grid
+ * code without duplicating the defaults logic.
+ */
+export function buildNewRowDefaults({
+  view,
+  fields,
+  registry,
+  suppliedValues = {},
+}) {
+  const defaultItems = view?.default_row_values ?? []
+  const defaultsByFieldId = {}
+  for (const item of defaultItems) {
+    if (item.enabled && (item.value != null || item.function)) {
+      defaultsByFieldId[item.field] = item
+    }
+  }
+  const newRow = {}
+  for (const field of fields) {
+    const name = `field_${field.id}`
+    if (name in suppliedValues) {
+      newRow[name] = suppliedValues[name]
+      continue
+    }
+    const fieldTypeKey = field._?.type?.type || field.type
+    const fieldType = registry.get('field', fieldTypeKey)
+    const defaultViewItem = defaultsByFieldId[field.id]
+    const supportedFunctions = fieldType.getSupportedDefaultValueFunctions
+      ? fieldType.getSupportedDefaultValueFunctions().map((f) => f.name)
+      : []
+    if (
+      defaultViewItem?.function &&
+      supportedFunctions.includes(defaultViewItem.function)
+    ) {
+      newRow[name] = fieldType.resolveDefaultValueFunction(
+        defaultViewItem.function,
+        field
+      )
+    } else if (
+      defaultViewItem?.value != null &&
+      (!defaultViewItem.field_type ||
+        defaultViewItem.field_type === fieldTypeKey)
+    ) {
+      newRow[name] = fieldType.parseDefaultRowValue(
+        field,
+        defaultViewItem.value
+      )
+    } else if (fieldType.getNewRowValue) {
+      newRow[name] = fieldType.getNewRowValue(field)
+    }
+  }
+  return newRow
+}
+
+/**
+ * Decide whether a row still belongs at its current position after a change:
+ * whether it still matches the view's filters, and whether it lands at the same
+ * sorted index amongst the comparison set. The grouped grid can pass only the
+ * rows from the current group section; the flat grid can pass every loaded row.
+ */
+export function computeRowMatchFlags({
+  row,
+  view,
+  fields,
+  registry,
+  rowsInSortingGroup = [],
+  groupBys = [],
+}) {
+  const matchFilters = view?.filters_disabled
+    ? true
+    : matchSearchFilters(
+        registry,
+        view.filter_type,
+        view.filters ?? [],
+        view.filter_groups ?? [],
+        fields ?? [],
+        row
+      )
+
+  let matchSortings = true
+  if (fields && fields.length > 0) {
+    const sortFn = getRowSortFunction(
+      registry,
+      view?.sortings ?? [],
+      fields,
+      groupBys
+    )
+    const currentIndex = rowsInSortingGroup.findIndex((r) => r.id === row.id)
+    if (currentIndex >= 0) {
+      const rowsForSorting = [...rowsInSortingGroup]
+      rowsForSorting[currentIndex] = {
+        ...rowsForSorting[currentIndex],
+        ...row,
+      }
+      const sorted = rowsForSorting.sort(sortFn)
+      const sortedIndex = sorted.findIndex((r) => r.id === row.id)
+      matchSortings = currentIndex === sortedIndex
+    }
+  }
+
+  return { matchFilters, matchSortings }
+}
+
+/**
+ * Compute the per-cell flags used by the area / checkbox multi-cell
+ * highlight: `{selected, top, right, bottom, left}`. The view's row
+ * component passes this object to `GridViewCell` which uses it to
+ * paint the outer borders only on the rectangle's perimeter (not on
+ * internal cell edges).
+ *
+ * Pure function. Grid row components can call it with their own coordinate
+ * model as long as coordinates use the same model as the flat grid's
+ * multi-select state: integer row index in the visible row list and integer
+ * field index in the visible fields list.
+ */
+export function computeMultiSelectPosition({
+  isAreaSelectionActive,
+  isCheckboxSelected,
+  rowIndex,
+  fieldIndex,
+  rowIndexRange,
+  fieldIndexRange,
+}) {
+  const position = {
+    selected: false,
+    top: false,
+    right: false,
+    bottom: false,
+    left: false,
+  }
+  if (!isAreaSelectionActive) {
+    if (isCheckboxSelected) position.selected = true
+    return position
+  }
+  const [minRow, maxRow] = rowIndexRange ?? [-1, -1]
+  const [minField, maxField] = fieldIndexRange ?? [-1, -1]
+  if (
+    rowIndex < 0 ||
+    fieldIndex < 0 ||
+    rowIndex < minRow ||
+    rowIndex > maxRow ||
+    fieldIndex < minField ||
+    fieldIndex > maxField
+  ) {
+    return position
+  }
+  position.selected = true
+  if (rowIndex === minRow) position.top = true
+  if (rowIndex === maxRow) position.bottom = true
+  if (fieldIndex === minField) position.left = true
+  if (fieldIndex === maxField) position.right = true
+  return position
 }
 
 /**

--- a/web-frontend/modules/database/utils/row.js
+++ b/web-frontend/modules/database/utils/row.js
@@ -91,58 +91,6 @@ export function prepareNewOldAndUpdateRequestValues(
 }
 
 /**
- * Multi-field variant of `prepareNewOldAndUpdateRequestValues`. Given a single
- * row and multiple `(field, value, oldValue)` triples, return one combined
- * `{newRowValues, oldRowValues, updateRequestValues}` so the row can be patched
- * once with every field change at the same time. Side-effect optimistic values
- * (`onRowChange`) are still computed for unedited fields against a virtual row
- * that already reflects every new value.
- */
-export function prepareRowMultiFieldUpdate(
-  row,
-  allFields,
-  fieldValuePairs,
-  registry
-) {
-  const newRowValues = { id: row.id }
-  const oldRowValues = { id: row.id }
-  const updateRequestValues = { id: row.id }
-  const editedFieldIds = new Set(fieldValuePairs.map((p) => p.field.id))
-
-  for (const { field, value, oldValue } of fieldValuePairs) {
-    const fieldKey = `field_${field.id}`
-    newRowValues[fieldKey] = value
-    oldRowValues[fieldKey] = oldValue
-    const fieldType = registry.get('field', field.type)
-    updateRequestValues[fieldKey] = fieldType.prepareValueForUpdate(
-      field,
-      value
-    )
-  }
-
-  const virtualRow = { ...row, ...newRowValues }
-  for (const otherField of allFields) {
-    if (editedFieldIds.has(otherField.id)) {
-      continue
-    }
-    const fieldType = registry.get('field', otherField.type)
-    const fieldKey = `field_${otherField.id}`
-    const currentFieldValue = row[fieldKey]
-    const optimisticFieldValue = fieldType.onRowChange(
-      virtualRow,
-      otherField,
-      currentFieldValue
-    )
-    if (currentFieldValue !== optimisticFieldValue) {
-      newRowValues[fieldKey] = optimisticFieldValue
-      oldRowValues[fieldKey] = currentFieldValue
-    }
-  }
-
-  return { newRowValues, oldRowValues, updateRequestValues }
-}
-
-/**
  * Compute the row-form values a brand-new row should start with,
  * combining: explicit caller-supplied values (highest priority),
  * view-level default_row_values, and each field type's own default
@@ -151,9 +99,6 @@ export function prepareRowMultiFieldUpdate(
  * field type's `prepareValueForUpdate` separately to build the BE
  * payload.
  *
- * This is the same computation the flat-grid create flow previously did
- * inline; extracting it keeps row default handling reusable by other grid
- * code without duplicating the defaults logic.
  */
 export function buildNewRowDefaults({
   view,
@@ -208,8 +153,7 @@ export function buildNewRowDefaults({
 /**
  * Decide whether a row still belongs at its current position after a change:
  * whether it still matches the view's filters, and whether it lands at the same
- * sorted index amongst the comparison set. The grouped grid can pass only the
- * rows from the current group section; the flat grid can pass every loaded row.
+ * sorted index amongst the comparison set.
  */
 export function computeRowMatchFlags({
   row,
@@ -262,7 +206,7 @@ export function computeRowMatchFlags({
  * internal cell edges).
  *
  * Pure function. Grid row components can call it with their own coordinate
- * model as long as coordinates use the same model as the flat grid's
+ * model as long as coordinates use the same model as the grid's
  * multi-select state: integer row index in the visible row list and integer
  * field index in the visible fields list.
  */

--- a/web-frontend/modules/database/utils/row.js
+++ b/web-frontend/modules/database/utils/row.js
@@ -372,3 +372,35 @@ export function updateRowMetadataType(row, rowMetadataType, updateFunction) {
 export function getRowMetadata(row, metadata = {}) {
   return { ...metadata, ...(row.metadata || {}) }
 }
+
+/**
+ * Compute where `row` belongs among `existingRows` according to the given sorts.
+ *
+ * Returns `{ anchorRowId, sortedIndex, isFirst, isLast }`:
+ * - `anchorRowId` is the id of the row immediately before `row` in sorted order,
+ *   or null when `row` sorts first.
+ * - `sortedIndex` is the 0-based position of `row` in the merged, sorted result.
+ *
+ * Expressing the insert position by row identity rather than numeric index lets
+ * both flat-array stores and group-tree stores consume the result without
+ * needing to agree on a shared index space.
+ */
+export function computeRowInsertPosition(
+  row,
+  existingRows,
+  sorts,
+  fields,
+  registry,
+  groupBys = []
+) {
+  const sortFn = getRowSortFunction(registry, sorts, fields, groupBys)
+  const sorted = [...existingRows, row].sort(sortFn)
+  const sortedIndex = sorted.findIndex((r) => r.id === row.id)
+  const anchorRowId = sortedIndex > 0 ? sorted[sortedIndex - 1].id : null
+  return {
+    anchorRowId,
+    sortedIndex,
+    isFirst: sortedIndex === 0,
+    isLast: sortedIndex === sorted.length - 1,
+  }
+}

--- a/web-frontend/modules/database/utils/rowLifecycle.js
+++ b/web-frontend/modules/database/utils/rowLifecycle.js
@@ -32,19 +32,30 @@ function resolveContext(context) {
   return context.groupBys === undefined ? { ...context, groupBys: [] } : context
 }
 
+/**
+ * Fill in the optional `mutations` callbacks with no-op defaults so the
+ * lifecycle functions can call `applyMatchFlags`/`rowsForMatchCheck`
+ * unconditionally instead of guarding each call site.
+ */
+function normalizeMutations(mutations) {
+  return {
+    ...mutations,
+    applyMatchFlags: mutations.applyMatchFlags ?? noop,
+    rowsForMatchCheck: mutations.rowsForMatchCheck ?? emptyRows,
+  }
+}
+
 function applyCurrentMatchFlags(context, row, mutations) {
-  const rowsForMatchCheck = mutations.rowsForMatchCheck ?? emptyRows
   const flags = computeRowMatchFlags({
     row,
     view: context.view,
     fields: context.fields,
     registry: context.registry,
-    rowsInSortingGroup: rowsForMatchCheck(row),
+    rowsInSortingGroup: mutations.rowsForMatchCheck(row),
     groupBys: context.groupBys,
   })
 
-  const applyMatchFlags = mutations.applyMatchFlags ?? noop
-  applyMatchFlags(row.id, flags)
+  mutations.applyMatchFlags(row.id, flags)
   return flags
 }
 
@@ -56,7 +67,11 @@ export function reapplyMatchFlags({ context, mutations, row }) {
   if (!row) {
     return
   }
-  applyCurrentMatchFlags(resolveContext(context), row, mutations)
+  applyCurrentMatchFlags(
+    resolveContext(context),
+    row,
+    normalizeMutations(mutations)
+  )
 }
 
 /**
@@ -65,13 +80,14 @@ export function reapplyMatchFlags({ context, mutations, row }) {
  */
 export function handleRowDeleted({ context, mutations, row }) {
   const lifecycleContext = resolveContext(context)
+  const lifecycleMutations = normalizeMutations(mutations)
 
   const flags = computeRowMatchFlags({
     row,
     view: lifecycleContext.view,
     fields: lifecycleContext.fields,
     registry: lifecycleContext.registry,
-    rowsInSortingGroup: (mutations.rowsForMatchCheck ?? emptyRows)(row),
+    rowsInSortingGroup: lifecycleMutations.rowsForMatchCheck(row),
     groupBys: lifecycleContext.groupBys,
   })
 
@@ -79,7 +95,7 @@ export function handleRowDeleted({ context, mutations, row }) {
     return
   }
 
-  mutations.remove(row.id)
+  lifecycleMutations.remove(row.id)
 }
 
 /**
@@ -96,21 +112,22 @@ export function handleRowDeleted({ context, mutations, row }) {
  */
 export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
   const lifecycleContext = resolveContext(context)
+  const lifecycleMutations = normalizeMutations(mutations)
 
   const oldFlags = computeRowMatchFlags({
     row: oldRow,
     view: lifecycleContext.view,
     fields: lifecycleContext.fields,
     registry: lifecycleContext.registry,
-    rowsInSortingGroup: (mutations.rowsForMatchCheck ?? emptyRows)(oldRow),
+    rowsInSortingGroup: lifecycleMutations.rowsForMatchCheck(oldRow),
     groupBys: lifecycleContext.groupBys,
   })
 
   // Compute newRow flags using rows that exclude newRow itself, so the row
   // is not compared against its own position when deciding where it belongs.
-  const rowsExcludingNew = (mutations.rowsForMatchCheck ?? emptyRows)(
-    newRow
-  ).filter((r) => r.id !== newRow.id)
+  const rowsExcludingNew = lifecycleMutations
+    .rowsForMatchCheck(newRow)
+    .filter((r) => r.id !== newRow.id)
   const newFlags = computeRowMatchFlags({
     row: newRow,
     view: lifecycleContext.view,
@@ -125,7 +142,7 @@ export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
 
   if (wasInView && !isInView) {
     // Row moved out of the view — remove it.
-    mutations.remove(newRow.id)
+    lifecycleMutations.remove(newRow.id)
   } else if (!wasInView && isInView) {
     // Row moved into the view — insert at its new position.
     const position = computeRowInsertPosition(
@@ -136,9 +153,8 @@ export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
       lifecycleContext.registry,
       lifecycleContext.groupBys
     )
-    mutations.insertAtPosition(newRow, position)
-    const applyMatchFlags = mutations.applyMatchFlags ?? noop
-    applyMatchFlags(newRow.id, newFlags)
+    lifecycleMutations.insertAtPosition(newRow, position)
+    lifecycleMutations.applyMatchFlags(newRow.id, newFlags)
   } else if (!wasInView && !isInView) {
     // Row was not and is still not visible — nothing to do.
   } else {
@@ -151,9 +167,8 @@ export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
       lifecycleContext.registry,
       lifecycleContext.groupBys
     )
-    mutations.replaceAtPosition(newRow.id, newRow, position)
-    const applyMatchFlags = mutations.applyMatchFlags ?? noop
-    applyMatchFlags(newRow.id, newFlags)
+    lifecycleMutations.replaceAtPosition(newRow.id, newRow, position)
+    lifecycleMutations.applyMatchFlags(newRow.id, newFlags)
   }
 }
 
@@ -163,7 +178,8 @@ export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
  */
 export function handleRowCreated({ context, mutations, row }) {
   const lifecycleContext = resolveContext(context)
-  const existingRows = (mutations.rowsForMatchCheck ?? emptyRows)(row)
+  const lifecycleMutations = normalizeMutations(mutations)
+  const existingRows = lifecycleMutations.rowsForMatchCheck(row)
 
   const flags = computeRowMatchFlags({
     row,
@@ -187,7 +203,6 @@ export function handleRowCreated({ context, mutations, row }) {
     lifecycleContext.groupBys
   )
 
-  mutations.insertAtPosition(row, position)
-  const applyMatchFlags = mutations.applyMatchFlags ?? noop
-  applyMatchFlags(row.id, flags)
+  lifecycleMutations.insertAtPosition(row, position)
+  lifecycleMutations.applyMatchFlags(row.id, flags)
 }

--- a/web-frontend/modules/database/utils/rowLifecycle.js
+++ b/web-frontend/modules/database/utils/rowLifecycle.js
@@ -19,6 +19,11 @@ import {
 const noop = () => {}
 const emptyRows = () => []
 
+/**
+ * Build the shared context object the row-lifecycle handlers expect, bundling
+ * registry/view/fields/group-bys with a default empty `groupBys` so callers
+ * don't have to pass it.
+ */
 export function createRowLifecycleContext({
   registry,
   view,

--- a/web-frontend/modules/database/utils/rowLifecycle.js
+++ b/web-frontend/modules/database/utils/rowLifecycle.js
@@ -14,6 +14,7 @@
 import RowService from '@baserow/modules/database/services/row'
 import {
   buildNewRowDefaults,
+  computeRowInsertPosition,
   computeRowMatchFlags,
   prepareNewOldAndUpdateRequestValues,
 } from '@baserow/modules/database/utils/row'
@@ -38,31 +39,41 @@ function resolveContext(context) {
   return context.rowService ? context : createRowLifecycleContext(context)
 }
 
-function buildOptimisticRow(context, suppliedValues) {
+function buildInitialCreateValues(context, suppliedValues) {
+  return buildNewRowDefaults({
+    view: context.view,
+    fields: context.fields,
+    registry: context.registry,
+    suppliedValues,
+  })
+}
+
+function buildOptimisticRow(rowValues) {
   return {
     id: generateTempRowId(),
-    ...buildNewRowDefaults({
-      view: context.view,
-      fields: context.fields,
-      registry: context.registry,
-      suppliedValues,
-    }),
+    ...rowValues,
     _: { loading: true },
   }
 }
 
-function prepareCreateRequestValues(context, suppliedValues) {
+function prepareCreateRequestValues(context, rowValues) {
   const values = {}
   for (const field of context.fields ?? []) {
     const key = `field_${field.id}`
-    if (!(key in suppliedValues)) {
+    if (!(key in rowValues)) {
       continue
     }
 
     const fieldType = context.registry.get('field', field.type)
+    if (
+      fieldType.canWriteFieldValues &&
+      !fieldType.canWriteFieldValues(field)
+    ) {
+      continue
+    }
     values[key] = fieldType.prepareValueForUpdate
-      ? fieldType.prepareValueForUpdate(field, suppliedValues[key])
-      : suppliedValues[key]
+      ? fieldType.prepareValueForUpdate(field, rowValues[key])
+      : rowValues[key]
   }
   return values
 }
@@ -138,7 +149,11 @@ export async function createRowOptimistically({
   selection = {},
 }) {
   const lifecycleContext = resolveContext(context)
-  const optimisticRow = buildOptimisticRow(lifecycleContext, suppliedValues)
+  const initialValues = buildInitialCreateValues(
+    lifecycleContext,
+    suppliedValues
+  )
+  const optimisticRow = buildOptimisticRow(initialValues)
 
   mutations.insert(optimisticRow, optimisticRow.id)
 
@@ -146,7 +161,7 @@ export async function createRowOptimistically({
   try {
     const response = await lifecycleContext.rowService.create(
       lifecycleContext.table.id,
-      prepareCreateRequestValues(lifecycleContext, suppliedValues),
+      prepareCreateRequestValues(lifecycleContext, initialValues),
       beforeId,
       lifecycleContext.view.id
     )
@@ -244,4 +259,137 @@ export function reapplyMatchFlags({ context, mutations, row }) {
     return
   }
   applyCurrentMatchFlags(resolveContext(context), row, mutations)
+}
+
+/**
+ * Handle a row that was deleted externally (e.g. via a real-time event).
+ * Removes the row only if it was visible in the current view.
+ */
+export function handleRowDeleted({ context, mutations, row }) {
+  const lifecycleContext = resolveContext(context)
+
+  const flags = computeRowMatchFlags({
+    row,
+    view: lifecycleContext.view,
+    fields: lifecycleContext.fields,
+    registry: lifecycleContext.registry,
+    rowsInSortingGroup: (mutations.rowsForMatchCheck ?? emptyRows)(row),
+    groupBys: lifecycleContext.groupBys,
+  })
+
+  if (!flags.matchFilters) {
+    return
+  }
+
+  mutations.remove(row.id)
+}
+
+/**
+ * Handle a row that was updated externally (e.g. via a real-time event).
+ *
+ * Four cases based on whether the old and new row match the current view:
+ *
+ * | oldRow in view | newRow in view | Action                                |
+ * |----------------|----------------|---------------------------------------|
+ * | yes            | no             | remove                                |
+ * | no             | yes            | insertAtPosition + applyMatchFlags    |
+ * | no             | no             | noop                                  |
+ * | yes            | yes            | replaceAtPosition + applyMatchFlags   |
+ */
+export function handleRowUpdated({ context, mutations, oldRow, newRow }) {
+  const lifecycleContext = resolveContext(context)
+
+  const oldFlags = computeRowMatchFlags({
+    row: oldRow,
+    view: lifecycleContext.view,
+    fields: lifecycleContext.fields,
+    registry: lifecycleContext.registry,
+    rowsInSortingGroup: (mutations.rowsForMatchCheck ?? emptyRows)(oldRow),
+    groupBys: lifecycleContext.groupBys,
+  })
+
+  // Compute newRow flags using rows that exclude newRow itself, so the row
+  // is not compared against its own position when deciding where it belongs.
+  const rowsExcludingNew = (mutations.rowsForMatchCheck ?? emptyRows)(
+    newRow
+  ).filter((r) => r.id !== newRow.id)
+  const newFlags = computeRowMatchFlags({
+    row: newRow,
+    view: lifecycleContext.view,
+    fields: lifecycleContext.fields,
+    registry: lifecycleContext.registry,
+    rowsInSortingGroup: rowsExcludingNew,
+    groupBys: lifecycleContext.groupBys,
+  })
+
+  const wasInView = oldFlags.matchFilters
+  const isInView = newFlags.matchFilters
+
+  if (wasInView && !isInView) {
+    // Row moved out of the view — remove it.
+    mutations.remove(newRow.id)
+  } else if (!wasInView && isInView) {
+    // Row moved into the view — insert at its new position.
+    const position = computeRowInsertPosition(
+      newRow,
+      rowsExcludingNew,
+      lifecycleContext.view.sortings ?? [],
+      lifecycleContext.fields,
+      lifecycleContext.registry,
+      lifecycleContext.groupBys
+    )
+    mutations.insertAtPosition(newRow, position)
+    const applyMatchFlags = mutations.applyMatchFlags ?? noop
+    applyMatchFlags(newRow.id, newFlags)
+  } else if (!wasInView && !isInView) {
+    // Row was not and is still not visible — nothing to do.
+  } else {
+    // Row stays in the view — update its position and flags.
+    const position = computeRowInsertPosition(
+      newRow,
+      rowsExcludingNew,
+      lifecycleContext.view.sortings ?? [],
+      lifecycleContext.fields,
+      lifecycleContext.registry,
+      lifecycleContext.groupBys
+    )
+    mutations.replaceAtPosition(newRow.id, newRow, position)
+    const applyMatchFlags = mutations.applyMatchFlags ?? noop
+    applyMatchFlags(newRow.id, newFlags)
+  }
+}
+
+/**
+ * Handle a row that was created externally (e.g. via a real-time event).
+ * Inserts the row only if it matches the current view; skips silently otherwise.
+ */
+export function handleRowCreated({ context, mutations, row }) {
+  const lifecycleContext = resolveContext(context)
+  const existingRows = (mutations.rowsForMatchCheck ?? emptyRows)(row)
+
+  const flags = computeRowMatchFlags({
+    row,
+    view: lifecycleContext.view,
+    fields: lifecycleContext.fields,
+    registry: lifecycleContext.registry,
+    rowsInSortingGroup: existingRows,
+    groupBys: lifecycleContext.groupBys,
+  })
+
+  if (!flags.matchFilters) {
+    return
+  }
+
+  const position = computeRowInsertPosition(
+    row,
+    existingRows,
+    lifecycleContext.view.sortings ?? [],
+    lifecycleContext.fields,
+    lifecycleContext.registry,
+    lifecycleContext.groupBys
+  )
+
+  mutations.insertAtPosition(row, position)
+  const applyMatchFlags = mutations.applyMatchFlags ?? noop
+  applyMatchFlags(row.id, flags)
 }

--- a/web-frontend/modules/database/utils/rowLifecycle.js
+++ b/web-frontend/modules/database/utils/rowLifecycle.js
@@ -1,0 +1,247 @@
+/**
+ * Shared row-lifecycle pipelines: optimistic create, update, delete,
+ * and post-mutation match-flag re-evaluation.
+ *
+ * Callers provide:
+ * - `context`: shared grid/service inputs (`client`, `registry`, `table`,
+ *   `view`, `fields`, optional `groupBys`)
+ * - `mutations`: store-specific row operations (`insert`, `replace`, `remove`,
+ *   `applyValues`, `applyMatchFlags`, `rowsForMatchCheck`)
+ *
+ * The lifecycle code owns the common async flow and rollback rules; each store
+ * owns where rows are inserted or patched.
+ */
+import RowService from '@baserow/modules/database/services/row'
+import {
+  buildNewRowDefaults,
+  computeRowMatchFlags,
+  prepareNewOldAndUpdateRequestValues,
+} from '@baserow/modules/database/utils/row'
+
+const noop = () => {}
+const emptyRows = () => []
+const generateTempRowId = () => -Math.floor(Math.random() * 1e9) - 1
+
+export function createRowLifecycleContext({
+  client,
+  registry,
+  table,
+  view,
+  fields,
+  groupBys = [],
+  rowService = RowService(client),
+}) {
+  return { client, registry, table, view, fields, groupBys, rowService }
+}
+
+function resolveContext(context) {
+  return context.rowService ? context : createRowLifecycleContext(context)
+}
+
+function buildOptimisticRow(context, suppliedValues) {
+  return {
+    id: generateTempRowId(),
+    ...buildNewRowDefaults({
+      view: context.view,
+      fields: context.fields,
+      registry: context.registry,
+      suppliedValues,
+    }),
+    _: { loading: true },
+  }
+}
+
+function prepareCreateRequestValues(context, suppliedValues) {
+  const values = {}
+  for (const field of context.fields ?? []) {
+    const key = `field_${field.id}`
+    if (!(key in suppliedValues)) {
+      continue
+    }
+
+    const fieldType = context.registry.get('field', field.type)
+    values[key] = fieldType.prepareValueForUpdate
+      ? fieldType.prepareValueForUpdate(field, suppliedValues[key])
+      : suppliedValues[key]
+  }
+  return values
+}
+
+function applyCurrentMatchFlags(context, row, mutations) {
+  const rowsForMatchCheck = mutations.rowsForMatchCheck ?? emptyRows
+  const flags = computeRowMatchFlags({
+    row,
+    view: context.view,
+    fields: context.fields,
+    registry: context.registry,
+    rowsInSortingGroup: rowsForMatchCheck(row),
+    groupBys: context.groupBys,
+  })
+
+  const applyMatchFlags = mutations.applyMatchFlags ?? noop
+  applyMatchFlags(row.id, flags)
+  return flags
+}
+
+function selectPrimaryCell(context, row, selection) {
+  if (!selection.selectPrimaryCell) {
+    return
+  }
+
+  const primary = (context.fields ?? []).find((field) => field.primary)
+  if (primary) {
+    const selectCell = selection.selectCell ?? noop
+    selectCell(row.id, primary.id)
+  }
+}
+
+export function createRowLifecycle(context, mutations) {
+  const lifecycleContext = resolveContext(context)
+  return {
+    create: (options = {}) =>
+      createRowOptimistically({
+        context: lifecycleContext,
+        mutations,
+        ...options,
+      }),
+    update: (options) =>
+      updateRowOptimistically({
+        context: lifecycleContext,
+        mutations,
+        ...options,
+      }),
+    delete: (options) =>
+      deleteRowOptimistically({
+        context: lifecycleContext,
+        mutations,
+        ...options,
+      }),
+    reapplyMatchFlags: (options) =>
+      reapplyMatchFlags({
+        context: lifecycleContext,
+        mutations,
+        ...options,
+      }),
+  }
+}
+
+/**
+ * Optimistic create: insert a temporary loading row, POST, replace it with
+ * the backend row, then re-evaluate match flags. Rolls back on errors and on
+ * empty backend responses.
+ */
+export async function createRowOptimistically({
+  context,
+  mutations,
+  suppliedValues = {},
+  beforeId = null,
+  selection = {},
+}) {
+  const lifecycleContext = resolveContext(context)
+  const optimisticRow = buildOptimisticRow(lifecycleContext, suppliedValues)
+
+  mutations.insert(optimisticRow, optimisticRow.id)
+
+  let beRow = null
+  try {
+    const response = await lifecycleContext.rowService.create(
+      lifecycleContext.table.id,
+      prepareCreateRequestValues(lifecycleContext, suppliedValues),
+      beforeId,
+      lifecycleContext.view.id
+    )
+    beRow = response?.data ?? null
+  } catch (error) {
+    mutations.remove(optimisticRow.id)
+    throw error
+  }
+
+  if (!beRow) {
+    mutations.remove(optimisticRow.id)
+    return null
+  }
+
+  mutations.replace(optimisticRow.id, beRow)
+  applyCurrentMatchFlags(lifecycleContext, beRow, mutations)
+  selectPrimaryCell(lifecycleContext, beRow, selection)
+  return beRow
+}
+
+/**
+ * Optimistic single-cell update: apply the edited value immediately, PATCH,
+ * layer the backend row over the optimistic state, then re-evaluate match
+ * flags. Rolls back to the old values on backend errors.
+ */
+export async function updateRowOptimistically({ context, mutations, edit }) {
+  const lifecycleContext = resolveContext(context)
+  const { row, field, value, oldValue } = edit
+  const { newRowValues, oldRowValues, updateRequestValues } =
+    prepareNewOldAndUpdateRequestValues(
+      row,
+      lifecycleContext.fields,
+      field,
+      value,
+      oldValue,
+      lifecycleContext.registry
+    )
+  const rowId = row.id
+
+  mutations.applyValues(rowId, newRowValues)
+
+  let beRow = null
+  try {
+    const response = await lifecycleContext.rowService.batchUpdate(
+      lifecycleContext.table.id,
+      [updateRequestValues],
+      null,
+      lifecycleContext.view.id
+    )
+    const items = response?.data?.items ?? []
+    beRow = items.find((item) => item.id === rowId) ?? items[0] ?? null
+  } catch (error) {
+    mutations.applyValues(rowId, oldRowValues)
+    throw error
+  }
+
+  if (beRow) {
+    mutations.applyValues(rowId, beRow)
+    applyCurrentMatchFlags(lifecycleContext, beRow, mutations)
+  }
+  return beRow
+}
+
+/**
+ * Optimistic delete: remove locally, DELETE, then re-insert the original row
+ * if the backend call fails.
+ */
+export async function deleteRowOptimistically({ context, mutations, row }) {
+  if (!row || row.id == null) {
+    return false
+  }
+
+  const lifecycleContext = resolveContext(context)
+  mutations.remove(row.id)
+  try {
+    await lifecycleContext.rowService.delete(
+      lifecycleContext.table.id,
+      row.id,
+      lifecycleContext.view?.id ?? null
+    )
+    return true
+  } catch (error) {
+    const insert = mutations.insert ?? noop
+    insert(row, row.id)
+    throw error
+  }
+}
+
+/**
+ * Re-evaluate `matchFilters` and `matchSortings` for a row and apply the
+ * resulting warning flags through the caller's store adapter.
+ */
+export function reapplyMatchFlags({ context, mutations, row }) {
+  if (!row) {
+    return
+  }
+  applyCurrentMatchFlags(resolveContext(context), row, mutations)
+}

--- a/web-frontend/modules/database/utils/rowLifecycle.js
+++ b/web-frontend/modules/database/utils/rowLifecycle.js
@@ -1,81 +1,35 @@
 /**
- * Shared row-lifecycle pipelines: optimistic create, update, delete,
- * and post-mutation match-flag re-evaluation.
+ * Shared row-lifecycle helpers for row visibility, positioning, and
+ * post-mutation match-flag re-evaluation.
  *
  * Callers provide:
- * - `context`: shared grid/service inputs (`client`, `registry`, `table`,
- *   `view`, `fields`, optional `groupBys`)
- * - `mutations`: store-specific row operations (`insert`, `replace`, `remove`,
- *   `applyValues`, `applyMatchFlags`, `rowsForMatchCheck`)
+ * - `context`: shared grid inputs (`client`, `registry`, `table`, `view`,
+ *   `fields`, optional `groupBys`)
+ * - `mutations`: store-specific row operations (`insertAtPosition`,
+ *   `replaceAtPosition`, `remove`, `applyMatchFlags`, `rowsForMatchCheck`)
  *
- * The lifecycle code owns the common async flow and rollback rules; each store
- * owns where rows are inserted or patched.
+ * The lifecycle code owns the common decision rules; the store owns where rows
+ * are inserted or patched.
  */
-import RowService from '@baserow/modules/database/services/row'
 import {
-  buildNewRowDefaults,
   computeRowInsertPosition,
   computeRowMatchFlags,
-  prepareNewOldAndUpdateRequestValues,
 } from '@baserow/modules/database/utils/row'
 
 const noop = () => {}
 const emptyRows = () => []
-const generateTempRowId = () => -Math.floor(Math.random() * 1e9) - 1
 
 export function createRowLifecycleContext({
-  client,
   registry,
-  table,
   view,
   fields,
   groupBys = [],
-  rowService = RowService(client),
 }) {
-  return { client, registry, table, view, fields, groupBys, rowService }
+  return { registry, view, fields, groupBys }
 }
 
 function resolveContext(context) {
-  return context.rowService ? context : createRowLifecycleContext(context)
-}
-
-function buildInitialCreateValues(context, suppliedValues) {
-  return buildNewRowDefaults({
-    view: context.view,
-    fields: context.fields,
-    registry: context.registry,
-    suppliedValues,
-  })
-}
-
-function buildOptimisticRow(rowValues) {
-  return {
-    id: generateTempRowId(),
-    ...rowValues,
-    _: { loading: true },
-  }
-}
-
-function prepareCreateRequestValues(context, rowValues) {
-  const values = {}
-  for (const field of context.fields ?? []) {
-    const key = `field_${field.id}`
-    if (!(key in rowValues)) {
-      continue
-    }
-
-    const fieldType = context.registry.get('field', field.type)
-    if (
-      fieldType.canWriteFieldValues &&
-      !fieldType.canWriteFieldValues(field)
-    ) {
-      continue
-    }
-    values[key] = fieldType.prepareValueForUpdate
-      ? fieldType.prepareValueForUpdate(field, rowValues[key])
-      : rowValues[key]
-  }
-  return values
+  return context.groupBys === undefined ? { ...context, groupBys: [] } : context
 }
 
 function applyCurrentMatchFlags(context, row, mutations) {
@@ -92,162 +46,6 @@ function applyCurrentMatchFlags(context, row, mutations) {
   const applyMatchFlags = mutations.applyMatchFlags ?? noop
   applyMatchFlags(row.id, flags)
   return flags
-}
-
-function selectPrimaryCell(context, row, selection) {
-  if (!selection.selectPrimaryCell) {
-    return
-  }
-
-  const primary = (context.fields ?? []).find((field) => field.primary)
-  if (primary) {
-    const selectCell = selection.selectCell ?? noop
-    selectCell(row.id, primary.id)
-  }
-}
-
-export function createRowLifecycle(context, mutations) {
-  const lifecycleContext = resolveContext(context)
-  return {
-    create: (options = {}) =>
-      createRowOptimistically({
-        context: lifecycleContext,
-        mutations,
-        ...options,
-      }),
-    update: (options) =>
-      updateRowOptimistically({
-        context: lifecycleContext,
-        mutations,
-        ...options,
-      }),
-    delete: (options) =>
-      deleteRowOptimistically({
-        context: lifecycleContext,
-        mutations,
-        ...options,
-      }),
-    reapplyMatchFlags: (options) =>
-      reapplyMatchFlags({
-        context: lifecycleContext,
-        mutations,
-        ...options,
-      }),
-  }
-}
-
-/**
- * Optimistic create: insert a temporary loading row, POST, replace it with
- * the backend row, then re-evaluate match flags. Rolls back on errors and on
- * empty backend responses.
- */
-export async function createRowOptimistically({
-  context,
-  mutations,
-  suppliedValues = {},
-  beforeId = null,
-  selection = {},
-}) {
-  const lifecycleContext = resolveContext(context)
-  const initialValues = buildInitialCreateValues(
-    lifecycleContext,
-    suppliedValues
-  )
-  const optimisticRow = buildOptimisticRow(initialValues)
-
-  mutations.insert(optimisticRow, optimisticRow.id)
-
-  let beRow = null
-  try {
-    const response = await lifecycleContext.rowService.create(
-      lifecycleContext.table.id,
-      prepareCreateRequestValues(lifecycleContext, initialValues),
-      beforeId,
-      lifecycleContext.view.id
-    )
-    beRow = response?.data ?? null
-  } catch (error) {
-    mutations.remove(optimisticRow.id)
-    throw error
-  }
-
-  if (!beRow) {
-    mutations.remove(optimisticRow.id)
-    return null
-  }
-
-  mutations.replace(optimisticRow.id, beRow)
-  applyCurrentMatchFlags(lifecycleContext, beRow, mutations)
-  selectPrimaryCell(lifecycleContext, beRow, selection)
-  return beRow
-}
-
-/**
- * Optimistic single-cell update: apply the edited value immediately, PATCH,
- * layer the backend row over the optimistic state, then re-evaluate match
- * flags. Rolls back to the old values on backend errors.
- */
-export async function updateRowOptimistically({ context, mutations, edit }) {
-  const lifecycleContext = resolveContext(context)
-  const { row, field, value, oldValue } = edit
-  const { newRowValues, oldRowValues, updateRequestValues } =
-    prepareNewOldAndUpdateRequestValues(
-      row,
-      lifecycleContext.fields,
-      field,
-      value,
-      oldValue,
-      lifecycleContext.registry
-    )
-  const rowId = row.id
-
-  mutations.applyValues(rowId, newRowValues)
-
-  let beRow = null
-  try {
-    const response = await lifecycleContext.rowService.batchUpdate(
-      lifecycleContext.table.id,
-      [updateRequestValues],
-      null,
-      lifecycleContext.view.id
-    )
-    const items = response?.data?.items ?? []
-    beRow = items.find((item) => item.id === rowId) ?? items[0] ?? null
-  } catch (error) {
-    mutations.applyValues(rowId, oldRowValues)
-    throw error
-  }
-
-  if (beRow) {
-    mutations.applyValues(rowId, beRow)
-    applyCurrentMatchFlags(lifecycleContext, beRow, mutations)
-  }
-  return beRow
-}
-
-/**
- * Optimistic delete: remove locally, DELETE, then re-insert the original row
- * if the backend call fails.
- */
-export async function deleteRowOptimistically({ context, mutations, row }) {
-  if (!row || row.id == null) {
-    return false
-  }
-
-  const lifecycleContext = resolveContext(context)
-  mutations.remove(row.id)
-  try {
-    await lifecycleContext.rowService.delete(
-      lifecycleContext.table.id,
-      row.id,
-      lifecycleContext.view?.id ?? null
-    )
-    return true
-  } catch (error) {
-    const insert = mutations.insert ?? noop
-    insert(row, row.id)
-    throw error
-  }
 }
 
 /**

--- a/web-frontend/modules/database/utils/view.js
+++ b/web-frontend/modules/database/utils/view.js
@@ -540,6 +540,18 @@ export function canRowsBeOptimisticallyUpdatedInView(
   return !needsServerSideCalculation
 }
 
+/**
+ * Returns true when changing a row can affect its visible position, visibility,
+ * or mismatch warning in the current view.
+ */
+export function viewHasRulesThatCanMoveOrHideRows(view, activeSearchTerm) {
+  const hasSortings = (view.sortings?.length ?? 0) > 0
+  const hasGroupBys = (view.group_bys?.length ?? 0) > 0
+  const hasFilters = !view.filters_disabled && (view.filters?.length ?? 0) > 0
+
+  return hasSortings || hasGroupBys || hasFilters || Boolean(activeSearchTerm)
+}
+
 export function getOrderBy(view, adhocSorting) {
   if (adhocSorting) {
     const serializeSort = (sort) => {

--- a/web-frontend/modules/database/viewTypes.js
+++ b/web-frontend/modules/database/viewTypes.js
@@ -676,8 +676,8 @@ export class GridViewType extends ViewType {
       { field, fieldType, view: selectedView },
       { root: true }
     )
-    // Sync the grid store's activeGroupBys with the view's group_bys which
-    // may have been updated by the field restore above.
+    // Sync activeGroupBys with the view's group_bys which may have been updated
+    // by the field restore above.
     await dispatch(
       storePrefix + 'view/grid/updateActiveGroupBys',
       clone(selectedView.group_bys || []),

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -1523,6 +1523,86 @@ describe('Grid view store', () => {
     })
   })
 
+  test('group by metadata ignores created and deleted rows outside view filters', async () => {
+    const state = Object.assign(gridStore.state(), {
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      rows: [],
+      count: 100,
+      activeGroupBys: [
+        {
+          id: 1,
+          field: 1,
+          order: 'ASC',
+        },
+      ],
+      groupByMetadata: {
+        field_1: [
+          {
+            field_1: 'a',
+            count: 2,
+          },
+        ],
+      },
+    })
+
+    store.replaceState({ ...store.state, grid: state })
+
+    const view = {
+      id: 1,
+      filters_disabled: false,
+      filter_type: 'AND',
+      filters: [
+        {
+          id: 1,
+          view: 1,
+          field: 2,
+          type: EqualViewFilterType.getType(),
+          value: 'visible',
+        },
+      ],
+      sortings: [],
+      ownership_type: 'collaborative',
+    }
+    const fields = [
+      {
+        id: 1,
+        name: 'Group',
+        type: 'text',
+        primary: true,
+      },
+      {
+        id: 2,
+        name: 'Visibility',
+        type: 'text',
+        primary: false,
+      },
+    ]
+    const hiddenRow = {
+      id: 1,
+      order: '1.00000000000000000000',
+      field_1: 'a',
+      field_2: 'hidden',
+    }
+    const getScrollTop = () => 0
+
+    await store.dispatch('grid/createdNewRow', {
+      view,
+      fields,
+      values: hiddenRow,
+      getScrollTop,
+    })
+    expect(store.state.grid.groupByMetadata.field_1[0].count).toBe(2)
+
+    await store.dispatch('grid/deletedExistingRow', {
+      view,
+      fields,
+      row: hiddenRow,
+      getScrollTop,
+    })
+    expect(store.state.grid.groupByMetadata.field_1[0].count).toBe(2)
+  })
+
   test('group by metadata count change on row update', async () => {
     const state = Object.assign(gridStore.state(), {
       bufferStartIndex: 0,

--- a/web-frontend/test/unit/database/utils/row.spec.js
+++ b/web-frontend/test/unit/database/utils/row.spec.js
@@ -2,6 +2,10 @@ import {
   prepareRowForRequest,
   prepareNewOldAndUpdateRequestValues,
   extractRowReadOnlyValues,
+  computeMultiSelectPosition,
+  computeRowMatchFlags,
+  buildNewRowDefaults,
+  prepareRowMultiFieldUpdate,
 } from '@baserow/modules/database/utils/row'
 import { TestApp } from '@baserow/test/helpers/testApp'
 
@@ -182,6 +186,454 @@ describe('Row utilities', () => {
     expect(updateRequestValues).toEqual({
       field_1: 1,
       id: row.id,
+    })
+  })
+
+  describe('computeMultiSelectPosition', () => {
+    const area = (extra) => ({
+      isAreaSelectionActive: true,
+      isCheckboxSelected: false,
+      rowIndexRange: [0, 2],
+      fieldIndexRange: [0, 2],
+      ...extra,
+    })
+
+    test('no area selection and no checkbox returns all false', () => {
+      expect(
+        computeMultiSelectPosition({
+          isAreaSelectionActive: false,
+          isCheckboxSelected: false,
+          rowIndex: 1,
+          fieldIndex: 1,
+        })
+      ).toEqual({
+        selected: false,
+        top: false,
+        right: false,
+        bottom: false,
+        left: false,
+      })
+    })
+
+    test('no area selection with selected checkbox returns selected only', () => {
+      const pos = computeMultiSelectPosition({
+        isAreaSelectionActive: false,
+        isCheckboxSelected: true,
+        rowIndex: 1,
+        fieldIndex: 1,
+      })
+      expect(pos.selected).toBe(true)
+      expect(pos.top).toBe(false)
+      expect(pos.left).toBe(false)
+    })
+
+    test('area selection with cell inside rectangle returns selected only', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: 1, fieldIndex: 1 }))
+      ).toEqual({
+        selected: true,
+        top: false,
+        right: false,
+        bottom: false,
+        left: false,
+      })
+    })
+
+    test('area selection with top-left corner returns top and left borders', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: 0, fieldIndex: 0 }))
+      ).toEqual({
+        selected: true,
+        top: true,
+        right: false,
+        bottom: false,
+        left: true,
+      })
+    })
+
+    test('area selection with bottom-right corner returns bottom and right borders', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: 2, fieldIndex: 2 }))
+      ).toEqual({
+        selected: true,
+        top: false,
+        right: true,
+        bottom: true,
+        left: false,
+      })
+    })
+
+    test('area selection with one cell rectangle returns all four borders', () => {
+      expect(
+        computeMultiSelectPosition(
+          area({
+            rowIndex: 1,
+            fieldIndex: 1,
+            rowIndexRange: [1, 1],
+            fieldIndexRange: [1, 1],
+          })
+        )
+      ).toEqual({
+        selected: true,
+        top: true,
+        right: true,
+        bottom: true,
+        left: true,
+      })
+    })
+
+    test('area selection with row outside range returns not selected', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: 5, fieldIndex: 1 }))
+          .selected
+      ).toBe(false)
+    })
+
+    test('area selection with field outside range returns not selected', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: 1, fieldIndex: 5 }))
+          .selected
+      ).toBe(false)
+    })
+
+    test('area selection with negative row index returns not selected', () => {
+      expect(
+        computeMultiSelectPosition(area({ rowIndex: -1, fieldIndex: 1 }))
+          .selected
+      ).toBe(false)
+    })
+  })
+
+  describe('computeRowMatchFlags', () => {
+    const textField = { id: 1, name: 'Name', type: 'text', primary: true }
+    const baseView = (extra = {}) => ({
+      filters_disabled: true,
+      filter_type: 'AND',
+      filter_groups: [],
+      filters: [],
+      sortings: [],
+      ...extra,
+    })
+
+    test('filters disabled makes matchFilters true regardless of row values', () => {
+      const { matchFilters } = computeRowMatchFlags({
+        row: { id: 1, field_1: 'anything' },
+        view: baseView({ filters_disabled: true }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [{ id: 1, field_1: 'anything' }],
+      })
+      expect(matchFilters).toBe(true)
+    })
+
+    test('enabled equal filter returns matchFilters true for matching row', () => {
+      const { matchFilters } = computeRowMatchFlags({
+        row: { id: 1, field_1: 'Alice' },
+        view: baseView({
+          filters_disabled: false,
+          filters: [
+            { id: 1, view: 1, field: 1, type: 'equal', value: 'Alice' },
+          ],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [{ id: 1, field_1: 'Alice' }],
+      })
+      expect(matchFilters).toBe(true)
+    })
+
+    test('enabled equal filter returns matchFilters false for non-matching row', () => {
+      const { matchFilters } = computeRowMatchFlags({
+        row: { id: 1, field_1: 'Bob' },
+        view: baseView({
+          filters_disabled: false,
+          filters: [
+            { id: 1, view: 1, field: 1, type: 'equal', value: 'Alice' },
+          ],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [{ id: 1, field_1: 'Bob' }],
+      })
+      expect(matchFilters).toBe(false)
+    })
+
+    test('row that is the only member of its sort group matches sorting', () => {
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 1, field_1: 'Z' },
+        view: baseView({
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [{ id: 1, field_1: 'Z' }],
+      })
+      expect(matchSortings).toBe(true)
+    })
+
+    test('row at its sorted position matches sorting', () => {
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 1, field_1: 'A' },
+        view: baseView({
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [
+          { id: 1, field_1: 'A' },
+          { id: 2, field_1: 'B' },
+        ],
+      })
+      expect(matchSortings).toBe(true)
+    })
+
+    test('row out of sorted position does not match sorting', () => {
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 99, field_1: 'A' },
+        view: baseView({
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [
+          { id: 2, field_1: 'Z' },
+          { id: 99, field_1: 'A' },
+        ],
+      })
+      expect(matchSortings).toBe(false)
+    })
+
+    test('sorting uses the updated row values even if the comparison set is stale', () => {
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 99, field_1: 'A' },
+        view: baseView({
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [
+          { id: 1, field_1: 'B' },
+          { id: 99, field_1: 'Z' },
+        ],
+      })
+      expect(matchSortings).toBe(false)
+    })
+
+    test('row absent from rowsInSortingGroup matches sorting by default', () => {
+      const { matchSortings } = computeRowMatchFlags({
+        row: { id: 99, field_1: 'A' },
+        view: baseView({
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        }),
+        fields: [textField],
+        registry: store.$registry,
+        rowsInSortingGroup: [{ id: 1, field_1: 'B' }],
+      })
+      expect(matchSortings).toBe(true)
+    })
+  })
+
+  describe('buildNewRowDefaults', () => {
+    const field = (id) => ({ id, name: `f${id}`, type: 'text' })
+    const makeRegistry = (overrides = {}) => ({
+      get() {
+        return {
+          getNewRowValue: () => 'field_default',
+          getSupportedDefaultValueFunctions: () => [],
+          parseDefaultRowValue: (_field, value) => `parsed:${value}`,
+          resolveDefaultValueFunction: (fn) => `resolved:${fn}`,
+          ...overrides,
+        }
+      },
+    })
+
+    test('no view defaults -> getNewRowValue for each field', () => {
+      expect(
+        buildNewRowDefaults({
+          view: { default_row_values: [] },
+          fields: [field(1), field(2)],
+          registry: makeRegistry(),
+        })
+      ).toEqual({ field_1: 'field_default', field_2: 'field_default' })
+    })
+
+    test('suppliedValues take priority over defaults', () => {
+      const result = buildNewRowDefaults({
+        view: { default_row_values: [] },
+        fields: [field(1), field(2)],
+        registry: makeRegistry(),
+        suppliedValues: { field_1: 'supplied' },
+      })
+      expect(result.field_1).toBe('supplied')
+      expect(result.field_2).toBe('field_default')
+    })
+
+    test('view default value with matching field_type -> parseDefaultRowValue result', () => {
+      expect(
+        buildNewRowDefaults({
+          view: {
+            default_row_values: [
+              {
+                field: 1,
+                enabled: true,
+                value: 'hello',
+                field_type: 'text',
+                function: null,
+              },
+            ],
+          },
+          fields: [field(1)],
+          registry: makeRegistry(),
+        })
+      ).toEqual({ field_1: 'parsed:hello' })
+    })
+
+    test('view default with supported function -> resolveDefaultValueFunction result', () => {
+      expect(
+        buildNewRowDefaults({
+          view: {
+            default_row_values: [
+              {
+                field: 1,
+                enabled: true,
+                value: null,
+                function: 'today',
+                field_type: null,
+              },
+            ],
+          },
+          fields: [field(1)],
+          registry: makeRegistry({
+            getSupportedDefaultValueFunctions: () => [{ name: 'today' }],
+          }),
+        })
+      ).toEqual({ field_1: 'resolved:today' })
+    })
+
+    test('disabled default -> ignored, falls back to getNewRowValue', () => {
+      expect(
+        buildNewRowDefaults({
+          view: {
+            default_row_values: [
+              {
+                field: 1,
+                enabled: false,
+                value: 'ignored',
+                field_type: 'text',
+                function: null,
+              },
+            ],
+          },
+          fields: [field(1)],
+          registry: makeRegistry(),
+        })
+      ).toEqual({ field_1: 'field_default' })
+    })
+
+    test('view default with mismatched field_type -> falls back to getNewRowValue', () => {
+      expect(
+        buildNewRowDefaults({
+          view: {
+            default_row_values: [
+              {
+                field: 1,
+                enabled: true,
+                value: 'x',
+                field_type: 'number',
+                function: null,
+              },
+            ],
+          },
+          fields: [field(1)], // type: 'text', not 'number'
+          registry: makeRegistry(),
+        })
+      ).toEqual({ field_1: 'field_default' })
+    })
+  })
+
+  describe('prepareRowMultiFieldUpdate', () => {
+    const field = (id) => ({ id, name: `f${id}`, type: 'text' })
+    const registry = {
+      get() {
+        return {
+          prepareValueForUpdate: (_field, value) => `prepared:${value}`,
+          onRowChange: (row, f, value) =>
+            f.id === 3 && row.field_1 !== undefined
+              ? `reacted:${row.field_1}`
+              : value,
+        }
+      },
+    }
+
+    const row = { id: 5, field_1: 'old1', field_2: 'old2', field_3: 'old3' }
+    const allFields = [field(1), field(2), field(3)]
+
+    test('edited fields appear in all output objects with correct values', () => {
+      const { newRowValues, oldRowValues, updateRequestValues } =
+        prepareRowMultiFieldUpdate(
+          row,
+          allFields,
+          [
+            { field: field(1), value: 'new1', oldValue: 'old1' },
+            { field: field(2), value: 'new2', oldValue: 'old2' },
+          ],
+          registry
+        )
+
+      expect(newRowValues).toMatchObject({
+        id: 5,
+        field_1: 'new1',
+        field_2: 'new2',
+      })
+      expect(oldRowValues).toMatchObject({
+        id: 5,
+        field_1: 'old1',
+        field_2: 'old2',
+      })
+      expect(updateRequestValues).toMatchObject({
+        id: 5,
+        field_1: 'prepared:new1',
+        field_2: 'prepared:new2',
+      })
+    })
+
+    test('updateRequestValues uses prepared values instead of raw values', () => {
+      const { updateRequestValues } = prepareRowMultiFieldUpdate(
+        row,
+        allFields,
+        [{ field: field(1), value: 'rawValue', oldValue: 'old1' }],
+        registry
+      )
+      expect(updateRequestValues.field_1).toBe('prepared:rawValue')
+    })
+
+    test('unedited onRowChange side effects are captured outside request values', () => {
+      const { newRowValues, oldRowValues, updateRequestValues } =
+        prepareRowMultiFieldUpdate(
+          row,
+          allFields,
+          [{ field: field(1), value: 'trigger', oldValue: 'old1' }],
+          registry
+        )
+
+      expect(newRowValues.field_3).toBe('reacted:trigger')
+      expect(oldRowValues.field_3).toBe('old3')
+      expect(updateRequestValues.field_3).toBeUndefined()
+    })
+
+    test('edited fields are not reprocessed through onRowChange side effects', () => {
+      const { newRowValues } = prepareRowMultiFieldUpdate(
+        row,
+        allFields,
+        [
+          { field: field(1), value: 'A', oldValue: 'old1' },
+          { field: field(2), value: 'B', oldValue: 'old2' },
+        ],
+        registry
+      )
+
+      expect(newRowValues.field_1).toBe('A')
+      expect(newRowValues.field_2).toBe('B')
     })
   })
 

--- a/web-frontend/test/unit/database/utils/row.spec.js
+++ b/web-frontend/test/unit/database/utils/row.spec.js
@@ -5,7 +5,6 @@ import {
   computeMultiSelectPosition,
   computeRowMatchFlags,
   buildNewRowDefaults,
-  prepareRowMultiFieldUpdate,
   computeRowInsertPosition,
 } from '@baserow/modules/database/utils/row'
 import { TestApp } from '@baserow/test/helpers/testApp'
@@ -549,92 +548,6 @@ describe('Row utilities', () => {
           registry: makeRegistry(),
         })
       ).toEqual({ field_1: 'field_default' })
-    })
-  })
-
-  describe('prepareRowMultiFieldUpdate', () => {
-    const field = (id) => ({ id, name: `f${id}`, type: 'text' })
-    const registry = {
-      get() {
-        return {
-          prepareValueForUpdate: (_field, value) => `prepared:${value}`,
-          onRowChange: (row, f, value) =>
-            f.id === 3 && row.field_1 !== undefined
-              ? `reacted:${row.field_1}`
-              : value,
-        }
-      },
-    }
-
-    const row = { id: 5, field_1: 'old1', field_2: 'old2', field_3: 'old3' }
-    const allFields = [field(1), field(2), field(3)]
-
-    test('edited fields appear in all output objects with correct values', () => {
-      const { newRowValues, oldRowValues, updateRequestValues } =
-        prepareRowMultiFieldUpdate(
-          row,
-          allFields,
-          [
-            { field: field(1), value: 'new1', oldValue: 'old1' },
-            { field: field(2), value: 'new2', oldValue: 'old2' },
-          ],
-          registry
-        )
-
-      expect(newRowValues).toMatchObject({
-        id: 5,
-        field_1: 'new1',
-        field_2: 'new2',
-      })
-      expect(oldRowValues).toMatchObject({
-        id: 5,
-        field_1: 'old1',
-        field_2: 'old2',
-      })
-      expect(updateRequestValues).toMatchObject({
-        id: 5,
-        field_1: 'prepared:new1',
-        field_2: 'prepared:new2',
-      })
-    })
-
-    test('updateRequestValues uses prepared values instead of raw values', () => {
-      const { updateRequestValues } = prepareRowMultiFieldUpdate(
-        row,
-        allFields,
-        [{ field: field(1), value: 'rawValue', oldValue: 'old1' }],
-        registry
-      )
-      expect(updateRequestValues.field_1).toBe('prepared:rawValue')
-    })
-
-    test('unedited onRowChange side effects are captured outside request values', () => {
-      const { newRowValues, oldRowValues, updateRequestValues } =
-        prepareRowMultiFieldUpdate(
-          row,
-          allFields,
-          [{ field: field(1), value: 'trigger', oldValue: 'old1' }],
-          registry
-        )
-
-      expect(newRowValues.field_3).toBe('reacted:trigger')
-      expect(oldRowValues.field_3).toBe('old3')
-      expect(updateRequestValues.field_3).toBeUndefined()
-    })
-
-    test('edited fields are not reprocessed through onRowChange side effects', () => {
-      const { newRowValues } = prepareRowMultiFieldUpdate(
-        row,
-        allFields,
-        [
-          { field: field(1), value: 'A', oldValue: 'old1' },
-          { field: field(2), value: 'B', oldValue: 'old2' },
-        ],
-        registry
-      )
-
-      expect(newRowValues.field_1).toBe('A')
-      expect(newRowValues.field_2).toBe('B')
     })
   })
 

--- a/web-frontend/test/unit/database/utils/row.spec.js
+++ b/web-frontend/test/unit/database/utils/row.spec.js
@@ -6,6 +6,7 @@ import {
   computeRowMatchFlags,
   buildNewRowDefaults,
   prepareRowMultiFieldUpdate,
+  computeRowInsertPosition,
 } from '@baserow/modules/database/utils/row'
 import { TestApp } from '@baserow/test/helpers/testApp'
 
@@ -634,6 +635,120 @@ describe('Row utilities', () => {
 
       expect(newRowValues.field_1).toBe('A')
       expect(newRowValues.field_2).toBe('B')
+    })
+  })
+
+  describe('computeRowInsertPosition', () => {
+    const makeSortRegistry = () => ({
+      get: (_, type) =>
+        type === 'text'
+          ? {
+              getSortTypes: () => ({
+                default: {
+                  function: (fieldName, order) => (a, b) => {
+                    const va = a[fieldName]
+                    const vb = b[fieldName]
+                    const cmp = va < vb ? -1 : va > vb ? 1 : 0
+                    return order === 'DESC' ? -cmp : cmp
+                  },
+                },
+              }),
+            }
+          : {},
+    })
+    const textField = { id: 1, type: 'text' }
+    const ascSort = [{ field: 1, order: 'ASC', type: 'default' }]
+
+    const row = (id, val) => ({ id, order: '0', field_1: val })
+
+    test('row sorts first returns anchorRowId null and isFirst true', () => {
+      const result = computeRowInsertPosition(
+        row(10, 'A'),
+        [row(1, 'B'), row(2, 'C')],
+        ascSort,
+        [textField],
+        makeSortRegistry()
+      )
+      expect(result).toEqual({
+        anchorRowId: null,
+        sortedIndex: 0,
+        isFirst: true,
+        isLast: false,
+      })
+    })
+
+    test('row sorts last returns correct anchorRowId and isLast true', () => {
+      const result = computeRowInsertPosition(
+        row(10, 'Z'),
+        [row(1, 'A'), row(2, 'M')],
+        ascSort,
+        [textField],
+        makeSortRegistry()
+      )
+      expect(result).toEqual({
+        anchorRowId: 2,
+        sortedIndex: 2,
+        isFirst: false,
+        isLast: true,
+      })
+    })
+
+    test('row sorts in the middle returns correct anchorRowId and index', () => {
+      const result = computeRowInsertPosition(
+        row(10, 'M'),
+        [row(1, 'A'), row(2, 'Z')],
+        ascSort,
+        [textField],
+        makeSortRegistry()
+      )
+      expect(result).toEqual({
+        anchorRowId: 1,
+        sortedIndex: 1,
+        isFirst: false,
+        isLast: false,
+      })
+    })
+
+    test('empty existing rows makes the new row both first and last', () => {
+      const result = computeRowInsertPosition(
+        row(10, 'X'),
+        [],
+        ascSort,
+        [textField],
+        makeSortRegistry()
+      )
+      expect(result).toEqual({
+        anchorRowId: null,
+        sortedIndex: 0,
+        isFirst: true,
+        isLast: true,
+      })
+    })
+
+    test('group bys are applied before sortings when computing row position', () => {
+      const groupField = { id: 2, type: 'text' }
+      const groupedRow = (id, name, group) => ({
+        id,
+        order: '0',
+        field_1: name,
+        field_2: group,
+      })
+
+      const result = computeRowInsertPosition(
+        groupedRow(10, 'M', 'A'),
+        [groupedRow(1, 'A', 'B'), groupedRow(2, 'Z', 'A')],
+        ascSort,
+        [textField, groupField],
+        makeSortRegistry(),
+        [{ field: 2, order: 'ASC', type: 'default' }]
+      )
+
+      expect(result).toEqual({
+        anchorRowId: null,
+        sortedIndex: 0,
+        isFirst: true,
+        isLast: false,
+      })
     })
   })
 

--- a/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
+++ b/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
@@ -1,15 +1,11 @@
 /**
- * Tests for the shared row-lifecycle helpers. The helpers own the common
- * create / update / delete / re-evaluate-flags flows, while each grid store
- * supplies its own row mutations.
+ * Tests for the shared row-lifecycle helpers. The helpers own common
+ * row visibility and positioning decisions, while each grid store supplies its
+ * own row mutations.
  */
 import { vi } from 'vitest'
 import {
-  createRowLifecycle,
   createRowLifecycleContext,
-  createRowOptimistically,
-  updateRowOptimistically,
-  deleteRowOptimistically,
   reapplyMatchFlags,
   handleRowCreated,
   handleRowDeleted,
@@ -47,20 +43,9 @@ const stubRegistry = {
   },
 }
 
-const registryWithPreparedValues = {
-  get() {
-    return {
-      ...stubRegistry.get(),
-      prepareValueForUpdate: (_field, value) => `prepared:${value}`,
-    }
-  },
-}
-
 const baseContext = (overrides = {}) =>
   createRowLifecycleContext({
-    client: {},
     registry: stubRegistry,
-    table: { id: 99 },
     view: {
       id: 7,
       sortings: [],
@@ -71,15 +56,11 @@ const baseContext = (overrides = {}) =>
       default_row_values: [],
     },
     fields: [textField(1), textField(2)],
-    rowService: {},
     ...overrides,
   })
 
 const baseMutations = (overrides = {}) => ({
-  insert: vi.fn(),
-  replace: vi.fn(),
   remove: vi.fn(),
-  applyValues: vi.fn(),
   applyMatchFlags: vi.fn(),
   rowsForMatchCheck: vi.fn(() => []),
   ...overrides,
@@ -87,317 +68,6 @@ const baseMutations = (overrides = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks()
-})
-
-describe('rowLifecycle / createRowOptimistically', () => {
-  test('happy path: insert -> POST -> replace -> applyMatchFlags', async () => {
-    const calls = []
-    const beRow = { id: 42, field_1: 'A', field_2: 'be-default' }
-    const service = {
-      create: vi.fn().mockResolvedValue({ data: beRow }),
-    }
-    const mutations = baseMutations({
-      insert: vi.fn((row, tempId) =>
-        calls.push(['insert', tempId, row.field_1])
-      ),
-      replace: vi.fn((tempId, row) => calls.push(['replace', tempId, row.id])),
-      remove: vi.fn(() => calls.push(['remove'])),
-      applyMatchFlags: vi.fn((id, flags) => calls.push(['flags', id, flags])),
-      rowsForMatchCheck: vi.fn(() => [beRow]),
-    })
-    const selectCell = vi.fn()
-
-    const result = await createRowOptimistically({
-      context: baseContext({
-        registry: registryWithPreparedValues,
-        rowService: service,
-        fields: [textField(1, { primary: true }), textField(2)],
-      }),
-      mutations,
-      beforeId: 24,
-      suppliedValues: { field_1: 'A' },
-      selection: {
-        selectPrimaryCell: true,
-        selectCell,
-      },
-    })
-
-    expect(result).toMatchObject({ id: 42, field_1: 'A' })
-    expect(mutations.insert).toHaveBeenCalledTimes(1)
-    expect(mutations.insert.mock.calls[0][0]).toMatchObject({
-      field_1: 'A',
-      field_2: '',
-      _: { loading: true },
-    })
-    expect(mutations.insert.mock.calls[0][0].id).toBeLessThan(0)
-    expect(service.create).toHaveBeenCalledWith(
-      99,
-      { field_1: 'prepared:A', field_2: 'prepared:' },
-      24,
-      7
-    )
-    expect(mutations.replace).toHaveBeenCalledTimes(1)
-    expect(mutations.remove).not.toHaveBeenCalled()
-    expect(mutations.rowsForMatchCheck).toHaveBeenCalledWith(beRow)
-    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(42, {
-      matchFilters: true,
-      matchSortings: true,
-    })
-    expect(selectCell).toHaveBeenCalledWith(42, 1)
-    expect(calls.map((call) => call[0])).toEqual(['insert', 'replace', 'flags'])
-    expect(calls[1][1]).toBe(calls[0][1])
-    expect(calls[2][1]).toBe(42)
-  })
-
-  test('BE failure: insert -> POST throws -> remove -> re-throw', async () => {
-    const mutations = baseMutations()
-    const service = {
-      create: vi.fn().mockRejectedValue(new Error('BE down')),
-    }
-
-    await expect(
-      createRowOptimistically({
-        context: baseContext({ rowService: service }),
-        mutations,
-        suppliedValues: { field_1: 'A' },
-      })
-    ).rejects.toThrow('BE down')
-
-    expect(mutations.insert).toHaveBeenCalledTimes(1)
-    expect(mutations.remove).toHaveBeenCalledWith(
-      mutations.insert.mock.calls[0][1]
-    )
-    expect(mutations.replace).not.toHaveBeenCalled()
-  })
-
-  test('BE returns null data: removes optimistic row and returns null', async () => {
-    const mutations = baseMutations()
-    const service = {
-      create: vi.fn().mockResolvedValue({ data: null }),
-    }
-
-    const result = await createRowOptimistically({
-      context: baseContext({ rowService: service }),
-      mutations,
-      suppliedValues: { field_1: 'A' },
-    })
-
-    expect(result).toBeNull()
-    expect(mutations.insert).toHaveBeenCalled()
-    expect(mutations.replace).not.toHaveBeenCalled()
-    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
-    expect(mutations.remove).toHaveBeenCalledWith(
-      mutations.insert.mock.calls[0][1]
-    )
-  })
-
-  test('view default row values are included in the create request', async () => {
-    const beRow = { id: 42, field_1: 'Default name' }
-    const service = {
-      create: vi.fn().mockResolvedValue({ data: beRow }),
-    }
-    const mutations = baseMutations({
-      rowsForMatchCheck: vi.fn(() => [beRow]),
-    })
-
-    await createRowOptimistically({
-      context: baseContext({
-        registry: registryWithPreparedValues,
-        rowService: service,
-        view: {
-          id: 7,
-          sortings: [],
-          filters: [],
-          filter_groups: [],
-          filters_disabled: true,
-          filter_type: 'AND',
-          default_row_values: [
-            {
-              field: 1,
-              enabled: true,
-              value: 'Default name',
-              field_type: 'text',
-              function: null,
-            },
-          ],
-        },
-        fields: [textField(1)],
-      }),
-      mutations,
-    })
-
-    expect(mutations.insert.mock.calls[0][0]).toMatchObject({
-      field_1: 'Default name',
-      _: { loading: true },
-    })
-    expect(service.create).toHaveBeenCalledWith(
-      99,
-      { field_1: 'prepared:Default name' },
-      null,
-      7
-    )
-  })
-
-  test('non-writable fields are not included in the create request', async () => {
-    const service = {
-      create: vi.fn().mockResolvedValue({
-        data: { id: 42, field_1: 'A', field_2: 'Readonly' },
-      }),
-    }
-    const registry = {
-      get(_type, name) {
-        return {
-          ...registryWithPreparedValues.get(),
-          canWriteFieldValues: () => name !== 'formula',
-        }
-      },
-    }
-
-    await createRowOptimistically({
-      context: baseContext({
-        registry,
-        rowService: service,
-        fields: [textField(1), textField(2, { type: 'formula' })],
-      }),
-      mutations: baseMutations(),
-      suppliedValues: { field_1: 'A', field_2: 'Readonly' },
-    })
-
-    expect(service.create).toHaveBeenCalledWith(
-      99,
-      { field_1: 'prepared:A' },
-      null,
-      7
-    )
-  })
-})
-
-describe('rowLifecycle / updateRowOptimistically', () => {
-  const buildRow = () => ({ id: 5, field_1: 'old', field_2: 'unchanged' })
-
-  test('happy path: optimistic write -> PATCH -> write BE response -> flags', async () => {
-    const calls = []
-    const beRow = { id: 5, field_1: 'new', field_2: 'unchanged' }
-    const service = {
-      batchUpdate: vi.fn().mockResolvedValue({
-        data: { items: [beRow] },
-      }),
-    }
-    const mutations = baseMutations({
-      applyValues: vi.fn((id, values) =>
-        calls.push(['applyValues', id, values.field_1])
-      ),
-      applyMatchFlags: vi.fn((id, flags) => calls.push(['flags', id, flags])),
-      rowsForMatchCheck: vi.fn(() => [beRow]),
-    })
-
-    await updateRowOptimistically({
-      context: baseContext({
-        registry: registryWithPreparedValues,
-        rowService: service,
-      }),
-      mutations,
-      edit: {
-        row: buildRow(),
-        field: textField(1),
-        value: 'new',
-        oldValue: 'old',
-      },
-    })
-
-    expect(mutations.applyValues).toHaveBeenCalledTimes(2)
-    expect(calls[0]).toEqual(['applyValues', 5, 'new'])
-    expect(calls[1][0]).toBe('applyValues')
-    expect(service.batchUpdate).toHaveBeenCalledWith(
-      99,
-      [{ id: 5, field_1: 'prepared:new' }],
-      null,
-      7
-    )
-    expect(mutations.rowsForMatchCheck).toHaveBeenCalledWith(beRow)
-    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(5, {
-      matchFilters: true,
-      matchSortings: true,
-    })
-  })
-
-  test('BE failure: writes optimistic -> BE fails -> reverts to oldValue -> throws', async () => {
-    const seen = []
-    const service = {
-      batchUpdate: vi.fn().mockRejectedValue(new Error('BE down')),
-    }
-    const mutations = baseMutations({
-      applyValues: vi.fn((_id, values) => seen.push(values.field_1)),
-    })
-
-    await expect(
-      updateRowOptimistically({
-        context: baseContext({ rowService: service }),
-        mutations,
-        edit: {
-          row: buildRow(),
-          field: textField(1),
-          value: 'new',
-          oldValue: 'old',
-        },
-      })
-    ).rejects.toThrow('BE down')
-
-    expect(seen).toEqual(['new', 'old'])
-  })
-})
-
-describe('rowLifecycle / deleteRowOptimistically', () => {
-  test('happy path: remove -> DELETE -> return true', async () => {
-    const mutations = baseMutations()
-    const service = {
-      delete: vi.fn().mockResolvedValue({}),
-    }
-
-    const result = await deleteRowOptimistically({
-      context: baseContext({ rowService: service }),
-      mutations,
-      row: { id: 5, field_1: 'A' },
-    })
-
-    expect(result).toBe(true)
-    expect(mutations.remove).toHaveBeenCalledWith(5)
-    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
-    expect(mutations.insert).not.toHaveBeenCalled()
-  })
-
-  test('BE failure: remove -> DELETE throws -> re-insert original -> re-throw', async () => {
-    const row = { id: 5, field_1: 'A' }
-    const mutations = baseMutations()
-    const service = {
-      delete: vi.fn().mockRejectedValue(new Error('BE down')),
-    }
-
-    await expect(
-      deleteRowOptimistically({
-        context: baseContext({ rowService: service }),
-        mutations,
-        row,
-      })
-    ).rejects.toThrow('BE down')
-
-    expect(mutations.remove).toHaveBeenCalledWith(5)
-    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
-    expect(mutations.insert).toHaveBeenCalledWith(row, 5)
-  })
-
-  test('missing row: no-op, returns false', async () => {
-    const mutations = baseMutations()
-
-    const result = await deleteRowOptimistically({
-      context: baseContext(),
-      mutations,
-      row: null,
-    })
-
-    expect(result).toBe(false)
-    expect(mutations.remove).not.toHaveBeenCalled()
-  })
 })
 
 describe('rowLifecycle / reapplyMatchFlags', () => {
@@ -822,23 +492,5 @@ describe('handleRowUpdated', () => {
     })
     expect(mutations.remove).not.toHaveBeenCalled()
     expect(mutations.insertAtPosition).not.toHaveBeenCalled()
-  })
-})
-
-describe('createRowLifecycle', () => {
-  test('returns methods bound to a context and mutation adapter', async () => {
-    const mutations = baseMutations()
-    const service = {
-      delete: vi.fn().mockResolvedValue({}),
-    }
-    const lifecycle = createRowLifecycle(
-      baseContext({ rowService: service }),
-      mutations
-    )
-
-    await expect(lifecycle.delete({ row: { id: 5 } })).resolves.toBe(true)
-
-    expect(mutations.remove).toHaveBeenCalledWith(5)
-    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
   })
 })

--- a/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
+++ b/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
@@ -11,6 +11,9 @@ import {
   updateRowOptimistically,
   deleteRowOptimistically,
   reapplyMatchFlags,
+  handleRowCreated,
+  handleRowDeleted,
+  handleRowUpdated,
 } from '@baserow/modules/database/utils/rowLifecycle'
 
 const textField = (id, extra = {}) => ({
@@ -26,6 +29,7 @@ const stubRegistry = {
       isEqual: (_field, a, b) => JSON.stringify(a) === JSON.stringify(b),
       onRowChange: (_row, _field, value) => value,
       prepareValueForUpdate: (_field, value) => value,
+      canWriteFieldValues: () => true,
       getNewRowValue: () => '',
       getSupportedDefaultValueFunctions: () => [],
       parseDefaultRowValue: (_field, value) => value,
@@ -128,7 +132,7 @@ describe('rowLifecycle / createRowOptimistically', () => {
     expect(mutations.insert.mock.calls[0][0].id).toBeLessThan(0)
     expect(service.create).toHaveBeenCalledWith(
       99,
-      { field_1: 'prepared:A' },
+      { field_1: 'prepared:A', field_2: 'prepared:' },
       24,
       7
     )
@@ -184,6 +188,86 @@ describe('rowLifecycle / createRowOptimistically', () => {
     expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
     expect(mutations.remove).toHaveBeenCalledWith(
       mutations.insert.mock.calls[0][1]
+    )
+  })
+
+  test('view default row values are included in the create request', async () => {
+    const beRow = { id: 42, field_1: 'Default name' }
+    const service = {
+      create: vi.fn().mockResolvedValue({ data: beRow }),
+    }
+    const mutations = baseMutations({
+      rowsForMatchCheck: vi.fn(() => [beRow]),
+    })
+
+    await createRowOptimistically({
+      context: baseContext({
+        registry: registryWithPreparedValues,
+        rowService: service,
+        view: {
+          id: 7,
+          sortings: [],
+          filters: [],
+          filter_groups: [],
+          filters_disabled: true,
+          filter_type: 'AND',
+          default_row_values: [
+            {
+              field: 1,
+              enabled: true,
+              value: 'Default name',
+              field_type: 'text',
+              function: null,
+            },
+          ],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+    })
+
+    expect(mutations.insert.mock.calls[0][0]).toMatchObject({
+      field_1: 'Default name',
+      _: { loading: true },
+    })
+    expect(service.create).toHaveBeenCalledWith(
+      99,
+      { field_1: 'prepared:Default name' },
+      null,
+      7
+    )
+  })
+
+  test('non-writable fields are not included in the create request', async () => {
+    const service = {
+      create: vi.fn().mockResolvedValue({
+        data: { id: 42, field_1: 'A', field_2: 'Readonly' },
+      }),
+    }
+    const registry = {
+      get(_type, name) {
+        return {
+          ...registryWithPreparedValues.get(),
+          canWriteFieldValues: () => name !== 'formula',
+        }
+      },
+    }
+
+    await createRowOptimistically({
+      context: baseContext({
+        registry,
+        rowService: service,
+        fields: [textField(1), textField(2, { type: 'formula' })],
+      }),
+      mutations: baseMutations(),
+      suppliedValues: { field_1: 'A', field_2: 'Readonly' },
+    })
+
+    expect(service.create).toHaveBeenCalledWith(
+      99,
+      { field_1: 'prepared:A' },
+      null,
+      7
     )
   })
 })
@@ -320,8 +404,8 @@ describe('rowLifecycle / reapplyMatchFlags', () => {
   test('computes flags via matchSearchFilters + sort, applies via callback', () => {
     const mutations = baseMutations({
       rowsForMatchCheck: vi.fn(() => [
-        { id: 1, field_1: 'A' },
-        { id: 2, field_1: 'B' },
+        { id: 1, field_1: 'A', order: '0' },
+        { id: 2, field_1: 'B', order: '0' },
       ]),
     })
 
@@ -334,7 +418,7 @@ describe('rowLifecycle / reapplyMatchFlags', () => {
         fields: [textField(1)],
       }),
       mutations,
-      row: { id: 1, field_1: 'A' },
+      row: { id: 1, field_1: 'A', order: '0' },
     })
 
     expect(mutations.applyMatchFlags).toHaveBeenCalledWith(1, {
@@ -346,8 +430,8 @@ describe('rowLifecycle / reapplyMatchFlags', () => {
   test('marks matchSortings false when the row is not at its sort position', () => {
     const mutations = baseMutations({
       rowsForMatchCheck: vi.fn(() => [
-        { id: 2, field_1: 'Z' },
-        { id: 99, field_1: 'A' },
+        { id: 2, field_1: 'Z', order: '0' },
+        { id: 99, field_1: 'A', order: '0' },
       ]),
     })
 
@@ -360,7 +444,7 @@ describe('rowLifecycle / reapplyMatchFlags', () => {
         fields: [textField(1)],
       }),
       mutations,
-      row: { id: 99, field_1: 'A' },
+      row: { id: 99, field_1: 'A', order: '0' },
     })
 
     const [, flags] = mutations.applyMatchFlags.mock.calls[0]
@@ -377,6 +461,367 @@ describe('rowLifecycle / reapplyMatchFlags', () => {
     })
 
     expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleRowCreated', () => {
+  const row = { id: 10, field_1: 'new', order: '0' }
+
+  test('row matches view: inserts at computed position and applies flags', () => {
+    const existingRows = [
+      { id: 1, field_1: 'A', order: '0' },
+      { id: 2, field_1: 'Z', order: '0' },
+    ]
+    const mutations = baseMutations({
+      insertAtPosition: vi.fn(),
+      rowsForMatchCheck: vi.fn(() => existingRows),
+    })
+
+    handleRowCreated({
+      context: baseContext({
+        view: {
+          filters_disabled: true,
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+          filters: [],
+          filter_groups: [],
+          filter_type: 'AND',
+          default_row_values: [],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+      row,
+    })
+
+    expect(mutations.insertAtPosition).toHaveBeenCalledTimes(1)
+    const [insertedRow, position] = mutations.insertAtPosition.mock.calls[0]
+    expect(insertedRow).toBe(row)
+    // Lexicographic ASC: 'A' < 'Z' < 'new' (lowercase 'n' > uppercase 'Z' in Unicode)
+    // so 'new' lands at index 2, after 'Z' (id=2)
+    expect(position.sortedIndex).toBe(2)
+    expect(position.anchorRowId).toBe(2)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(10, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+  })
+
+  test("row doesn't match filters: returns without inserting", () => {
+    // Registry that handles viewFilter types so matchSearchFilters can
+    // evaluate the 'equal' filter and return false.
+    const registryWithFilterType = {
+      get(type, name) {
+        if (type === 'viewFilter') {
+          return {
+            matches: (_rowValue, _filterValue, _field, _fieldType) => false,
+          }
+        }
+        return stubRegistry.get()
+      },
+    }
+    const mutations = baseMutations({
+      insertAtPosition: vi.fn(),
+      rowsForMatchCheck: vi.fn(() => []),
+    })
+
+    handleRowCreated({
+      context: baseContext({
+        registry: registryWithFilterType,
+        view: {
+          filters_disabled: false,
+          sortings: [],
+          filters: [
+            { field: 1, type: 'equal', value: 'other', preload_values: {} },
+          ],
+          filter_groups: [],
+          filter_type: 'AND',
+          default_row_values: [],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+      row,
+    })
+
+    expect(mutations.insertAtPosition).not.toHaveBeenCalled()
+    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+  })
+
+  test('rowsForMatchCheck absent: falls back to empty rows', () => {
+    const { rowsForMatchCheck: _omitted, ...mutationsWithoutRows } =
+      baseMutations()
+    const mutations = { ...mutationsWithoutRows, insertAtPosition: vi.fn() }
+
+    handleRowCreated({
+      context: baseContext(),
+      mutations,
+      row,
+    })
+
+    expect(mutations.insertAtPosition).toHaveBeenCalledTimes(1)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(10, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+  })
+})
+
+describe('handleRowDeleted', () => {
+  const row = { id: 10, field_1: 'gone' }
+
+  test('row was visible: remove is called', () => {
+    const mutations = baseMutations()
+
+    handleRowDeleted({
+      context: baseContext(),
+      mutations,
+      row,
+    })
+
+    expect(mutations.remove).toHaveBeenCalledWith(10)
+  })
+
+  test('row did not match filters: remove is not called', () => {
+    const registryWithFilterType = {
+      get(type) {
+        if (type === 'viewFilter') {
+          return { matches: () => false }
+        }
+        return stubRegistry.get()
+      },
+    }
+    const mutations = baseMutations()
+
+    handleRowDeleted({
+      context: baseContext({
+        registry: registryWithFilterType,
+        view: {
+          filters_disabled: false,
+          sortings: [],
+          filters: [
+            { field: 1, type: 'equal', value: 'other', preload_values: {} },
+          ],
+          filter_groups: [],
+          filter_type: 'AND',
+          default_row_values: [],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+      row,
+    })
+
+    expect(mutations.remove).not.toHaveBeenCalled()
+  })
+
+  test('rowsForMatchCheck absent: falls back to empty rows, still removes', () => {
+    const { rowsForMatchCheck: _omitted, ...mutationsWithoutRows } =
+      baseMutations()
+
+    handleRowDeleted({
+      context: baseContext(),
+      mutations: mutationsWithoutRows,
+      row,
+    })
+
+    expect(mutationsWithoutRows.remove).toHaveBeenCalledWith(10)
+  })
+})
+
+describe('handleRowUpdated', () => {
+  // A view context with ASC sorting on field_1 so position assertions are concrete.
+  const sortedView = {
+    filters_disabled: true,
+    sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+    filters: [],
+    filter_groups: [],
+    filter_type: 'AND',
+    default_row_values: [],
+  }
+
+  test('old in view, new NOT in view: remove(newRow.id)', () => {
+    // Use a value-aware filter registry.
+    const registryValueAware = {
+      get(type) {
+        if (type === 'viewFilter') {
+          // matches only when value === 'keep'
+          return { matches: (rowValue) => rowValue === 'keep' }
+        }
+        return stubRegistry.get()
+      },
+    }
+    const viewWithFilter = {
+      filters_disabled: false,
+      sortings: [],
+      filters: [{ field: 1, type: 'equal', value: 'keep', preload_values: {} }],
+      filter_groups: [],
+      filter_type: 'AND',
+      default_row_values: [],
+    }
+    const oldRow = { id: 5, field_1: 'keep' } // was in view
+    const newRow = { id: 5, field_1: 'gone' } // no longer in view
+    const mutations = {
+      ...baseMutations(),
+      insertAtPosition: vi.fn(),
+      replaceAtPosition: vi.fn(),
+    }
+
+    handleRowUpdated({
+      context: baseContext({
+        registry: registryValueAware,
+        view: viewWithFilter,
+        fields: [textField(1)],
+      }),
+      mutations,
+      oldRow,
+      newRow,
+    })
+
+    expect(mutations.remove).toHaveBeenCalledWith(5)
+    expect(mutations.insertAtPosition).not.toHaveBeenCalled()
+    expect(mutations.replaceAtPosition).not.toHaveBeenCalled()
+    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+  })
+
+  test('old NOT in view, new in view: insertAtPosition + applyMatchFlags', () => {
+    const registryValueAware = {
+      get(type) {
+        if (type === 'viewFilter') {
+          return { matches: (rowValue) => rowValue === 'keep' }
+        }
+        return stubRegistry.get()
+      },
+    }
+    const viewWithFilter = {
+      filters_disabled: false,
+      sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+      filters: [{ field: 1, type: 'equal', value: 'keep', preload_values: {} }],
+      filter_groups: [],
+      filter_type: 'AND',
+      default_row_values: [],
+    }
+    const oldRow = { id: 5, field_1: 'gone', order: '0' } // was NOT in view (filter: 'gone' !== 'keep')
+    const newRow = { id: 5, field_1: 'keep', order: '0' } // now in view; 'keep' sorts between 'alpha' and 'zebra'
+    // ASC: 'alpha' < 'keep' < 'zebra', so newRow inserts at index 1, after id=1
+    const existingRows = [
+      { id: 1, field_1: 'alpha', order: '0' },
+      { id: 2, field_1: 'zebra', order: '0' },
+    ]
+    const mutations = {
+      ...baseMutations({
+        rowsForMatchCheck: vi.fn(() => existingRows),
+      }),
+      insertAtPosition: vi.fn(),
+      replaceAtPosition: vi.fn(),
+    }
+
+    handleRowUpdated({
+      context: baseContext({
+        registry: registryValueAware,
+        view: viewWithFilter,
+        fields: [textField(1)],
+      }),
+      mutations,
+      oldRow,
+      newRow,
+    })
+
+    expect(mutations.insertAtPosition).toHaveBeenCalledTimes(1)
+    const [insertedRow, position] = mutations.insertAtPosition.mock.calls[0]
+    expect(insertedRow).toBe(newRow)
+    expect(position.sortedIndex).toBe(1)
+    expect(position.anchorRowId).toBe(1)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(5, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+    expect(mutations.remove).not.toHaveBeenCalled()
+    expect(mutations.replaceAtPosition).not.toHaveBeenCalled()
+  })
+
+  test('old NOT in view, new NOT in view: noop', () => {
+    const registryValueAware = {
+      get(type) {
+        if (type === 'viewFilter') {
+          return { matches: (rowValue) => rowValue === 'keep' }
+        }
+        return stubRegistry.get()
+      },
+    }
+    const viewWithFilter = {
+      filters_disabled: false,
+      sortings: [],
+      filters: [{ field: 1, type: 'equal', value: 'keep', preload_values: {} }],
+      filter_groups: [],
+      filter_type: 'AND',
+      default_row_values: [],
+    }
+    const oldRow = { id: 5, field_1: 'gone' }
+    const newRow = { id: 5, field_1: 'also-gone' }
+    const mutations = {
+      ...baseMutations(),
+      insertAtPosition: vi.fn(),
+      replaceAtPosition: vi.fn(),
+    }
+
+    handleRowUpdated({
+      context: baseContext({
+        registry: registryValueAware,
+        view: viewWithFilter,
+        fields: [textField(1)],
+      }),
+      mutations,
+      oldRow,
+      newRow,
+    })
+
+    expect(mutations.remove).not.toHaveBeenCalled()
+    expect(mutations.insertAtPosition).not.toHaveBeenCalled()
+    expect(mutations.replaceAtPosition).not.toHaveBeenCalled()
+    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+  })
+
+  test('old in view, new in view: replaceAtPosition + applyMatchFlags, position excludes self', () => {
+    // filters_disabled so both old and new pass
+    const existingRows = [
+      { id: 1, field_1: 'A', order: '0' },
+      { id: 5, field_1: 'B', order: '0' }, // the row being updated — must be excluded from position calc
+      { id: 9, field_1: 'Z', order: '0' },
+    ]
+    const oldRow = { id: 5, field_1: 'B', order: '0' }
+    const newRow = { id: 5, field_1: 'M', order: '0' } // moves between A and Z
+    const mutations = {
+      ...baseMutations({
+        rowsForMatchCheck: vi.fn(() => existingRows),
+      }),
+      insertAtPosition: vi.fn(),
+      replaceAtPosition: vi.fn(),
+    }
+
+    handleRowUpdated({
+      context: baseContext({
+        view: sortedView,
+        fields: [textField(1)],
+      }),
+      mutations,
+      oldRow,
+      newRow,
+    })
+
+    expect(mutations.replaceAtPosition).toHaveBeenCalledTimes(1)
+    const [rowId, replacedRow, position] =
+      mutations.replaceAtPosition.mock.calls[0]
+    expect(rowId).toBe(5)
+    expect(replacedRow).toBe(newRow)
+    // Rows excluding self: [{id:1,'A'}, {id:9,'Z'}].  'M' sorts between 'A' and 'Z' → index 1.
+    expect(position.sortedIndex).toBe(1)
+    expect(position.anchorRowId).toBe(1)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(5, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+    expect(mutations.remove).not.toHaveBeenCalled()
+    expect(mutations.insertAtPosition).not.toHaveBeenCalled()
   })
 })
 

--- a/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
+++ b/web-frontend/test/unit/database/utils/rowLifecycle.spec.js
@@ -1,0 +1,399 @@
+/**
+ * Tests for the shared row-lifecycle helpers. The helpers own the common
+ * create / update / delete / re-evaluate-flags flows, while each grid store
+ * supplies its own row mutations.
+ */
+import { vi } from 'vitest'
+import {
+  createRowLifecycle,
+  createRowLifecycleContext,
+  createRowOptimistically,
+  updateRowOptimistically,
+  deleteRowOptimistically,
+  reapplyMatchFlags,
+} from '@baserow/modules/database/utils/rowLifecycle'
+
+const textField = (id, extra = {}) => ({
+  id,
+  name: `f${id}`,
+  type: 'text',
+  ...extra,
+})
+
+const stubRegistry = {
+  get() {
+    return {
+      isEqual: (_field, a, b) => JSON.stringify(a) === JSON.stringify(b),
+      onRowChange: (_row, _field, value) => value,
+      prepareValueForUpdate: (_field, value) => value,
+      getNewRowValue: () => '',
+      getSupportedDefaultValueFunctions: () => [],
+      parseDefaultRowValue: (_field, value) => value,
+      getSortTypes: () => ({
+        default: {
+          function: (fieldName, order) => (a, b) => {
+            const av = a[fieldName]
+            const bv = b[fieldName]
+            const cmp = av < bv ? -1 : av > bv ? 1 : 0
+            return order === 'DESC' ? -cmp : cmp
+          },
+        },
+      }),
+    }
+  },
+}
+
+const registryWithPreparedValues = {
+  get() {
+    return {
+      ...stubRegistry.get(),
+      prepareValueForUpdate: (_field, value) => `prepared:${value}`,
+    }
+  },
+}
+
+const baseContext = (overrides = {}) =>
+  createRowLifecycleContext({
+    client: {},
+    registry: stubRegistry,
+    table: { id: 99 },
+    view: {
+      id: 7,
+      sortings: [],
+      filters: [],
+      filter_groups: [],
+      filters_disabled: true,
+      filter_type: 'AND',
+      default_row_values: [],
+    },
+    fields: [textField(1), textField(2)],
+    rowService: {},
+    ...overrides,
+  })
+
+const baseMutations = (overrides = {}) => ({
+  insert: vi.fn(),
+  replace: vi.fn(),
+  remove: vi.fn(),
+  applyValues: vi.fn(),
+  applyMatchFlags: vi.fn(),
+  rowsForMatchCheck: vi.fn(() => []),
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('rowLifecycle / createRowOptimistically', () => {
+  test('happy path: insert -> POST -> replace -> applyMatchFlags', async () => {
+    const calls = []
+    const beRow = { id: 42, field_1: 'A', field_2: 'be-default' }
+    const service = {
+      create: vi.fn().mockResolvedValue({ data: beRow }),
+    }
+    const mutations = baseMutations({
+      insert: vi.fn((row, tempId) =>
+        calls.push(['insert', tempId, row.field_1])
+      ),
+      replace: vi.fn((tempId, row) => calls.push(['replace', tempId, row.id])),
+      remove: vi.fn(() => calls.push(['remove'])),
+      applyMatchFlags: vi.fn((id, flags) => calls.push(['flags', id, flags])),
+      rowsForMatchCheck: vi.fn(() => [beRow]),
+    })
+    const selectCell = vi.fn()
+
+    const result = await createRowOptimistically({
+      context: baseContext({
+        registry: registryWithPreparedValues,
+        rowService: service,
+        fields: [textField(1, { primary: true }), textField(2)],
+      }),
+      mutations,
+      beforeId: 24,
+      suppliedValues: { field_1: 'A' },
+      selection: {
+        selectPrimaryCell: true,
+        selectCell,
+      },
+    })
+
+    expect(result).toMatchObject({ id: 42, field_1: 'A' })
+    expect(mutations.insert).toHaveBeenCalledTimes(1)
+    expect(mutations.insert.mock.calls[0][0]).toMatchObject({
+      field_1: 'A',
+      field_2: '',
+      _: { loading: true },
+    })
+    expect(mutations.insert.mock.calls[0][0].id).toBeLessThan(0)
+    expect(service.create).toHaveBeenCalledWith(
+      99,
+      { field_1: 'prepared:A' },
+      24,
+      7
+    )
+    expect(mutations.replace).toHaveBeenCalledTimes(1)
+    expect(mutations.remove).not.toHaveBeenCalled()
+    expect(mutations.rowsForMatchCheck).toHaveBeenCalledWith(beRow)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(42, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+    expect(selectCell).toHaveBeenCalledWith(42, 1)
+    expect(calls.map((call) => call[0])).toEqual(['insert', 'replace', 'flags'])
+    expect(calls[1][1]).toBe(calls[0][1])
+    expect(calls[2][1]).toBe(42)
+  })
+
+  test('BE failure: insert -> POST throws -> remove -> re-throw', async () => {
+    const mutations = baseMutations()
+    const service = {
+      create: vi.fn().mockRejectedValue(new Error('BE down')),
+    }
+
+    await expect(
+      createRowOptimistically({
+        context: baseContext({ rowService: service }),
+        mutations,
+        suppliedValues: { field_1: 'A' },
+      })
+    ).rejects.toThrow('BE down')
+
+    expect(mutations.insert).toHaveBeenCalledTimes(1)
+    expect(mutations.remove).toHaveBeenCalledWith(
+      mutations.insert.mock.calls[0][1]
+    )
+    expect(mutations.replace).not.toHaveBeenCalled()
+  })
+
+  test('BE returns null data: removes optimistic row and returns null', async () => {
+    const mutations = baseMutations()
+    const service = {
+      create: vi.fn().mockResolvedValue({ data: null }),
+    }
+
+    const result = await createRowOptimistically({
+      context: baseContext({ rowService: service }),
+      mutations,
+      suppliedValues: { field_1: 'A' },
+    })
+
+    expect(result).toBeNull()
+    expect(mutations.insert).toHaveBeenCalled()
+    expect(mutations.replace).not.toHaveBeenCalled()
+    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+    expect(mutations.remove).toHaveBeenCalledWith(
+      mutations.insert.mock.calls[0][1]
+    )
+  })
+})
+
+describe('rowLifecycle / updateRowOptimistically', () => {
+  const buildRow = () => ({ id: 5, field_1: 'old', field_2: 'unchanged' })
+
+  test('happy path: optimistic write -> PATCH -> write BE response -> flags', async () => {
+    const calls = []
+    const beRow = { id: 5, field_1: 'new', field_2: 'unchanged' }
+    const service = {
+      batchUpdate: vi.fn().mockResolvedValue({
+        data: { items: [beRow] },
+      }),
+    }
+    const mutations = baseMutations({
+      applyValues: vi.fn((id, values) =>
+        calls.push(['applyValues', id, values.field_1])
+      ),
+      applyMatchFlags: vi.fn((id, flags) => calls.push(['flags', id, flags])),
+      rowsForMatchCheck: vi.fn(() => [beRow]),
+    })
+
+    await updateRowOptimistically({
+      context: baseContext({
+        registry: registryWithPreparedValues,
+        rowService: service,
+      }),
+      mutations,
+      edit: {
+        row: buildRow(),
+        field: textField(1),
+        value: 'new',
+        oldValue: 'old',
+      },
+    })
+
+    expect(mutations.applyValues).toHaveBeenCalledTimes(2)
+    expect(calls[0]).toEqual(['applyValues', 5, 'new'])
+    expect(calls[1][0]).toBe('applyValues')
+    expect(service.batchUpdate).toHaveBeenCalledWith(
+      99,
+      [{ id: 5, field_1: 'prepared:new' }],
+      null,
+      7
+    )
+    expect(mutations.rowsForMatchCheck).toHaveBeenCalledWith(beRow)
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(5, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+  })
+
+  test('BE failure: writes optimistic -> BE fails -> reverts to oldValue -> throws', async () => {
+    const seen = []
+    const service = {
+      batchUpdate: vi.fn().mockRejectedValue(new Error('BE down')),
+    }
+    const mutations = baseMutations({
+      applyValues: vi.fn((_id, values) => seen.push(values.field_1)),
+    })
+
+    await expect(
+      updateRowOptimistically({
+        context: baseContext({ rowService: service }),
+        mutations,
+        edit: {
+          row: buildRow(),
+          field: textField(1),
+          value: 'new',
+          oldValue: 'old',
+        },
+      })
+    ).rejects.toThrow('BE down')
+
+    expect(seen).toEqual(['new', 'old'])
+  })
+})
+
+describe('rowLifecycle / deleteRowOptimistically', () => {
+  test('happy path: remove -> DELETE -> return true', async () => {
+    const mutations = baseMutations()
+    const service = {
+      delete: vi.fn().mockResolvedValue({}),
+    }
+
+    const result = await deleteRowOptimistically({
+      context: baseContext({ rowService: service }),
+      mutations,
+      row: { id: 5, field_1: 'A' },
+    })
+
+    expect(result).toBe(true)
+    expect(mutations.remove).toHaveBeenCalledWith(5)
+    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
+    expect(mutations.insert).not.toHaveBeenCalled()
+  })
+
+  test('BE failure: remove -> DELETE throws -> re-insert original -> re-throw', async () => {
+    const row = { id: 5, field_1: 'A' }
+    const mutations = baseMutations()
+    const service = {
+      delete: vi.fn().mockRejectedValue(new Error('BE down')),
+    }
+
+    await expect(
+      deleteRowOptimistically({
+        context: baseContext({ rowService: service }),
+        mutations,
+        row,
+      })
+    ).rejects.toThrow('BE down')
+
+    expect(mutations.remove).toHaveBeenCalledWith(5)
+    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
+    expect(mutations.insert).toHaveBeenCalledWith(row, 5)
+  })
+
+  test('missing row: no-op, returns false', async () => {
+    const mutations = baseMutations()
+
+    const result = await deleteRowOptimistically({
+      context: baseContext(),
+      mutations,
+      row: null,
+    })
+
+    expect(result).toBe(false)
+    expect(mutations.remove).not.toHaveBeenCalled()
+  })
+})
+
+describe('rowLifecycle / reapplyMatchFlags', () => {
+  test('computes flags via matchSearchFilters + sort, applies via callback', () => {
+    const mutations = baseMutations({
+      rowsForMatchCheck: vi.fn(() => [
+        { id: 1, field_1: 'A' },
+        { id: 2, field_1: 'B' },
+      ]),
+    })
+
+    reapplyMatchFlags({
+      context: baseContext({
+        view: {
+          filters_disabled: true,
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+      row: { id: 1, field_1: 'A' },
+    })
+
+    expect(mutations.applyMatchFlags).toHaveBeenCalledWith(1, {
+      matchFilters: true,
+      matchSortings: true,
+    })
+  })
+
+  test('marks matchSortings false when the row is not at its sort position', () => {
+    const mutations = baseMutations({
+      rowsForMatchCheck: vi.fn(() => [
+        { id: 2, field_1: 'Z' },
+        { id: 99, field_1: 'A' },
+      ]),
+    })
+
+    reapplyMatchFlags({
+      context: baseContext({
+        view: {
+          filters_disabled: true,
+          sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+        },
+        fields: [textField(1)],
+      }),
+      mutations,
+      row: { id: 99, field_1: 'A' },
+    })
+
+    const [, flags] = mutations.applyMatchFlags.mock.calls[0]
+    expect(flags.matchSortings).toBe(false)
+  })
+
+  test('null row: no-op', () => {
+    const mutations = baseMutations()
+
+    reapplyMatchFlags({
+      context: baseContext(),
+      mutations,
+      row: null,
+    })
+
+    expect(mutations.applyMatchFlags).not.toHaveBeenCalled()
+  })
+})
+
+describe('createRowLifecycle', () => {
+  test('returns methods bound to a context and mutation adapter', async () => {
+    const mutations = baseMutations()
+    const service = {
+      delete: vi.fn().mockResolvedValue({}),
+    }
+    const lifecycle = createRowLifecycle(
+      baseContext({ rowService: service }),
+      mutations
+    )
+
+    await expect(lifecycle.delete({ row: { id: 5 } })).resolves.toBe(true)
+
+    expect(mutations.remove).toHaveBeenCalledWith(5)
+    expect(service.delete).toHaveBeenCalledWith(99, 5, 7)
+  })
+})

--- a/web-frontend/test/unit/database/viewFilters.spec.js
+++ b/web-frontend/test/unit/database/viewFilters.spec.js
@@ -105,7 +105,7 @@ describe('View Filter Tests', () => {
   })
 
   async function editFieldWithoutSavingNewValue(row, fieldType, newValue) {
-    await store.dispatch('page/view/grid/updateMatchFilters', {
+    await store.dispatch('page/view/grid/onRowChange', {
       view: store.getters['view/first'],
       fields: [
         {


### PR DESCRIPTION
## Summary

The main goal of this PR is to introduce a proper grid-view test plan and E2E coverage so the later collapsible group-by refactor can be done safely. It documents the expected grid behaviours and adds tests around row creation, editing, deletion, filtering, sorting, search, selection, clipboard, row menus, frozen columns, row identifiers, and public shared grids.

This PR also extracts `GridRowContextItems` into its own component and introduces the `rowLifecycle` layer. `rowLifecycle` starts decoupling the grid store from the concrete row data structure used by the rendered grid. Without group-by, storing rows as an array is fine; with group-by, the grid will need a tree. To reuse the existing row lifecycle logic across both shapes, we need to move away from assuming array indexes everywhere in the store.

`rowLifecycle` is only the first step. Cell and row selection still depend heavily on the current array/index model, and that decoupling will happen in the next PR to keep this store change bounded.

This PR is intended to be mergeable on its own. It should not change product behaviour beyond fixing small details so the implementation matches the behaviours described in the test plan, such as pressing `Esc` to discard the active cell selection.

The E2E workflow now runs the Chrome project and installs/caches Chromium, because Playwright cannot grant the clipboard permissions needed by the real clipboard test in Firefox.

Closes #5465 

## Test plan

- Read and verify the completeness of `docs/testing/grid-view-test-plan.md`
- Verify that the new e2e test correctly covers the scenarios reported in the test plan
- Verify tests are easy to read, understand and likely to maintain. They are also short, fast, and reuse common fixtures whenever possible.
- Manually verify the missing tests
- Verify that the new changes don't introduce regressions
