### PR TITLE
Fix OTP input dropping fast alternating digits

### DIFF
--- a/web-frontend/modules/core/components/settings/twoFactorAuth/AuthCodeInput.vue
+++ b/web-frontend/modules/core/components/settings/twoFactorAuth/AuthCodeInput.vue
@@ -11,7 +11,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(1, $event)"
     />
@@ -23,7 +23,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(2, $event)"
     />
@@ -35,7 +35,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(3, $event)"
     />
@@ -47,7 +47,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(4, $event)"
     />
@@ -59,7 +59,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(5, $event)"
     />
@@ -71,7 +71,7 @@
       inputmode="numeric"
       class="auth-code-input__input"
       :class="{ 'auth-code-input__input--filled': allFilled }"
-      @keyup="handleKeyUp"
+      @input="handleInput"
       @keydown="handleKeyDown"
       @paste="pasteAt(6, $event)"
     />
@@ -210,9 +210,9 @@ export default {
         }
       }
     },
-    handleKeyUp(event) {
+    handleInput(event) {
       const input = event.target
-      const value = input.value
+      const value = this.sanitizeInput(input.value)
       const isDigit = /\d/g.test(value)
 
       // Auto-focus to next input when a digit is entered

--- a/web-frontend/test/unit/core/components/settings/twoFactorAuth/AuthCodeInput.spec.js
+++ b/web-frontend/test/unit/core/components/settings/twoFactorAuth/AuthCodeInput.spec.js
@@ -1,0 +1,42 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+
+import AuthCodeInput from '@baserow/modules/core/components/settings/twoFactorAuth/AuthCodeInput.vue'
+
+describe('AuthCodeInput.vue', () => {
+  async function mountAuthCodeInput() {
+    return await mountSuspended(AuthCodeInput, {
+      attachTo: document.body,
+    })
+  }
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('moves focus to the next input as soon as a digit is entered', async () => {
+    const wrapper = await mountAuthCodeInput()
+    const inputs = wrapper.findAll('input')
+
+    inputs.at(0).element.value = '2'
+    await inputs.at(0).trigger('input')
+
+    expect(document.activeElement).toBe(inputs.at(1).element)
+  })
+
+  test('captures alternating digits entered through the focused input sequence', async () => {
+    const wrapper = await mountAuthCodeInput()
+    const inputs = wrapper.findAll('input')
+
+    for (const digit of '212121') {
+      const activeInput = inputs.find(
+        (input) => input.element === document.activeElement
+      )
+
+      activeInput.element.value = digit
+      await activeInput.trigger('input')
+    }
+
+    expect(inputs.map((input) => input.element.value).join('')).toBe('212121')
+    expect(wrapper.emitted('all-filled')[0]).toEqual(['212121'])
+  })
+})


### PR DESCRIPTION
Fixes #5431

## What changed

<img width="1280" height="720" alt="baserow otp preview issue resolved" src="https://github.com/user-attachments/assets/7177792f-c053-40b9-b10a-7f0fae13229f" />

This PR fixes OTP code entry dropping digits when users type alternating keys quickly.

The shared two-factor authentication code input previously advanced focus on `keyup`. That leaves a short timing window where the next `keydown` can arrive while focus is still on the previous one-character input. Because the previous input already has `maxlength="1"`, the next digit can be ignored by the browser.

This changes focus advancement to happen on the `input` event, so focus moves as soon as the value is accepted by the field.

## Why

Fast typing sequences like `212121` could be captured incorrectly, while repeated same-key sequences like `222222` were more likely to work. This made OTP entry feel unreliable and could force users to delete and re-enter codes.

The issue affects the shared `AuthCodeInput` component, so the fix applies to both:

- the two-factor authentication login challenge
- the two-factor authentication setup flow in account settings

## Testing

Added regression coverage for:

- moving focus to the next OTP input immediately after a digit is entered
- capturing the full alternating digit sequence `212121`

Tested locally with:

```bash
yarn test:core test/unit/core/components/settings/twoFactorAuth/AuthCodeInput.spec.js --run
```

Result:

```text
Test Files 1 passed
Tests 2 passed
```
