### PR TITLE
Add search to Kanban view (#768)

### DIFF
--- a/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/kanban/KanbanViewHeader.vue
@@ -80,6 +80,15 @@
         @update-cover-image-field="updateCoverImageField"
       ></ViewFieldsContext>
     </li>
+    <li class="header__filter-item header__filter-item--full-width">
+      <ViewSearch
+        :view="view"
+        :fields="fields"
+        :store-prefix="storePrefix"
+        :always-hide-rows-not-matching-search="true"
+        @refresh="$emit('refresh', $event)"
+      ></ViewSearch>
+    </li>
   </ul>
 </template>
 
@@ -88,13 +97,14 @@ import { mapState, mapGetters } from 'vuex'
 
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import ViewFieldsContext from '@baserow/modules/database/components/view/ViewFieldsContext'
+import ViewSearch from '@baserow/modules/database/components/view/ViewSearch'
 import KanbanViewStackedBy from '@baserow_premium/components/views/kanban/KanbanViewStackedBy'
 import kanbanViewHelper from '@baserow_premium/mixins/kanbanViewHelper'
 
 export default {
   name: 'KanbanViewHeader',
   emits: ['refresh'],
-  components: { KanbanViewStackedBy, ViewFieldsContext },
+  components: { KanbanViewStackedBy, ViewFieldsContext, ViewSearch },
   mixins: [kanbanViewHelper],
   props: {
     database: {
@@ -116,6 +126,11 @@ export default {
     readOnly: {
       type: Boolean,
       required: true,
+    },
+    storePrefix: {
+      type: String,
+      required: false,
+      default: '',
     },
   },
   computed: {


### PR DESCRIPTION
## Description
Adds search/filter functionality to the Kanban view in Baserow Premium. Users can now filter Kanban board cards by text content.

## Changes
- Added `<ViewSearch>` component to `KanbanViewHeader.vue`
- Configured search with proper `storePrefix` for Kanban store integration
- Followed the same pattern used by other views (Grid, Gallery, Form) that already have search

## Related Issue
Closes #768