### PR TITLE
fix: show 'unnamed row X' in link row dropdown when primary field is empty

### DIFF
--- a/backend/src/baserow/contrib/database/table/models.py
+++ b/backend/src/baserow/contrib/database/table/models.py
@@ -1048,9 +1048,11 @@ class Table(
             if not field:
                 return f"unnamed row {self.id}"
 
-            return field["type"].get_human_readable_value(
-                getattr(self, field["name"]), field
-            )
+            value = getattr(self, field["name"])
+            readable = field["type"].get_human_readable_value(value, field)
+            if not readable:
+                return f"unnamed row {self.id}"
+            return readable
 
         attrs = {
             "Meta": meta,


### PR DESCRIPTION
Fixes #5422. Link-to-table form dropdown shows blank options instead of 'unnamed row X' when the linked row's primary field value is empty.

Root cause: __str__ in generated table models calls get_human_readable_value() which returns empty string for empty primary field values. Added fallback: if readable is falsy, return 'unnamed row {self.id}'.