### PR TITLE
fix(backend): server error when creating or importing a table with malformed data

### DIFF
--- a/backend/src/baserow/contrib/database/api/tables/serializers.py
+++ b/backend/src/baserow/contrib/database/api/tables/serializers.py
@@ -102,6 +102,7 @@ class TableCreateSerializer(serializers.ModelSerializer):
     data = serializers.ListField(
         min_length=1,
         default=None,
+        child=serializers.ListField(allow_empty=False),
         help_text=(
             "A list of rows that needs to be created as initial table data. "
             "Each row is a list of values that are going to be added in the new "
@@ -152,6 +153,7 @@ class TableImportSerializer(serializers.Serializer):
     data = serializers.ListField(
         min_length=1,
         required=True,
+        child=serializers.ListField(allow_empty=False),
         help_text=(
             "A list of rows you want to add to the specified table. "
             "Each row is a list of values, one for each **writable** field. "

--- a/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
+++ b/backend/tests/baserow/contrib/database/api/tables/test_table_views.py
@@ -486,6 +486,56 @@ def test_create_table_with_data(
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "invalid_data",
+    [[None], [1], ["string"], [[]]],
+)
+def test_create_table_with_invalid_data_shape_async(
+    api_client, data_fixture, patch_filefield_storage, invalid_data
+):
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+    url = reverse(
+        "api:database:tables:async_create", kwargs={"database_id": database.id}
+    )
+
+    with patch_filefield_storage():
+        response = api_client.post(
+            url,
+            {"name": "Test", "data": invalid_data, "first_row_header": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "invalid_data",
+    [[None], [1], ["string"], [[]]],
+)
+def test_create_table_with_invalid_data_shape_sync(
+    api_client, data_fixture, patch_filefield_storage, invalid_data
+):
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+    url = reverse("api:database:tables:list", kwargs={"database_id": database.id})
+
+    with patch_filefield_storage():
+        response = api_client.post(
+            url,
+            {"name": "Test", "data": invalid_data, "first_row_header": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+
+
+@pytest.mark.django_db(transaction=True)
 def test_create_table_with_data_sync(api_client, data_fixture, patch_filefield_storage):
     user, token = data_fixture.create_user_and_token()
     database = data_fixture.create_database_application(user=user)
@@ -1018,3 +1068,27 @@ def test_import_table_call(api_client, data_fixture):
             },
         },
     }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "invalid_data",
+    [[None], [1], ["string"], [[]]],
+)
+def test_import_table_with_invalid_data_shape(api_client, data_fixture, invalid_data):
+    user, token = data_fixture.create_user_and_token()
+    database = data_fixture.create_database_application(user=user)
+    table = data_fixture.create_database_table(database=database)
+    data_fixture.create_text_field(table=table, user=user)
+
+    url = reverse("api:database:tables:import_async", kwargs={"table_id": table.id})
+
+    response = api_client.post(
+        url,
+        HTTP_AUTHORIZATION=f"JWT {token}",
+        data={"data": invalid_data},
+        format="json",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_REQUEST_BODY_VALIDATION"

--- a/changelog/entries/unreleased/bug/fixes_a_server_error_when_creating_or_importing_a__table_wit.json
+++ b/changelog/entries/unreleased/bug/fixes_a_server_error_when_creating_or_importing_a__table_wit.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixes a server error when creating or importing a table with malformed data",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-01"
+}

--- a/changelog/entries/unreleased/bug/fixes_a_server_error_when_creating_or_importing_a__table_wit.json
+++ b/changelog/entries/unreleased/bug/fixes_a_server_error_when_creating_or_importing_a__table_wit.json
@@ -2,7 +2,7 @@
   "type": "bug",
   "message": "Fixes a server error when creating or importing a table with malformed data",
   "issue_origin": "github",
-  "issue_number": null,
+  "issue_number": 3950,
   "domain": "database",
   "bullet_points": [],
   "created_at": "2026-06-01"


### PR DESCRIPTION
### What is in this PR

Fixes a server error (HTTP 500) when the `data` field in `POST /api/database/tables/database/{id}/`, `POST /api/database/tables/database/{id}/async/`, or `POST /api/database/tables/{id}/import/async/` is a list of non-list values (e.g. `[null]`, `[1]`, `["string"]`).

Closes #3950.

### Root cause

`TableCreateSerializer.data` and `TableImportSerializer.data` were declared as bare `serializers.ListField(min_length=1, ...)` with **no `child=` validator**. That made DRF accept any list whose length ≥ 1 — including lists of non-lists.

The downstream handler `TableHandler.normalize_initial_table_data` (`backend/src/baserow/contrib/database/table/handler.py:526`) assumes the documented `List[List[Any]]` contract and calls:

```python
largest_column_count = len(max(data, key=len))
```

When an element isn't a list, `len()` raises `TypeError: object of type 'NoneType'/'int' has no len()`. That exception isn't mapped to an API error code, so the request crashes with a 500 (Sentry issue 6945634469) instead of returning a clean 400.

The fix moves the shape check up to the serializer by adding `child=serializers.ListField(allow_empty=False)`, mirroring the existing `TableImportConfiguration.upsert_values` pattern in the same file.

### How to test this PR

#### Automated

```bash
DATABASE_URL='' \
  just b test tests/baserow/contrib/database/api/tables/test_table_views.py -k=invalid_data_shape
```

The new parametrized tests cover \`[None]\`, \`[1]\`, \`["string"]\`, and \`[[]]\` against the **async create**, **sync create**, and **import** endpoints — 12 cases total. Each asserts HTTP 400 with \`ERROR_REQUEST_BODY_VALIDATION\`.

Also re-run the pre-existing valid-data paths to confirm no regression:

```bash
DATABASE_URL='' \
  just b test tests/baserow/contrib/database/api/tables/test_table_views.py \
    -k=test_create_table_with_data
DATABASE_URL=postgres://baserow:baserow@127.0.0.1:5432/baserow \
  just b test tests/baserow/contrib/database/api/tables/test_table_views.py \
    -k=import_table_call
```

#### Manual smoke

With the dev stack up, a JWT in \`\$TOKEN\`, a database id in \`\$DB_ID\`, and a table id in \`\$TABLE_ID\`:

```bash
# Sync create — should be 400 ERROR_REQUEST_BODY_VALIDATION (was 500 before)
curl -s -X POST -H "Authorization: JWT \$TOKEN" -H 'Content-Type: application/json' \
  -d '{"name":"x","first_row_header":false,"data":[null]}' \
  http://localhost:8000/api/database/tables/database/\$DB_ID/

# Async create — same expectation (was 202 before, with the job crashing later)
curl -s -X POST -H "Authorization: JWT \$TOKEN" -H 'Content-Type: application/json' \
  -d '{"name":"x","first_row_header":false,"data":[1]}' \
  http://localhost:8000/api/database/tables/database/\$DB_ID/async/

# Import — same expectation
curl -s -X POST -H "Authorization: JWT \$TOKEN" -H 'Content-Type: application/json' \
  -d '{"data":["string"]}' \
  http://localhost:8000/api/database/tables/\$TABLE_ID/import/async/

# Sanity: valid 2D array still works
curl -s -X POST -H "Authorization: JWT \$TOKEN" -H 'Content-Type: application/json' \
  -d '{"name":"x","first_row_header":false,"data":[["a","b"],["c","d"]]}' \
  http://localhost:8000/api/database/tables/database/\$DB_ID/
```

Expected response shape on the failing cases:

```json
{
  "error": "ERROR_REQUEST_BODY_VALIDATION",
  "detail": {
    "data": {
      "0": [
        {"error": "Expected a list of items but got type \"NoneType\".", "code": "not_a_list"}
      ]
    }
  }
}
```

### Checklist

- [x] A changelog entry has been added to \`changelog/entries/unreleased\` using \`changelog/src/changelog.py\`
- [x] Security impact of change has been considered