### PR TITLE
fix(frontend): Do not show import workspace for builder or lower roles

### DIFF
--- a/changelog/entries/unreleased/bug/5440_fix_for_builder_and_lower_roles_should_not_be_able_to_import.json
+++ b/changelog/entries/unreleased/bug/5440_fix_for_builder_and_lower_roles_should_not_be_able_to_import.json
@@ -1,9 +1,9 @@
 {
     "type": "bug",
-    "message": "Fix for Builder and lower roles should not be able to import/export workspace",
+    "message": "Hide workspace import/export options for Builder and lower roles.",
     "issue_origin": "github",
     "issue_number": 5440,
-    "domain": "database",
+    "domain": "core",
     "bullet_points": [],
     "created_at": "2026-06-02"
 }

--- a/changelog/entries/unreleased/bug/5440_fix_for_builder_and_lower_roles_should_not_be_able_to_import.json
+++ b/changelog/entries/unreleased/bug/5440_fix_for_builder_and_lower_roles_should_not_be_able_to_import.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix for Builder and lower roles should not be able to import/export workspace",
+    "issue_origin": "github",
+    "issue_number": 5440,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-02"
+}

--- a/changelog/src/handler.py
+++ b/changelog/src/handler.py
@@ -66,6 +66,7 @@ class ChangelogHandler:
                 bullet_points=bullet_points,
             )
             json.dump(entry, entry_file, indent=4)
+            entry_file.write(LINE_BREAK_CHARACTER)
 
         return full_path
 

--- a/web-frontend/modules/core/components/application/CreateApplicationContext.vue
+++ b/web-frontend/modules/core/components/application/CreateApplicationContext.vue
@@ -71,12 +71,9 @@
           :workspace="workspace"
         ></TemplateModal>
       </li>
-      <li class="context__menu-item">
+      <li v-if="canImportWorkspace" class="context__menu-item">
         <a
           class="context__menu-item-link context__menu-item-link--with-desc"
-          :class="{
-            disabled: !canCreateCreateApplication,
-          }"
           @click="openImportWorkspaceModal()"
         >
           <span class="context__menu-item-title">
@@ -135,6 +132,13 @@ export default {
         this.workspace.id
       )
     },
+    canImportWorkspace() {
+      return this.$hasPermission(
+        'workspace.export',
+        this.workspace,
+        this.workspace.id
+      )
+    },
   },
   methods: {
     async fetchRolesAndPermissions() {
@@ -150,7 +154,7 @@ export default {
       this.hide()
     },
     openImportWorkspaceModal() {
-      if (!this.canCreateCreateApplication) {
+      if (!this.canImportWorkspace) {
         return
       }
 

--- a/web-frontend/modules/core/components/workspace/WorkspaceContext.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceContext.vue
@@ -24,13 +24,7 @@
         </a>
       </li>
       <li
-        v-if="
-          $hasPermission(
-            'workspace.create_application',
-            workspace,
-            workspace.id
-          )
-        "
+        v-if="$hasPermission('workspace.export', workspace, workspace.id)"
         class="context__menu-item"
       >
         <a class="context__menu-item-link" @click="openImportData">
@@ -124,9 +118,7 @@
     >
     </ExportWorkspaceModal>
     <ImportWorkspaceModal
-      v-if="
-        $hasPermission('workspace.create_application', workspace, workspace.id)
-      "
+      v-if="$hasPermission('workspace.export', workspace, workspace.id)"
       ref="importWorkspaceModal"
       :workspace="workspace"
     ></ImportWorkspaceModal>


### PR DESCRIPTION
### What is in this PR
Closes #5440 

### How to test this PR
- As admin open workspace and note that Import and Export workspace are available and work
- As builder (or lower) role test that those options are not available in UI

#### Note:
Backend already handles that by raising 401

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
