### PR TITLE
fix(frontend): fix duplicated rows scaling comma-decimal formatted number values

### DIFF
--- a/changelog/entries/unreleased/bug/5445_fix_duplicated_rows_scaling_commadecimal_formatted_number_va.json
+++ b/changelog/entries/unreleased/bug/5445_fix_duplicated_rows_scaling_commadecimal_formatted_number_va.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix duplicated rows scaling comma-decimal formatted number values",
+    "issue_origin": "github",
+    "issue_number": 5445,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-02"
+}

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1960,6 +1960,9 @@ export class NumberFieldType extends FieldType {
   }
 
   prepareValueForDuplicate(field, value) {
+    if (value == null || value === '') {
+      return null
+    }
     return parseNumberValue(field, new BigNumber(value))
   }
 

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1959,6 +1959,10 @@ export class NumberFieldType extends FieldType {
     return parseNumberValue(field, value)
   }
 
+  prepareValueForDuplicate(field, value) {
+    return parseNumberValue(field, new BigNumber(value))
+  }
+
   parseFromLinkedRowItemValue(field, value) {
     if (value === '') {
       return null

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -783,6 +783,34 @@ describe('FieldType tests', () => {
     }
   )
 
+  test.each([
+    '',
+    'SPACE_COMMA',
+    'SPACE_PERIOD',
+    'COMMA_PERIOD',
+    'PERIOD_COMMA',
+  ])(
+    'Verify that NumberFieldType preserves canonical decimal values when duplicating rows with %s formatting',
+    (numberSeparator) => {
+      const field = {
+        number_decimal_places: 2,
+        number_negative: false,
+        number_prefix: '',
+        number_suffix: '',
+        number_separator: numberSeparator,
+      }
+      const fieldType = new NumberFieldType()
+
+      const duplicatedValue = fieldType.prepareValueForDuplicate(field, '78.40')
+      const requestValue = fieldType.prepareValueForUpdate(
+        field,
+        duplicatedValue
+      )
+
+      expect(requestValue.toString()).toBe('78.4')
+    }
+  )
+
   test.each(queryParametersForParsing)(
     'Verify that parseQueryParameter returns the expected output for each field type',
     ({ input, output, fieldType }) => {

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -811,6 +811,22 @@ describe('FieldType tests', () => {
     }
   )
 
+  test.each([null, ''])(
+    'Verify that NumberFieldType prepareValueForDuplicate returns null for %s',
+    (emptyValue) => {
+      const field = {
+        number_decimal_places: 2,
+        number_negative: false,
+        number_prefix: '',
+        number_suffix: '',
+        number_separator: 'PERIOD_COMMA',
+      }
+      const fieldType = new NumberFieldType()
+
+      expect(fieldType.prepareValueForDuplicate(field, emptyValue)).toBeNull()
+    }
+  )
+
   test.each(queryParametersForParsing)(
     'Verify that parseQueryParameter returns the expected output for each field type',
     ({ input, output, fieldType }) => {


### PR DESCRIPTION
### What is in this PR
Closes #5445 

Address [issue reported by community](https://community.baserow.io/t/bug-with-number-field-in-row-details/10125/19?u=przemek)

Issue was related to lacking `prepareValueForDuplicate` to properly parse value when rows are duplicated.

Added tests

### How to test this PR
Follow reproduction steps and observe it works as expected.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
