### PR TITLE
fix(backend): moving a row no longer modifies the updated_on value

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -1552,6 +1552,7 @@ class DateFieldType(FieldType):
 class CreatedOnLastModifiedBaseFieldType(ReadOnlyFieldType, DateFieldType):
     can_be_in_form_view = False
     field_data_is_derived_from_attrs = True
+    include_in_row_move_updated_fields = False
 
     source_field_name = None
     model_field_class = SyncedDateTimeField

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -2824,7 +2824,7 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
         )
 
         row.order = self.get_unique_orders_before_row(before_row, model)[0]
-        row.save(update_fields=["order", "updated_on"])
+        row.save(update_fields=["order"])
 
         # All fields must be marked as updated because the lookup fields can depend
         # on the row order. Only fields that are specifically marked as

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -1245,6 +1245,72 @@ def test_move_row(before_send_mock, send_mock, data_fixture):
 
 
 @pytest.mark.django_db
+def test_move_row_does_not_update_last_modified(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(name="Car", user=user)
+    last_modified_field = data_fixture.create_last_modified_field(table=table)
+    created_on_field = data_fixture.create_created_on_field(table=table)
+
+    handler = RowHandler()
+
+    with freeze_time("2020-01-01 12:00"):
+        row_1 = handler.create_row(user=user, table=table)
+        row_2 = handler.create_row(user=user, table=table)
+        handler.create_row(user=user, table=table)
+
+    created_on_before = row_1.created_on
+    updated_on_before = row_1.updated_on
+    last_modified_before = getattr(row_1, last_modified_field.db_column)
+    created_on_field_before = getattr(row_1, created_on_field.db_column)
+
+    with freeze_time("2020-06-01 12:00"):
+        handler.move_row_by_id(
+            user=user, table=table, row_id=row_1.id, before_row=row_2
+        )
+
+    returned_row = handler.move_row_by_id(user=user, table=table, row_id=row_1.id)
+    assert returned_row.updated_on == updated_on_before
+    assert returned_row.created_on == created_on_before
+    assert getattr(returned_row, last_modified_field.db_column) == last_modified_before
+
+    row_1.refresh_from_db()
+
+    assert row_1.created_on == created_on_before
+    assert row_1.updated_on == updated_on_before
+    assert getattr(row_1, last_modified_field.db_column) == last_modified_before
+    assert getattr(row_1, created_on_field.db_column) == created_on_field_before
+
+
+@pytest.mark.django_db
+def test_move_row_does_not_recompute_last_modified_dependent_formula(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(name="Car", user=user)
+    last_modified_field = data_fixture.create_last_modified_field(
+        table=table, name="lm"
+    )
+    formula_field = data_fixture.create_formula_field(
+        table=table, formula=f"field('{last_modified_field.name}')"
+    )
+
+    handler = RowHandler()
+
+    with freeze_time("2020-01-01 12:00"):
+        row_1 = handler.create_row(user=user, table=table)
+        row_2 = handler.create_row(user=user, table=table)
+        handler.create_row(user=user, table=table)
+
+    formula_before = getattr(row_1, formula_field.db_column)
+
+    with freeze_time("2020-06-01 12:00"):
+        handler.move_row_by_id(
+            user=user, table=table, row_id=row_1.id, before_row=row_2
+        )
+
+    row_1.refresh_from_db()
+    assert getattr(row_1, formula_field.db_column) == formula_before
+
+
+@pytest.mark.django_db
 @patch("baserow.contrib.database.rows.signals.rows_deleted.send")
 @patch("baserow.contrib.database.rows.signals.before_rows_delete.send")
 def test_delete_row(before_send_mock, send_mock, data_fixture):

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -1264,11 +1264,10 @@ def test_move_row_does_not_update_last_modified(data_fixture):
     created_on_field_before = getattr(row_1, created_on_field.db_column)
 
     with freeze_time("2020-06-01 12:00"):
-        handler.move_row_by_id(
+        returned_row = handler.move_row_by_id(
             user=user, table=table, row_id=row_1.id, before_row=row_2
         )
 
-    returned_row = handler.move_row_by_id(user=user, table=table, row_id=row_1.id)
     assert returned_row.updated_on == updated_on_before
     assert returned_row.created_on == created_on_before
     assert getattr(returned_row, last_modified_field.db_column) == last_modified_before
@@ -1279,35 +1278,6 @@ def test_move_row_does_not_update_last_modified(data_fixture):
     assert row_1.updated_on == updated_on_before
     assert getattr(row_1, last_modified_field.db_column) == last_modified_before
     assert getattr(row_1, created_on_field.db_column) == created_on_field_before
-
-
-@pytest.mark.django_db
-def test_move_row_does_not_recompute_last_modified_dependent_formula(data_fixture):
-    user = data_fixture.create_user()
-    table = data_fixture.create_database_table(name="Car", user=user)
-    last_modified_field = data_fixture.create_last_modified_field(
-        table=table, name="lm"
-    )
-    formula_field = data_fixture.create_formula_field(
-        table=table, formula=f"field('{last_modified_field.name}')"
-    )
-
-    handler = RowHandler()
-
-    with freeze_time("2020-01-01 12:00"):
-        row_1 = handler.create_row(user=user, table=table)
-        row_2 = handler.create_row(user=user, table=table)
-        handler.create_row(user=user, table=table)
-
-    formula_before = getattr(row_1, formula_field.db_column)
-
-    with freeze_time("2020-06-01 12:00"):
-        handler.move_row_by_id(
-            user=user, table=table, row_id=row_1.id, before_row=row_2
-        )
-
-    row_1.refresh_from_db()
-    assert getattr(row_1, formula_field.db_column) == formula_before
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/breaking_change/3054_moving_a_row_no_longer_updates_the_rows_updated_on_field_las.json
+++ b/changelog/entries/unreleased/breaking_change/3054_moving_a_row_no_longer_updates_the_rows_updated_on_field_las.json
@@ -1,0 +1,9 @@
+{
+  "type": "breaking_change",
+  "message": "Moving a row no longer updates the row's updated_on field. Last modified fields tied to updated_on (and formulas depending on them) are no longer recomputed when reordering rows.",
+  "issue_origin": "github",
+  "issue_number": 3054,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-03"
+}

--- a/changelog/entries/unreleased/bug/moving_a_row_no_longer_modifies_the_updated_on_value.json
+++ b/changelog/entries/unreleased/bug/moving_a_row_no_longer_modifies_the_updated_on_value.json
@@ -1,6 +1,6 @@
 {
   "type": "bug",
-  "message": "Moving a row no longer modify the updated_on value",
+  "message": "Moving a row no longer modifies the updated_on value",
   "issue_origin": "github",
   "issue_number": 3054,
   "domain": "database",

--- a/changelog/entries/unreleased/bug/moving_a_row_no_longer_modify_the_updated_on_value.json
+++ b/changelog/entries/unreleased/bug/moving_a_row_no_longer_modify_the_updated_on_value.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Moving a row no longer modify the updated_on value",
+  "issue_origin": "github",
+  "issue_number": 3054,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-02"
+}


### PR DESCRIPTION
### What is in this PR
Stops `row.updated_on` from advancing when a row is moved.

Closes #3054

### Root cause

`RowHandler.move_row` (`backend/.../rows/handler.py`) saved the row with `update_fields=["order", "updated_on"]`. Because `updated_on` has `auto_now=True`, Django wrote a fresh `now()` into the row's internal `updated_on` column on every move — even though a move only changes the row's *position*, not any field value (and correctly produces no row-history entry).

### Fix

1. **`backend/.../rows/handler.py`** — replaced `row.save(update_fields=["order", "updated_on"])` with `row.save(update_fields=["order"])`. Django only calls `pre_save` on fields listed in `update_fields`, so `auto_now` on `updated_on` and `BaserowLastModifiedField.pre_save` (synced with `updated_on`) no longer fire.
2. **`backend/.../fields/field_types.py`** — set `include_in_row_move_updated_fields = False` on `CreatedOnLastModifiedBaseFieldType`, so dependents of `last_modified` / `created_on` are no longer recomputed on a row move.

### How to test this PR

#### Automated
- `backend/tests/baserow/contrib/database/rows/test_rows_handler.py::test_move_row_does_not_update_last_modified` — asserts `row.updated_on`, `row.created_on`, and the user-created Last Modified / Created On column values are unchanged after a move, both in memory and in DB.
- The test fails on `develop` without the fix and passes with it.

#### Manual sanity check
1. Open a database table with a **Last modified** field.
2. Drag a row to a new position.
3. Confirm the Last modified cell value is unchanged, the row order changed, and no row-history entry was created.

### Breaking change

This is a behavior change for anyone relying on row moves bumping `updated_on` (or recomputing Last modified fields and formulas that depend on them). A `breaking_change` changelog entry has been added alongside the `bug` entry.

### Checklist

- [x] A changelog entry has been added to \`changelog/entries/unreleased\` using \`changelog/src/changelog.py\`
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] Security impact of change has been considered