### PR TITLE
feat: add resource-level license status check for public endpoints (closes #2835)

### DIFF
--- a/premium/backend/src/baserow_premium/api/views/calendar/views.py
+++ b/premium/backend/src/baserow_premium/api/views/calendar/views.py
@@ -406,6 +406,11 @@ class PublicCalendarViewView(APIView):
             authorization_token=get_public_view_authorization_token(request),
         )
 
+        # Check that the workspace still has an active premium license.
+        # The public view is accessible without authentication, so we need
+        # to verify the license status via the resource's workspace.
+        LicenseHandler.raise_if_resource_doesnt_have_feature(PREMIUM, view)
+        
         date_field = view.date_field
         if not date_field:
             raise CalendarViewHasNoDateField(
@@ -518,6 +523,13 @@ class ICalView(APIView):
         )
         if not view.ical_public:
             raise ViewDoesNotExist()
+
+        # Check that the workspace still has an active premium license.
+        # Without this check, the iCal feed would remain accessible even
+        # after the premium license has expired, because there is no
+        # authenticated user context in this public endpoint.
+        LicenseHandler.raise_if_resource_doesnt_have_feature(PREMIUM, view)
+
         qs = view_handler.get_queryset(request.user, view)
         cal = build_calendar(qs, view, limit=settings.BASEROW_ICAL_VIEW_MAX_EVENTS)
         return HttpResponse(

--- a/premium/backend/src/baserow_premium/license/handler.py
+++ b/premium/backend/src/baserow_premium/license/handler.py
@@ -169,6 +169,98 @@ class LicenseHandler:
         return license_plugin.user_has_feature_instance_wide(feature, user)
 
     @classmethod
+
+    @classmethod
+    def raise_if_resource_doesnt_have_feature(
+        cls, feature: str, resource
+    ):
+        """
+        Raises the `FeaturesNotAvailableError` if the resource's workspace
+        does not have an active license granting the provided feature.
+        This works without requiring a user context, making it suitable
+        for public endpoints (e.g. iCal feeds, public shared views).
+
+        :param feature: The feature to check.
+        :param resource: The resource (e.g. a View, Application, etc.)
+            that belongs to a workspace.
+        :raises FeaturesNotAvailableError: When the feature is not available.
+        """
+
+        if not cls.resource_has_feature(feature, resource):
+            raise FeaturesNotAvailableError()
+
+    @classmethod
+    def resource_has_feature(cls, feature: str, resource) -> bool:
+        """
+        Checks if a resource's workspace has a particular feature granted
+        by an active license, without requiring a user context.
+
+        :param feature: The feature to check.
+        :param resource: The resource (e.g. a View, Application, etc.)
+            that belongs to a workspace.
+        :return: True if the feature is available for the resource's workspace.
+        """
+
+        workspace = cls._get_workspace_from_resource(resource)
+        if workspace is None:
+            return False
+        return cls.workspace_has_feature(feature, workspace)
+
+    @classmethod
+    def _get_workspace_from_resource(cls, resource) -> Optional[Workspace]:
+        """
+        Tries to extract a Workspace from any resource object by following
+        common relationship paths:
+
+        - View -> table -> database -> workspace
+        - Application -> workspace
+        - Workspace -> itself
+
+        :param resource: The resource to extract the workspace from.
+        :return: The workspace, or None if it cannot be determined.
+        """
+
+        from baserow.contrib.database.views.models import View
+        from baserow.contrib.database.table.models import Table
+        from baserow.core.models import Application
+
+        if hasattr(resource, "workspace") and isinstance(
+            getattr(resource, "workspace", None), Workspace
+        ):
+            return resource.workspace
+
+        if isinstance(resource, View):
+            try:
+                return resource.table.database.workspace
+            except AttributeError:
+                pass
+
+        if isinstance(resource, Application):
+            return resource.workspace
+
+        if isinstance(resource, Table):
+            try:
+                return resource.database.workspace
+            except AttributeError:
+                pass
+
+        # Try duck-typing: look for common workspace relation patterns
+        for attr in ["workspace", "group"]:
+            candidate = getattr(resource, attr, None)
+            if isinstance(candidate, Workspace):
+                return candidate
+
+        # Try following model relations
+        if hasattr(resource, "_meta"):
+            for field in resource._meta.get_fields():
+                if hasattr(field, "related_model") and field.related_model == Workspace:
+                    try:
+                        return getattr(resource, field.name)
+                    except Exception:
+                        pass
+
+        return None
+
     def _get_license_plugin(cls):
         from baserow_premium.plugins import PremiumPlugin
 


### PR DESCRIPTION
## Summary

This PR addresses issue #2835 by adding a way to determine license status for resources accessed **without a user context** (e.g. iCal feeds, public shared views).

## Problem

When a premium resource (like a Calendar View) is accessed via a public endpoint (e.g. iCal feed at `/{ical_slug}.ics`), there is **no authenticated user** to check against. The existing `LicenseHandler.user_has_feature()` requires a user, so public endpoints had no way to verify license status. This meant premium resources remained accessible even after the license had expired.

## Changes

### `LicenseHandler` (`premium/backend/src/baserow_premium/license/handler.py`)

Added three new methods:

1. **`resource_has_feature(feature, resource)`** — Checks if a resource's workspace has a particular feature from an active license, **without requiring a user**. It traces the resource back to its workspace via common relationship paths (View→table→database→workspace, Application→workspace, etc.).

2. **`raise_if_resource_doesnt_have_feature(feature, resource)`** — Convenience method that raises `FeaturesNotAvailableError` if the resource's workspace lacks the feature.

3. **`_get_workspace_from_resource(resource)`** — Internal helper that extracts the workspace from various resource types (View, Application, Table, or any model with a `workspace` FK).

### `ICalView` & `PublicCalendarViewView` (`premium/backend/src/baserow_premium/api/views/calendar/views.py`)

Added `LicenseHandler.raise_if_resource_doesnt_have_feature(PREMIUM, view)` to both public calendar endpoints:
- `ICalView.get()` — The iCal feed endpoint `/{ical_slug}.ics`
- `PublicCalendarViewView.get()` — The public slug-based view endpoint `/{slug}/public/rows/`

## Testing

- [ ] Create a Calendar View with iCal enabled in a premium workspace
- [ ] Verify the iCal feed is accessible while the license is active
- [ ] Expire or remove the license → verify the iCal feed returns an error
- [ ] Verify the public slug-based endpoint also rejects requests after license expiry
- [ ] Run existing premium tests to ensure no regressions

Closes #2835