### PR TITLE
fix(backend): don't update last_modified when moving a row

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -1552,6 +1552,9 @@ class DateFieldType(FieldType):
 class CreatedOnLastModifiedBaseFieldType(ReadOnlyFieldType, DateFieldType):
     can_be_in_form_view = False
     field_data_is_derived_from_attrs = True
+    # Moving a row only changes its order, not the row itself, so the created/last
+    # modified fields must not be marked as updated when a row is moved.
+    include_in_row_move_updated_fields = False
 
     source_field_name = None
     model_field_class = SyncedDateTimeField

--- a/backend/src/baserow/contrib/database/rows/handler.py
+++ b/backend/src/baserow/contrib/database/rows/handler.py
@@ -2824,7 +2824,11 @@ class RowHandler(metaclass=baserow_trace_methods(tracer)):
         )
 
         row.order = self.get_unique_orders_before_row(before_row, model)[0]
-        row.save(update_fields=["order", "updated_on"])
+        # Only the `order` is persisted because changing the position of a row is not
+        # considered an edit of the row itself. Including `updated_on` would bump the
+        # `last_modified` value without a matching entry in the row edit history, which
+        # is confusing because moving one row also re-orders many other rows.
+        row.save(update_fields=["order"])
 
         # All fields must be marked as updated because the lookup fields can depend
         # on the row order. Only fields that are specifically marked as

--- a/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
+++ b/backend/tests/baserow/contrib/database/rows/test_rows_handler.py
@@ -1245,6 +1245,32 @@ def test_move_row(before_send_mock, send_mock, data_fixture):
 
 
 @pytest.mark.django_db
+def test_move_row_does_not_update_last_modified(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    handler = RowHandler()
+
+    with freeze_time("2020-01-01 12:00"):
+        row_1 = handler.create_row(user=user, table=table)
+        row_2 = handler.create_row(user=user, table=table)
+
+    created_on = datetime(2020, 1, 1, 12, 0, tzinfo=timezone.utc)
+    assert row_1.updated_on == created_on
+    assert row_2.updated_on == created_on
+
+    # Moving a row at a later point in time must not bump its `updated_on`
+    # (last modified) value, because re-ordering a row is not an edit of the row
+    # itself and isn't recorded in the row edit history.
+    with freeze_time("2020-01-02 12:00"):
+        handler.move_row_by_id(user=user, table=table, row_id=row_1.id)
+
+    row_1.refresh_from_db()
+    row_2.refresh_from_db()
+    assert row_1.updated_on == created_on
+    assert row_2.updated_on == created_on
+
+
+@pytest.mark.django_db
 @patch("baserow.contrib.database.rows.signals.rows_deleted.send")
 @patch("baserow.contrib.database.rows.signals.before_rows_delete.send")
 def test_delete_row(before_send_mock, send_mock, data_fixture):

--- a/changelog/entries/unreleased/bug/3054_moving_a_row_no_longer_updates_the_last_modified_field.json
+++ b/changelog/entries/unreleased/bug/3054_moving_a_row_no_longer_updates_the_last_modified_field.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Moving a row no longer updates its last modified date, because re-ordering a row is not an edit of the row itself.",
+    "issue_origin": "github",
+    "issue_number": 3054,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-03"
+}


### PR DESCRIPTION
## Problem

Closes #3054.

Moving a row updates the row's `last_modified` (`updated_on`) value, even though re-ordering a row is not an edit of the row itself and produces no entry in the row edit history. Because changing the position of one row also shifts the position of many other rows, the `last_modified` timestamp should not change on a move.

Steps to reproduce (from the issue):
1. Create a table with a "Last modified" field.
2. Move a row.
3. The last modified time changes, but there is no entry in the row edit history.

## Fix

This follows the approach suggested by the maintainer in the issue:

- `RowHandler.move_row` now saves with `update_fields=["order"]` instead of `update_fields=["order", "updated_on"]`, so the move no longer bumps `updated_on`.
- `CreatedOnLastModifiedBaseFieldType` now sets `include_in_row_move_updated_fields = False`, so the created-on / last-modified field types are not marked as updated when a row is moved.

## Tests

Added `test_move_row_does_not_update_last_modified`, which creates rows at one point in time, moves a row at a later (frozen) time, and asserts that `updated_on` is unchanged.

A changelog entry was added under `changelog/entries/unreleased/bug/`.