### PR TITLE
chore: introduce trashing and undo/redo in the builder module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Frontend code uses Vue 3, Nuxt 3, Vuex, Vite, Vitest, Storybook, SCSS, ESLint, S
 
 Backend tests use `pytest` with `pytest-django`; frontend tests use `vitest`; browser flows live in `e2e-tests/`. Add unit tests for backend changes and targeted frontend tests for component or store behavior. 
 
-Examples: `just b test backend/tests/path/`, `just b test-coverage`, `just f test -- --coverage`, `just f yarn test:core path/to/test`.
+Examples: `just b test tests/path/`, `just b test-coverage`, `just f test -- --coverage`, `just f yarn test:core path/to/test`.
 
 ## Commit & Pull Request Guidelines
 

--- a/backend/src/baserow/contrib/automation/nodes/models.py
+++ b/backend/src/baserow/contrib/automation/nodes/models.py
@@ -92,6 +92,9 @@ class AutomationNode(
 
         return automation_node_type_registry
 
+    def __str__(self):
+        return str(self.get_type().display_name)
+
     def get_parent(self):
         return self.workflow
 

--- a/backend/src/baserow/contrib/automation/nodes/node_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/node_types.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import AbstractUser
 from django.db import router
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from baserow.contrib.automation.nodes.exceptions import (
     AutomationNodeFirstNodeMustBeTrigger,
@@ -130,18 +130,21 @@ class LocalBaserowUpsertRowNodeType(AutomationNodeActionNodeType):
 
 
 class LocalBaserowCreateRowNodeType(LocalBaserowUpsertRowNodeType):
+    display_name = _("Local Baserow create row")
     type = "local_baserow_create_row"
     compat_type = "create_row"
     model_class = LocalBaserowCreateRowActionNode
 
 
 class LocalBaserowUpdateRowNodeType(LocalBaserowUpsertRowNodeType):
+    display_name = _("Local Baserow update row")
     type = "local_baserow_update_row"
     compat_type = "update_row"
     model_class = LocalBaserowUpdateRowActionNode
 
 
 class LocalBaserowDeleteRowNodeType(AutomationNodeActionNodeType):
+    display_name = _("Local Baserow delete row")
     type = "local_baserow_delete_row"
     compat_type = "delete_row"
     model_class = LocalBaserowDeleteRowActionNode
@@ -149,6 +152,7 @@ class LocalBaserowDeleteRowNodeType(AutomationNodeActionNodeType):
 
 
 class LocalBaserowGetRowNodeType(AutomationNodeActionNodeType):
+    display_name = _("Local Baserow get row")
     type = "local_baserow_get_row"
     compat_type = "get_row"
     model_class = LocalBaserowGetRowActionNode
@@ -156,6 +160,7 @@ class LocalBaserowGetRowNodeType(AutomationNodeActionNodeType):
 
 
 class LocalBaserowListRowsNodeType(AutomationNodeActionNodeType):
+    display_name = _("Local Baserow list rows")
     type = "local_baserow_list_rows"
     compat_type = "list_rows"
     model_class = LocalBaserowListRowsActionNode
@@ -163,6 +168,7 @@ class LocalBaserowListRowsNodeType(AutomationNodeActionNodeType):
 
 
 class LocalBaserowAggregateRowsNodeType(AutomationNodeActionNodeType):
+    display_name = _("Local Baserow aggregate rows")
     type = "local_baserow_aggregate_rows"
     compat_type = "aggregate_rows"
     model_class = LocalBaserowAggregateRowsActionNode
@@ -170,12 +176,14 @@ class LocalBaserowAggregateRowsNodeType(AutomationNodeActionNodeType):
 
 
 class CoreHttpRequestNodeType(AutomationNodeActionNodeType):
+    display_name = _("HTTP request")
     type = "http_request"
     model_class = CoreHTTPRequestActionNode
     service_type = CoreHTTPRequestServiceType.type
 
 
 class CoreIteratorNodeType(ContainerNodeTypeMixin, AutomationNodeActionNodeType):
+    display_name = _("Iterator")
     type = "iterator"
     model_class = CoreIteratorActionNode
     service_type = CoreIteratorServiceType.type
@@ -188,18 +196,21 @@ class CoreCSVFileReaderNodeType(AutomationNodeActionNodeType):
 
 
 class CoreSMTPEmailNodeType(AutomationNodeActionNodeType):
+    display_name = _("Send email")
     type = "smtp_email"
     model_class = CoreSMTPEmailActionNode
     service_type = CoreSMTPEmailServiceType.type
 
 
 class AIAgentActionNodeType(AutomationNodeActionNodeType):
+    display_name = _("AI agent")
     type = "ai_agent"
     model_class = AIAgentActionNode
     service_type = AIAgentServiceType.type
 
 
 class CoreRouterActionNodeType(AutomationNodeActionNodeType):
+    display_name = _("Router")
     type = "router"
     model_class = CoreRouterActionNode
     service_type = CoreRouterServiceType.type
@@ -394,6 +405,7 @@ class AutomationNodeTriggerType(AutomationNodeType):
 
 
 class LocalBaserowRowsCreatedNodeTriggerType(AutomationNodeTriggerType):
+    display_name = _("Local Baserow rows created")
     type = "local_baserow_rows_created"
     compat_type = "rows_created"
     model_class = LocalBaserowRowsCreatedTriggerNode
@@ -401,6 +413,7 @@ class LocalBaserowRowsCreatedNodeTriggerType(AutomationNodeTriggerType):
 
 
 class LocalBaserowRowsUpdatedNodeTriggerType(AutomationNodeTriggerType):
+    display_name = _("Local Baserow rows updated")
     type = "local_baserow_rows_updated"
     compat_type = "rows_updated"
     model_class = LocalBaserowRowsUpdatedTriggerNode
@@ -408,6 +421,7 @@ class LocalBaserowRowsUpdatedNodeTriggerType(AutomationNodeTriggerType):
 
 
 class LocalBaserowRowsDeletedNodeTriggerType(AutomationNodeTriggerType):
+    display_name = _("Local Baserow rows deleted")
     type = "local_baserow_rows_deleted"
     compat_type = "rows_deleted"
     model_class = LocalBaserowRowsDeletedTriggerNode
@@ -417,18 +431,21 @@ class LocalBaserowRowsDeletedNodeTriggerType(AutomationNodeTriggerType):
 class CorePeriodicTriggerNodeType(
     AutomationNodeTriggerType,
 ):
+    display_name = _("Periodic trigger")
     type = "periodic"
     model_class = CorePeriodicTriggerNode
     service_type = CorePeriodicServiceType.type
 
 
 class CoreHTTPTriggerNodeType(AutomationNodeTriggerType):
+    display_name = _("HTTP trigger")
     type = "http_trigger"
     model_class = CoreHTTPTriggerNode
     service_type = CoreHTTPTriggerServiceType.type
 
 
 class SlackWriteMessageActionNodeType(AutomationNodeActionNodeType):
+    display_name = _("Slack write message")
     type = "slack_write_message"
     model_class = SlackWriteMessageActionNode
     service_type = SlackWriteMessageServiceType.type

--- a/backend/src/baserow/contrib/automation/nodes/registries.py
+++ b/backend/src/baserow/contrib/automation/nodes/registries.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
 from django.contrib.auth.models import AbstractUser
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import PermissionDenied
 
@@ -43,6 +44,8 @@ class AutomationNodeType(
     ModelInstanceMixin,
     Instance,
 ):
+    display_name = _("Unnamed")
+
     service_type = None
     parent_property_name = "workflow"
     id_mapping_name = "automation_workflow_nodes"

--- a/backend/src/baserow/contrib/automation/nodes/registries.py
+++ b/backend/src/baserow/contrib/automation/nodes/registries.py
@@ -44,7 +44,7 @@ class AutomationNodeType(
     ModelInstanceMixin,
     Instance,
 ):
-    display_name = _("Unnamed")
+    display_name = _("Unnamed node")
 
     service_type = None
     parent_property_name = "workflow"

--- a/backend/src/baserow/contrib/automation/nodes/trash_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/trash_types.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from django.contrib.auth.models import AbstractUser
 
 from baserow.contrib.automation.nodes.handler import AutomationNodeHandler
@@ -11,26 +13,69 @@ from baserow.contrib.automation.nodes.registries import (
 from baserow.contrib.automation.nodes.signals import automation_node_created
 from baserow.contrib.automation.workflows.models import AutomationWorkflow
 from baserow.contrib.automation.workflows.signals import automation_workflow_updated
+from baserow.core.graph.models import GraphPointTrashableItemType
 from baserow.core.models import TrashEntry
 from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
-from baserow.core.trash.registries import TrashableItemType
-
-from .exceptions import AutomationNodeDoesNotExist
 
 
-class AutomationNodeTrashableItemType(TrashableItemType):
+class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
+    """
+    Trashable item type for `AutomationNode`.
+
+    The graph-aware trash/restore behaviour (removing the node from its workflow
+    graph, cascading to its children and re-inserting everything on restore) is
+    inherited from `GraphPointTrashableItemType`. This class layers on the
+    automation-specific concerns:
+
+    - Skipping the graph mutation during a node "replace" (see `_should_mutate_graph`),
+    - Not running the container guard while cascading (see `_before_cascade_delete`),
+    - Rejecting a restore whose reference branch/output no longer exists (see
+      `_validate_reference`),
+    - Emitting the node/workflow realtime signals and invalidating the workflow's
+      node cache.
+    """
+
     type = "automation_node"
     model_class = AutomationNode
 
     def get_parent(self, trashed_item: AutomationActionNode) -> AutomationWorkflow:
         return trashed_item.workflow
 
-    def get_name(self, trashed_item: AutomationActionNode) -> str:
-        return f"{trashed_item} ({trashed_item.id})".lower()
+    def get_restore_operation_type(self) -> str:
+        return RestoreAutomationNodeOperationType.type
 
-    def get_additional_restoration_data(self, trashed_item: AutomationActionNode):
-        # We save the previous position for the restoration
-        return trashed_item.workflow.get_graph().get_position(trashed_item)
+    def _should_mutate_graph(self, trash_entry: TrashEntry) -> bool:
+        """
+        A "replace" rearranges the graph itself (swapping one node for another), so
+        trash/restore must not also remove/insert the node.
+        """
+
+        return (
+            trash_entry.trash_operation_type
+            != ReplaceAutomationNodeTrashOperationType.type
+        )
+
+    def _before_cascade_delete(self, descendant: AutomationNode):
+        """
+        Container nodes guard against deletion while they still have children
+        (raising `AutomationNodeNotDeletable`). During a trash cascade the whole
+        subtree is soft-deleted together, so we skip that per-descendant guard.
+        """
+
+    def _validate_reference(self, reference: Optional[AutomationNode], output: str):
+        """
+        The reference node's output must still exist for the node to re-attach to
+        it; the branch it was on may have been deleted in the meantime.
+        """
+
+        if (
+            reference is not None
+            and output
+            not in reference.service.get_type().get_edges(reference.service.specific)
+        ):
+            raise TrashItemRestorationDisallowed(
+                "This automation node cannot be restored as its branch has been deleted."
+            )
 
     def trash(
         self,
@@ -38,15 +83,15 @@ class AutomationNodeTrashableItemType(TrashableItemType):
         requesting_user: AbstractUser,
         trash_entry: TrashEntry,
     ):
+        """
+        Trash the node via the base graph logic, then (unless this is a replace)
+        notify clients the workflow changed, and invalidate the node cache.
+        """
+
         super().trash(item_to_trash, requesting_user, trash_entry)
 
-        if (
-            trash_entry.trash_operation_type
-            != ReplaceAutomationNodeTrashOperationType.type
-        ):
-            item_to_trash.workflow.get_graph().remove(item_to_trash)
+        if self._should_mutate_graph(trash_entry):
             item_to_trash.workflow.refresh_from_db()
-
             automation_workflow_updated.send(
                 self, workflow=item_to_trash.workflow, user=requesting_user
             )
@@ -58,56 +103,21 @@ class AutomationNodeTrashableItemType(TrashableItemType):
         trashed_item: AutomationActionNode,
         trash_entry: TrashEntry,
     ):
-        workflow = trashed_item.workflow
+        """
+        Restore the node (and any cascaded children) via the base graph logic,
+        invalidate the node cache, then (unless this is a replace) broadcast each
+        restored node and the updated workflow.
+        """
 
-        super().restore(trashed_item, trash_entry)
+        restored_nodes: List[AutomationNode] = super().restore(
+            trashed_item, trash_entry
+        )
 
         AutomationNodeHandler().invalidate_node_cache(trashed_item.workflow)
 
-        if (
-            trash_entry.trash_operation_type
-            != ReplaceAutomationNodeTrashOperationType.type
-        ):
-            (
-                reference_node_id,
-                position,
-                output,
-            ) = trash_entry.additional_restoration_data
-
-            try:
-                reference_node = (
-                    AutomationNodeHandler().get_node(reference_node_id)
-                    if reference_node_id
-                    else None
-                )
-            except AutomationNodeDoesNotExist as exc:
-                raise TrashItemRestorationDisallowed(
-                    "This automation node cannot be "
-                    "restored as its reference node has been deleted."
-                ) from exc
-
-            # Does the output still exists?
-            if (
-                reference_node is not None
-                and output
-                not in reference_node.service.get_type().get_edges(
-                    reference_node.service.specific
-                )
-            ):
-                raise TrashItemRestorationDisallowed(
-                    "This automation node cannot be "
-                    "restored as its branch has been deleted."
-                )
-
-            workflow.get_graph().insert(trashed_item, reference_node, position, output)
-
-            automation_node_created.send(self, node=trashed_item, user=None)
-            automation_workflow_updated.send(self, workflow=workflow, user=None)
-
-    def permanently_delete_item(
-        self, trashed_item: AutomationNode, trash_item_lookup_cache=None
-    ):
-        trashed_item.delete()
-
-    def get_restore_operation_type(self) -> str:
-        return RestoreAutomationNodeOperationType.type
+        if self._should_mutate_graph(trash_entry):
+            for node in restored_nodes:
+                automation_node_created.send(self, node=node, user=None)
+            automation_workflow_updated.send(
+                self, workflow=trashed_item.workflow, user=None
+            )

--- a/backend/src/baserow/contrib/automation/nodes/trash_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/trash_types.py
@@ -27,10 +27,10 @@ class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
     inherited from `GraphPointTrashableItemType`. This class layers on the
     automation-specific concerns:
 
-    - Skipping the graph mutation during a node "replace" (see `_should_mutate_graph`),
-    - Not running the container guard while cascading (see `_before_cascade_delete`),
+    - Skipping the graph mutation during a node "replace" (see `should_mutate_graph`),
+    - Not running the container guard while cascading (see `before_cascade_delete`),
     - Rejecting a restore whose reference branch/output no longer exists (see
-      `_validate_reference`),
+      `validate_reference`),
     - Emitting the node/workflow realtime signals and invalidating the workflow's
       node cache.
     """
@@ -44,7 +44,7 @@ class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
     def get_restore_operation_type(self) -> str:
         return RestoreAutomationNodeOperationType.type
 
-    def _should_mutate_graph(self, trash_entry: TrashEntry) -> bool:
+    def should_mutate_graph(self, trash_entry: TrashEntry) -> bool:
         """
         A "replace" rearranges the graph itself (swapping one node for another), so
         trash/restore must not also remove/insert the node.
@@ -55,14 +55,14 @@ class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
             != ReplaceAutomationNodeTrashOperationType.type
         )
 
-    def _before_cascade_delete(self, descendant: AutomationNode):
+    def before_cascade_delete(self, descendant: AutomationNode):
         """
         Container nodes guard against deletion while they still have children
         (raising `AutomationNodeNotDeletable`). During a trash cascade the whole
         subtree is soft-deleted together, so we skip that per-descendant guard.
         """
 
-    def _validate_reference(self, reference: Optional[AutomationNode], output: str):
+    def validate_reference(self, reference: Optional[AutomationNode], output: str):
         """
         The reference node's output must still exist for the node to re-attach to
         it; the branch it was on may have been deleted in the meantime.
@@ -90,7 +90,7 @@ class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
 
         super().trash(item_to_trash, requesting_user, trash_entry)
 
-        if self._should_mutate_graph(trash_entry):
+        if self.should_mutate_graph(trash_entry):
             item_to_trash.workflow.refresh_from_db()
             automation_workflow_updated.send(
                 self, workflow=item_to_trash.workflow, user=requesting_user
@@ -115,7 +115,7 @@ class AutomationNodeTrashableItemType(GraphPointTrashableItemType):
 
         AutomationNodeHandler().invalidate_node_cache(trashed_item.workflow)
 
-        if self._should_mutate_graph(trash_entry):
+        if self.should_mutate_graph(trash_entry):
             for node in restored_nodes:
                 automation_node_created.send(self, node=node, user=None)
             automation_workflow_updated.send(

--- a/backend/src/baserow/contrib/automation/nodes/trash_types.py
+++ b/backend/src/baserow/contrib/automation/nodes/trash_types.py
@@ -26,7 +26,7 @@ class AutomationNodeTrashableItemType(TrashableItemType):
         return trashed_item.workflow
 
     def get_name(self, trashed_item: AutomationActionNode) -> str:
-        return f"{trashed_item.get_type().type} ({trashed_item.id})"
+        return f"{trashed_item} ({trashed_item.id})".lower()
 
     def get_additional_restoration_data(self, trashed_item: AutomationActionNode):
         # We save the previous position for the restoration

--- a/backend/src/baserow/contrib/automation/workflows/models.py
+++ b/backend/src/baserow/contrib/automation/workflows/models.py
@@ -5,6 +5,7 @@ from django.db import models
 
 from baserow.contrib.automation.constants import WORKFLOW_NAME_MAX_LEN
 from baserow.contrib.automation.workflows.constants import WorkflowState
+from baserow.core.graph.models import GraphModelMixin
 from baserow.core.cache import local_cache
 from baserow.core.graph.models import GraphModelMixin
 from baserow.core.jobs.mixins import (
@@ -51,6 +52,8 @@ class AutomationWorkflow(
     OrderableMixin,
     GraphModelMixin,
 ):
+    supports_edges = True
+
     automation = models.ForeignKey(
         "automation.Automation", on_delete=models.CASCADE, related_name="workflows"
     )

--- a/backend/src/baserow/contrib/automation/workflows/models.py
+++ b/backend/src/baserow/contrib/automation/workflows/models.py
@@ -5,7 +5,6 @@ from django.db import models
 
 from baserow.contrib.automation.constants import WORKFLOW_NAME_MAX_LEN
 from baserow.contrib.automation.workflows.constants import WorkflowState
-from baserow.core.graph.models import GraphModelMixin
 from baserow.core.cache import local_cache
 from baserow.core.graph.models import GraphModelMixin
 from baserow.core.jobs.mixins import (

--- a/backend/src/baserow/contrib/automation/workflows/trash_types.py
+++ b/backend/src/baserow/contrib/automation/workflows/trash_types.py
@@ -18,7 +18,7 @@ class AutomationWorkflowTrashableItemType(TrashableItemType):
         return trashed_item.automation
 
     def get_name(self, trashed_item: AutomationWorkflow) -> str:
-        return trashed_item.name
+        return f"{trashed_item.name} ({trashed_item.id})"
 
     def trash(
         self,

--- a/backend/src/baserow/contrib/builder/action_scopes.py
+++ b/backend/src/baserow/contrib/builder/action_scopes.py
@@ -1,0 +1,65 @@
+from typing import Optional, cast
+
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+from baserow.core.action.registries import ActionScopeStr, ActionScopeType
+
+ELEMENT_ACTION_CONTEXT = _(
+    'of type "%(element_type)s" on page (%(page_id)s) in builder '
+    '"%(builder_name)s" (%(builder_id)s).'
+)
+
+
+class PageActionScopeType(ActionScopeType):
+    type = "page"
+
+    @classmethod
+    def value(cls, page_id: int) -> ActionScopeStr:
+        return cast(ActionScopeStr, cls.type + str(page_id))
+
+    def get_request_serializer_field(self) -> serializers.Field:
+        return serializers.IntegerField(
+            min_value=0,
+            allow_null=True,
+            required=False,
+            help_text="If set to a page id then any actions directly related "
+            "to that page will be included when undoing or redoing.",
+        )
+
+    def valid_serializer_value_to_scope_str(
+        self, value: int
+    ) -> Optional[ActionScopeStr]:
+        return self.value(value)
+
+
+class SharedPageActionScopeType(ActionScopeType):
+    """
+    Scope for elements living on a builder's shared page (header/footer elements
+    and their children). These elements appear on every content page, so their
+    actions are scoped to the shared page id rather than a content page id. The
+    editor sends this scope alongside the content `page` scope (they are different
+    scope types, so both can be present in a single undo/redo request), which lets
+    shared-element edits be undone while editing any content page.
+    """
+
+    type = "shared_page"
+
+    @classmethod
+    def value(cls, shared_page_id: int) -> ActionScopeStr:
+        return cast(ActionScopeStr, cls.type + str(shared_page_id))
+
+    def get_request_serializer_field(self) -> serializers.Field:
+        return serializers.IntegerField(
+            min_value=0,
+            allow_null=True,
+            required=False,
+            help_text="If set to a shared page id then any actions related to that "
+            "builder's shared elements will be included when undoing or redoing.",
+        )
+
+    def valid_serializer_value_to_scope_str(
+        self, value: int
+    ) -> Optional[ActionScopeStr]:
+        return self.value(value)

--- a/backend/src/baserow/contrib/builder/api/elements/views.py
+++ b/backend/src/baserow/contrib/builder/api/elements/views.py
@@ -46,6 +46,13 @@ from baserow.contrib.builder.api.pages.errors import (
 )
 from baserow.contrib.builder.application_types import BuilderApplicationType
 from baserow.contrib.builder.data_sources.exceptions import DataSourceDoesNotExist
+from baserow.contrib.builder.elements.actions import (
+    CreateElementActionType,
+    DeleteElementActionType,
+    DuplicateElementActionType,
+    MoveElementActionType,
+    UpdateElementActionType,
+)
 from baserow.contrib.builder.elements.exceptions import (
     CollectionElementPropertyOptionsNotUnique,
     ElementDoesNotExist,
@@ -187,9 +194,7 @@ class ElementsView(APIView):
         page = PageHandler().get_page(page_id)
 
         element_type = element_type_registry.get(type_name)
-        element = ElementService().create_element(
-            request.user, element_type, page, **data
-        )
+        element = CreateElementActionType.do(request.user, element_type, page, data)
 
         serializer = element_type_registry.get_serializer(element, ElementSerializer)
         return Response(serializer.data)
@@ -261,7 +266,7 @@ class ElementView(APIView):
             return_validated=True,
         )
 
-        element_updated = ElementService().update_element(request.user, element, **data)
+        element_updated = UpdateElementActionType.do(request.user, element, data)
 
         serializer = element_type_registry.get_serializer(
             element_updated, ElementSerializer
@@ -305,7 +310,7 @@ class ElementView(APIView):
 
         element = ElementHandler().get_element_for_update(element_id)
 
-        ElementService().delete_element(request.user, element)
+        DeleteElementActionType.do(request.user, element)
 
         return Response(status=204)
 
@@ -378,12 +383,12 @@ class MoveElementView(APIView):
         except PageDoesNotExist as e:
             raise PageNotInBuilder(target_page_id) from e
 
-        element_move = ElementService().move_element(
-            request.user, target_page, element, **data
+        moved_element = MoveElementActionType.do(
+            request.user, element, target_page, **data
         )
 
         serializer = element_type_registry.get_serializer(
-            element_move.element, ElementSerializer
+            moved_element, ElementSerializer
         )
         return Response(serializer.data)
 
@@ -426,7 +431,7 @@ class DuplicateElementView(APIView):
 
         element = ElementHandler().get_element_for_update(element_id)
 
-        elements_and_workflow_actions_duplicated = ElementService().duplicate_element(
+        elements_and_workflow_actions_duplicated = DuplicateElementActionType.do(
             request.user, element
         )
 

--- a/backend/src/baserow/contrib/builder/apps.py
+++ b/backend/src/baserow/contrib/builder/apps.py
@@ -234,6 +234,29 @@ class BuilderConfig(AppConfig):
         trash_item_type_registry.register(PageTrashableItemType())
         trash_item_type_registry.register(ElementTrashableItemType())
 
+        from baserow.core.action.registries import (
+            action_scope_registry,
+            action_type_registry,
+        )
+
+        from .action_scopes import PageActionScopeType, SharedPageActionScopeType
+        from .elements.actions import (
+            CreateElementActionType,
+            DeleteElementActionType,
+            DuplicateElementActionType,
+            MoveElementActionType,
+            UpdateElementActionType,
+        )
+
+        action_scope_registry.register(PageActionScopeType())
+        action_scope_registry.register(SharedPageActionScopeType())
+
+        action_type_registry.register(CreateElementActionType())
+        action_type_registry.register(UpdateElementActionType())
+        action_type_registry.register(DeleteElementActionType())
+        action_type_registry.register(DuplicateElementActionType())
+        action_type_registry.register(MoveElementActionType())
+
         from baserow.contrib.builder.data_providers.registries import (
             builder_data_provider_type_registry,
         )

--- a/backend/src/baserow/contrib/builder/apps.py
+++ b/backend/src/baserow/contrib/builder/apps.py
@@ -66,6 +66,7 @@ class BuilderConfig(AppConfig):
             DeletePageOperationType,
             DuplicatePageOperationType,
             ReadPageOperationType,
+            RestorePageOperationType,
             UpdatePageOperationType,
         )
 
@@ -74,6 +75,7 @@ class BuilderConfig(AppConfig):
         operation_type_registry.register(UpdatePageOperationType())
         operation_type_registry.register(ReadPageOperationType())
         operation_type_registry.register(DuplicatePageOperationType())
+        operation_type_registry.register(RestorePageOperationType())
 
         from baserow.contrib.builder.domains.operations import (
             CreateDomainOperationType,
@@ -122,6 +124,7 @@ class BuilderConfig(AppConfig):
             ListElementsPageOperationType,
             OrderElementsPageOperationType,
             ReadElementOperationType,
+            RestoreElementOperationType,
             UpdateElementOperationType,
         )
 
@@ -131,6 +134,7 @@ class BuilderConfig(AppConfig):
         operation_type_registry.register(ReadElementOperationType())
         operation_type_registry.register(UpdateElementOperationType())
         operation_type_registry.register(DeleteElementOperationType())
+        operation_type_registry.register(RestoreElementOperationType())
 
         from baserow.contrib.builder.workflow_actions.operations import (
             CreateBuilderWorkflowActionOperationType,
@@ -223,8 +227,12 @@ class BuilderConfig(AppConfig):
         domain_type_registry.register(SubDomainType())
 
         from .domains.trash_types import DomainTrashableItemType
+        from .elements.trash_types import ElementTrashableItemType
+        from .pages.trash_types import PageTrashableItemType
 
         trash_item_type_registry.register(DomainTrashableItemType())
+        trash_item_type_registry.register(PageTrashableItemType())
+        trash_item_type_registry.register(ElementTrashableItemType())
 
         from baserow.contrib.builder.data_providers.registries import (
             builder_data_provider_type_registry,

--- a/backend/src/baserow/contrib/builder/elements/actions.py
+++ b/backend/src/baserow/contrib/builder/elements/actions.py
@@ -1,0 +1,376 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from django.contrib.auth.models import AbstractUser
+from django.utils.translation import gettext_lazy as _
+
+from baserow.contrib.builder.action_scopes import (
+    ELEMENT_ACTION_CONTEXT,
+    PageActionScopeType,
+    SharedPageActionScopeType,
+)
+from baserow.contrib.builder.elements.handler import ElementHandler
+from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.registries import ElementType
+from baserow.contrib.builder.elements.service import ElementService
+from baserow.contrib.builder.elements.trash_types import ElementTrashableItemType
+from baserow.contrib.builder.elements.types import ElementsAndWorkflowActions
+from baserow.contrib.builder.pages.handler import PageHandler
+from baserow.contrib.builder.pages.models import Page
+from baserow.core.action.models import Action
+from baserow.core.action.registries import (
+    ActionScopeStr,
+    ActionTypeDescription,
+    UndoableActionType,
+)
+from baserow.core.graph.types import GraphPointPositionType
+from baserow.core.trash.handler import TrashHandler
+
+
+def element_action_scope(page: Page) -> ActionScopeStr:
+    """
+    Returns the undo/redo scope for an action on an element living on ``page``.
+
+    Elements on the builder's shared page (header/footer elements and their
+    children) are scoped to that shared page so they stay undoable from whichever
+    content page the user is editing. Regular elements are scoped to their own
+    content page.
+    """
+
+    if page.shared:
+        return SharedPageActionScopeType.value(page.id)
+    return PageActionScopeType.value(page.id)
+
+
+class CreateElementActionType(UndoableActionType):
+    type = "create_element"
+    description = ActionTypeDescription(
+        _("Create element"),
+        _("Element (%(element_id)s) created"),
+        ELEMENT_ACTION_CONTEXT,
+    )
+
+    @dataclass
+    class Params:
+        builder_id: int
+        builder_name: str
+        page_id: int
+        element_id: int
+        element_type: str
+
+    @classmethod
+    def do(
+        cls,
+        user: AbstractUser,
+        element_type: ElementType,
+        page: Page,
+        data: dict,
+    ) -> Element:
+        element = ElementService().create_element(user, element_type, page, **data)
+
+        builder = page.builder
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                builder.id,
+                builder.name,
+                page.id,
+                element.id,
+                element.get_type().type,
+            ),
+            scope=cls.scope(page),
+            workspace=builder.workspace,
+        )
+        return element
+
+    @classmethod
+    def scope(cls, page: Page):
+        return element_action_scope(page)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        ElementService().delete_element(user, element)
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        TrashHandler.restore_item(
+            user,
+            ElementTrashableItemType.type,
+            params.element_id,
+        )
+
+
+class UpdateElementActionType(UndoableActionType):
+    type = "update_element"
+    description = ActionTypeDescription(
+        _("Update element"),
+        _("Element (%(element_id)s) updated"),
+        ELEMENT_ACTION_CONTEXT,
+    )
+
+    @dataclass
+    class Params:
+        builder_id: int
+        builder_name: str
+        page_id: int
+        element_id: int
+        element_type: str
+        element_original_params: Dict[str, Any]
+        element_new_params: Dict[str, Any]
+
+    @classmethod
+    def do(cls, user: AbstractUser, element: Element, new_data: dict) -> Element:
+        updated = ElementService().update_element(user, element, **new_data)
+
+        builder = updated.element.page.builder
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                builder.id,
+                builder.name,
+                updated.element.page_id,
+                updated.element.id,
+                updated.element.get_type().type,
+                updated.original_values,
+                updated.new_values,
+            ),
+            scope=cls.scope(updated.element.page),
+            workspace=builder.workspace,
+        )
+        return updated.element
+
+    @classmethod
+    def scope(cls, page: Page):
+        return element_action_scope(page)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        ElementService().update_element(user, element, **params.element_original_params)
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        ElementService().update_element(user, element, **params.element_new_params)
+
+
+class DeleteElementActionType(UndoableActionType):
+    type = "delete_element"
+    description = ActionTypeDescription(
+        _("Delete element"),
+        _("Element (%(element_id)s) deleted"),
+        ELEMENT_ACTION_CONTEXT,
+    )
+
+    @dataclass
+    class Params:
+        builder_id: int
+        builder_name: str
+        page_id: int
+        element_id: int
+        element_type: str
+
+    @classmethod
+    def do(cls, user: AbstractUser, element: Element) -> None:
+        page = element.page
+        builder = page.builder
+        # Captured before the element is trashed and removed from the graph.
+        params = cls.Params(
+            builder.id,
+            builder.name,
+            page.id,
+            element.id,
+            element.get_type().type,
+        )
+
+        ElementService().delete_element(user, element)
+
+        cls.register_action(
+            user=user,
+            params=params,
+            scope=cls.scope(page),
+            workspace=builder.workspace,
+        )
+
+    @classmethod
+    def scope(cls, page: Page):
+        return element_action_scope(page)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        TrashHandler.restore_item(
+            user,
+            ElementTrashableItemType.type,
+            params.element_id,
+        )
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        ElementService().delete_element(user, element)
+
+
+class DuplicateElementActionType(UndoableActionType):
+    type = "duplicate_element"
+    description = ActionTypeDescription(
+        _("Duplicate element"),
+        _("Element (%(element_id)s) duplicated"),
+        ELEMENT_ACTION_CONTEXT,
+    )
+
+    @dataclass
+    class Params:
+        builder_id: int
+        builder_name: str
+        page_id: int
+        element_id: int  # The source element id
+        element_type: str  # The source element type
+        duplicated_element_id: int
+
+    @classmethod
+    def do(cls, user: AbstractUser, element: Element) -> ElementsAndWorkflowActions:
+        page = element.page
+        builder = page.builder
+
+        result = ElementService().duplicate_element(user, element)
+        # The handler returns the duplicated root element first, followed by its
+        # children (see ElementHandler._duplicate_element_recursive).
+        duplicated_root = result["elements"][0]
+
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                builder.id,
+                builder.name,
+                page.id,
+                element.id,
+                element.get_type().type,
+                duplicated_root.id,
+            ),
+            scope=cls.scope(page),
+            workspace=builder.workspace,
+        )
+        return result
+
+    @classmethod
+    def scope(cls, page: Page):
+        return element_action_scope(page)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        # Trash the duplicated element (its children cascade with it).
+        element = ElementHandler().get_element_for_update(params.duplicated_element_id)
+        ElementService().delete_element(user, element)
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        TrashHandler.restore_item(
+            user,
+            ElementTrashableItemType.type,
+            params.duplicated_element_id,
+        )
+
+
+class MoveElementActionType(UndoableActionType):
+    type = "move_element"
+    description = ActionTypeDescription(
+        _("Move element"),
+        _("Element (%(element_id)s) moved"),
+        ELEMENT_ACTION_CONTEXT,
+    )
+
+    @dataclass
+    class Params:
+        builder_id: int
+        builder_name: str
+        page_id: int  # The source page id, used as the undo/redo scope.
+        element_id: int
+        element_type: str
+        origin_page_id: int
+        origin_reference_element_id: int | None
+        origin_position: GraphPointPositionType
+        origin_place_in_container: str
+        destination_page_id: int
+        destination_reference_element_id: int | None
+        destination_position: GraphPointPositionType
+        destination_place_in_container: str
+
+    @classmethod
+    def do(
+        cls,
+        user: AbstractUser,
+        element: Element,
+        target_page: Page,
+        place_in_container: str,
+        reference_element_id: int | None,
+        position: GraphPointPositionType,
+    ) -> Element:
+        # Captured before the move reassigns element.page. Cross-page moves are
+        # scoped to the source page (the page the user acted from).
+        source_page = element.page
+        source_page_id = source_page.id
+
+        move = ElementService().move_element(
+            user,
+            target_page,
+            element,
+            place_in_container=place_in_container,
+            reference_element_id=reference_element_id,
+            position=position,
+        )
+
+        builder = target_page.builder
+        cls.register_action(
+            user=user,
+            params=cls.Params(
+                builder.id,
+                builder.name,
+                source_page_id,
+                move.element.id,
+                move.element.get_type().type,
+                source_page_id,
+                move.previous_reference_element.id
+                if move.previous_reference_element
+                else None,
+                move.previous_position,
+                move.previous_output,
+                target_page.id,
+                reference_element_id,
+                position,
+                place_in_container,
+            ),
+            scope=cls.scope(source_page),
+            workspace=builder.workspace,
+        )
+        return move.element
+
+    @classmethod
+    def scope(cls, page: Page):
+        return element_action_scope(page)
+
+    @classmethod
+    def undo(cls, user: AbstractUser, params: Params, action_to_undo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        origin_page = PageHandler().get_page(params.origin_page_id)
+        ElementService().move_element(
+            user,
+            origin_page,
+            element,
+            place_in_container=params.origin_place_in_container,
+            reference_element_id=params.origin_reference_element_id,
+            position=params.origin_position,
+        )
+
+    @classmethod
+    def redo(cls, user: AbstractUser, params: Params, action_to_redo: Action):
+        element = ElementHandler().get_element_for_update(params.element_id)
+        destination_page = PageHandler().get_page(params.destination_page_id)
+        ElementService().move_element(
+            user,
+            destination_page,
+            element,
+            place_in_container=params.destination_place_in_container,
+            reference_element_id=params.destination_reference_element_id,
+            position=params.destination_position,
+        )

--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -19,6 +19,7 @@ from typing import (
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db.models import Q, QuerySet
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -133,6 +134,7 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
     in a column.
     """
 
+    display_name = _("Column")
     type = "column"
     model_class = ColumnElement
 
@@ -215,6 +217,7 @@ class ColumnElementType(ContainerElementTypeMixin, ElementType):
 
 
 class FormContainerElementType(ContainerElementTypeMixin, ElementType):
+    display_name = _("Form")
     type = "form_container"
     model_class = FormContainerElement
     allowed_fields = [
@@ -286,6 +289,7 @@ class FormContainerElementType(ContainerElementTypeMixin, ElementType):
 
 
 class SimpleContainerElementType(ContainerElementTypeMixin, ElementType):
+    display_name = _("Container")
     type = "simple_container"
     model_class = SimpleContainerElement
 
@@ -297,6 +301,7 @@ class SimpleContainerElementType(ContainerElementTypeMixin, ElementType):
 
 
 class TableElementType(CollectionElementWithFieldsTypeMixin, ElementType):
+    display_name = _("Table")
     type = "table"
     model_class = TableElement
 
@@ -361,6 +366,7 @@ class TableElementType(CollectionElementWithFieldsTypeMixin, ElementType):
 class RepeatElementType(
     CollectionElementTypeMixin, ContainerElementTypeMixin, ElementType
 ):
+    display_name = _("Repeat")
     type = "repeat"
     model_class = RepeatElement
 
@@ -428,6 +434,7 @@ class RepeatElementType(
 class RecordSelectorElementType(
     FormElementTypeMixin, CollectionElementTypeMixin, ElementType
 ):
+    display_name = _("Record selector")
     type = "record_selector"
     model_class = RecordSelectorElement
     simple_formula_fields = CollectionElementTypeMixin.simple_formula_fields + [
@@ -676,6 +683,7 @@ class HeadingElementType(ElementType):
     A simple heading element that can be used to display a title.
     """
 
+    display_name = _("Heading")
     type = "heading"
     model_class = HeadingElement
     serializer_field_names = ["value", "level"]
@@ -742,6 +750,7 @@ class TextElementType(ElementType):
     A text element that allows plain or markdown content.
     """
 
+    display_name = _("Text")
     type = "text"
     model_class = TextElement
     serializer_field_names = ["value", "format"]
@@ -963,6 +972,7 @@ class LinkElementType(ElementType):
     A link element that can be used to navigate to a page or a URL.
     """
 
+    display_name = _("Link")
     type = "link"
     model_class = LinkElement
     simple_formula_fields = NavigationElementManager.simple_formula_fields + ["value"]
@@ -1100,6 +1110,7 @@ class ImageElementType(ElementType):
     or via an uploaded file
     """
 
+    display_name = _("Image")
     type = "image"
     model_class = ImageElement
     serializer_field_names = [
@@ -1263,6 +1274,7 @@ class InputElementType(FormElementTypeMixin, ElementType, abc.ABC):
 
 
 class RatingElementType(ElementType):
+    display_name = _("Rating")
     type = "rating"
     model_class = RatingElement
     allowed_fields = [
@@ -1309,6 +1321,7 @@ class RatingElementType(ElementType):
 
 
 class RatingInputElementType(InputElementType):
+    display_name = _("Rating input")
     type = "rating_input"
     model_class = RatingInputElement
     allowed_fields = [
@@ -1394,6 +1407,7 @@ class RatingInputElementType(InputElementType):
 
 
 class InputTextElementType(InputElementType):
+    display_name = _("Input text")
     type = "input_text"
     model_class = InputTextElement
     allowed_fields = [
@@ -1533,6 +1547,7 @@ class InputTextElementType(InputElementType):
 
 
 class ButtonElementType(ElementType):
+    display_name = _("Button")
     type = "button"
     model_class = ButtonElement
     allowed_fields = ["value"]
@@ -1577,6 +1592,7 @@ class ButtonElementType(ElementType):
 
 
 class CheckboxElementType(InputElementType):
+    display_name = _("Checkbox")
     type = "checkbox"
     model_class = CheckboxElement
     allowed_fields = ["label", "default_value", "required"]
@@ -1650,6 +1666,7 @@ class CheckboxElementType(InputElementType):
 
 
 class ChoiceElementType(FormElementTypeMixin, ElementType):
+    display_name = _("Choice")
     type = "choice"
     model_class = ChoiceElement
     allowed_fields = [
@@ -1962,6 +1979,7 @@ class ChoiceElementType(FormElementTypeMixin, ElementType):
 
 
 class IFrameElementType(ElementType):
+    display_name = _("Iframe")
     type = "iframe"
     model_class = IFrameElement
     allowed_fields = ["source_type", "url", "embed", "height"]
@@ -2020,6 +2038,7 @@ class IFrameElementType(ElementType):
 
 
 class DateTimePickerElementType(FormElementTypeMixin, ElementType):
+    display_name = _("Date time picker")
     type = "datetime_picker"
     model_class = DateTimePickerElement
     allowed_fields = [
@@ -2163,6 +2182,7 @@ class HeaderElementType(MultiPageContainerElementType):
     A container element that can be displayed on multiple pages.
     """
 
+    display_name = _("Shared header")
     type = "header"
     model_class = HeaderElement
 
@@ -2172,6 +2192,7 @@ class FooterElementType(MultiPageContainerElementType):
     A container element that can be displayed on multiple pages.
     """
 
+    display_name = _("Shared footer")
     type = "footer"
     model_class = FooterElement
 
@@ -2181,6 +2202,7 @@ class MenuElementType(ElementType):
     A Menu element that provides navigation capabilities to the application.
     """
 
+    display_name = _("Menu")
     type = "menu"
     model_class = MenuElement
     serializer_field_names = ["orientation", "alignment", "menu_items", "variant"]

--- a/backend/src/baserow/contrib/builder/elements/handler.py
+++ b/backend/src/baserow/contrib/builder/elements/handler.py
@@ -656,10 +656,25 @@ class ElementHandler:
             workflow_actions=workflow_actions_duplicated,
         )
 
+        # The first child duplicated into a given place becomes the head of that
+        # slot (inserted as a CHILD of the duplicated parent); every subsequent
+        # child in the same place chains SOUTH of the previously duplicated
+        # sibling. This reproduces the original slot order faithfully and is
+        # independent of how insert(..., CHILD, ...) orders multiple children
+        # (which prepends, to stay the inverse of get_position).
+        last_duplicated_in_place: Dict[str, Element] = {}
         for child in element.get_child_points():
+            place = child.place_in_container
+            if place in last_duplicated_in_place:
+                child_reference = last_duplicated_in_place[place]
+                child_position = GraphPointPosition.SOUTH
+            else:
+                child_reference = element_duplicated
+                child_position = GraphPointPosition.CHILD
             children_duplicated = self._duplicate_element_recursive(
-                child.specific, id_mapping, element_duplicated, GraphPointPosition.CHILD
+                child.specific, id_mapping, child_reference, child_position
             )
+            last_duplicated_in_place[place] = children_duplicated["elements"][0]
             elements_and_workflow_actions_duplicated["elements"] += children_duplicated[
                 "elements"
             ]

--- a/backend/src/baserow/contrib/builder/elements/handler.py
+++ b/backend/src/baserow/contrib/builder/elements/handler.py
@@ -521,26 +521,6 @@ class ElementHandler:
 
         return element
 
-    def delete_element(self, element: Element):
-        """
-        Deletes an element and all of its graph-reachable descendants.
-
-        :param element: The to-be-deleted element.
-        """
-
-        page = element.page
-        element.get_type().before_delete(element)
-
-        result = page.get_graph().remove(element)
-        element.delete()
-
-        for dep in result.dependencies_removed:
-            specific = dep.specific
-            specific.get_type().before_delete(specific)
-            specific.delete()
-
-        self.invalidate_element_cache(page)
-
     def update_element(self, element: ElementForUpdate, **kwargs) -> Element:
         """
         Updates and element with values. Will also check if the values are allowed

--- a/backend/src/baserow/contrib/builder/elements/models.py
+++ b/backend/src/baserow/contrib/builder/elements/models.py
@@ -349,6 +349,9 @@ class Element(
 
         return element_type_registry
 
+    def __str__(self):
+        return str(self.get_type().display_name)
+
     def get_parent(self):
         return self.page
 

--- a/backend/src/baserow/contrib/builder/elements/operations.py
+++ b/backend/src/baserow/contrib/builder/elements/operations.py
@@ -32,3 +32,7 @@ class UpdateElementOperationType(BuilderElementOperationType):
 
 class ReadElementOperationType(BuilderElementOperationType):
     type = "builder.page.element.read"
+
+
+class RestoreElementOperationType(BuilderElementOperationType):
+    type = "builder.page.element.restore"

--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -65,7 +65,7 @@ class ElementType(
     parent_property_name = "page"
     id_mapping_name = BUILDER_PAGE_ELEMENTS
 
-    display_name = _("Unnamed")
+    display_name = _("Unnamed element")
 
     # Is this element type a container-type element?
     is_container = False

--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -77,7 +77,7 @@ class ElementType(
         """
         Returns the places available from this element in the graph.
 
-        The default builder element place is the unnamed ``next`` edge.
+        The default builder element place is the unnamed `next` edge.
         Container elements override this to expose their child slots.
         """
 
@@ -101,6 +101,43 @@ class ElementType(
         :param instance: The existing instance that is being updated
         :return: Values that should be used for the update or creation of the element.
         """
+
+        return values
+
+    def export_prepared_values(self, instance: Element) -> Dict[str, Any]:
+        """
+        Returns a JSON-serializable dict of the element's `allowed_fields`, used by
+        the undo/redo `ActionHandler` to snapshot values so they can be restored
+        later. Relation fields are exported as their id so the result stays
+        JSON-serializable.
+
+        Note: re-applying a stored relation id through `update_element` only
+        round-trips for element types whose update path accepts that id (e.g. those
+        exposing an `<field>_id` allowed field). Update undo/redo therefore only
+        snapshots the fields actually changed by an update (see the update action),
+        keeping scalar/JSON field changes fully reversible.
+
+        :param instance: The element instance to export values for.
+        :return: A dict of prepared values keyed by field name.
+        """
+
+        from django.core.exceptions import FieldDoesNotExist
+
+        values: Dict[str, Any] = {}
+        for field_name in self.allowed_fields:
+            try:
+                model_field = instance._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                values[field_name] = getattr(instance, field_name)
+                continue
+
+            if model_field.is_relation:
+                # Use the relation's attname (e.g. "data_source_id") to read the id,
+                # which keeps the value JSON-serializable. allowed_fields may already
+                # use the attname form, so we never construct "<name>_id" ourselves.
+                values[field_name] = getattr(instance, model_field.attname)
+            else:
+                values[field_name] = getattr(instance, field_name)
 
         return values
 

--- a/backend/src/baserow/contrib/builder/elements/registries.py
+++ b/backend/src/baserow/contrib/builder/elements/registries.py
@@ -18,6 +18,7 @@ from zipfile import ZipFile
 
 from django.core.files.storage import Storage
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -63,6 +64,8 @@ class ElementType(
     SerializedDict: Type[ElementDictSubClass]
     parent_property_name = "page"
     id_mapping_name = BUILDER_PAGE_ELEMENTS
+
+    display_name = _("Unnamed")
 
     # Is this element type a container-type element?
     is_container = False

--- a/backend/src/baserow/contrib/builder/elements/service.py
+++ b/backend/src/baserow/contrib/builder/elements/service.py
@@ -19,7 +19,6 @@ from baserow.contrib.builder.elements.operations import (
 from baserow.contrib.builder.elements.registries import ElementType
 from baserow.contrib.builder.elements.signals import (
     element_created,
-    element_deleted,
     element_moved,
     element_updated,
     elements_created,
@@ -37,6 +36,7 @@ from baserow.core.graph.exceptions import (
 )
 from baserow.core.graph.types import GraphPointPosition, GraphPointPositionType
 from baserow.core.handler import CoreHandler
+from baserow.core.trash.handler import TrashHandler
 
 if TYPE_CHECKING:
     from baserow.contrib.builder.models import Builder
@@ -246,8 +246,6 @@ class ElementService:
         :param element: The to-be-deleted element.
         """
 
-        page = element.page
-
         CoreHandler().check_permissions(
             user,
             DeleteElementOperationType.type,
@@ -255,20 +253,10 @@ class ElementService:
             context=element,
         )
 
-        # Collect the descendants before deletion so realtime receivers can tell
-        # other clients which records to remove — deleting a container removes its
-        # whole subtree.
-        descendant_ids = [d.id for d in page.get_graph().get_descendants(element)]
+        element.get_type().before_delete(element.specific)
 
-        self.handler.delete_element(element)
-
-        element_deleted.send(
-            self,
-            element_id=element.id,
-            descendant_ids=descendant_ids,
-            page=page,
-            user=user,
-        )
+        builder = element.page.builder
+        TrashHandler.trash(user, builder.workspace, builder, element)
 
     def move_element(
         self,

--- a/backend/src/baserow/contrib/builder/elements/service.py
+++ b/backend/src/baserow/contrib/builder/elements/service.py
@@ -27,6 +27,7 @@ from baserow.contrib.builder.elements.types import (
     ElementForUpdate,
     ElementMove,
     ElementsAndWorkflowActions,
+    UpdatedElement,
 )
 from baserow.contrib.builder.pages.exceptions import PageNotInBuilder
 from baserow.contrib.builder.pages.models import Page
@@ -213,7 +214,7 @@ class ElementService:
 
     def update_element(
         self, user: AbstractUser, element: ElementForUpdate, **kwargs
-    ) -> Element:
+    ) -> UpdatedElement:
         """
         Updates and element with values. Will also check if the values are allowed
         to be set on the element first.
@@ -222,7 +223,8 @@ class ElementService:
         :param element: The element that should be updated.
         :param values: The values that should be set on the element.
         :param kwargs: Additional attributes of the element.
-        :return: The updated element.
+        :return: An `UpdatedElement` holding the updated element and the original and
+            new values of the changed fields (used by undo/redo).
         """
 
         CoreHandler().check_permissions(
@@ -232,11 +234,31 @@ class ElementService:
             context=element,
         )
 
+        element_type = element.get_type()
+
+        # Snapshot only the fields actually being changed so undo/redo never tries to
+        # re-apply unrelated relation fields (which don't round-trip from an id).
+        original_values = {
+            key: value
+            for key, value in element_type.export_prepared_values(element).items()
+            if key in kwargs
+        }
+
         element = self.handler.update_element(element, **kwargs)
+
+        new_values = {
+            key: value
+            for key, value in element_type.export_prepared_values(element).items()
+            if key in kwargs
+        }
 
         element_updated.send(self, element=element, user=user)
 
-        return element
+        return UpdatedElement(
+            element=element,
+            original_values=original_values,
+            new_values=new_values,
+        )
 
     def delete_element(self, user: AbstractUser, element: ElementForUpdate):
         """

--- a/backend/src/baserow/contrib/builder/elements/service.py
+++ b/backend/src/baserow/contrib/builder/elements/service.py
@@ -278,7 +278,7 @@ class ElementService:
         # NB: we deliberately do not call `before_delete` here. Deletion is a soft
         # trash, and `before_delete` permanently removes owned related data (e.g. a
         # collection element's fields) that a restore needs to bring back. That
-        # cleanup is deferred to permanent deletion via `_before_permanent_delete`
+        # cleanup is deferred to permanent deletion via `before_permanent_delete`
         # on the trashable item type.
         builder = element.page.builder
         TrashHandler.trash(user, builder.workspace, builder, element)

--- a/backend/src/baserow/contrib/builder/elements/service.py
+++ b/backend/src/baserow/contrib/builder/elements/service.py
@@ -275,8 +275,11 @@ class ElementService:
             context=element,
         )
 
-        element.get_type().before_delete(element.specific)
-
+        # NB: we deliberately do not call `before_delete` here. Deletion is a soft
+        # trash, and `before_delete` permanently removes owned related data (e.g. a
+        # collection element's fields) that a restore needs to bring back. That
+        # cleanup is deferred to permanent deletion via `_before_permanent_delete`
+        # on the trashable item type.
         builder = element.page.builder
         TrashHandler.trash(user, builder.workspace, builder, element)
 

--- a/backend/src/baserow/contrib/builder/elements/service.py
+++ b/backend/src/baserow/contrib/builder/elements/service.py
@@ -326,6 +326,14 @@ class ElementService:
                 f"The reference element {reference_element_id} doesn't exist"
             ) from e
 
+        # An element can't be moved relative to itself: the graph removes it before
+        # re-inserting, so referencing itself would leave it dangling. Guard it as a
+        # handled error rather than letting the graph raise an unhandled exception.
+        if reference_element is not None and reference_element.id == element.id:
+            raise GraphPointReferencePointInvalid(
+                "An element cannot be moved relative to itself."
+            )
+
         # Check we are on the same builder.
         if target_page.builder != element.page.builder:
             raise PageNotInBuilder()

--- a/backend/src/baserow/contrib/builder/elements/trash_types.py
+++ b/backend/src/baserow/contrib/builder/elements/trash_types.py
@@ -75,7 +75,7 @@ class ElementTrashableItemType(GraphPointTrashableItemType):
             user=None,
         )
 
-    def _before_permanent_delete(self, item: Element) -> None:
+    def before_permanent_delete(self, item: Element) -> None:
         """
         Clean up the element's owned related data (e.g. a collection element's
         fields, a menu element's items) when it is permanently deleted. This runs

--- a/backend/src/baserow/contrib/builder/elements/trash_types.py
+++ b/backend/src/baserow/contrib/builder/elements/trash_types.py
@@ -1,116 +1,65 @@
-from typing import Any, List, Optional
+from typing import TYPE_CHECKING, List
 
-from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
+from django.contrib.auth.models import AbstractUser
+
 from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.models import Element
 from baserow.contrib.builder.elements.operations import RestoreElementOperationType
+from baserow.core.graph.models import GraphPointTrashableItemType
 from baserow.core.models import TrashEntry
-from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
-from baserow.core.trash.registries import TrashableItemType
 
 from .signals import element_deleted, elements_created
 
+if TYPE_CHECKING:
+    from baserow.contrib.builder.pages.models import Page
 
-class ElementTrashableItemType(TrashableItemType):
+
+class ElementTrashableItemType(GraphPointTrashableItemType):
+    """
+    Trashable item type for `Element`.
+
+    The graph-aware trash/restore behaviour (removing the element from its page
+    graph, cascading to its children and re-inserting everything on restore) is
+    inherited from `GraphPointTrashableItemType`. This class only layers on
+    the builder-specific concerns: emitting the element realtime signals and
+    invalidating the page's element cache.
+    """
+
     type = "builder_element"
     model_class = Element
 
-    def get_parent(self, trashed_item: Element) -> Optional[Any]:
+    def get_parent(self, trashed_item: Element) -> "Page":
         return trashed_item.page
 
-    def get_name(self, trashed_item: Element) -> str:
-        return f"{trashed_item} ({trashed_item.id})".lower()
+    def trash(
+        self,
+        item_to_trash: Element,
+        requesting_user: AbstractUser,
+        trash_entry: TrashEntry,
+    ) -> None:
+        """
+        Trash the element via the base graph logic, then notify clients the element
+        was deleted and invalidate the page's element cache.
+        """
 
-    def get_additional_restoration_data(self, trashed_item: Element):
-        graph = trashed_item.page.get_graph()
-        position_triplet = graph.get_position(trashed_item)
-
-        # Capture all descendants' positions in DFS order before the graph is mutated.
-        # This order also guarantees that each ancestor is restored before any
-        # element that references it, so insert() calls in restore() always succeed.
-        children_positions: List = []
-        for desc in graph.collect_all_descendants(trashed_item):
-            ref_id, position_type, output = graph.get_position(desc)
-            children_positions.append([desc.id, ref_id, position_type, output])
-
-        return {
-            "position": list(position_triplet),
-            "children": children_positions,
-        }
-
-    def trash(self, item_to_trash: Element, requesting_user, trash_entry: TrashEntry):
-        page = item_to_trash.page
         super().trash(item_to_trash, requesting_user, trash_entry)
-        result = page.get_graph().remove(item_to_trash)
-
-        # Soft-delete children removed by the graph cascade so they can be
-        # restored alongside the container. before_delete cleans up related
-        # data (workflow actions, menu items, etc.) before we mark them trashed.
-        for dep in result.dependencies_removed:
-            specific = dep.specific
-            specific.get_type().before_delete(specific)
-            specific.trashed = True
-            specific.save(update_fields=["trashed"])
 
         element_deleted.send(
-            self, element_id=item_to_trash.id, page=page, user=requesting_user
+            self,
+            element_id=item_to_trash.id,
+            page=item_to_trash.page,
+            user=requesting_user,
         )
-        ElementHandler().invalidate_element_cache(page)
+        ElementHandler().invalidate_element_cache(item_to_trash.page)
 
-    def restore(self, trashed_item: Element, trash_entry: TrashEntry):
-        super().restore(trashed_item, trash_entry)
+    def restore(self, trashed_item: Element, trash_entry: TrashEntry) -> None:
+        """
+        Restore the element (and any cascaded children) via the base graph logic,
+        then invalidate the page's element cache and broadcast the restored
+        elements so clients re-create them.
+        """
 
-        data = trash_entry.additional_restoration_data
-        if isinstance(data, dict):
-            position_triplet = data["position"]
-            children_positions = data.get("children", [])
-        else:
-            # Old-format trash entries (plain list): no children to restore.
-            position_triplet = data
-            children_positions = []
-
-        reference_element_id, position_type, output = position_triplet
-        reference_element = None
-        if reference_element_id is not None:
-            try:
-                reference_element = ElementHandler().get_element(
-                    int(reference_element_id)
-                )
-            except ElementDoesNotExist:
-                raise TrashItemRestorationDisallowed(
-                    "This element cannot be restored as its reference element "
-                    "has been deleted."
-                )
-
-        graph = trashed_item.page.get_graph()
-        graph.insert(trashed_item, reference_element, position_type, output)
-
-        # Collect restored elements starting with the container itself.
-        # .specific is needed because element_type_registry serializers expect
-        # the concrete subclass, not the generic Element base instance.
-        restored_elements = [trashed_item.specific]
-
-        # Restore children in DFS order (ancestors before their dependants),
-        # un-trashing each and re-inserting into the graph at its stored position.
-        for child_id, ref_id, child_position_type, child_output in children_positions:
-            try:
-                child = Element.objects_and_trash.get(id=child_id, trashed=True)
-            except Element.DoesNotExist:
-                raise TrashItemRestorationDisallowed(
-                    f"This element cannot be fully restored because a child element "
-                    f"({child_id}) has been permanently deleted."
-                )
-
-            child.trashed = False
-            child.save(update_fields=["trashed"])
-
-            child_reference = None
-            if ref_id is not None:
-                child_reference = Element.objects_and_trash.get(id=int(ref_id))
-
-            graph.insert(child, child_reference, child_position_type, child_output)
-            restored_elements.append(child.specific)
-
+        restored_elements: List[Element] = super().restore(trashed_item, trash_entry)
         ElementHandler().invalidate_element_cache(trashed_item.page)
         elements_created.send(
             self,
@@ -118,27 +67,6 @@ class ElementTrashableItemType(TrashableItemType):
             page=trashed_item.page,
             user=None,
         )
-
-    def permanently_delete_item(
-        self, trashed_item: Element, trash_item_lookup_cache=None
-    ):
-        # Permanently delete any children that were soft-deleted alongside this
-        # container. They have no TrashEntry of their own, so they must be cleaned
-        # up here using the IDs we stored in additional_restoration_data.
-        try:
-            trash_entry = TrashEntry.objects.get(
-                trash_item_type=self.type,
-                trash_item_id=trashed_item.id,
-            )
-            data = trash_entry.additional_restoration_data
-            if isinstance(data, dict):
-                child_ids = [row[0] for row in data.get("children", [])]
-                if child_ids:
-                    Element.trash.filter(id__in=child_ids).delete()
-        except TrashEntry.DoesNotExist:
-            pass
-
-        trashed_item.delete()
 
     def get_restore_operation_type(self) -> str:
         return RestoreElementOperationType.type

--- a/backend/src/baserow/contrib/builder/elements/trash_types.py
+++ b/backend/src/baserow/contrib/builder/elements/trash_types.py
@@ -1,0 +1,144 @@
+from typing import Any, List, Optional
+
+from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
+from baserow.contrib.builder.elements.handler import ElementHandler
+from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.operations import RestoreElementOperationType
+from baserow.core.models import TrashEntry
+from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
+from baserow.core.trash.registries import TrashableItemType
+
+from .signals import element_deleted, elements_created
+
+
+class ElementTrashableItemType(TrashableItemType):
+    type = "builder_element"
+    model_class = Element
+
+    def get_parent(self, trashed_item: Element) -> Optional[Any]:
+        return trashed_item.page
+
+    def get_name(self, trashed_item: Element) -> str:
+        return f"{trashed_item} ({trashed_item.id})".lower()
+
+    def get_additional_restoration_data(self, trashed_item: Element):
+        graph = trashed_item.page.get_graph()
+        position_triplet = graph.get_position(trashed_item)
+
+        # Capture all descendants' positions in DFS order before the graph is mutated.
+        # This order also guarantees that each ancestor is restored before any
+        # element that references it, so insert() calls in restore() always succeed.
+        children_positions: List = []
+        for desc in graph.collect_all_descendants(trashed_item):
+            ref_id, position_type, output = graph.get_position(desc)
+            children_positions.append([desc.id, ref_id, position_type, output])
+
+        return {
+            "position": list(position_triplet),
+            "children": children_positions,
+        }
+
+    def trash(self, item_to_trash: Element, requesting_user, trash_entry: TrashEntry):
+        page = item_to_trash.page
+        super().trash(item_to_trash, requesting_user, trash_entry)
+        result = page.get_graph().remove(item_to_trash)
+
+        # Soft-delete children removed by the graph cascade so they can be
+        # restored alongside the container. before_delete cleans up related
+        # data (workflow actions, menu items, etc.) before we mark them trashed.
+        for dep in result.dependencies_removed:
+            specific = dep.specific
+            specific.get_type().before_delete(specific)
+            specific.trashed = True
+            specific.save(update_fields=["trashed"])
+
+        element_deleted.send(
+            self, element_id=item_to_trash.id, page=page, user=requesting_user
+        )
+        ElementHandler().invalidate_element_cache(page)
+
+    def restore(self, trashed_item: Element, trash_entry: TrashEntry):
+        super().restore(trashed_item, trash_entry)
+
+        data = trash_entry.additional_restoration_data
+        if isinstance(data, dict):
+            position_triplet = data["position"]
+            children_positions = data.get("children", [])
+        else:
+            # Old-format trash entries (plain list): no children to restore.
+            position_triplet = data
+            children_positions = []
+
+        reference_element_id, position_type, output = position_triplet
+        reference_element = None
+        if reference_element_id is not None:
+            try:
+                reference_element = ElementHandler().get_element(
+                    int(reference_element_id)
+                )
+            except ElementDoesNotExist:
+                raise TrashItemRestorationDisallowed(
+                    "This element cannot be restored as its reference element "
+                    "has been deleted."
+                )
+
+        graph = trashed_item.page.get_graph()
+        graph.insert(trashed_item, reference_element, position_type, output)
+
+        # Collect restored elements starting with the container itself.
+        # .specific is needed because element_type_registry serializers expect
+        # the concrete subclass, not the generic Element base instance.
+        restored_elements = [trashed_item.specific]
+
+        # Restore children in DFS order (ancestors before their dependants),
+        # un-trashing each and re-inserting into the graph at its stored position.
+        for child_id, ref_id, child_position_type, child_output in children_positions:
+            try:
+                child = Element.objects_and_trash.get(id=child_id, trashed=True)
+            except Element.DoesNotExist:
+                raise TrashItemRestorationDisallowed(
+                    f"This element cannot be fully restored because a child element "
+                    f"({child_id}) has been permanently deleted."
+                )
+
+            child.trashed = False
+            child.save(update_fields=["trashed"])
+
+            child_reference = None
+            if ref_id is not None:
+                child_reference = Element.objects_and_trash.get(id=int(ref_id))
+
+            graph.insert(child, child_reference, child_position_type, child_output)
+            restored_elements.append(child.specific)
+
+        ElementHandler().invalidate_element_cache(trashed_item.page)
+        elements_created.send(
+            self,
+            elements=restored_elements,
+            page=trashed_item.page,
+            user=None,
+        )
+
+    def permanently_delete_item(
+        self, trashed_item: Element, trash_item_lookup_cache=None
+    ):
+        # Permanently delete any children that were soft-deleted alongside this
+        # container. They have no TrashEntry of their own, so they must be cleaned
+        # up here using the IDs we stored in additional_restoration_data.
+        try:
+            trash_entry = TrashEntry.objects.get(
+                trash_item_type=self.type,
+                trash_item_id=trashed_item.id,
+            )
+            data = trash_entry.additional_restoration_data
+            if isinstance(data, dict):
+                child_ids = [row[0] for row in data.get("children", [])]
+                if child_ids:
+                    Element.trash.filter(id__in=child_ids).delete()
+        except TrashEntry.DoesNotExist:
+            pass
+
+        trashed_item.delete()
+
+    def get_restore_operation_type(self) -> str:
+        return RestoreElementOperationType.type

--- a/backend/src/baserow/contrib/builder/elements/trash_types.py
+++ b/backend/src/baserow/contrib/builder/elements/trash_types.py
@@ -75,5 +75,15 @@ class ElementTrashableItemType(GraphPointTrashableItemType):
             user=None,
         )
 
+    def _before_permanent_delete(self, item: Element) -> None:
+        """
+        Clean up the element's owned related data (e.g. a collection element's
+        fields, a menu element's items) when it is permanently deleted. This runs
+        only on permanent deletion — never at trash time — so that a restore brings
+        the element back with its related data intact.
+        """
+
+        item.get_type().before_delete(item)
+
     def get_restore_operation_type(self) -> str:
         return RestoreElementOperationType.type

--- a/backend/src/baserow/contrib/builder/elements/trash_types.py
+++ b/backend/src/baserow/contrib/builder/elements/trash_types.py
@@ -42,13 +42,20 @@ class ElementTrashableItemType(GraphPointTrashableItemType):
         was deleted and invalidate the page's element cache.
         """
 
-        super().trash(item_to_trash, requesting_user, trash_entry)
+        # The base returns the full set of trashed records (the element plus any
+        # cascaded descendants). Realtime receivers need the descendants separately
+        # so other clients can remove a trashed container's whole subtree.
+        trashed = super().trash(item_to_trash, requesting_user, trash_entry)
+        descendant_ids = [
+            record.id for record in trashed if record.id != item_to_trash.id
+        ]
 
         element_deleted.send(
             self,
             element_id=item_to_trash.id,
             page=item_to_trash.page,
             user=requesting_user,
+            descendant_ids=descendant_ids,
         )
         ElementHandler().invalidate_element_cache(item_to_trash.page)
 

--- a/backend/src/baserow/contrib/builder/elements/types.py
+++ b/backend/src/baserow/contrib/builder/elements/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, NewType, TypedDict, TypeVar, Union
+from typing import Any, Dict, List, NewType, TypedDict, TypeVar, Union
 
 from baserow.contrib.builder.types import ElementDict
 from baserow.core.graph.types import GraphPointPositionType
@@ -26,3 +26,10 @@ class ElementMove:
     previous_output: str
     previous_reference_element: Element | None
     previous_position: GraphPointPositionType
+
+
+@dataclass
+class UpdatedElement:
+    element: Element
+    original_values: Dict[str, Any]
+    new_values: Dict[str, Any]

--- a/backend/src/baserow/contrib/builder/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/contrib/builder/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-15 14:36+0000\n"
+"POT-Creation-Date: 2026-06-15 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,13 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: src/baserow/contrib/builder/action_scopes.py:10
+#, python-format
+msgid ""
+"of type \"%(element_type)s\" on page (%(page_id)s) in builder "
+"\"%(builder_name)s\" (%(builder_id)s)."
+msgstr ""
 
 #: src/baserow/contrib/builder/builder_beta_init_application.py:45
 msgid "Homepage"
@@ -55,9 +62,142 @@ msgstr ""
 msgid "Data source"
 msgstr ""
 
+#: src/baserow/contrib/builder/elements/actions.py:48
+msgid "Create element"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:49
+#, python-format
+msgid "Element (%(element_id)s) created"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:107
+msgid "Update element"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:108
+#, python-format
+msgid "Element (%(element_id)s) updated"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:161
+msgid "Delete element"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:162
+#, python-format
+msgid "Element (%(element_id)s) deleted"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:217
+msgid "Duplicate element"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:218
+#, python-format
+msgid "Element (%(element_id)s) duplicated"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:278
+msgid "Move element"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/actions.py:279
+#, python-format
+msgid "Element (%(element_id)s) moved"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:137
+msgid "Column"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:220
+msgid "Form"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:292
+msgid "Container"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:304
+msgid "Table"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:369
+msgid "Repeat"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:437
+msgid "Record selector"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:686
+msgid "Heading"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:753
+msgid "Text"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:975
+msgid "Link"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1113
+msgid "Image"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1277
+msgid "Rating"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1324
+msgid "Rating input"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1410
+msgid "Input text"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1550
+msgid "Button"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1595
+msgid "Checkbox"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1669
+msgid "Choice"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:1982
+msgid "Iframe"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:2041
+msgid "Date time picker"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:2185
+msgid "Shared header"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:2195
+msgid "Shared footer"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/element_types.py:2205
+msgid "Menu"
+msgstr ""
+
 #: src/baserow/contrib/builder/elements/mixins.py:707
 #: src/baserow/contrib/builder/elements/mixins.py:712
 #: src/baserow/contrib/builder/elements/mixins.py:717
 #, python-format
 msgid "Column %(count)s"
+msgstr ""
+
+#: src/baserow/contrib/builder/elements/registries.py:68
+msgid "Unnamed element"
 msgstr ""

--- a/backend/src/baserow/contrib/builder/pages/models.py
+++ b/backend/src/baserow/contrib/builder/pages/models.py
@@ -21,14 +21,24 @@ if typing.TYPE_CHECKING:
     from baserow.contrib.builder.models import Builder
 
 
-class PageWithoutSharedManager(models.Manager):
+class PageNoTrashManager(models.Manager):
     """
-    Manager for the Page model.
-    Excludes by default the shared page.
+    Default manager for Page: excludes trashed pages.
+    Uses models.Manager (not CTEManager) as the base so that Django can safely
+    use it as the _base_manager for reverse FK relations (e.g. builder.page_set).
     """
 
     def get_queryset(self):
-        return super().get_queryset().filter(shared=False)
+        return super().get_queryset().filter(trashed=False)
+
+
+class PageWithoutSharedManager(models.Manager):
+    """
+    Excludes both the shared page and trashed pages.
+    """
+
+    def get_queryset(self):
+        return super().get_queryset().filter(shared=False, trashed=False)
 
 
 class Page(
@@ -48,7 +58,7 @@ class Page(
         ALLOW_ALL_EXCEPT = "allow_all_except"
         DISALLOW_ALL_EXCEPT = "disallow_all_except"
 
-    objects = models.Manager()
+    objects = PageNoTrashManager()
     objects_without_shared = PageWithoutSharedManager()
 
     builder = models.ForeignKey("builder.Builder", on_delete=models.CASCADE)

--- a/backend/src/baserow/contrib/builder/pages/operations.py
+++ b/backend/src/baserow/contrib/builder/pages/operations.py
@@ -25,3 +25,7 @@ class ReadPageOperationType(BuilderPageOperationType):
 
 class DuplicatePageOperationType(BuilderPageOperationType):
     type = "builder.page.duplicate"
+
+
+class RestorePageOperationType(BuilderPageOperationType):
+    type = "builder.page.restore"

--- a/backend/src/baserow/contrib/builder/pages/service.py
+++ b/backend/src/baserow/contrib/builder/pages/service.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import AbstractUser
 
 from baserow.contrib.builder.models import Builder
 from baserow.contrib.builder.operations import OrderPagesBuilderOperationType
+from baserow.contrib.builder.pages.exceptions import SharedPageIsReadOnly
 from baserow.contrib.builder.pages.handler import PageHandler
 from baserow.contrib.builder.pages.models import Page
 from baserow.contrib.builder.pages.operations import (
@@ -15,12 +16,12 @@ from baserow.contrib.builder.pages.operations import (
 )
 from baserow.contrib.builder.pages.signals import (
     page_created,
-    page_deleted,
     page_updated,
     pages_reordered,
 )
 from baserow.contrib.builder.pages.types import PagePathParams, PageQueryParams
 from baserow.core.handler import CoreHandler
+from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import ChildProgressBuilder, extract_allowed
 
 
@@ -91,6 +92,9 @@ class PageService:
         :param page: The page that must be deleted
         """
 
+        if page.shared:
+            raise SharedPageIsReadOnly()
+
         CoreHandler().check_permissions(
             user,
             DeletePageOperationType.type,
@@ -98,11 +102,8 @@ class PageService:
             context=page,
         )
 
-        page_id = page.id
-
-        self.handler.delete_page(page)
-
-        page_deleted.send(self, builder=page.builder, page_id=page_id, user=user)
+        builder = page.builder
+        TrashHandler.trash(user, builder.workspace, builder, page)
 
     def update_page(self, user: AbstractUser, page: Page, **kwargs) -> Page:
         """

--- a/backend/src/baserow/contrib/builder/pages/trash_types.py
+++ b/backend/src/baserow/contrib/builder/pages/trash_types.py
@@ -1,0 +1,43 @@
+from typing import Any, Optional
+
+from baserow.contrib.builder.pages.handler import PageHandler
+from baserow.contrib.builder.pages.models import Page
+from baserow.contrib.builder.pages.operations import RestorePageOperationType
+from baserow.core.models import TrashEntry
+from baserow.core.trash.registries import TrashableItemType
+
+from .signals import page_created, page_deleted
+
+
+class PageTrashableItemType(TrashableItemType):
+    type = "builder_page"
+    model_class = Page
+
+    def get_parent(self, trashed_item: Page) -> Optional[Any]:
+        return trashed_item.builder
+
+    def get_name(self, trashed_item: Page) -> str:
+        page_name = (
+            trashed_item.name if not trashed_item.shared else trashed_item.builder.name
+        )
+        return f"{page_name} ({trashed_item.id})"
+
+    def trash(self, item_to_trash: Page, requesting_user, trash_entry: TrashEntry):
+        super().trash(item_to_trash, requesting_user, trash_entry)
+        page_deleted.send(
+            self,
+            builder=item_to_trash.builder,
+            page_id=item_to_trash.id,
+            user=requesting_user,
+        )
+
+    def restore(self, trashed_item: Page, trash_entry: TrashEntry):
+        super().restore(trashed_item, trash_entry)
+        PageHandler().invalidate_page_cache(trashed_item)
+        page_created.send(self, page=trashed_item, user=None)
+
+    def permanently_delete_item(self, trashed_item: Page, trash_item_lookup_cache=None):
+        trashed_item.delete()
+
+    def get_restore_operation_type(self) -> str:
+        return RestorePageOperationType.type

--- a/backend/src/baserow/core/graph/handler.py
+++ b/backend/src/baserow/core/graph/handler.py
@@ -736,19 +736,17 @@ class BaseGraphHandler(ABC):
             ref_info = self.get_info(reference_point)
             children_dict = self._get_children_dict(ref_info)
 
+            # The new point always becomes the *head* of the slot's children
+            # chain; the previous head (if any) becomes the new point's next on
+            # the default edge. This mirrors `get_position`, which only ever
+            # reports `(ref, "child", output)` for the head child (subsequent
+            # children are `(prev_sibling, "south", "")`), so prepending keeps
+            # insert the faithful inverse of get_position — required for move
+            # undo/redo to round-trip. It also matches the frontend's
+            # `_insertAt('child')`, keeping the optimistic graph consistent.
             if output in children_dict:
-                # Follow the next[""] chain from the first child to find the
-                # last element in the chain, then append the new point there.
-                current_id = children_dict[output][0]
-                while True:
-                    next_ids = self.get_info(current_id).get("next", {}).get("", [])
-                    if not next_ids:
-                        break
-                    current_id = next_ids[0]
-                self.get_info(current_id).setdefault("next", {})[""] = [point.id]
-            else:
-                # No children yet in this slot — set as the first child.
-                self._set_children(ref_info, output, [point.id])
+                new_next = children_dict[output]
+            self._set_children(ref_info, output, [point.id])
 
         if new_next:
             point_info["next"] = {"": new_next}

--- a/backend/src/baserow/core/graph/handler.py
+++ b/backend/src/baserow/core/graph/handler.py
@@ -913,7 +913,7 @@ class BaseGraphHandler(ABC):
             # insert() sets the correct `next` for the new position.
             descendant_entries = {
                 str(d.id): deepcopy(self.get_info(d))
-                for d in self._collect_all_descendants(point_to_move)
+                for d in self.collect_all_descendants(point_to_move)
             }
             root_children = deepcopy(self.get_info(point_to_move).get("children"))
 

--- a/backend/src/baserow/core/graph/handler.py
+++ b/backend/src/baserow/core/graph/handler.py
@@ -540,9 +540,9 @@ class BaseGraphHandler(ABC):
         :return: The list of descendant points.
         """
 
-        return self._collect_all_descendants(point)
+        return self.collect_all_descendants(point)
 
-    def _collect_all_descendants(self, point: GraphPoint) -> List[GraphPoint]:
+    def collect_all_descendants(self, point: GraphPoint) -> List[GraphPoint]:
         """
         Returns all descendants (direct and transitive children) of a point in
         depth-first order, by recursing into each child returned by get_children.
@@ -551,7 +551,7 @@ class BaseGraphHandler(ABC):
         result = []
         for child in self.get_children(point):
             result.append(child)
-            result.extend(self._collect_all_descendants(child))
+            result.extend(self.collect_all_descendants(child))
         return result
 
     def merge_children_into_place(
@@ -786,7 +786,7 @@ class BaseGraphHandler(ABC):
         if not keep_info:
             # Collect all descendants before touching the graph so that the traversal
             # still has access to the full graph structure.
-            dependencies = self._collect_all_descendants(point_to_delete)
+            dependencies = self.collect_all_descendants(point_to_delete)
             for dep in dependencies:
                 graph.pop(str(dep.id), None)
 
@@ -948,7 +948,7 @@ class BaseGraphHandler(ABC):
             removed.
         """
 
-        for dep in self._collect_all_descendants(point):
+        for dep in self.collect_all_descendants(point):
             self.graph.pop(str(dep.id), None)
         self.graph.pop(str(point.id), None)
         self._update_graph()

--- a/backend/src/baserow/core/graph/models.py
+++ b/backend/src/baserow/core/graph/models.py
@@ -416,11 +416,22 @@ class GraphPointTrashableItemType(TrashableItemType):
         item_to_trash: "GraphPointMixin",
         requesting_user,
         trash_entry: "TrashEntry",
-    ):
+    ) -> List["GraphPointMixin"]:
+        """
+        Trash the point and (unless the graph is left untouched) the subtree it
+        cascades to.
+
+        :return: The definitive set of records that were trashed, as `.specific`
+            instances, starting with the point itself followed by any cascaded
+            descendants in DFS order. Mirrors `restore`, which returns the same
+            shape for the records it brings back, so subclasses can broadcast the
+            full set without recomputing the cascade.
+        """
+
         super().trash(item_to_trash, requesting_user, trash_entry)
 
         if not self._should_mutate_graph(trash_entry):
-            return
+            return [item_to_trash.specific]
 
         result = item_to_trash.get_parent().get_graph().remove(item_to_trash)
 
@@ -431,6 +442,11 @@ class GraphPointTrashableItemType(TrashableItemType):
             self._before_cascade_delete(specific)
             specific.trashed = True
             specific.save(update_fields=["trashed"])
+
+        return [
+            item_to_trash.specific,
+            *(dep.specific for dep in result.dependencies_removed),
+        ]
 
     def restore(self, trashed_item: "GraphPointMixin", trash_entry: "TrashEntry"):
         position_triplet, children_positions, hierarchical_parent_id = (

--- a/backend/src/baserow/core/graph/models.py
+++ b/backend/src/baserow/core/graph/models.py
@@ -1,4 +1,3 @@
-from decimal import Decimal
 from typing import TYPE_CHECKING, List, Optional, Self
 
 from django.core.exceptions import ObjectDoesNotExist

--- a/backend/src/baserow/core/graph/models.py
+++ b/backend/src/baserow/core/graph/models.py
@@ -280,12 +280,12 @@ class GraphPointTrashableItemType(TrashableItemType):
     Subclasses override `trash` / `restore` to call `super()` and then send
     their own realtime signals and invalidate their own caches. `restore`
     returns the list of restored (`.specific`) records so subclasses can
-    broadcast them. The small hooks below (`_should_mutate_graph`,
-    `_before_cascade_delete`, `_validate_reference`) cover the per-type
+    broadcast them. The small hooks below (`should_mutate_graph`,
+    `before_cascade_delete`, `validate_reference`) cover the per-type
     differences without forcing every subclass to reimplement the algorithm.
     """
 
-    def _should_mutate_graph(self, trash_entry: "TrashEntry") -> bool:
+    def should_mutate_graph(self, trash_entry: "TrashEntry") -> bool:
         """
         Whether trash/restore should mutate the graph. Defaults to `True`.
         Subclasses whose trash operation rearranges the graph itself (e.g. an
@@ -294,16 +294,16 @@ class GraphPointTrashableItemType(TrashableItemType):
 
         return True
 
-    def _before_cascade_delete(self, descendant: "GraphPointMixin"):
+    def before_cascade_delete(self, descendant: "GraphPointMixin"):
         """
         Run on each descendant soft-deleted by the trash cascade, before it is
         marked trashed. Defaults to a no-op: trashing must be fully reversible, so a
         type's owned related data is cleaned up only on permanent deletion (see
-        `_before_permanent_delete`), never here. Subclasses may override to react to
+        `before_permanent_delete`), never here. Subclasses may override to react to
         the cascade without destroying restorable data.
         """
 
-    def _before_permanent_delete(self, item: "GraphPointMixin"):
+    def before_permanent_delete(self, item: "GraphPointMixin"):
         """
         Run on the point (and each cascaded child) just before it is permanently
         deleted, so types can clean up owned related data that the database cascade
@@ -312,7 +312,7 @@ class GraphPointTrashableItemType(TrashableItemType):
         :param item: The `.specific` instance about to be permanently deleted.
         """
 
-    def _validate_reference(self, reference: Optional["GraphPointMixin"], output: str):
+    def validate_reference(self, reference: Optional["GraphPointMixin"], output: str):
         """
         Validate the resolved reference point before re-insertion on restore.
         Defaults to a no-op. Subclasses can override (e.g. to check the reference's
@@ -438,7 +438,7 @@ class GraphPointTrashableItemType(TrashableItemType):
 
         super().trash(item_to_trash, requesting_user, trash_entry)
 
-        if not self._should_mutate_graph(trash_entry):
+        if not self.should_mutate_graph(trash_entry):
             return [item_to_trash.specific]
 
         result = item_to_trash.get_parent().get_graph().remove(item_to_trash)
@@ -447,7 +447,7 @@ class GraphPointTrashableItemType(TrashableItemType):
         # alongside their container.
         for dep in result.dependencies_removed:
             specific = dep.specific
-            self._before_cascade_delete(specific)
+            self.before_cascade_delete(specific)
             specific.trashed = True
             specific.save(update_fields=["trashed"])
 
@@ -461,7 +461,7 @@ class GraphPointTrashableItemType(TrashableItemType):
             self._parse_restoration_data(trash_entry.additional_restoration_data)
         )
 
-        mutate_graph = self._should_mutate_graph(trash_entry)
+        mutate_graph = self.should_mutate_graph(trash_entry)
         if mutate_graph:
             # Block restoration up-front (before un-trashing) when the parent
             # container is still trashed, naming the record to restore first.
@@ -477,7 +477,7 @@ class GraphPointTrashableItemType(TrashableItemType):
 
         reference_id, position_type, output = position_triplet
         reference = self._resolve_reference(reference_id)
-        self._validate_reference(reference, output)
+        self.validate_reference(reference, output)
 
         graph = trashed_item.get_parent().get_graph()
         graph.insert(trashed_item, reference, position_type, output)
@@ -530,9 +530,9 @@ class GraphPointTrashableItemType(TrashableItemType):
         # Clean up owned related data (e.g. collection fields) now, at permanent
         # deletion. This is intentionally not done at trash time so a restore can
         # bring the item back intact.
-        self._before_permanent_delete(trashed_item.specific)
+        self.before_permanent_delete(trashed_item.specific)
         for child in children:
-            self._before_permanent_delete(child.specific)
+            self.before_permanent_delete(child.specific)
 
         if child_ids:
             self.model_class.trash.filter(id__in=child_ids).delete()

--- a/backend/src/baserow/core/graph/models.py
+++ b/backend/src/baserow/core/graph/models.py
@@ -297,12 +297,20 @@ class GraphPointTrashableItemType(TrashableItemType):
     def _before_cascade_delete(self, descendant: "GraphPointMixin"):
         """
         Run on each descendant soft-deleted by the trash cascade, before it is
-        marked trashed. Defaults to running the type's `before_delete` so related
-        data is cleaned up. Subclasses can override (e.g. to skip a container guard
-        that would otherwise reject deleting a node that still has children).
+        marked trashed. Defaults to a no-op: trashing must be fully reversible, so a
+        type's owned related data is cleaned up only on permanent deletion (see
+        `_before_permanent_delete`), never here. Subclasses may override to react to
+        the cascade without destroying restorable data.
         """
 
-        descendant.get_type().before_delete(descendant)
+    def _before_permanent_delete(self, item: "GraphPointMixin"):
+        """
+        Run on the point (and each cascaded child) just before it is permanently
+        deleted, so types can clean up owned related data that the database cascade
+        won't remove (e.g. a collection element's fields). Defaults to a no-op.
+
+        :param item: The `.specific` instance about to be permanently deleted.
+        """
 
     def _validate_reference(self, reference: Optional["GraphPointMixin"], output: str):
         """
@@ -505,6 +513,7 @@ class GraphPointTrashableItemType(TrashableItemType):
         # Permanently delete any children that were soft-deleted alongside this
         # container. They have no TrashEntry of their own, so they must be cleaned
         # up here using the IDs we stored in additional_restoration_data.
+        child_ids: List[int] = []
         try:
             trash_entry = TrashEntry.objects.get(
                 trash_item_type=self.type,
@@ -513,9 +522,19 @@ class GraphPointTrashableItemType(TrashableItemType):
             data = trash_entry.additional_restoration_data
             if isinstance(data, dict):
                 child_ids = [row[0] for row in data.get("children", [])]
-                if child_ids:
-                    self.model_class.trash.filter(id__in=child_ids).delete()
         except TrashEntry.DoesNotExist:
             pass
+
+        children = list(self.model_class.trash.filter(id__in=child_ids))
+
+        # Clean up owned related data (e.g. collection fields) now, at permanent
+        # deletion. This is intentionally not done at trash time so a restore can
+        # bring the item back intact.
+        self._before_permanent_delete(trashed_item.specific)
+        for child in children:
+            self._before_permanent_delete(child.specific)
+
+        if child_ids:
+            self.model_class.trash.filter(id__in=child_ids).delete()
 
         trashed_item.delete()

--- a/backend/src/baserow/core/graph/models.py
+++ b/backend/src/baserow/core/graph/models.py
@@ -1,5 +1,7 @@
-from typing import Self
+from decimal import Decimal
+from typing import TYPE_CHECKING, List, Optional, Self
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -10,6 +12,11 @@ from baserow.core.graph.types import (
     GraphPointPositionType,
     SerializedGraph,
 )
+from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
+from baserow.core.trash.registries import TrashableItemType
+
+if TYPE_CHECKING:
+    from baserow.core.models import TrashEntry
 
 
 class GraphModelMixin(models.Model):
@@ -38,7 +45,7 @@ class GraphModelMixin(models.Model):
 
         If the cached handler was seeded by a *different* Python instance of the
         same row (e.g. a freshly fetched reference_element.page), we rebind it
-        to ``self`` so that mutations remain visible via ``self.graph``.
+        to `self` so that mutations remain visible via `self.graph`.
         """
 
         handler_class = self.get_graph_handler()
@@ -222,7 +229,7 @@ class GraphPointMixin:
 
     def get_parent_point(self) -> Self | None:
         """
-        Returns the direct parent container point, or ``None`` if this point
+        Returns the direct parent container point, or `None` if this point
         has no parent. Uses the cached previous-position map so the chain is
         resolved with O(depth) dict lookups rather than a full graph traversal.
         """
@@ -258,3 +265,242 @@ class GraphPointMixin:
         """
 
         return self._get_graph().get_next_points(self, output_uid)
+
+
+class GraphPointTrashableItemType(TrashableItemType):
+    """
+    A base trashable item type for models that are points in a graph - i.e. they
+    inherit `GraphPointMixin` and live inside a parent's `GraphModelMixin`
+    graph (builder elements, automation nodes).
+
+    It centralises the graph-aware trash/restore logic:
+    - Capturing a point's position (and its descendants') before trashing,
+    - Removing it from the graph and soft-deleting any cascaded children on trash,
+    - Re-inserting the point and its children at their stored positions on restore.
+
+    Subclasses override `trash` / `restore` to call `super()` and then send
+    their own realtime signals and invalidate their own caches. `restore`
+    returns the list of restored (`.specific`) records so subclasses can
+    broadcast them. The small hooks below (`_should_mutate_graph`,
+    `_before_cascade_delete`, `_validate_reference`) cover the per-type
+    differences without forcing every subclass to reimplement the algorithm.
+    """
+
+    def _should_mutate_graph(self, trash_entry: "TrashEntry") -> bool:
+        """
+        Whether trash/restore should mutate the graph. Defaults to `True`.
+        Subclasses whose trash operation rearranges the graph itself (e.g. an
+        automation node "replace") return `False` to skip the remove/insert.
+        """
+
+        return True
+
+    def _before_cascade_delete(self, descendant: "GraphPointMixin"):
+        """
+        Run on each descendant soft-deleted by the trash cascade, before it is
+        marked trashed. Defaults to running the type's `before_delete` so related
+        data is cleaned up. Subclasses can override (e.g. to skip a container guard
+        that would otherwise reject deleting a node that still has children).
+        """
+
+        descendant.get_type().before_delete(descendant)
+
+    def _validate_reference(self, reference: Optional["GraphPointMixin"], output: str):
+        """
+        Validate the resolved reference point before re-insertion on restore.
+        Defaults to a no-op. Subclasses can override (e.g. to check the reference's
+        output/branch still exists).
+        """
+
+    def _resolve_reference(
+        self, reference_id: Optional[int]
+    ) -> Optional["GraphPointMixin"]:
+        """
+        Resolve the reference point a restored item attaches to, distinguishing a
+        permanently deleted reference from a merely trashed one so the user gets an
+        actionable message naming what to restore first.
+        """
+
+        if reference_id is None:
+            return None
+
+        reference = self.model_class.objects_and_trash.filter(id=reference_id).first()
+        if reference is None:
+            raise TrashItemRestorationDisallowed(
+                "This record cannot be restored as its reference record "
+                "has been deleted."
+            )
+        if reference.trashed:
+            raise TrashItemRestorationDisallowed(
+                f"This record cannot be restored until {reference} "
+                f"({reference.id}) is restored first."
+            )
+        return reference.specific
+
+    def _assert_hierarchical_parent_not_trashed(
+        self, hierarchical_parent_id: Optional[int]
+    ):
+        """
+        Refuse restoration when the point's parent point is itself trashed.
+
+        Only the immediate parent needs checking: the graph is a connected tree, so
+        a non-trashed parent is guaranteed to be in the graph together with all of
+        its own ancestors. The recursion across nesting levels therefore happens
+        naturally — restoring a deeply nested point first requires restoring its
+        parent, which in turn requires restoring its grandparent, and so on.
+
+        :param hierarchical_parent_id: The id of the parent container, or None.
+        :raises TrashItemRestorationDisallowed: If the parent is still trashed.
+        """
+
+        if hierarchical_parent_id is None:
+            return
+
+        parent = self.model_class.objects_and_trash.filter(
+            id=hierarchical_parent_id
+        ).first()
+        if parent is not None and parent.trashed:
+            raise TrashItemRestorationDisallowed(
+                f"This record cannot be restored until its parent "
+                f"{parent} ({parent.id}) is restored first."
+            )
+
+    def get_name(self, trashed_item: "GraphPointMixin") -> str:
+        name = f"{trashed_item} ({trashed_item.id})"
+        # Mention the parent container (if any) so that, when restoration is blocked
+        # because the parent is still trashed, the user can tell which record they
+        # need to restore first.
+        parent = trashed_item.get_parent_point()
+        if parent is not None:
+            name += f" inside {parent} ({parent.id})"
+        return name.lower()
+
+    def get_additional_restoration_data(self, trashed_item: "GraphPointMixin"):
+        graph = trashed_item.get_parent().get_graph()
+        position_triplet = graph.get_position(trashed_item)
+
+        # The container this point lives in (None for top-level points). Captured
+        # while still in the graph so restore() can refuse if the parent is trashed.
+        parent = trashed_item.get_parent_point()
+
+        # Capture all descendants' positions in DFS order before the graph is
+        # mutated. This order also guarantees that each ancestor is restored before
+        # any point that references it, so insert() calls in restore() succeed.
+        children_positions: List = []
+        for desc in graph.collect_all_descendants(trashed_item):
+            ref_id, position_type, output = graph.get_position(desc)
+            children_positions.append([desc.id, ref_id, position_type, output])
+
+        return {
+            "position": list(position_triplet),
+            "hierarchical_parent_id": parent.id if parent is not None else None,
+            "children": children_positions,
+        }
+
+    def _parse_restoration_data(self, data):
+        """
+        Read the position triplet, children and hierarchical parent from the stored
+        restoration data, tolerating the legacy bare-tuple shape (old automation
+        entries) which only carried the position.
+        """
+
+        if isinstance(data, dict):
+            return (
+                data["position"],
+                data.get("children", []),
+                data.get("hierarchical_parent_id"),
+            )
+        return data, [], None
+
+    def trash(
+        self,
+        item_to_trash: "GraphPointMixin",
+        requesting_user,
+        trash_entry: "TrashEntry",
+    ):
+        super().trash(item_to_trash, requesting_user, trash_entry)
+
+        if not self._should_mutate_graph(trash_entry):
+            return
+
+        result = item_to_trash.get_parent().get_graph().remove(item_to_trash)
+
+        # Soft-delete children removed by the graph cascade so they can be restored
+        # alongside their container.
+        for dep in result.dependencies_removed:
+            specific = dep.specific
+            self._before_cascade_delete(specific)
+            specific.trashed = True
+            specific.save(update_fields=["trashed"])
+
+    def restore(self, trashed_item: "GraphPointMixin", trash_entry: "TrashEntry"):
+        position_triplet, children_positions, hierarchical_parent_id = (
+            self._parse_restoration_data(trash_entry.additional_restoration_data)
+        )
+
+        mutate_graph = self._should_mutate_graph(trash_entry)
+        if mutate_graph:
+            # Block restoration up-front (before un-trashing) when the parent
+            # container is still trashed, naming the record to restore first.
+            self._assert_hierarchical_parent_not_trashed(hierarchical_parent_id)
+
+        super().restore(trashed_item, trash_entry)
+
+        # Collect restored records starting with the point itself. .specific is
+        # needed because type registry serializers expect the concrete subclass.
+        restored_records = [trashed_item.specific]
+        if not mutate_graph:
+            return restored_records
+
+        reference_id, position_type, output = position_triplet
+        reference = self._resolve_reference(reference_id)
+        self._validate_reference(reference, output)
+
+        graph = trashed_item.get_parent().get_graph()
+        graph.insert(trashed_item, reference, position_type, output)
+
+        # Restore children in DFS order (ancestors before their dependants),
+        # un-trashing each and re-inserting into the graph at its stored position.
+        for child_id, ref_id, child_position_type, child_output in children_positions:
+            try:
+                child = self.model_class.objects_and_trash.get(
+                    id=child_id, trashed=True
+                )
+            except ObjectDoesNotExist:
+                raise TrashItemRestorationDisallowed(
+                    f"This record cannot be fully restored because a child record "
+                    f"({child_id}) has been permanently deleted."
+                )
+
+            child.trashed = False
+            child.save(update_fields=["trashed"])
+
+            child_reference = None
+            if ref_id is not None:
+                child_reference = self.model_class.objects_and_trash.get(id=int(ref_id))
+
+            graph.insert(child, child_reference, child_position_type, child_output)
+            restored_records.append(child.specific)
+
+        return restored_records
+
+    def permanently_delete_item(self, trashed_item, trash_item_lookup_cache=None):
+        from baserow.core.models import TrashEntry
+
+        # Permanently delete any children that were soft-deleted alongside this
+        # container. They have no TrashEntry of their own, so they must be cleaned
+        # up here using the IDs we stored in additional_restoration_data.
+        try:
+            trash_entry = TrashEntry.objects.get(
+                trash_item_type=self.type,
+                trash_item_id=trashed_item.id,
+            )
+            data = trash_entry.additional_restoration_data
+            if isinstance(data, dict):
+                child_ids = [row[0] for row in data.get("children", [])]
+                if child_ids:
+                    self.model_class.trash.filter(id__in=child_ids).delete()
+        except TrashEntry.DoesNotExist:
+            pass
+
+        trashed_item.delete()

--- a/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-15 14:36+0000\n"
+"POT-Creation-Date: 2026-06-15 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -242,7 +242,7 @@ msgstr ""
 msgid "Decimal number"
 msgstr ""
 
-#: src/baserow/core/graph/models.py:157
+#: src/baserow/core/graph/models.py:163
 msgid "Unlabeled"
 msgstr ""
 

--- a/backend/src/baserow/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-15 14:36+0000\n"
+"POT-Creation-Date: 2026-06-15 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -110,8 +110,80 @@ msgstr ""
 msgid "Node (%(node_id)s) moved"
 msgstr ""
 
-#: src/baserow/contrib/automation/nodes/node_types.py:268
+#: src/baserow/contrib/automation/nodes/node_types.py:133
+msgid "Local Baserow create row"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:140
+msgid "Local Baserow update row"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:147
+msgid "Local Baserow delete row"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:155
+msgid "Local Baserow get row"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:163
+msgid "Local Baserow list rows"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:171
+msgid "Local Baserow aggregate rows"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:179
+msgid "HTTP request"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:186
+msgid "Iterator"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:199
+msgid "Send email"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:206
+msgid "AI agent"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:213
+msgid "Router"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:279
 msgid "Branch"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:408
+msgid "Local Baserow rows created"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:416
+msgid "Local Baserow rows updated"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:424
+msgid "Local Baserow rows deleted"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:434
+msgid "Periodic trigger"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:441
+msgid "HTTP trigger"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/node_types.py:448
+msgid "Slack write message"
+msgstr ""
+
+#: src/baserow/contrib/automation/nodes/registries.py:47
+msgid "Unnamed node"
 msgstr ""
 
 #: src/baserow/contrib/automation/notification_types.py:57

--- a/backend/src/baserow/test_utils/fixtures/element.py
+++ b/backend/src/baserow/test_utils/fixtures/element.py
@@ -163,11 +163,23 @@ class ElementFixtures:
         place_in_container = kwargs.pop("place_in_container", None)
         # For "child" positions, the output determines the container slot.
         # For all other positions (south/north), the graph edge is always "".
-        output = (
-            place_in_container
-            if position == GraphPointPosition.CHILD and place_in_container is not None
-            else last_output
-        )
+        if position == GraphPointPosition.CHILD and place_in_container is not None:
+            # Mirror the real editor, which appends a new element after the last
+            # existing child of the target slot. A raw insert(..., CHILD, ...)
+            # would instead make it the slot's new head (CHILD prepends, to stay
+            # the inverse of get_position), reversing the order tests create
+            # their children in. Only an empty slot falls back to a CHILD insert.
+            existing_children = page.get_graph().get_children(
+                reference_element, output=place_in_container, first_only=False
+            )
+            if existing_children:
+                reference_element = existing_children[-1]
+                position = GraphPointPosition.SOUTH
+                output = ""
+            else:
+                output = place_in_container
+        else:
+            output = last_output
 
         with local_cache.context():  # We make sure the cache is empty
             created_element = ElementHandler().create_element(

--- a/backend/tests/baserow/contrib/automation/nodes/test_node_trash_types.py
+++ b/backend/tests/baserow/contrib/automation/nodes/test_node_trash_types.py
@@ -1,5 +1,6 @@
 import pytest
 
+from baserow.contrib.automation.nodes.models import AutomationNode
 from baserow.contrib.automation.nodes.trash_types import AutomationNodeTrashableItemType
 from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
 from baserow.core.trash.handler import TrashHandler
@@ -29,11 +30,11 @@ def test_trashing_and_restoring_node_updates_graph(data_fixture):
     automation = workflow.automation
     trash_entry = TrashHandler.trash(user, automation.workspace, automation, first)
 
-    assert trash_entry.additional_restoration_data == (
-        str(trigger.id),
-        "south",
-        "",
-    )
+    assert trash_entry.additional_restoration_data == {
+        "position": [str(trigger.id), "south", ""],
+        "hierarchical_parent_id": None,
+        "children": [],
+    }
 
     workflow.assert_reference(
         {
@@ -105,11 +106,11 @@ def test_trashing_and_restoring_node_updates_graph_with_router(data_fixture):
         user, automation.workspace, automation, second_router
     )
 
-    assert trash_entry.additional_restoration_data == (
-        str(initial_router.id),
-        "south",
-        str(initial_router_edge.uid),
-    )
+    assert trash_entry.additional_restoration_data == {
+        "position": [str(initial_router.id), "south", str(initial_router_edge.uid)],
+        "hierarchical_parent_id": None,
+        "children": [],
+    }
 
     workflow.assert_reference(
         {
@@ -180,3 +181,87 @@ def test_restoring_a_trashed_output_node_after_its_edge_is_destroyed_is_disallow
         exc.value.args[0] == "This automation node cannot "
         "be restored as its branch has been deleted."
     )
+
+
+@pytest.mark.django_db
+def test_restoring_node_whose_reference_is_still_trashed_is_disallowed(data_fixture):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user)
+    first = data_fixture.create_local_baserow_create_row_action_node(
+        workflow=workflow, label="first action"
+    )
+    second = data_fixture.create_local_baserow_create_row_action_node(
+        workflow=workflow, label="second action"
+    )
+
+    automation = workflow.automation
+
+    # Trash the second node first (its reference is the first node), then trash the
+    # first node too. Both have their own trash entry.
+    TrashHandler.trash(user, automation.workspace, automation, second)
+    TrashHandler.trash(user, automation.workspace, automation, first)
+
+    # The second node cannot be restored while its reference node is still trashed.
+    # The message names the node that must be restored first rather than misleadingly
+    # claiming the reference was deleted.
+    with pytest.raises(TrashItemRestorationDisallowed) as exc:
+        TrashHandler.restore_item(
+            user,
+            AutomationNodeTrashableItemType.type,
+            second.id,
+        )
+
+    assert exc.value.args[0] == (
+        f"This record cannot be restored until {first} ({first.id}) is restored first."
+    )
+
+    second.refresh_from_db()
+    assert second.trashed is True
+
+    # Once the reference node is restored, the second node can be restored too.
+    TrashHandler.restore_item(user, AutomationNodeTrashableItemType.type, first.id)
+    TrashHandler.restore_item(user, AutomationNodeTrashableItemType.type, second.id)
+
+    second.refresh_from_db()
+    first.refresh_from_db()
+    assert second.trashed is False
+    assert first.trashed is False
+
+
+@pytest.mark.django_db
+def test_trashing_container_node_cascades_children_and_restore_brings_them_back(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    workflow = data_fixture.create_automation_workflow(user)
+    iterator = data_fixture.create_core_iterator_action_node(
+        workflow=workflow, label="iterator"
+    )
+    child = data_fixture.create_automation_node(
+        workflow=workflow, label="child", reference_node=iterator, position="child"
+    )
+
+    automation = workflow.automation
+    trash_entry = TrashHandler.trash(user, automation.workspace, automation, iterator)
+
+    # Container is trashed; the child is soft-deleted alongside it (cascade).
+    iterator.refresh_from_db()
+    assert iterator.trashed is True
+    assert not AutomationNode.objects.filter(id=child.id).exists()
+    assert AutomationNode.trash.filter(id=child.id).exists()
+
+    # Restoration data records the child so it can be restored with the container.
+    child_ids = [row[0] for row in trash_entry.additional_restoration_data["children"]]
+    assert child.id in child_ids
+
+    # Restore brings the container and its child back into the graph.
+    TrashHandler.restore_item(user, AutomationNodeTrashableItemType.type, iterator.id)
+
+    iterator.refresh_from_db()
+    child.refresh_from_db()
+    assert iterator.trashed is False
+    assert child.trashed is False
+
+    workflow.refresh_from_db(fields=["graph"])
+    assert str(iterator.id) in workflow.graph
+    assert str(child.id) in workflow.graph

--- a/backend/tests/baserow/contrib/automation/nodes/test_node_types.py
+++ b/backend/tests/baserow/contrib/automation/nodes/test_node_types.py
@@ -698,3 +698,15 @@ def test_periodic_trigger_node_on_event_only_updates_dispatched_services(data_fi
         # `trigger_node_b2` is the only due service which we've found to be
         # appropriate for dispatching (its workflow is live/published).
         assert list(services_dispatched) == [trigger_node_b2.service]
+
+
+@pytest.mark.parametrize(
+    "node_type",
+    [pytest.param(nt, id=nt.type) for nt in automation_node_type_registry.get_all()],
+)
+def test_automation_node_type_has_display_name(node_type):
+    from django.utils.translation import gettext_lazy as _
+
+    assert node_type.display_name != _("Unnamed"), (
+        f"{type(node_type).__name__}.display_name is still the default 'Unnamed'"
+    )

--- a/backend/tests/baserow/contrib/automation/nodes/test_node_types.py
+++ b/backend/tests/baserow/contrib/automation/nodes/test_node_types.py
@@ -707,6 +707,6 @@ def test_periodic_trigger_node_on_event_only_updates_dispatched_services(data_fi
 def test_automation_node_type_has_display_name(node_type):
     from django.utils.translation import gettext_lazy as _
 
-    assert node_type.display_name != _("Unnamed"), (
-        f"{type(node_type).__name__}.display_name is still the default 'Unnamed'"
+    assert node_type.display_name != _("Unnamed element"), (
+        f"{type(node_type).__name__}.display_name is still the default 'Unnamed element'"
     )

--- a/backend/tests/baserow/contrib/automation/workflows/test_automation_trash_types.py
+++ b/backend/tests/baserow/contrib/automation/workflows/test_automation_trash_types.py
@@ -21,7 +21,7 @@ def test_workflow_trashable_get_name(data_fixture):
 
     result = AutomationWorkflowTrashableItemType().get_name(workflow)
 
-    assert result == workflow.name
+    assert result == f"{workflow.name} ({workflow.id})"
 
 
 def get_trash_entry(user, workflow):

--- a/backend/tests/baserow/contrib/automation/workflows/test_graph_handler.py
+++ b/backend/tests/baserow/contrib/automation/workflows/test_graph_handler.py
@@ -403,12 +403,14 @@ def test_graph_handler_get_siblings(mock_get_points, node_id, expected_result):
                 "0": 1,
                 "1": {"next": {"": [2]}},
                 "2": {"next": {"": [3]}},
-                "3": {"children": [7], "next": {"": [4]}},
+                # The new child is prepended as the head of the slot; the previous
+                # head (7) becomes its next.
+                "3": {"children": {"": [11]}, "next": {"": [4]}},
+                "11": {"next": {"": [7]}},
                 "4": {"next": {"": [5], "randomUid": [9]}},
                 "7": {"next": {"": [8]}},
-                "8": {"children": [], "next": {"": [11]}},
+                "8": {"children": []},
                 "9": {},
-                "11": {},
             },
         ),
         (
@@ -823,11 +825,13 @@ def test_graph_handler_replace(
             {
                 "0": 1,
                 "1": {"next": {"": [3]}},
-                "2": {},
-                "3": {"children": [7], "next": {"": [4]}},
+                # Moved in as the head of node 3's child slot; the previous head (7)
+                # becomes the moved node's next.
+                "3": {"children": {"": [2]}, "next": {"": [4]}},
+                "2": {"next": {"": [7]}},
                 "4": {"next": {"": [5], "randomUid": [9]}},
                 "7": {"next": {"": [8]}},
-                "8": {"children": [], "next": {"": [2]}},
+                "8": {"children": []},
                 "9": {},
             },
         ),

--- a/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
@@ -20,7 +20,16 @@ from baserow.contrib.builder.elements.models import (
 )
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
+from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.core.graph.types import GraphPointPosition
+
+
+def pytest_generate_tests(metafunc):
+    if "element_type" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "element_type",
+            [pytest.param(e, id=e.type) for e in element_type_registry.get_all()],
+        )
 
 
 @pytest.mark.django_db
@@ -1247,12 +1256,11 @@ def test_choice_options_updated(api_client, data_fixture):
 
 
 @pytest.mark.django_db
-def test_choice_options_deleted(api_client, data_fixture):
+def test_choice_options_preserved_on_trash(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     page = data_fixture.create_builder_page(user=user)
     choice_element = data_fixture.create_builder_choice_element(page=page)
 
-    # Add an existing option
     ChoiceElementOption.objects.create(choice=choice_element)
 
     url = reverse("api:builder:element:item", kwargs={"element_id": choice_element.id})
@@ -1263,7 +1271,10 @@ def test_choice_options_deleted(api_client, data_fixture):
     )
 
     assert response.status_code == HTTP_204_NO_CONTENT
-    assert ChoiceElementOption.objects.count() == 0
+    # Trashing soft-deletes the element; options survive so they can be
+    # restored together with the element. Django's CASCADE only fires on
+    # permanent deletion (permanently_delete_item → .delete()).
+    assert ChoiceElementOption.objects.count() == 1
 
 
 @pytest.mark.django_db
@@ -1489,3 +1500,69 @@ def test_list_elements_heals_orphan_on_shared_page(api_client, data_fixture):
     graph_patch = json.loads(response["X-Baserow-Builder-Graph-Patch"])
     assert str(orphan.id) in graph_patch
     assert str(header.id) in graph_patch
+
+
+@pytest.mark.django_db
+def test_element_trash_and_restore_lifecycle(api_client, data_fixture, element_type):
+    user, token = data_fixture.create_user_and_token()
+
+    if element_type.is_multi_page_element:
+        builder = data_fixture.create_builder_application(user=user)
+        page = builder.shared_page
+    else:
+        page = data_fixture.create_builder_page(user=user)
+
+    if element_type.is_deactivated(page.builder.workspace):
+        pytest.skip(f"{element_type.type} is deactivated in this workspace")
+
+    response = api_client.post(
+        reverse("api:builder:element:list", kwargs={"page_id": page.id}),
+        {"type": element_type.type},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK, response.json()
+    element_id = response.json()["id"]
+
+    # For containers, add a HeadingElement child so we can assert that children
+    # are soft-deleted alongside the parent and restored with it.
+    # Refresh the page so its cached graph reflects the element just created by the API.
+    child_id = None
+    if element_type.is_container:
+        page.refresh_from_db(fields=["graph"])
+        parent_element = Element.objects.get(id=element_id)
+        child = data_fixture.create_builder_heading_element(
+            page=page,
+            position=GraphPointPosition.CHILD,
+            reference_element=parent_element,
+            place_in_container="0",
+        )
+        child_id = child.id
+
+    response = api_client.delete(
+        reverse("api:builder:element:item", kwargs={"element_id": element_id}),
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+    element_row = Element.objects_and_trash.get(id=element_id)
+    assert element_row.trashed is True
+
+    if child_id is not None:
+        child_row = Element.objects_and_trash.get(id=child_id)
+        assert child_row.trashed is True
+
+    response = api_client.patch(
+        reverse("api:trash:restore"),
+        {"trash_item_type": "builder_element", "trash_item_id": element_id},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+    element_row.refresh_from_db()
+    assert element_row.trashed is False
+
+    if child_id is not None:
+        child_row.refresh_from_db()
+        assert child_row.trashed is False

--- a/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
@@ -20,7 +20,6 @@ from baserow.contrib.builder.elements.models import (
 )
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
-from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.core.graph.types import GraphPointPosition
 from baserow.core.trash.handler import TrashHandler
 

--- a/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
+++ b/backend/tests/baserow/contrib/builder/api/elements/test_element_views.py
@@ -22,6 +22,7 @@ from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.core.graph.types import GraphPointPosition
+from baserow.core.trash.handler import TrashHandler
 
 
 def pytest_generate_tests(metafunc):
@@ -1503,7 +1504,8 @@ def test_list_elements_heals_orphan_on_shared_page(api_client, data_fixture):
 
 
 @pytest.mark.django_db
-def test_element_trash_and_restore_lifecycle(api_client, data_fixture, element_type):
+def test_element_full_lifecycle(api_client, data_fixture, element_type):
+    # create → trash → verify → restore → verify → trash → permanently delete → verify
     user, token = data_fixture.create_user_and_token()
 
     if element_type.is_multi_page_element:
@@ -1566,3 +1568,15 @@ def test_element_trash_and_restore_lifecycle(api_client, data_fixture, element_t
     if child_id is not None:
         child_row.refresh_from_db()
         assert child_row.trashed is False
+
+    response = api_client.delete(
+        reverse("api:builder:element:item", kwargs={"element_id": element_id}),
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_204_NO_CONTENT
+
+    TrashHandler.permanently_delete(element_row)
+
+    assert not Element.objects_and_trash.filter(id=element_id).exists()
+    if child_id is not None:
+        assert not Element.objects_and_trash.filter(id=child_id).exists()

--- a/backend/tests/baserow/contrib/builder/elements/test_element_actions.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_actions.py
@@ -1,0 +1,197 @@
+import uuid
+
+import pytest
+
+from baserow.contrib.builder.action_scopes import (
+    PageActionScopeType,
+    SharedPageActionScopeType,
+)
+from baserow.contrib.builder.elements.actions import (
+    CreateElementActionType,
+    DeleteElementActionType,
+    DuplicateElementActionType,
+    MoveElementActionType,
+    UpdateElementActionType,
+)
+from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.registries import element_type_registry
+from baserow.core.action.handler import ActionHandler
+
+
+def _next_id(page, element_id):
+    # The graph handler is cached per page id within the test process and mutated
+    # in place by the action's do/undo/redo, so reading it back reflects the
+    # current state without re-fetching from the database. Returns the id of the
+    # element directly after ``element_id`` on the default edge.
+    return page.get_graph().graph[str(element_id)]["next"][""][0]
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_create_element_action(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+    heading_type = element_type_registry.get("heading")
+
+    element = CreateElementActionType.do(user, heading_type, page, {})
+
+    assert Element.objects.filter(id=element.id).exists()
+    assert str(element.id) in page.get_graph().graph
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db(fields=["trashed"])
+    assert element.trashed
+    assert str(element.id) not in page.get_graph().graph
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db(fields=["trashed"])
+    assert not element.trashed
+    assert str(element.id) in page.get_graph().graph
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_update_element_action(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_heading_element(page=page, level=1)
+
+    UpdateElementActionType.do(user, element, {"level": 3})
+
+    element.refresh_from_db()
+    assert element.level == 3
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db()
+    assert element.level == 1
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db()
+    assert element.level == 3
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_delete_element_action(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_heading_element(page=page)
+
+    DeleteElementActionType.do(user, element)
+
+    element.refresh_from_db(fields=["trashed"])
+    assert element.trashed
+    assert str(element.id) not in page.get_graph().graph
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db(fields=["trashed"])
+    assert not element.trashed
+    assert str(element.id) in page.get_graph().graph
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    element.refresh_from_db(fields=["trashed"])
+    assert element.trashed
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_duplicate_element_action(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_heading_element(page=page)
+
+    result = DuplicateElementActionType.do(user, element)
+    duplicated = result["elements"][0]
+
+    assert duplicated.id != element.id
+    assert Element.objects.filter(id=duplicated.id).exists()
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    duplicated.refresh_from_db(fields=["trashed"])
+    assert duplicated.trashed
+    # The source element is untouched.
+    element.refresh_from_db(fields=["trashed"])
+    assert not element.trashed
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    duplicated.refresh_from_db(fields=["trashed"])
+    assert not duplicated.trashed
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_move_element_action(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+    first = data_fixture.create_builder_heading_element(page=page)
+    second = data_fixture.create_builder_heading_element(page=page)
+    third = data_fixture.create_builder_heading_element(page=page)
+
+    # Initial chain: first -> second -> third.
+    assert _next_id(page, first.id) == second.id
+
+    # Move third to be south of first: first -> third -> second.
+    MoveElementActionType.do(
+        user,
+        third,
+        page,
+        "",
+        first.id,
+        "south",
+    )
+
+    assert _next_id(page, first.id) == third.id
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    assert _next_id(page, first.id) == second.id
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    assert _next_id(page, first.id) == third.id
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_shared_element_action_is_scoped_to_shared_page(data_fixture):
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    builder = data_fixture.create_builder_application(user=user)
+    content_page = data_fixture.create_builder_page(builder=builder)
+    shared_page = builder.shared_page
+    header_type = element_type_registry.get("header")
+
+    # A header element lives on the builder's shared page.
+    element = CreateElementActionType.do(user, header_type, shared_page, {})
+    assert Element.objects.filter(id=element.id).exists()
+
+    # The content page scope alone must NOT undo a shared element's action.
+    ActionHandler.undo(user, [PageActionScopeType.value(content_page.id)], session_id)
+    element.refresh_from_db(fields=["trashed"])
+    assert not element.trashed
+
+    # The shared page scope (sent by the editor alongside the content page) does.
+    ActionHandler.undo(
+        user, [SharedPageActionScopeType.value(shared_page.id)], session_id
+    )
+    element.refresh_from_db(fields=["trashed"])
+    assert element.trashed
+
+    ActionHandler.redo(
+        user, [SharedPageActionScopeType.value(shared_page.id)], session_id
+    )
+    element.refresh_from_db(fields=["trashed"])
+    assert not element.trashed

--- a/backend/tests/baserow/contrib/builder/elements/test_element_actions.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_actions.py
@@ -13,9 +13,12 @@ from baserow.contrib.builder.elements.actions import (
     MoveElementActionType,
     UpdateElementActionType,
 )
+from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.models import Element
 from baserow.contrib.builder.elements.registries import element_type_registry
+from baserow.contrib.builder.elements.service import ElementService
 from baserow.core.action.handler import ActionHandler
+from baserow.core.graph.types import GraphPointPosition
 
 
 def _next_id(page, element_id):
@@ -162,6 +165,69 @@ def test_move_element_action(data_fixture):
     ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
 
     assert _next_id(page, first.id) == third.id
+
+
+@pytest.mark.django_db
+@pytest.mark.undo_redo
+def test_move_element_out_of_container_undo_restores_head_child_position(
+    data_fixture,
+):
+    # Regression: moving the *first* child out of a container and then undoing
+    # must put it back as the head of the container's child chain (before its
+    # former sibling), not appended after it. get_position reports "child" only
+    # for the head child, so the move undo replays insert(..., "child", ...),
+    # which must therefore prepend.
+    session_id = str(uuid.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    page = data_fixture.create_builder_page(user=user)
+
+    container = ElementService().create_element(
+        user, element_type_registry.get("simple_container"), page=page
+    )
+    child1 = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="",
+    )
+    child2 = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.SOUTH,
+        reference_element=child1,
+        place_in_container="",
+    )
+    outside = data_fixture.create_builder_heading_element(page=page)
+
+    # The container's "" slot chain is child1 -> child2.
+    assert page.get_graph().graph[str(container.id)]["children"][""] == [child1.id]
+    assert _next_id(page, child1.id) == child2.id
+
+    # Move child1 (the head child) out, to be south of the outside element.
+    MoveElementActionType.do(
+        user,
+        ElementHandler().get_element_for_update(child1.id),
+        page,
+        "",
+        outside.id,
+        GraphPointPosition.SOUTH,
+    )
+
+    graph = page.get_graph().graph
+    assert graph[str(container.id)]["children"][""] == [child2.id]
+    assert _next_id(page, outside.id) == child1.id
+
+    ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    # child1 is back as the *head* child, before child2 — not appended after it.
+    graph = page.get_graph().graph
+    assert graph[str(container.id)]["children"][""] == [child1.id]
+    assert _next_id(page, child1.id) == child2.id
+
+    ActionHandler.redo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    graph = page.get_graph().graph
+    assert graph[str(container.id)]["children"][""] == [child2.id]
+    assert _next_id(page, outside.id) == child1.id
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/elements/test_element_handler.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_handler.py
@@ -161,51 +161,6 @@ def test_get_builder_elements(
 
 
 @pytest.mark.django_db
-def test_delete_element(data_fixture):
-    element = data_fixture.create_builder_heading_element()
-
-    ElementHandler().delete_element(element)
-
-    assert Element.objects.count() == 0
-
-
-@pytest.mark.django_db
-def test_delete_container_element_deletes_children(data_fixture):
-    page = data_fixture.create_builder_page()
-    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
-    child1 = data_fixture.create_builder_heading_element(
-        page=page,
-        position=GraphPointPosition.CHILD,
-        reference_element=container,
-        place_in_container="0",
-    )
-    child2 = data_fixture.create_builder_column_element(
-        page=page,
-        column_amount=1,
-        position=GraphPointPosition.CHILD,
-        reference_element=container,
-        place_in_container="1",
-    )
-    grandchild = data_fixture.create_builder_heading_element(
-        page=page,
-        position=GraphPointPosition.CHILD,
-        reference_element=child2,
-        place_in_container="0",
-    )
-
-    ElementHandler().delete_element(container)
-
-    assert not Element.objects.filter(
-        id__in=[container.id, child1.id, child2.id, grandchild.id]
-    ).exists()
-
-    page.refresh_from_db(fields=["graph"])
-    for element_id in [container.id, child1.id, child2.id, grandchild.id]:
-        assert str(element_id) not in page.graph
-    assert page.graph == {}
-
-
-@pytest.mark.django_db
 def test_update_element(data_fixture):
     user = data_fixture.create_user()
     element = data_fixture.create_builder_heading_element(user=user)

--- a/backend/tests/baserow/contrib/builder/elements/test_element_service.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_service.py
@@ -343,21 +343,62 @@ def test_get_builder_elements(data_fixture, stub_check_permissions):
 
 
 @pytest.mark.django_db
-@patch("baserow.contrib.builder.elements.service.element_deleted")
-def test_delete_element(element_deleted_mock, data_fixture):
+def test_delete_element(data_fixture):
     user = data_fixture.create_user()
     element = data_fixture.create_builder_heading_element(user=user)
+    element_id = element.id
 
-    service = ElementService()
-    service.delete_element(user, element)
+    ElementService().delete_element(user, element)
 
-    element_deleted_mock.send.assert_called_once_with(
-        service,
-        element_id=element.id,
-        descendant_ids=[],
-        page=element.page,
-        user=user,
+    element.refresh_from_db()
+    assert element.trashed is True
+    assert not Element.objects.filter(id=element_id, trashed=False).exists()
+
+
+@pytest.mark.django_db
+def test_delete_container_element_removes_container_and_graph_entries(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
+    child1 = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="0",
     )
+    child2 = data_fixture.create_builder_column_element(
+        page=page,
+        column_amount=1,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="1",
+    )
+    grandchild = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=child2,
+        place_in_container="0",
+    )
+
+    ElementService().delete_element(user, container)
+
+    container.refresh_from_db()
+    assert container.trashed is True
+
+    # Children are soft-deleted (trashed) alongside the container so they can be
+    # restored if the container is restored. Not accessible via the default manager.
+    assert not Element.objects.filter(
+        id__in=[child1.id, child2.id, grandchild.id]
+    ).exists()
+    assert (
+        Element.trash.filter(id__in=[child1.id, child2.id, grandchild.id]).count() == 3
+    )
+
+    # All graph entries for the container and its descendants are gone.
+    page.refresh_from_db(fields=["graph"])
+    for element_id in [container.id, child1.id, child2.id, grandchild.id]:
+        assert str(element_id) not in page.graph
+    assert page.graph == {}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/backend/tests/baserow/contrib/builder/elements/test_element_service.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_service.py
@@ -670,6 +670,23 @@ def test_move_element_not_same_builder(data_fixture, stub_check_permissions):
 
 
 @pytest.mark.django_db
+def test_move_element_relative_to_itself_is_disallowed(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    element = data_fixture.create_builder_heading_element(page=page)
+
+    with pytest.raises(GraphPointReferencePointInvalid):
+        ElementService().move_element(
+            user,
+            page,
+            element,
+            element.place_in_container,
+            element.id,  # the element references itself
+            GraphPointPosition.SOUTH,
+        )
+
+
+@pytest.mark.django_db
 def test_move_element_permission_denied(data_fixture, stub_check_permissions):
     user = data_fixture.create_user()
     page = data_fixture.create_builder_page(user=user)

--- a/backend/tests/baserow/contrib/builder/elements/test_element_service.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_service.py
@@ -420,10 +420,10 @@ def test_update_element(element_updated_mock, data_fixture):
     element = data_fixture.create_builder_heading_element(user=user)
 
     service = ElementService()
-    element_updated = service.update_element(user, element, value="newValue")
+    updated = service.update_element(user, element, value="newValue")
 
     element_updated_mock.send.assert_called_once_with(
-        service, element=element_updated, user=user
+        service, element=updated.element, user=user
     )
 
 

--- a/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
@@ -16,9 +16,9 @@ def test_trashing_and_restoring_element_updates_graph(data_fixture):
 
     page.assert_reference(
         {
-            "0": "heading",
-            "heading": {"next": {"": ["heading-"]}},
-            "heading-": {},
+            "0": "heading-0",
+            "heading-0": {"next": {"": ["heading-1"]}},
+            "heading-1": {},
         }
     )
 
@@ -34,8 +34,8 @@ def test_trashing_and_restoring_element_updates_graph(data_fixture):
     page.refresh_from_db()
     page.assert_reference(
         {
-            "0": "heading",
-            "heading": {},
+            "0": "heading-0",
+            "heading-0": {},
         }
     )
 
@@ -48,9 +48,9 @@ def test_trashing_and_restoring_element_updates_graph(data_fixture):
     page.refresh_from_db()
     page.assert_reference(
         {
-            "0": "heading",
-            "heading": {"next": {"": ["heading-"]}},
-            "heading-": {},
+            "0": "heading-0",
+            "heading-0": {"next": {"": ["heading-1"]}},
+            "heading-1": {},
         }
     )
 

--- a/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
@@ -27,6 +27,7 @@ def test_trashing_and_restoring_element_updates_graph(data_fixture):
 
     assert trash_entry.additional_restoration_data == {
         "position": [None, "south", ""],
+        "hierarchical_parent_id": None,
         "children": [],
     }
 
@@ -66,6 +67,7 @@ def test_trashing_second_element_stores_reference_to_first(data_fixture):
 
     assert trash_entry.additional_restoration_data == {
         "position": [str(first.id), "south", ""],
+        "hierarchical_parent_id": None,
         "children": [],
     }
 
@@ -90,7 +92,7 @@ def test_restoring_element_after_reference_deleted_is_disallowed(data_fixture):
         )
 
     assert exc.value.args[0] == (
-        "This element cannot be restored as its reference element has been deleted."
+        "This record cannot be restored as its reference record has been deleted."
     )
 
 
@@ -140,3 +142,89 @@ def test_trashing_container_soft_deletes_children_and_restore_brings_them_back(
     page.refresh_from_db(fields=["graph"])
     for element_id in [container.id, child1.id, child2.id]:
         assert str(element_id) in page.graph
+
+
+@pytest.mark.django_db
+def test_trashing_child_records_its_parent(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
+    child = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="0",
+    )
+
+    builder = page.builder
+    trash_entry = TrashHandler.trash(user, builder.workspace, builder, child)
+
+    # The child's restoration data records the container as its parent so that the
+    # restore can later refuse if the parent is still trashed.
+    assert (
+        trash_entry.additional_restoration_data["hierarchical_parent_id"]
+        == container.id
+    )
+
+
+@pytest.mark.django_db
+def test_get_name_mentions_parent_for_nested_element(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
+    child = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="0",
+    )
+
+    name = ElementTrashableItemType().get_name(child)
+
+    assert name == f"heading ({child.id}) inside column ({container.id})"
+
+
+@pytest.mark.django_db
+def test_restoring_child_before_parent_is_disallowed(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
+    child = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="0",
+    )
+
+    builder = page.builder
+
+    # Trash the child first, then its parent container. Both have their own entry.
+    TrashHandler.trash(user, builder.workspace, builder, child)
+    TrashHandler.trash(user, builder.workspace, builder, container)
+
+    # The child cannot be restored while its parent is still trashed. The message
+    # names the parent so the user knows what to restore first.
+    with pytest.raises(TrashItemRestorationDisallowed) as exc:
+        TrashHandler.restore_item(user, ElementTrashableItemType.type, child.id)
+
+    assert exc.value.args[0] == (
+        f"This record cannot be restored until its parent "
+        f"Column ({container.id}) is restored first."
+    )
+
+    # The child is still trashed (the failed restore rolled back).
+    child.refresh_from_db()
+    assert child.trashed is True
+
+    # Once the parent is restored, the child can be restored too.
+    TrashHandler.restore_item(user, ElementTrashableItemType.type, container.id)
+    TrashHandler.restore_item(user, ElementTrashableItemType.type, child.id)
+
+    child.refresh_from_db()
+    container.refresh_from_db()
+    assert child.trashed is False
+    assert container.trashed is False
+
+    page.refresh_from_db(fields=["graph"])
+    assert str(child.id) in page.graph
+    assert str(container.id) in page.graph

--- a/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
@@ -1,6 +1,8 @@
 import pytest
 
-from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.handler import ElementHandler
+from baserow.contrib.builder.elements.models import CollectionField, Element
+from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.elements.trash_types import ElementTrashableItemType
 from baserow.core.graph.types import GraphPointPosition
 from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
@@ -228,3 +230,76 @@ def test_restoring_child_before_parent_is_disallowed(data_fixture):
     page.refresh_from_db(fields=["graph"])
     assert str(child.id) in page.graph
     assert str(container.id) in page.graph
+
+
+@pytest.mark.django_db
+def test_trashing_collection_element_preserves_its_fields(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table = data_fixture.create_builder_table_element(page=page, user=user)
+
+    field_ids = set(table.fields.values_list("id", flat=True))
+    assert len(field_ids) > 0
+
+    ElementService().delete_element(
+        user, ElementHandler().get_element_for_update(table.id)
+    )
+
+    table.refresh_from_db()
+    assert table.trashed is True
+    # The fields must not be destroyed by the soft delete.
+    assert set(table.fields.values_list("id", flat=True)) == field_ids
+
+    TrashHandler.restore_item(user, ElementTrashableItemType.type, table.id)
+
+    table.refresh_from_db()
+    assert table.trashed is False
+    assert set(table.fields.values_list("id", flat=True)) == field_ids
+
+
+@pytest.mark.django_db
+def test_trashing_container_preserves_child_collection_fields(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, user=user)
+    table = data_fixture.create_builder_table_element(
+        page=page,
+        user=user,
+        reference_element=container,
+        position=GraphPointPosition.CHILD,
+        place_in_container="0",
+    )
+
+    field_ids = set(table.fields.values_list("id", flat=True))
+    assert len(field_ids) > 0
+
+    ElementService().delete_element(
+        user, ElementHandler().get_element_for_update(container.id)
+    )
+
+    table.refresh_from_db()
+    assert table.trashed is True
+    assert set(table.fields.values_list("id", flat=True)) == field_ids
+
+    TrashHandler.restore_item(user, ElementTrashableItemType.type, container.id)
+
+    table.refresh_from_db()
+    assert table.trashed is False
+    assert set(table.fields.values_list("id", flat=True)) == field_ids
+
+
+@pytest.mark.django_db
+def test_permanently_deleting_collection_element_removes_its_fields(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table = data_fixture.create_builder_table_element(page=page, user=user)
+    field_ids = list(table.fields.values_list("id", flat=True))
+    assert len(field_ids) > 0
+
+    element = ElementHandler().get_element_for_update(table.id)
+    ElementService().delete_element(user, element)
+
+    TrashHandler.permanently_delete(element)
+
+    assert not Element.objects.filter(id=table.id).exists()
+    assert not CollectionField.objects.filter(id__in=field_ids).exists()

--- a/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_trash_types.py
@@ -1,0 +1,142 @@
+import pytest
+
+from baserow.contrib.builder.elements.models import Element
+from baserow.contrib.builder.elements.trash_types import ElementTrashableItemType
+from baserow.core.graph.types import GraphPointPosition
+from baserow.core.trash.exceptions import TrashItemRestorationDisallowed
+from baserow.core.trash.handler import TrashHandler
+
+
+@pytest.mark.django_db
+def test_trashing_and_restoring_element_updates_graph(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    first = data_fixture.create_builder_heading_element(page=page)
+    second = data_fixture.create_builder_heading_element(page=page)
+
+    page.assert_reference(
+        {
+            "0": "heading",
+            "heading": {"next": {"": ["heading-"]}},
+            "heading-": {},
+        }
+    )
+
+    builder = page.builder
+    trash_entry = TrashHandler.trash(user, builder.workspace, builder, first)
+
+    assert trash_entry.additional_restoration_data == {
+        "position": [None, "south", ""],
+        "children": [],
+    }
+
+    page.refresh_from_db()
+    page.assert_reference(
+        {
+            "0": "heading",
+            "heading": {},
+        }
+    )
+
+    TrashHandler.restore_item(
+        user,
+        ElementTrashableItemType.type,
+        first.id,
+    )
+
+    page.refresh_from_db()
+    page.assert_reference(
+        {
+            "0": "heading",
+            "heading": {"next": {"": ["heading-"]}},
+            "heading-": {},
+        }
+    )
+
+
+@pytest.mark.django_db
+def test_trashing_second_element_stores_reference_to_first(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    first = data_fixture.create_builder_heading_element(page=page)
+    second = data_fixture.create_builder_heading_element(page=page)
+
+    builder = page.builder
+    trash_entry = TrashHandler.trash(user, builder.workspace, builder, second)
+
+    assert trash_entry.additional_restoration_data == {
+        "position": [str(first.id), "south", ""],
+        "children": [],
+    }
+
+
+@pytest.mark.django_db
+def test_restoring_element_after_reference_deleted_is_disallowed(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    first = data_fixture.create_builder_heading_element(page=page)
+    second = data_fixture.create_builder_heading_element(page=page)
+
+    builder = page.builder
+    TrashHandler.trash(user, builder.workspace, builder, second)
+
+    first.delete()
+
+    with pytest.raises(TrashItemRestorationDisallowed) as exc:
+        TrashHandler.restore_item(
+            user,
+            ElementTrashableItemType.type,
+            second.id,
+        )
+
+    assert exc.value.args[0] == (
+        "This element cannot be restored as its reference element has been deleted."
+    )
+
+
+@pytest.mark.django_db
+def test_trashing_container_soft_deletes_children_and_restore_brings_them_back(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    container = data_fixture.create_builder_column_element(page=page, column_amount=2)
+    child1 = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="0",
+    )
+    child2 = data_fixture.create_builder_heading_element(
+        page=page,
+        position=GraphPointPosition.CHILD,
+        reference_element=container,
+        place_in_container="1",
+    )
+
+    builder = page.builder
+    trash_entry = TrashHandler.trash(user, builder.workspace, builder, container)
+
+    # Container is trashed; children are soft-deleted too (not accessible via objects).
+    assert container.trashed is True
+    assert not Element.objects.filter(id__in=[child1.id, child2.id]).exists()
+    assert Element.trash.filter(id__in=[child1.id, child2.id]).count() == 2
+
+    # Restoration data records both the container's own position and its children.
+    data = trash_entry.additional_restoration_data
+    assert data["position"] == [None, "south", ""]
+    assert len(data["children"]) == 2
+    child_ids = [row[0] for row in data["children"]]
+    assert child1.id in child_ids
+    assert child2.id in child_ids
+
+    # After restore the container and its children are all back in the graph.
+    TrashHandler.restore_item(user, ElementTrashableItemType.type, container.id)
+
+    container.refresh_from_db()
+    assert container.trashed is False
+    assert Element.objects.filter(id__in=[child1.id, child2.id]).count() == 2
+
+    page.refresh_from_db(fields=["graph"])
+    for element_id in [container.id, child1.id, child2.id]:
+        assert str(element_id) in page.graph

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -1607,6 +1607,6 @@ def test_datetime_picker_element_is_valid(
 def test_element_type_has_display_name(element_type):
     from django.utils.translation import gettext_lazy as _
 
-    assert element_type.display_name != _("Unnamed"), (
-        f"{type(element_type).__name__}.display_name is still the default 'Unnamed'"
+    assert element_type.display_name != _("Unnamed node"), (
+        f"{type(element_type).__name__}.display_name is still the default 'Unnamed node'"
     )

--- a/backend/tests/baserow/contrib/builder/elements/test_element_types.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_types.py
@@ -1602,3 +1602,11 @@ def test_datetime_picker_element_is_valid(
             element_type.is_valid(element, value, {})
     else:
         assert str(element_type.is_valid(element, value, {})) == expected
+
+
+def test_element_type_has_display_name(element_type):
+    from django.utils.translation import gettext_lazy as _
+
+    assert element_type.display_name != _("Unnamed"), (
+        f"{type(element_type).__name__}.display_name is still the default 'Unnamed'"
+    )

--- a/backend/tests/baserow/contrib/builder/elements/test_header_footer_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_header_footer_element_type.py
@@ -56,10 +56,14 @@ def test_header_footer_prepare_value_for_db(data_fixture, element_type):
         [page1.id, page2.id]
     )
 
-    updated_element = ElementService().update_element(
-        user,
-        created_element,
-        pages=[page1, page4, shared_page],
+    updated_element = (
+        ElementService()
+        .update_element(
+            user,
+            created_element,
+            pages=[page1, page4, shared_page],
+        )
+        .element
     )
 
     assert sorted([p.id for p in updated_element.pages.all()]) == sorted([page1.id])

--- a/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
@@ -13,6 +13,7 @@ from baserow.contrib.builder.workflow_actions.models import NotificationWorkflow
 from baserow.core.formula import BaserowFormulaObject
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
+from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import MirrorDict
 from baserow.test_utils.helpers import AnyInt
 
@@ -393,11 +394,19 @@ def test_all_workflow_actions_removed_when_menu_element_deleted(
     assert updated_menu_element.menu_items.count() == 2
     assert NotificationWorkflowAction.objects.count() == 2
 
-    # Trash the Menu element; before_delete cleans up menu items and workflow actions.
+    # Deleting only soft-trashes the element. Its menu items and workflow actions
+    # must survive so a restore can bring them back.
     ElementService().delete_element(menu_element_fixture["user"], menu_element)
 
-    # There should be no Menu Element, Menu items, or Notifications remaining
     assert MenuElement.objects.count() == 0
+    assert MenuItemElement.objects.count() == 2
+    assert NotificationWorkflowAction.objects.count() == 2
+
+    # Permanently deleting the element cleans up the menu items and their
+    # associated workflow actions.
+    TrashHandler.permanently_delete(menu_element)
+
+    assert MenuElement.objects_and_trash.count() == 0
     assert MenuItemElement.objects.count() == 0
     assert NotificationWorkflowAction.objects.count() == 0
 
@@ -452,9 +461,11 @@ def test_import_export(menu_element_fixture, data_fixture):
     exported = menu_element_type.export_serialized(menu_element)
     assert json.dumps(exported)
 
+    # Permanently delete so no Menu element or its items remain before re-importing.
     ElementService().delete_element(menu_element_fixture["user"], menu_element)
+    TrashHandler.permanently_delete(menu_element)
 
-    assert MenuElement.objects.count() == 0
+    assert MenuElement.objects_and_trash.count() == 0
     assert MenuItemElement.objects.count() == 0
 
     # After importing the Menu element the menu items should be correctly
@@ -516,7 +527,9 @@ def test_delete_duplicated_menu_doesnt_affect_initial_element(
 
     assert NotificationWorkflowAction.objects.count() == 2
 
+    # Permanently delete the clone so its workflow action is cleaned up.
     ElementService().delete_element(menu_element_fixture["user"], element)
+    TrashHandler.permanently_delete(element)
 
     # We want to make sure that deleting the clone doesn't delete the initial event
     assert NotificationWorkflowAction.objects.count() == 1

--- a/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
@@ -8,6 +8,7 @@ import pytest
 from baserow.contrib.builder.api.elements.serializers import MenuItemSerializer
 from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.models import MenuElement, MenuItemElement
+from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.workflow_actions.models import NotificationWorkflowAction
 from baserow.core.formula import BaserowFormulaObject
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
@@ -28,6 +29,7 @@ def menu_element_fixture(data_fixture):
     menu_element = data_fixture.create_builder_menu_element(user=user, page=page_a)
 
     return {
+        "user": user,
         "page_a": page_a,
         "page_b": page_b,
         "menu_element": menu_element,
@@ -391,8 +393,8 @@ def test_all_workflow_actions_removed_when_menu_element_deleted(
     assert updated_menu_element.menu_items.count() == 2
     assert NotificationWorkflowAction.objects.count() == 2
 
-    # Delete the Menu element, which will cascade delete all menu items
-    ElementHandler().delete_element(menu_element)
+    # Trash the Menu element; before_delete cleans up menu items and workflow actions.
+    ElementService().delete_element(menu_element_fixture["user"], menu_element)
 
     # There should be no Menu Element, Menu items, or Notifications remaining
     assert MenuElement.objects.count() == 0
@@ -450,7 +452,7 @@ def test_import_export(menu_element_fixture, data_fixture):
     exported = menu_element_type.export_serialized(menu_element)
     assert json.dumps(exported)
 
-    ElementHandler().delete_element(menu_element)
+    ElementService().delete_element(menu_element_fixture["user"], menu_element)
 
     assert MenuElement.objects.count() == 0
     assert MenuItemElement.objects.count() == 0
@@ -514,7 +516,7 @@ def test_delete_duplicated_menu_doesnt_affect_initial_element(
 
     assert NotificationWorkflowAction.objects.count() == 2
 
-    ElementHandler().delete_element(element)
+    ElementService().delete_element(menu_element_fixture["user"], element)
 
     # We want to make sure that deleting the clone doesn't delete the initial event
     assert NotificationWorkflowAction.objects.count() == 1

--- a/backend/tests/baserow/contrib/builder/elements/test_table_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_table_element_type.py
@@ -17,6 +17,7 @@ from baserow.contrib.builder.workflow_actions.models import NotificationWorkflow
 from baserow.core.formula import BaserowFormulaObject
 from baserow.core.formula.field import BASEROW_FORMULA_VERSION_INITIAL
 from baserow.core.formula.types import BASEROW_FORMULA_MODE_SIMPLE
+from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import MirrorDict
 
 
@@ -167,8 +168,13 @@ def test_delete_table_element_remove_fields(data_fixture):
 
     assert CollectionField.objects.count() == 3
 
+    # Deleting only soft-trashes the element; its fields must survive so a restore
+    # can bring them back.
     ElementService().delete_element(user, table_element)
+    assert CollectionField.objects.count() == 3
 
+    # Permanently deleting the element removes the fields for good.
+    TrashHandler.permanently_delete(table_element)
     assert CollectionField.objects.count() == 0
 
 
@@ -385,7 +391,13 @@ def test_delete_table_element_removes_associated_workflow_actions(data_fixture):
     )
 
     assert NotificationWorkflowAction.objects.count() == 1
+
+    # Deleting only soft-trashes the element; its fields' workflow actions survive.
     ElementService().delete_element(user, table_element)
+    assert NotificationWorkflowAction.objects.count() == 1
+
+    # Permanently deleting the element removes the associated workflow actions.
+    TrashHandler.permanently_delete(table_element)
     assert NotificationWorkflowAction.objects.count() == 0
 
 

--- a/backend/tests/baserow/contrib/builder/pages/test_page_service.py
+++ b/backend/tests/baserow/contrib/builder/pages/test_page_service.py
@@ -2,7 +2,10 @@ from unittest.mock import patch
 
 import pytest
 
-from baserow.contrib.builder.pages.exceptions import PageNotInBuilder
+from baserow.contrib.builder.pages.exceptions import (
+    PageNotInBuilder,
+    SharedPageIsReadOnly,
+)
 from baserow.contrib.builder.pages.models import Page
 from baserow.contrib.builder.pages.service import PageService
 from baserow.core.exceptions import UserNotInWorkspace
@@ -29,20 +32,16 @@ def test_create_page_user_not_in_workspace(data_fixture):
         PageService().create_page(user, builder, "test", "/test")
 
 
-@patch("baserow.contrib.builder.pages.service.page_deleted")
 @pytest.mark.django_db
-def test_page_deleted_signal_sent(page_deleted_mock, data_fixture):
+def test_delete_page_moves_to_trash(data_fixture):
     user = data_fixture.create_user()
     builder = data_fixture.create_builder_application(user=user)
     page = data_fixture.create_builder_page(builder=builder)
-    page_id = page.id
 
-    page_service = PageService()
-    page_service.delete_page(user, page)
+    PageService().delete_page(user, page)
 
-    page_deleted_mock.send.assert_called_once_with(
-        page_service, builder=builder, page_id=page_id, user=user
-    )
+    page.refresh_from_db()
+    assert page.trashed is True
 
 
 @pytest.mark.django_db(transaction=True)
@@ -163,3 +162,23 @@ def test_duplicate_page_user_not_in_workspace(data_fixture):
 
     with pytest.raises(UserNotInWorkspace):
         PageService().duplicate_page(user, page)
+
+
+@pytest.mark.django_db
+def test_delete_shared_page_raises_error(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+
+    with pytest.raises(SharedPageIsReadOnly):
+        PageService().delete_page(user, builder.shared_page)
+
+
+@pytest.mark.django_db
+def test_trashed_page_excluded_from_objects_manager(data_fixture):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+
+    PageService().delete_page(user, page)
+
+    assert not Page.objects.filter(id=page.id).exists()
+    assert Page.objects_and_trash.filter(id=page.id).exists()

--- a/backend/tests/baserow/contrib/builder/pages/test_page_trash_types.py
+++ b/backend/tests/baserow/contrib/builder/pages/test_page_trash_types.py
@@ -1,0 +1,97 @@
+import pytest
+
+from baserow.contrib.builder.pages.models import Page
+from baserow.contrib.builder.pages.trash_types import PageTrashableItemType
+from baserow.core.models import TrashEntry
+
+
+@pytest.mark.django_db
+def test_page_trashable_get_parent(data_fixture):
+    page = data_fixture.create_builder_page()
+
+    result = PageTrashableItemType().get_parent(page)
+
+    assert result == page.builder
+
+
+@pytest.mark.django_db
+def test_page_trashable_get_name(data_fixture):
+    page = data_fixture.create_builder_page(name="My Page")
+
+    result = PageTrashableItemType().get_name(page)
+
+    assert result == f"My Page ({page.id})"
+
+
+@pytest.mark.django_db
+def test_page_trashable_get_name_shared_page_uses_builder_name(data_fixture):
+    builder = data_fixture.create_builder_application(name="My Builder")
+    shared_page = builder.shared_page
+
+    result = PageTrashableItemType().get_name(shared_page)
+
+    assert result == f"My Builder ({shared_page.id})"
+
+
+def make_trash_entry(user, page):
+    return TrashEntry.objects.create(
+        user_who_trashed=user,
+        workspace=page.builder.workspace,
+        application=page.builder,
+        trash_item_type=PageTrashableItemType.type,
+        trash_item_id=page.id,
+        name=PageTrashableItemType().get_name(page),
+        names=PageTrashableItemType().get_names(page),
+    )
+
+
+@pytest.mark.django_db
+def test_page_trashable_trash(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(builder=builder)
+
+    trash_entry = make_trash_entry(user, page)
+    result = PageTrashableItemType().trash(page, user, trash_entry)
+
+    assert result is None
+    page.refresh_from_db()
+    assert page.trashed is True
+
+
+@pytest.mark.django_db
+def test_page_trashable_restore(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(builder=builder)
+
+    trash_entry = make_trash_entry(user, page)
+    PageTrashableItemType().trash(page, user, trash_entry)
+    page.refresh_from_db()
+    assert page.trashed is True
+
+    result = PageTrashableItemType().restore(page, trash_entry)
+
+    assert result is None
+    page.refresh_from_db()
+    assert page.trashed is False
+
+
+@pytest.mark.django_db
+def test_page_trashable_permanently_delete_item(data_fixture):
+    user = data_fixture.create_user()
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(builder=builder)
+    page_id = page.id
+
+    trash_entry = make_trash_entry(user, page)
+    PageTrashableItemType().trash(page, user, trash_entry)
+    PageTrashableItemType().permanently_delete_item(page)
+
+    assert Page.objects.filter(id=page_id).count() == 0
+
+
+def test_page_trashable_get_restore_operation_type():
+    result = PageTrashableItemType().get_restore_operation_type()
+
+    assert result == "builder.page.restore"

--- a/backend/tests/baserow/core/graph/test_graph_handler.py
+++ b/backend/tests/baserow/core/graph/test_graph_handler.py
@@ -233,11 +233,14 @@ def test_insert_permutations():
     graph.insert(p4, p2, "child", output="0")
     assert model.graph["2"]["children"]["0"] == [4]
 
-    # Insert another child of p2 in same place "0" — chains after p4
+    # Insert another child of p2 in same place "0" — the new child becomes the
+    # head of the slot and the previous head (p4) becomes its next. This mirrors
+    # get_position (which reports "child" only for the head child) and the
+    # frontend's _insertAt, so move undo/redo round-trips for a head child.
     p5 = make_point(5, model)
     graph.insert(p5, p2, "child", output="0")
-    assert model.graph["2"]["children"]["0"] == [4]
-    assert model.graph["4"]["next"][""] == [5]
+    assert model.graph["2"]["children"]["0"] == [5]
+    assert model.graph["5"]["next"][""] == [4]
 
     # Insert into graph with existing root (None ref) — new point becomes
     # root, old root (p1) becomes its next.
@@ -262,12 +265,12 @@ def test_insert_permutations():
     assert model.graph["3"]["next"][""] == [8]
     assert model.graph["8"]["next"][""] == [2]
 
-    # Insert north of p4 which is a child head — new point replaces p4 in
-    # children dict, p4 becomes new point's next.
+    # Insert north of p5 which is now the child head — new point replaces p5 in
+    # children dict, p5 becomes new point's next.
     p9 = make_point(9, model)
-    graph.insert(p9, p4, "north", output="")
+    graph.insert(p9, p5, "north", output="")
     assert model.graph["2"]["children"]["0"] == [9]
-    assert model.graph["9"]["next"][""] == [4]
+    assert model.graph["9"]["next"][""] == [5]
 
 
 def test_append_permutations():
@@ -335,22 +338,23 @@ def test_get_children_permutations():
     assert graph.get_children(p1, output="0") == [p4]
     assert graph.get_children(p1, output="1") == []  # wrong slot
 
-    # Chain p5 south of p4 (same slot "0") — first_only=False follows the chain
+    # Insert p5 as a child of p1 in slot "0" — it prepends as the new head, so
+    # the slot chain becomes p5 -> p4. first_only=False follows the chain.
     p5 = make_point(5, model)
     graph.insert(p5, p1, "child", output="0")
-    assert graph.get_children(p1, first_only=False) == [p4, p5]
-    assert graph.get_children(p1, first_only=True) == [p4]  # only entry-point
-    assert graph.get_children(p1, output="0", first_only=False) == [p4, p5]
-    assert graph.get_children(p1, output="0", first_only=True) == [p4]
+    assert graph.get_children(p1, first_only=False) == [p5, p4]
+    assert graph.get_children(p1, first_only=True) == [p5]  # only entry-point
+    assert graph.get_children(p1, output="0", first_only=False) == [p5, p4]
+    assert graph.get_children(p1, output="0", first_only=True) == [p5]
 
     # Second slot "1" with its own child p6
     p6 = make_point(6, model)
     graph.insert(p6, p1, "child", output="1")
     # No output filter — both slots included
-    assert graph.get_children(p1, first_only=False) == [p4, p5, p6]
-    assert graph.get_children(p1, first_only=True) == [p4, p6]
+    assert graph.get_children(p1, first_only=False) == [p5, p4, p6]
+    assert graph.get_children(p1, first_only=True) == [p5, p6]
     # Per-slot filtering still works
-    assert graph.get_children(p1, output="0", first_only=False) == [p4, p5]
+    assert graph.get_children(p1, output="0", first_only=False) == [p5, p4]
     assert graph.get_children(p1, output="1") == [p6]
 
     # Nested container: p4 has its own child p7 — get_children(p1) does NOT descend

--- a/enterprise/backend/src/baserow_enterprise/api/assistant/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/assistant/views.py
@@ -20,7 +20,10 @@ from baserow.api.errors import ERROR_GROUP_DOES_NOT_EXIST, ERROR_USER_NOT_IN_GRO
 from baserow.api.pagination import LimitOffsetPagination
 from baserow.api.schemas import get_error_schema
 from baserow.api.serializers import get_example_pagination_serializer_class
-from baserow.api.sessions import set_client_undo_redo_action_group_id
+from baserow.api.sessions import (
+    set_client_undo_redo_action_group_id,
+    set_untrusted_client_session_id_from_request_or_raise_if_invalid,
+)
 from baserow.core.exceptions import UserNotInWorkspace, WorkspaceDoesNotExist
 from baserow.core.handler import CoreHandler
 from baserow_enterprise.assistant.assistant import set_assistant_cancellation_key
@@ -161,6 +164,15 @@ class AssistantChatView(APIView):
 
         # Clearing the user websocket_id will make sure real-time updates are sent
         chat.user.web_socket_id = None
+
+        # The actions run by the assistant are registered against chat.user (a
+        # freshly fetched user that doesn't carry the request's session data).
+        # Copy the client session id from the request onto it so the actions are
+        # registered under the same session the client undoes with — otherwise
+        # undo can't find them ("No more actions to undo").
+        set_untrusted_client_session_id_from_request_or_raise_if_invalid(
+            chat.user, request
+        )
 
         # Used to group all the actions done to produce this message together
         # so they can be undone in one go.

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/agents.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/agents.py
@@ -541,7 +541,7 @@ def update_single_element_formulas(
 ) -> None:
     """Generate and apply formulas for a single updated element."""
 
-    from baserow.contrib.builder.elements.service import ElementService
+    from baserow.contrib.builder.elements.actions import UpdateElementActionType
 
     context = BuilderFormulaContext(page)
     context.load_page_context()
@@ -590,7 +590,7 @@ def update_single_element_formulas(
                                     mode=BASEROW_FORMULA_MODE_ADVANCED,
                                 )
                         if kwargs:
-                            ElementService().update_element(user, orm_element, **kwargs)
+                            UpdateElementActionType.do(user, orm_element, kwargs)
                 except Exception as exc:
                     logger.exception(
                         "Failed to generate formulas for element {}: {}",

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
@@ -504,7 +504,7 @@ def update_element(
     element_type = element.get_type().type
     kwargs = element_update.to_update_kwargs(element_type)
     if kwargs:
-        element = ElementService().update_element(user, element, **kwargs)
+        element = ElementService().update_element(user, element, **kwargs).element
 
     # Headers/footers are containers — menu_items belong on a child menu.
     if element_type in ("header", "footer") and element_update.menu_items:
@@ -587,7 +587,7 @@ def update_element_style(
     existing_styles = getattr(element, "styles", None) or {}
     kwargs = style_update.to_update_kwargs(element_type, existing_styles)
     if kwargs:
-        element = ElementService().update_element(user, element, **kwargs)
+        element = ElementService().update_element(user, element, **kwargs).element
     return element, element_type
 
 

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/helpers.py
@@ -11,6 +11,11 @@ from django.contrib.auth.models import AbstractUser
 
 from baserow.contrib.builder.data_sources.handler import DataSourceHandler
 from baserow.contrib.builder.data_sources.service import DataSourceService
+from baserow.contrib.builder.elements.actions import (
+    CreateElementActionType,
+    MoveElementActionType,
+    UpdateElementActionType,
+)
 from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
 from baserow.contrib.builder.elements.handler import ElementHandler
 from baserow.contrib.builder.elements.registries import element_type_registry
@@ -396,13 +401,15 @@ def create_element(
         reference_element_id = None
         position = "south"
 
-    element = ElementService().create_element(
+    element = CreateElementActionType.do(
         user,
         element_type,
         target_page,
-        reference_element_id=reference_element_id,
-        position=position,
-        **kwargs,
+        {
+            "reference_element_id": reference_element_id,
+            "position": position,
+            **kwargs,
+        },
     )
 
     action_pairs = element_create.post_create(user, element, target_page)
@@ -473,10 +480,9 @@ def move_element(
         position = "south"
         reference_element_id = last_ref.id if last_ref is not None else None
 
-    element_move_result = ElementService().move_element(
-        user, element.page, element, place, reference_element_id, position
+    return MoveElementActionType.do(
+        user, element, element.page, place, reference_element_id, position
     )
-    return element_move_result.element
 
 
 def update_element(
@@ -504,7 +510,7 @@ def update_element(
     element_type = element.get_type().type
     kwargs = element_update.to_update_kwargs(element_type)
     if kwargs:
-        element = ElementService().update_element(user, element, **kwargs).element
+        element = UpdateElementActionType.do(user, element, kwargs)
 
     # Headers/footers are containers — menu_items belong on a child menu.
     if element_type in ("header", "footer") and element_update.menu_items:
@@ -547,16 +553,18 @@ def _ensure_child_menu(
     ]
 
     if menu_child is not None:
-        ElementService().update_element(user, menu_child, menu_items=menu_items_orm)
+        UpdateElementActionType.do(user, menu_child, {"menu_items": menu_items_orm})
     else:
         menu_type = element_type_registry.get("menu")
-        ElementService().create_element(
+        CreateElementActionType.do(
             user,
             menu_type,
             header_element.page,
-            reference_element_id=header_element.id,
-            position="child",
-            menu_items=menu_items_orm,
+            {
+                "reference_element_id": header_element.id,
+                "position": "child",
+                "menu_items": menu_items_orm,
+            },
         )
 
 
@@ -587,7 +595,7 @@ def update_element_style(
     existing_styles = getattr(element, "styles", None) or {}
     kwargs = style_update.to_update_kwargs(element_type, existing_styles)
     if kwargs:
-        element = ElementService().update_element(user, element, **kwargs).element
+        element = UpdateElementActionType.do(user, element, kwargs)
     return element, element_type
 
 
@@ -1012,15 +1020,14 @@ def create_login_page(
     """
 
     from baserow.contrib.builder.elements.registries import element_type_registry
-    from baserow.contrib.builder.elements.service import ElementService
     from baserow.contrib.builder.pages.service import PageService
     from baserow.core.handler import CoreHandler
 
     page = PageService().create_page(user, builder, "Login", "/login")
 
     auth_form_type = element_type_registry.get("auth_form")
-    ElementService().create_element(
-        user, auth_form_type, page, user_source_id=user_source_id
+    CreateElementActionType.do(
+        user, auth_form_type, page, {"user_source_id": user_source_id}
     )
 
     CoreHandler().update_application(user, builder, login_page_id=page.id)

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/element.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/builder/types/element.py
@@ -478,8 +478,8 @@ def _header_footer_post_create(
     # If menu_items were provided on the header/footer itself, create a child
     # menu element — headers are containers, not menus.
     if el.menu_items:
+        from baserow.contrib.builder.elements.actions import CreateElementActionType
         from baserow.contrib.builder.elements.registries import element_type_registry
-        from baserow.contrib.builder.elements.service import ElementService
 
         menu_items_orm = [
             {
@@ -494,13 +494,15 @@ def _header_footer_post_create(
             for item in el.menu_items
         ]
         menu_type = element_type_registry.get("menu")
-        ElementService().create_element(
+        CreateElementActionType.do(
             user,
             menu_type,
             page,
-            reference_element_id=orm_element.id,
-            position=GraphPointPosition.CHILD,
-            menu_items=menu_items_orm,
+            {
+                "reference_element_id": orm_element.id,
+                "position": GraphPointPosition.CHILD,
+                "menu_items": menu_items_orm,
+            },
         )
 
 
@@ -659,7 +661,7 @@ def _update_simple_formulas(
     formulas: dict[str, str],
 ) -> None:
     """Default formula updater — sets fields directly on the element."""
-    from baserow.contrib.builder.elements.service import ElementService
+    from baserow.contrib.builder.elements.actions import UpdateElementActionType
 
     kwargs = {}
     for field_name, formula in formulas.items():
@@ -671,7 +673,7 @@ def _update_simple_formulas(
             )
 
     if kwargs:
-        ElementService().update_element(user, orm_element, **kwargs)
+        UpdateElementActionType.do(user, orm_element, kwargs)
 
 
 def _update_table_formulas(

--- a/enterprise/backend/src/baserow_enterprise/automation/nodes/node_types.py
+++ b/enterprise/backend/src/baserow_enterprise/automation/nodes/node_types.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from baserow.contrib.automation.nodes.node_types import AutomationNodeActionNodeType
 from baserow_enterprise.automation.nodes.models import (
     CoreCodeActionNode,
@@ -15,6 +17,7 @@ class CoreCodeNodeType(AutomationNodeActionNodeType):
     type = "code"
     model_class = CoreCodeActionNode
     service_type = CoreCodeServiceType.type
+    display_name = _("Code")
 
     def is_deactivated(self, workspace) -> bool:
         return not LicenseHandler.workspace_has_feature(CODE_RUNNER, workspace)

--- a/enterprise/backend/src/baserow_enterprise/builder/elements/element_types.py
+++ b/enterprise/backend/src/baserow_enterprise/builder/elements/element_types.py
@@ -1,6 +1,8 @@
 import mimetypes
 from typing import Any, Dict, Optional
 
+from django.utils.translation import gettext_lazy as _
+
 from rest_framework import serializers
 
 from baserow.api.exceptions import RequestBodyValidationException
@@ -26,6 +28,7 @@ class AuthFormElementType(ElementType):
     Element that use the selected user source to generate the login form/buttons.
     """
 
+    display_name = _("Auth form")
     type = "auth_form"
     model_class = AuthFormElement
     allowed_fields = ["user_source", "user_source_id", "login_button_label"]
@@ -133,6 +136,7 @@ class AuthFormElementType(ElementType):
 
 
 class FileInputElementType(InputElementType):
+    display_name = _("File input")
     type = "input_file"
     model_class = FileInputElement
     allowed_fields = [

--- a/enterprise/backend/src/baserow_enterprise/locale/en/LC_MESSAGES/django.po
+++ b/enterprise/backend/src/baserow_enterprise/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-15 14:36+0000\n"
+"POT-Creation-Date: 2026-06-15 14:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -348,6 +348,18 @@ msgstr ""
 
 #: src/baserow_enterprise/audit_log/models.py:32
 msgid "REDONE"
+msgstr ""
+
+#: src/baserow_enterprise/automation/nodes/node_types.py:20
+msgid "Code"
+msgstr ""
+
+#: src/baserow_enterprise/builder/elements/element_types.py:31
+msgid "Auth form"
+msgstr ""
+
+#: src/baserow_enterprise/builder/elements/element_types.py:139
+msgid "File input"
 msgstr ""
 
 #: src/baserow_enterprise/data_scanner/actions.py:18

--- a/enterprise/backend/src/baserow_enterprise/role/default_roles.py
+++ b/enterprise/backend/src/baserow_enterprise/role/default_roles.py
@@ -47,6 +47,7 @@ from baserow.contrib.builder.elements.operations import (
     ListElementsPageOperationType,
     OrderElementsPageOperationType,
     ReadElementOperationType,
+    RestoreElementOperationType,
     UpdateElementOperationType,
 )
 from baserow.contrib.builder.operations import (
@@ -60,6 +61,7 @@ from baserow.contrib.builder.pages.operations import (
     DeletePageOperationType,
     DuplicatePageOperationType,
     ReadPageOperationType,
+    RestorePageOperationType,
     UpdatePageOperationType,
 )
 from baserow.contrib.builder.theme.operations import UpdateThemeOperationType
@@ -454,6 +456,7 @@ default_roles[BUILDER_ROLE_UID].extend(
         CreatePageOperationType,
         DeletePageOperationType,
         UpdatePageOperationType,
+        RestorePageOperationType,
         UpdateThemeOperationType,
         DuplicatePageOperationType,
         CreateTableDatabaseTableOperationType,
@@ -520,6 +523,7 @@ default_roles[BUILDER_ROLE_UID].extend(
         CreateElementOperationType,
         UpdateElementOperationType,
         DeleteElementOperationType,
+        RestoreElementOperationType,
         ReadElementOperationType,
         ListElementsPageOperationType,
         OrderElementsPageOperationType,

--- a/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_builder_tools.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/assistant/test_assistant_builder_tools.py
@@ -316,6 +316,51 @@ def test_create_heading_element(data_fixture):
 
 
 @pytest.mark.django_db(transaction=True)
+def test_assistant_created_element_is_undoable(data_fixture):
+    # The assistant runs its element mutations through the undoable action types,
+    # registered under the user's session + a per-message action group (set on the
+    # user by the assistant view). This lets the client undo them with the standard
+    # session-scoped undo. Regression for "No more actions to undo" after the
+    # assistant created an element.
+    import uuid as uuid_module
+
+    from django.db import transaction
+
+    from baserow.api.sessions import set_client_undo_redo_action_group_id
+    from baserow.contrib.builder.action_scopes import PageActionScopeType
+    from baserow.contrib.builder.elements.models import Element
+    from baserow.core.action.handler import ActionHandler
+
+    session_id = str(uuid_module.uuid4())
+    user = data_fixture.create_user(session_id=session_id)
+    workspace = data_fixture.create_workspace(user=user)
+    builder = data_fixture.create_builder_application(user=user, workspace=workspace)
+    page = data_fixture.create_builder_page(builder=builder, name="Home", path="/home")
+
+    # Mirror the assistant view: a per-message action group on the acting user.
+    set_client_undo_redo_action_group_id(user, str(uuid_module.uuid4()))
+
+    ctx = make_test_ctx(user, workspace)
+    create_display_elements(
+        ctx,
+        page_id=page.id,
+        elements=[
+            DisplayElementCreate(ref="h1", type="heading", value="Welcome", level=1),
+        ],
+        thought="test",
+    )
+
+    element = Element.objects.get(page=page)
+
+    # The undo view runs inside a transaction (ActionHandler uses select_for_update).
+    with transaction.atomic():
+        ActionHandler.undo(user, [PageActionScopeType.value(page.id)], session_id)
+
+    # The element created by the assistant is gone after undo.
+    assert not Element.objects.filter(id=element.id).exists()
+
+
+@pytest.mark.django_db(transaction=True)
 def test_create_column_with_children(data_fixture):
     user = data_fixture.create_user()
     workspace = data_fixture.create_workspace(user=user)

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -347,13 +347,15 @@
   "trashType": {
     "workspace": "workspace",
     "application": "application",
-    "automation_workflow": "automation workflow",
-    "automation_node": "automation node",
     "table": "table",
     "field": "field",
     "row": "row",
     "rows": "rows",
-    "view": "view"
+    "view": "view",
+    "automation_workflow": "automation workflow",
+    "automation_node": "automation node",
+    "builder_page": "builder page",
+    "builder_element": "builder element"
   },
   "webhook": {
     "request": "Request",

--- a/web-frontend/modules/builder/composables/useDropElementTarget.js
+++ b/web-frontend/modules/builder/composables/useDropElementTarget.js
@@ -276,11 +276,14 @@ export function useDropElementTarget({
       referenceElementId = resolvedBefore.id
       position = 'north'
     } else if (resolvedParent) {
+      // Exclude the dragged element itself: when it's the only (or last) element
+      // in the target place, it must not become its own move reference — move()
+      // removes it from the graph first, so referencing it would then fail.
       const elementsInPlace = store.getters['element/getElementsInPlace'](
         targetPage.value,
         resolvedParent.id,
         resolvedPlace
-      )
+      ).filter((element) => element.id !== dragged.id)
       if (elementsInPlace.length > 0) {
         referenceElementId = elementsInPlace.at(-1).id
         position = 'south'
@@ -289,6 +292,13 @@ export function useDropElementTarget({
         position = 'child'
         resolvedPlaceInContainer = resolvedPlace
       }
+    }
+
+    // Dropping an element relative to itself is a no-op; bail out before move()
+    // (which would otherwise reference an element it has just removed).
+    if (referenceElementId === dragged.id) {
+      clearState()
+      return
     }
 
     try {

--- a/web-frontend/modules/builder/elementTypes.js
+++ b/web-frontend/modules/builder/elementTypes.js
@@ -599,7 +599,11 @@ export class ElementType extends Registerable {
       const placeIndex = places.findIndex(
         (place) => place === element.place_in_container
       )
-      if (placeIndex < places.length - 1) {
+      // placeIndex === -1 means the element's place isn't one of the parent's
+      // places (e.g. a single-slot container), so there's no place to move into.
+      // Guard it explicitly: -1 < length - 1 is otherwise true and would wrongly
+      // offer a RIGHT move that references the element itself.
+      if (placeIndex !== -1 && placeIndex < places.length - 1) {
         const nextPlace = places[placeIndex + 1]
         const elementsInNextPlace = this.app.$store.getters[
           'element/getElementsInPlace'

--- a/web-frontend/modules/builder/store/element.js
+++ b/web-frontend/modules/builder/store/element.js
@@ -277,7 +277,13 @@ const actions = {
         updatedValues
       )
 
-      commit('ADD_ITEM', { page, element })
+      // Add the element to the store exactly once. When forceCreate is set we
+      // add it via the forceCreate action below; adding it here as well would
+      // push a duplicate into page.elements, and DELETE_ITEM (which removes a
+      // single occurrence) would then leave a "phantom" copy behind on delete.
+      if (!forceCreate) {
+        commit('ADD_ITEM', { page, element })
+      }
 
       dispatch('graphReplace', {
         page,

--- a/web-frontend/modules/builder/store/page.js
+++ b/web-frontend/modules/builder/store/page.js
@@ -102,9 +102,13 @@ const actions = {
     // Check if the provided page id is found in the just selected builder.
     const page = getters.getById(builder, pageId)
 
+    // Send the shared page id alongside the content page id so that edits to
+    // shared (header/footer) elements remain undoable while editing this page.
+    const sharedPage = getters.getSharedPage(builder)
+
     dispatch(
       'undoRedo/updateCurrentScopeSet',
-      BUILDER_ACTION_SCOPES.page(page.id),
+      BUILDER_ACTION_SCOPES.page(page.id, sharedPage?.id ?? null),
       { root: true }
     )
 

--- a/web-frontend/modules/builder/store/page.js
+++ b/web-frontend/modules/builder/store/page.js
@@ -47,6 +47,7 @@ const mutations = {
   },
   DELETE_ITEM(state, { builder, id }) {
     const index = builder.pages.findIndex((item) => item.id === id)
+    if (index === -1) return
     // Clear the elements to void the page and prevent errors
     builder.pages[index].elements = []
     builder.pages[index].elementMap = {}

--- a/web-frontend/modules/builder/utils/undoRedoConstants.js
+++ b/web-frontend/modules/builder/utils/undoRedoConstants.js
@@ -1,8 +1,12 @@
 // The different types of undo/redo scopes available for the builder module.
 export const BUILDER_ACTION_SCOPES = {
-  page(pageId) {
+  // Scope for the page currently being edited. `sharedPageId` is sent alongside
+  // so that edits to shared (header/footer) elements — which live on the builder's
+  // shared page — are undoable while editing any content page.
+  page(pageId, sharedPageId = null) {
     return {
       page: pageId,
+      shared_page: sharedPageId,
     }
   },
 }

--- a/web-frontend/modules/core/graph/baseGraphHandler.js
+++ b/web-frontend/modules/core/graph/baseGraphHandler.js
@@ -419,6 +419,13 @@ export default class BaseGraphHandler {
   // into the target graph and removed from this (source) one. Its `next` (old
   // siblings) is NOT carried — insert() sets the new one.
   move(pointToMove, referencePoint, position, output, targetHandler = null) {
+    // Moving a point relative to itself is a no-op. Without this guard remove()
+    // would delete the point's graph entry before insert() tries to reference it,
+    // throwing "Cannot read properties of undefined".
+    if (referencePoint && referencePoint.id === pointToMove.id) {
+      return
+    }
+
     const target = targetHandler || this
     const isCrossGraph = target !== this
 

--- a/web-frontend/modules/core/graph/baseGraphHandler.js
+++ b/web-frontend/modules/core/graph/baseGraphHandler.js
@@ -247,17 +247,14 @@ export default class BaseGraphHandler {
       }
 
       case 'child': {
-        // Normalise legacy bare-array children to dict format before mutating, so
-        // moves/inserts into a container whose children haven't been rewritten yet
-        // don't bolt a string key onto an array (which getChildren would discard).
-        const refInfo = this.graph[referencePoint.id]
-        const childrenDict = this._getChildrenAsDict(refInfo.children)
-        if (!childrenDict[output]) {
-          childrenDict[output] = []
+        if (!this.graph[referencePoint.id].children) {
+          this.graph[referencePoint.id].children = {}
         }
-        newPointNext = childrenDict[output]
-        childrenDict[output] = [point.id]
-        refInfo.children = childrenDict
+        if (!this.graph[referencePoint.id].children[output]) {
+          this.graph[referencePoint.id].children[output] = []
+        }
+        newPointNext = this.graph[referencePoint.id].children[output]
+        this.graph[referencePoint.id].children[output] = [point.id]
         break
       }
 

--- a/web-frontend/test/unit/builder/store/element.spec.js
+++ b/web-frontend/test/unit/builder/store/element.spec.js
@@ -188,6 +188,73 @@ describe('element store', () => {
     })
   })
 
+  describe('create', () => {
+    // Element type stub with the methods create() touches.
+    const makeRegistry = () => ({
+      get: () => ({
+        getDefaultValues: () => ({}),
+        getPopulateStoreProperties: () => ({}),
+      }),
+    })
+
+    const makeContext = (commit) => ({
+      commit,
+      dispatch: vi.fn(() => Promise.resolve()),
+      getters: {
+        getElementById: () => null,
+        getParent: () => null,
+      },
+    })
+
+    const makeThis = (element) => ({
+      $registry: makeRegistry(),
+      $client: { post: vi.fn(() => Promise.resolve({ data: element })) },
+    })
+
+    test('does not add the element directly when forceCreate is true', async () => {
+      // Regression: with forceCreate the element is added via the forceCreate
+      // action; adding it here too pushes a duplicate into page.elements that
+      // DELETE_ITEM (single occurrence) leaves behind as a "phantom".
+      const element = { id: 5, type: 'heading' }
+      const page = makePage({ 0: 1, 1: {} }, [])
+      const commit = vi.fn()
+
+      await elementStore.actions.create.call(
+        makeThis(element),
+        makeContext(commit),
+        {
+          builder: {},
+          page,
+          elementType: 'heading',
+          forceCreate: true,
+        }
+      )
+
+      expect(commit).not.toHaveBeenCalledWith('ADD_ITEM', expect.anything())
+    })
+
+    test('adds the element directly when forceCreate is false', async () => {
+      const element = { id: 5, type: 'heading' }
+      const page = makePage({ 0: 1, 1: {} }, [])
+      const commit = vi.fn()
+      const context = makeContext(commit)
+
+      await elementStore.actions.create.call(makeThis(element), context, {
+        builder: {},
+        page,
+        elementType: 'heading',
+        forceCreate: false,
+      })
+
+      expect(commit).toHaveBeenCalledWith('ADD_ITEM', { page, element })
+      // forceCreate (which would also add it) must not run in this path.
+      const dispatchedActions = context.dispatch.mock.calls.map(
+        ([name]) => name
+      )
+      expect(dispatchedActions).not.toContain('forceCreate')
+    })
+  })
+
   describe('forceCreate', () => {
     const makeRegistry = () => ({
       get: () => ({

--- a/web-frontend/test/unit/core/graph/baseGraphHandler.spec.js
+++ b/web-frontend/test/unit/core/graph/baseGraphHandler.spec.js
@@ -472,6 +472,15 @@ describe('BaseGraphHandler', () => {
       expect(source.graph['0']).toBe(3)
     })
 
+    test('moving a point relative to itself is a no-op', () => {
+      // Mirrors the reported crash: a table is the sole child of a container and
+      // is dropped onto itself, so it becomes its own move reference. move() must
+      // not throw, and the graph must be left unchanged.
+      const h = make({ 0: 1, 1: { children: { '': [2] } }, 2: {} }, pm(1, 2))
+      expect(() => h.move(pt(2), pt(2), 'south', '')).not.toThrow()
+      expect(h.graph).toEqual({ 0: 1, 1: { children: { '': [2] } }, 2: {} })
+    })
+
     test('null reference + south appends to end of chain', () => {
       // pt(1) -> pt(2) -> pt(3); move pt(1) to last position
       const h = make(


### PR DESCRIPTION
### What is in this PR

Introduces trashing to the builder module's `Page` and `Element` records.

Also adds a "display name" to automation nodes and builder elements, which are localised. This makes the trash entry nicer in the UI, otherwise we default to the `type`.

### How to test this PR

- Test trashing and restoring pages.
    - In the editor
    - In preview
    - In published (i.e. nothing should happen, they're cloned)
- Test trashing and restoring elements
    - Simple elements
    - Containers (are all children trashing/restoring too?)
    - Shared elements (in the Trash, the entry will refer to the application, not the page)
 
### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
    - One changelog will be added at the end of this series of PRs.
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
