### PR TITLE
chore: Field type column conversion in Postgres function instead of pg_temp

### DIFF
--- a/backend/src/baserow/contrib/database/db/schema.py
+++ b/backend/src/baserow/contrib/database/db/schema.py
@@ -6,7 +6,9 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.ddl_references import Statement
 from django.db.backends.utils import strip_quotes
 
-from .sql_queries import sql_create_try_cast, sql_drop_try_cast
+from .sql_queries import sql_create_field_try_cast, sql_drop_field_try_cast
+
+TRY_CAST_FUNCTION_PLACEHOLDER = "__baserow_field_try_cast__"
 
 
 class PostgresqlLenientDatabaseSchemaEditor:
@@ -20,7 +22,7 @@ class PostgresqlLenientDatabaseSchemaEditor:
 
     sql_alter_column_type = (
         "ALTER COLUMN %(column)s TYPE %(type)s%(collation)s "
-        "USING pg_temp.try_cast(%(column)s::text)"
+        f"USING {TRY_CAST_FUNCTION_PLACEHOLDER}(%(column)s::text)"
     )
 
     def __init__(
@@ -36,6 +38,9 @@ class PostgresqlLenientDatabaseSchemaEditor:
         self.force_alter_column = force_alter_column
         super().__init__(*args, **kwargs)
 
+    def _try_cast_function_name(self, field):
+        return self.quote_name(f"{field.column}_try_cast")
+
     def _alter_field(
         self,
         model,
@@ -50,6 +55,7 @@ class PostgresqlLenientDatabaseSchemaEditor:
         if self.force_alter_column:
             old_type = f"{old_type}_forced"
 
+        try_cast_function = None
         if old_type != new_type:
             variables = {}
             if isinstance(self.alter_column_prepare_old_value, tuple):
@@ -67,10 +73,12 @@ class PostgresqlLenientDatabaseSchemaEditor:
             quoted_column_name = self.quote_name(new_field.column)
             for key, value in variables.items():
                 variables[key] = value.replace("$FUNCTION$", "")
-            self.execute(sql_drop_try_cast)
+            try_cast_function = self._try_cast_function_name(new_field)
+            self.execute(sql_drop_field_try_cast % {"function_name": try_cast_function})
             self.execute(
-                sql_create_try_cast
+                sql_create_field_try_cast
                 % {
+                    "function_name": try_cast_function,
                     "column": quoted_column_name,
                     "type": new_type,
                     "alter_column_prepare_old_value": alter_column_prepare_old_value,
@@ -79,7 +87,7 @@ class PostgresqlLenientDatabaseSchemaEditor:
                 variables,
             )
 
-        return super()._alter_field(
+        result = super()._alter_field(
             model,
             old_field,
             new_field,
@@ -90,7 +98,26 @@ class PostgresqlLenientDatabaseSchemaEditor:
             strict,
         )
 
+        if try_cast_function is not None:
+            # The cast function is for one-time use only. We want to drop is
+            # immediately after because we don't want to have millions of functions
+            # lingering at some point.
+            self.execute(sql_drop_field_try_cast % {"function_name": try_cast_function})
+
+        return result
+
     def _alter_column_type_sql(
+        self, model, old_field, new_field, new_type, old_collation, new_collation
+    ):
+        (sql, params), other_actions = self._build_alter_column_type_sql(
+            model, old_field, new_field, new_type, old_collation, new_collation
+        )
+        sql = sql.replace(
+            TRY_CAST_FUNCTION_PLACEHOLDER, self._try_cast_function_name(new_field)
+        )
+        return (sql, params), other_actions
+
+    def _build_alter_column_type_sql(
         self, model, old_field, new_field, new_type, old_collation, new_collation
     ):
         # Cast when data type changed.

--- a/backend/src/baserow/contrib/database/db/schema.py
+++ b/backend/src/baserow/contrib/database/db/schema.py
@@ -99,7 +99,7 @@ class PostgresqlLenientDatabaseSchemaEditor:
         )
 
         if try_cast_function is not None:
-            # The cast function is for one-time use only. We want to drop is
+            # The cast function is for one-time use only. We want to drop it
             # immediately after because we don't want to have millions of functions
             # lingering at some point.
             self.execute(sql_drop_field_try_cast % {"function_name": try_cast_function})

--- a/backend/src/baserow/contrib/database/db/sql_queries.py
+++ b/backend/src/baserow/contrib/database/db/sql_queries.py
@@ -1,6 +1,4 @@
-sql_drop_try_cast = "DROP FUNCTION IF EXISTS pg_temp.try_cast(text, int)"
-sql_create_try_cast = """
-    create or replace function pg_temp.try_cast(
+_try_cast_function_body = """(
         p_in text,
         p_default int default null
     )
@@ -19,3 +17,13 @@ sql_create_try_cast = """
     $FUNCTION$
     language plpgsql;
 """
+
+sql_drop_pg_temp_try_cast = "DROP FUNCTION IF EXISTS pg_temp.try_cast(text, int)"
+sql_create_pg_temp_try_cast = (
+    "create or replace function pg_temp.try_cast" + _try_cast_function_body
+)
+
+sql_drop_field_try_cast = "DROP FUNCTION IF EXISTS %(function_name)s(text, int)"
+sql_create_field_try_cast = (
+    "create or replace function %(function_name)s" + _try_cast_function_body
+)

--- a/backend/src/baserow/contrib/database/fields/handler.py
+++ b/backend/src/baserow/contrib/database/fields/handler.py
@@ -28,8 +28,8 @@ from baserow.contrib.database.db.schema import (
     safe_django_schema_editor,
 )
 from baserow.contrib.database.db.sql_queries import (
-    sql_create_try_cast,
-    sql_drop_try_cast,
+    sql_create_pg_temp_try_cast,
+    sql_drop_pg_temp_try_cast,
 )
 from baserow.contrib.database.fields.constants import (
     RESERVED_BASEROW_FIELD_NAMES,
@@ -1454,9 +1454,9 @@ class FieldHandler(metaclass=baserow_trace_methods(tracer)):
         # the that if the casting fails, the query doesn't fail hard, but falls back
         # `null`.
         with connection.cursor() as cursor:
-            cursor.execute(sql_drop_try_cast)
+            cursor.execute(sql_drop_pg_temp_try_cast)
             cursor.execute(
-                sql_create_try_cast
+                sql_create_pg_temp_try_cast
                 % {
                     "alter_column_prepare_old_value": alter_column_prepare_old_value
                     or "",

--- a/backend/tests/baserow/contrib/database/field/test_field_handler.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_handler.py
@@ -742,6 +742,111 @@ def test_update_field(send_mock, data_fixture):
     assert field_with_max_length_name.name == field_name_with_ok_length
 
 
+def _try_cast_function_count(field_id):
+    """
+    Returns how many functions named `field_{field_id}_try_cast` exist in the
+    database, regardless of schema.
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT count(*) FROM pg_proc WHERE proname = %s",
+            [f"field_{field_id}_try_cast"],
+        )
+        return cursor.fetchone()[0]
+
+
+@pytest.mark.django_db
+def test_lenient_alter_uses_field_scoped_try_cast_function(data_fixture):
+    """
+    During a field type change the lenient schema editor must use a function named
+    `field_{id}_try_cast` (created in the table's own schema, not `pg_temp`) so that
+    it is propagated by logical replication, and it must never be left behind.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{field.id}": "not a number"})
+    model.objects.create(**{f"field_{field.id}": "100"})
+
+    handler = FieldHandler()
+
+    # No leftover function before the conversion.
+    assert _try_cast_function_count(field.id) == 0
+
+    with CaptureQueriesContext(connection) as captured:
+        field = handler.update_field(
+            user=user,
+            field=field,
+            new_type_name="number",
+            number_decimal_places=0,
+            number_negative=False,
+        )
+
+    executed_sql = "\n".join(q["sql"] for q in captured.captured_queries)
+    # The field-scoped function must actually be used, and the old `pg_temp` variant
+    # (which isn't replicated) must not be used for the alter anymore.
+    assert f"field_{field.id}_try_cast" in executed_sql
+    assert "pg_temp.try_cast" not in executed_sql
+
+    # The conversion itself worked: the uncastable value became null, the castable
+    # one was converted. This proves the function was genuinely used to cast.
+    model = table.get_model()
+    row_0, row_1 = model.objects.all()
+    assert getattr(row_0, f"field_{field.id}") is None
+    assert getattr(row_1, f"field_{field.id}") == 100
+
+    # The one-time-use function must never linger after the alter.
+    assert _try_cast_function_count(field.id) == 0
+
+
+@pytest.mark.django_db
+def test_lenient_alter_drops_leftover_try_cast_function_before_recreating(
+    data_fixture,
+):
+    """
+    A function left behind by a previously crashed run (with an incompatible return
+    type) must not break a subsequent conversion: it is dropped before being
+    recreated, and is gone again afterwards.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_text_field(table=table)
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{field.id}": "100"})
+
+    # Simulate a leftover from a crashed run. The `text` return type is incompatible
+    # with the `numeric` one the next conversion needs, so a bare `create or replace`
+    # without a preceding drop would fail with "cannot change return type".
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f'CREATE FUNCTION "field_{field.id}_try_cast"(p_in text, '
+            f"p_default int default null) RETURNS text AS $$ BEGIN RETURN p_in; "
+            f"END; $$ LANGUAGE plpgsql;"
+        )
+    assert _try_cast_function_count(field.id) == 1
+
+    field = FieldHandler().update_field(
+        user=user,
+        field=field,
+        new_type_name="number",
+        number_decimal_places=0,
+        number_negative=False,
+    )
+
+    model = table.get_model()
+    (row_0,) = model.objects.all()
+    assert getattr(row_0, f"field_{field.id}") == 100
+
+    # The leftover was dropped and the freshly created function did not linger.
+    assert _try_cast_function_count(field.id) == 0
+
+
 @pytest.mark.django_db
 @pytest.mark.field_formula
 @patch("baserow.contrib.database.fields.signals.field_updated.send")

--- a/changelog/entries/unreleased/refactor/field_type_conversion_in_pg_function.json
+++ b/changelog/entries/unreleased/refactor/field_type_conversion_in_pg_function.json
@@ -1,0 +1,9 @@
+{
+  "type": "refactor",
+  "message": "Field type column conversion in Postgres function instead of pg_temp.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-03"
+}


### PR DESCRIPTION
### What is in this PR

When doing a field conversion, we're temporarily creating a PostgreSQL function named pg_temp.try_cash. Because it's a temporary function, it's not included when doing logical replication. This PR creates a "normal" PostgreSQL function that's being dropped immediately after. This will make sure that it works with logical replication.

The function will always be dropped because if the transaction does not commit, it will be removed, and if the transaction does commit, the "DROP FUNCTION" sql will be executed. There should not be a conflict with another function because the function is dropped/created in the transaction, it contains the field ID in function name, and the field is locked while doing the update.

The `FieldHandler::get_unique_row_values` still uses a pg_temp function, but because this is only used for reading, that it completely fine for logical replication.

### How to test this PR

- Convert a text field to a number field, and confirm that it works as expected.
- Confirm that field_{id}_try_cast function does not exist after the operation.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
