### PR TITLE
fix(web-frontend): show circular field dependency error in lookup field

### DIFF
--- a/changelog/entries/unreleased/bug/3637_shows_the_circular_field_dependency_error_in_the_lookup_fiel.json
+++ b/changelog/entries/unreleased/bug/3637_shows_the_circular_field_dependency_error_in_the_lookup_fiel.json
@@ -1,9 +1,9 @@
 {
-  "type": "bug",
-  "message": "Shows the circular field dependency error in the lookup field form",
-  "issue_origin": "github",
-  "issue_number": 3637,
-  "domain": "database",
-  "bullet_points": [],
-  "created_at": "2026-06-03"
+    "type": "bug",
+    "message": "Shows the circular field dependency error in the lookup field form.",
+    "issue_origin": "github",
+    "issue_number": 3637,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-03"
 }

--- a/changelog/entries/unreleased/bug/3637_shows_the_circular_field_dependency_error_in_the_lookup_fiel.json
+++ b/changelog/entries/unreleased/bug/3637_shows_the_circular_field_dependency_error_in_the_lookup_fiel.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Shows the circular field dependency error in the lookup field form",
+  "issue_origin": "github",
+  "issue_number": 3637,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-03"
+}

--- a/web-frontend/modules/database/components/field/FieldLookupSubForm.vue
+++ b/web-frontend/modules/database/components/field/FieldLookupSubForm.vue
@@ -26,6 +26,9 @@
       >
       </FormulaTypeSubForms>
     </template>
+    <div v-if="errorFromServer" class="error formula-field__error">
+      {{ errorFromServer }}
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
### What is in this PR
The lookup field form silently failed to save when the backend rejected a circular field dependency. The same error is now displayed inline, matching the existing behavior of the formula and rollup field forms

Closes #3637

### Root cause
`web-frontend/modules/database/mixins/lookupFieldSubForm.js` already implements `handleErrorByForm()` and stores the backend detail message on `this.errorFromServer` . so the captured error was never shown.

### How to test this PR
1. Open a database with two tables A and B linked by a link-row field.
2. In table A, create a lookup field that targets a lookup field in table B which already points back into table A
3. Confirm the lookup field form now displays "Fields cannot reference each other resulting in a circular chain of references." instead of failing silently.

### Video
https://github.com/user-attachments/assets/dbc7099e-c493-4bcb-b21b-1b5d15b93e45



### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
