### PR TITLE
chore: enable cache by default with 120s TTL

### DIFF
--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -443,7 +443,7 @@ if BASEROW_MAX_CONCURRENT_USER_REQUESTS > 0:
         "baserow.throttling.middleware.ConcurrentUserRequestsMiddleware",
     ]
 
-BASEROW_CACHE_TTL_SECONDS = int(os.getenv("BASEROW_CACHE_TTL_SECONDS", 0))
+BASEROW_CACHE_TTL_SECONDS = int(os.getenv("BASEROW_CACHE_TTL_SECONDS", 120))
 
 PUBLIC_VIEW_AUTHORIZATION_HEADER = "Baserow-View-Authorization"
 

--- a/changelog/entries/unreleased/feature/enables_caching_by_default_for_improved_performance.json
+++ b/changelog/entries/unreleased/feature/enables_caching_by_default_for_improved_performance.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Enables caching by default for improved performance",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-04"
+}


### PR DESCRIPTION
## Summary

We have verified that the new cache feature is working well, so this enables it for everyone by default by setting `BASEROW_CACHE_TTL_SECONDS` to `120` seconds (previously `0`, i.e. disabled).

Operators can still override this via the `BASEROW_CACHE_TTL_SECONDS` environment variable.

If you're interested in the PR that introduced this variable and what is cached, please take a look at https://github.com/baserow/baserow/pull/5205

## Test plan

- [ ] Confirm existing cache-related test suites still pass (`backend/tests/baserow/core/test_settings_cache.py`, `test_token_cache.py`, `test_user_cache.py`, `test_jwt_user_cache_perf.py`, premium `test_license_cache.py`).
- [ ] Verify cached values expire after 120s in a running instance.