### PR TITLE
fix(web-frontend): Show unnamed row label in row history instead of empty boxes

### DIFF
--- a/changelog/entries/unreleased/bug/show_unnamed_row_label_in_row_history_instead_of__empty_boxe.json
+++ b/changelog/entries/unreleased/bug/show_unnamed_row_label_in_row_history_instead_of__empty_boxe.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Show unnamed row label in row history instead of empty boxes",
+  "issue_origin": "github",
+  "issue_number": 3674,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-04"
+}

--- a/web-frontend/modules/database/components/row/RowHistoryFieldLinkRow.vue
+++ b/web-frontend/modules/database/components/row/RowHistoryFieldLinkRow.vue
@@ -59,8 +59,12 @@ export default {
   },
   methods: {
     rowName(id) {
-      return this.entry.fields_metadata[this.fieldIdentifier].linked_rows[id]
-        ?.value
+      const value =
+        this.entry.fields_metadata[this.fieldIdentifier].linked_rows[id]?.value
+      return (
+        value ||
+        this.$t('functionnalGridViewFieldLinkRow.unnamed', { value: id })
+      )
     },
   },
 }

--- a/web-frontend/test/unit/database/components/row/rowHistoryFieldLinkRow.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowHistoryFieldLinkRow.spec.js
@@ -1,0 +1,64 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import RowHistoryFieldLinkRow from '@baserow/modules/database/components/row/RowHistoryFieldLinkRow'
+
+describe('RowHistoryFieldLinkRow', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  const mountComponent = (entry) => {
+    return testApp.mount(RowHistoryFieldLinkRow, {
+      propsData: {
+        entry,
+        fieldIdentifier: 'field_1',
+      },
+    })
+  }
+
+  const buildEntry = (linkedRows) => ({
+    before: { field_1: [] },
+    after: { field_1: Object.keys(linkedRows).map((id) => Number(id)) },
+    fields_metadata: {
+      field_1: {
+        linked_rows: linkedRows,
+      },
+    },
+  })
+
+  test('renders the primary value when present', async () => {
+    const wrapper = await mountComponent(
+      buildEntry({
+        42: { value: 'Hello world' },
+      })
+    )
+    expect(wrapper.text()).toContain('Hello world')
+  })
+
+  test('falls back to the unnamed-row label when value is empty', async () => {
+    const wrapper = await mountComponent(
+      buildEntry({
+        42: { value: '' },
+      })
+    )
+    // The repo-wide i18n mock returns the key unchanged, so we assert on the
+    // key path rather than on the rendered English string.
+    expect(wrapper.text()).toContain('functionnalGridViewFieldLinkRow.unnamed')
+  })
+
+  test('falls back when the linked row metadata is missing entirely', async () => {
+    // The diff references row 42 but the metadata dict has no entry for it.
+    const entry = {
+      before: { field_1: [] },
+      after: { field_1: [42] },
+      fields_metadata: { field_1: { linked_rows: {} } },
+    }
+    const wrapper = await mountComponent(entry)
+    expect(wrapper.text()).toContain('functionnalGridViewFieldLinkRow.unnamed')
+  })
+})


### PR DESCRIPTION
### What is in this PR
In the row history side panel, link-row field diffs render empty boxes they should display unnamed row <id> instead.

Closes [#3674](https://github.com/baserow/baserow/issues/3674)

### Root cause: 
the frontend serializer stores each linked row as { value: str(linked_row) }. The model's `__str__`  only returns "unnamed row {id}" when the table has no primary field at all; when a primary field exists but is empty, get_human_readable_value(None, field) returns "". The history component renders value directly with no fallback, producing an empty chip.


### How to test this PR
- Created 2 linked tables A and B
- Add rows leaving the primary field empty
- Link a row from Table B to Table A
- Check the history tab

### Image after fix
<img width="969" height="709" alt="Screenshot 2026-06-04 at 22 50 47" src="https://github.com/user-attachments/assets/37379b8a-5fea-4a42-b3b8-ff850372d173" />


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] Security impact of change has been considered
