### PR TITLE
fix(backend): Fix airtable import when CDN omits Content-Length

### DIFF
--- a/backend/src/baserow/contrib/database/airtable/handler.py
+++ b/backend/src/baserow/contrib/database/airtable/handler.py
@@ -150,9 +150,11 @@ def download_airtable_file(
             except (TypeError, ValueError):
                 file_size_bytes = None
 
-    # If we cannot determine the size from headers, treat this as a download failure
+    # Fall back to measuring the actual downloaded content. This handles
+    # responses with Transfer-Encoding: chunked and Content-Encoding: gzip
+    # where no Content-Length header is present.
     if file_size_bytes is None:
-        raise FileDownloadFailed(f"Could not determine the size of file {name}.")
+        file_size_bytes = len(response.content)
 
     # Prevent upload to Baserow failures by excluding oversized files
     max_size_bytes = settings.BASEROW_FILE_UPLOAD_SIZE_LIMIT_MB
@@ -192,14 +194,17 @@ class AirtableFileImport:
         if name not in self.files_to_download:
             raise KeyError(f"File '{name}' not found in files_to_download")
 
-        response = download_airtable_file(
-            name=name,
-            download_file=self.files_to_download[name],
-            init_data=self.init_data,
-            request_id=self.request_id,
-            cookies=self.cookies,
-            headers=BASE_HEADERS,
-        )
+        try:
+            response = download_airtable_file(
+                name=name,
+                download_file=self.files_to_download[name],
+                init_data=self.init_data,
+                request_id=self.request_id,
+                cookies=self.cookies,
+                headers=BASE_HEADERS,
+            )
+        except FileDownloadFailed:
+            raise KeyError(f"File '{name}' could not be downloaded")
 
         stream = BytesIO(response.content)
         try:

--- a/backend/tests/baserow/contrib/database/airtable/test_airtable_handler.py
+++ b/backend/tests/baserow/contrib/database/airtable/test_airtable_handler.py
@@ -11,16 +11,21 @@ import responses
 from rest_framework import serializers
 
 from baserow.contrib.database.airtable.config import AirtableImportConfig
+from baserow.contrib.database.airtable.constants import (
+    AIRTABLE_DOWNLOAD_FILE_TYPE_FETCH,
+)
 from baserow.contrib.database.airtable.exceptions import (
     AirtableBaseRequiresAuthentication,
     AirtableShareIsNotABase,
+    FileDownloadFailed,
 )
 from baserow.contrib.database.airtable.handler import (
     AirtableFileImport,
     AirtableHandler,
+    download_airtable_file,
 )
 from baserow.contrib.database.airtable.job_types import AirtableImportJobType
-from baserow.contrib.database.airtable.models import AirtableImportJob
+from baserow.contrib.database.airtable.models import AirtableImportJob, DownloadFile
 from baserow.contrib.database.fields.models import TextField
 from baserow.core.exceptions import UserNotInWorkspace
 from baserow.core.jobs.constants import JOB_PENDING
@@ -28,6 +33,14 @@ from baserow.core.jobs.exceptions import JobDoesNotExist, MaxJobCountExceeded
 from baserow.core.jobs.handler import JobHandler
 from baserow.core.user_files.models import UserFile
 from baserow.core.utils import Progress
+
+STUB_AIRTABLE_FETCH_DOWNLOAD_FILE = DownloadFile(
+    url="https://example.com/file.pdf",
+    row_id="",
+    column_id="",
+    attachment_id="",
+    type=AIRTABLE_DOWNLOAD_FILE_TYPE_FETCH,
+)
 
 
 @pytest.mark.django_db
@@ -1427,3 +1440,141 @@ def test_get_airtable_import_job(data_fixture):
     job = JobHandler.get_job(user, job_1.id, job_model=AirtableImportJob)
     assert isinstance(job, AirtableImportJob)
     assert job.id == job_1.id
+
+
+@responses.activate
+def test_download_airtable_file_chunked_no_content_length():
+    file_content = b"%PDF-1.4 fake pdf content" * 1000
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=file_content,
+        status=200,
+        headers={"Transfer-Encoding": "chunked"},
+    )
+
+    response = download_airtable_file(
+        name="test.pdf",
+        download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+        init_data={},
+        request_id="req1",
+        cookies={},
+    )
+    assert response.content == file_content
+
+
+@responses.activate
+def test_download_airtable_file_with_content_length():
+    file_content = b"some file bytes"
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=file_content,
+        status=200,
+        headers={"Content-Length": str(len(file_content))},
+    )
+
+    response = download_airtable_file(
+        name="file.txt",
+        download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+        init_data={},
+        request_id="req1",
+        cookies={},
+    )
+    assert response.content == file_content
+
+
+@responses.activate
+def test_download_airtable_file_partial_content_range():
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=b"012345",
+        status=206,
+        headers={"Content-Range": "bytes 0-5/500000"},
+    )
+
+    response = download_airtable_file(
+        name="file.pdf",
+        download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+        init_data={},
+        request_id="req1",
+        cookies={},
+    )
+    assert response.status_code == 206
+
+
+@responses.activate
+def test_download_airtable_file_exceeds_size_limit():
+    file_content = b"x" * 100
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=file_content,
+        status=200,
+        headers={"Content-Length": str(len(file_content))},
+    )
+
+    with patch("baserow.contrib.database.airtable.handler.settings") as mock_settings:
+        mock_settings.BASEROW_FILE_UPLOAD_SIZE_LIMIT_MB = 50
+        with pytest.raises(FileDownloadFailed, match="exceeds the size limit"):
+            download_airtable_file(
+                name="big.bin",
+                download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+                init_data={},
+                request_id="req1",
+                cookies={},
+            )
+
+
+@responses.activate
+def test_download_airtable_file_chunked_exceeds_size_limit():
+    file_content = b"x" * 100
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=file_content,
+        status=200,
+        headers={"Transfer-Encoding": "chunked"},
+    )
+
+    with patch("baserow.contrib.database.airtable.handler.settings") as mock_settings:
+        mock_settings.BASEROW_FILE_UPLOAD_SIZE_LIMIT_MB = 50
+        with pytest.raises(FileDownloadFailed, match="exceeds the size limit"):
+            download_airtable_file(
+                name="big.bin",
+                download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+                init_data={},
+                request_id="req1",
+                cookies={},
+            )
+
+
+@responses.activate
+def test_download_airtable_file_http_error():
+    responses.add(responses.GET, STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url, status=404)
+
+    with pytest.raises(FileDownloadFailed, match="HTTP 404"):
+        download_airtable_file(
+            name="missing.pdf",
+            download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+            init_data={},
+            request_id="req1",
+            cookies={},
+        )
+
+
+@responses.activate
+def test_airtable_file_import_open_download_failure_raises_key_error():
+    responses.add(responses.GET, STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url, status=500)
+
+    file_import = AirtableFileImport(
+        init_data={},
+        request_id="req1",
+        cookies={},
+    )
+    file_import.add_files({"broken.pdf": STUB_AIRTABLE_FETCH_DOWNLOAD_FILE})
+
+    with pytest.raises(KeyError, match="could not be downloaded"):
+        with file_import.open("broken.pdf"):
+            pass

--- a/changelog/entries/unreleased/bug/5472_fix_airtable_import_when_cdn_omits_contentlength.json
+++ b/changelog/entries/unreleased/bug/5472_fix_airtable_import_when_cdn_omits_contentlength.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix airtable import when CDN omits Content-Length",
+    "issue_origin": "github",
+    "issue_number": 5472,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-08"
+}


### PR DESCRIPTION
### What is in this PR
Closes #5472 

### How to test this PR

Verify that airtable import works

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
