### PR TITLE
fix(tests): Fix webhook tests with domain resolution

### DIFF
--- a/backend/tests/baserow/contrib/database/api/webhooks/test_webhook_views.py
+++ b/backend/tests/baserow/contrib/database/api/webhooks/test_webhook_views.py
@@ -15,6 +15,13 @@ from baserow.contrib.database.webhooks.models import TableWebhook, TableWebhookE
 from baserow.core.utils import truncate_middle
 
 
+@pytest.fixture(autouse=True)
+def _bypass_webhook_url_dns_check(mocker):
+    mocker.patch(
+        "baserow.contrib.database.webhooks.validators.validating_create_connection"
+    )
+
+
 @pytest.mark.django_db
 def test_list_webhooks(api_client, data_fixture):
     user, jwt_token = data_fixture.create_user_and_token()


### PR DESCRIPTION
### What is in this PR

Webhook view tests use fake domains like mydomain.com in URL fields. The `url_validator` performs DNS resolution via `validating_create_connection` during serializer body validation, which runs before the view logic. When DNS resolution fails (offline environments, restricted networks, DNS changes), tests get 400 (body validation error) instead of the expected response codes.

Fix disable this dns validator check for tests. Validator itself is tested separately in `test_webhook_validators.py`

### How to test this PR
CI should pass
