### PR TITLE
bug: Improve list views endpoint performance

### DIFF
--- a/backend/src/baserow/contrib/database/api/views/views.py
+++ b/backend/src/baserow/contrib/database/api/views/views.py
@@ -333,6 +333,7 @@ class ViewsView(APIView):
             group_bys,
             default_row_values,
             query_params["limit"],
+            prefetch_field_options=False,
         )
 
         views_by_type = defaultdict(list)

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -666,6 +666,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         group_bys: bool = True,
         default_row_values: bool = False,
         limit: int | None = None,
+        prefetch_field_options: bool = True,
     ) -> Iterable[View]:
         """
         Lists available views for a user/table combination.
@@ -676,8 +677,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :param filters: If filters should be prefetched.
         :param sortings: If sorts should be prefetched.
         :param decorations: If view decorations should be prefetched.
+        :param group_bys: If group bys should be prefetched.
         :param default_row_values: If default row values should be prefetched.
         :param limit: To limit the number of returned views.
+        :param prefetch_field_options: If field options should be prefetched.
         :return: Iterator over returned views.
         """
 
@@ -721,7 +724,9 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             per_content_type_queryset_hook=(
                 lambda model, queryset: view_type_registry.get_by_model(
                     model
-                ).enhance_queryset(queryset)
+                ).enhance_queryset(
+                    queryset, prefetch_field_options=prefetch_field_options
+                )
             ),
         )
 

--- a/backend/src/baserow/contrib/database/views/registries.py
+++ b/backend/src/baserow/contrib/database/views/registries.py
@@ -925,7 +925,9 @@ class ViewType(
         return values
 
     def enhance_queryset(
-        self, queryset: django_models.QuerySet
+        self,
+        queryset: django_models.QuerySet,
+        prefetch_field_options: bool = True,
     ) -> django_models.QuerySet:
         """
         This hook can be used to enhance a queryset when fetching multiple views of a
@@ -936,6 +938,7 @@ class ViewType(
         `get_hidden_fields` method.
 
         :param queryset: The specific queryset that must be enhanced.
+        :param prefetch_field_options: If field options should be prefetched.
         :return: The enhanced queryset.
         """
 

--- a/backend/src/baserow/contrib/database/views/view_types.py
+++ b/backend/src/baserow/contrib/database/views/view_types.py
@@ -366,8 +366,10 @@ class GridViewType(ViewType):
 
         return hidden_field_ids
 
-    def enhance_queryset(self, queryset):
-        return queryset.prefetch_related("gridviewfieldoptions_set")
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("gridviewfieldoptions_set")
+        return queryset
 
 
 class GalleryViewType(ViewType):
@@ -595,8 +597,10 @@ class GalleryViewType(ViewType):
 
         return hidden_field_ids
 
-    def enhance_queryset(self, queryset):
-        return queryset.prefetch_related("galleryviewfieldoptions_set")
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("galleryviewfieldoptions_set")
+        return queryset
 
     def after_field_delete(self, field: Field) -> None:
         if isinstance(field, FileField):
@@ -1438,10 +1442,11 @@ class FormViewType(ViewType):
 
         return values
 
-    def enhance_queryset(self, queryset):
-        return queryset.prefetch_related(
-            "formviewfieldoptions_set", "users_to_notify_on_submit"
-        )
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        queryset = queryset.prefetch_related("users_to_notify_on_submit")
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("formviewfieldoptions_set")
+        return queryset
 
     def enhance_field_options_queryset(self, queryset):
         return queryset.prefetch_related(

--- a/changelog/entries/unreleased/bug/fix_multiple_select_no_value.json
+++ b/changelog/entries/unreleased/bug/fix_multiple_select_no_value.json
@@ -3,7 +3,7 @@
   "message": "Fix multiple select field no value in row edit modal.",
   "issue_origin": "github",
   "issue_number": null,
-  "domain": "builder",
+  "domain": "database",
   "bullet_points": [],
   "created_at": "2026-06-08"
 }

--- a/changelog/entries/unreleased/bug/improve_list_views_performance.json
+++ b/changelog/entries/unreleased/bug/improve_list_views_performance.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Improve list views endpoint performance when there are many views and fields.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-08"
+}

--- a/changelog/entries/unreleased/refactor/improve_list_views_performance.json
+++ b/changelog/entries/unreleased/refactor/improve_list_views_performance.json
@@ -1,5 +1,5 @@
 {
-  "type": "bug",
+  "type": "refactor",
   "message": "Improve list views endpoint performance when there are many views and fields.",
   "issue_origin": "github",
   "issue_number": null,

--- a/enterprise/backend/src/baserow_enterprise/assistant/tools/database/tools.py
+++ b/enterprise/backend/src/baserow_enterprise/assistant/tools/database/tools.py
@@ -359,6 +359,7 @@ def list_views(
         decorations=False,
         group_bys=False,
         limit=100,
+        prefetch_field_options=False,
     )
 
     return {"views": [ViewItem.from_django_orm(view).model_dump() for view in views]}

--- a/enterprise/backend/src/baserow_enterprise/view_ownership_types.py
+++ b/enterprise/backend/src/baserow_enterprise/view_ownership_types.py
@@ -1,7 +1,8 @@
+from collections import defaultdict
 from typing import List, Optional, Set
 
 from django.contrib.auth.models import AbstractUser
-from django.db.models import QuerySet
+from django.db.models import QuerySet, prefetch_related_objects
 
 from baserow.contrib.database.table.models import Table
 from baserow.contrib.database.views.handler import ViewHandler
@@ -119,6 +120,25 @@ class RestrictedViewOwnershipType(ViewOwnershipType):
             permission_checks.values(), workspace=views[0].table.database.workspace
         )
 
+        # The `view_type.get_hidden_fields` needs to have the field options in order
+        # to calculate the hidden fields. In order to keep things performant,
+        # they must be prefetched.
+        specifics_by_class = defaultdict(list)
+        for view in views:
+            if not check_results[permission_checks[f"update_field_options{view.id}"]]:
+                specific = view.specific
+                specifics_by_class[type(specific)].append(specific)
+
+        for model_class, specifics in specifics_by_class.items():
+            view_type = view_type_registry.get_by_model(model_class)
+            field_option_lookups = view_type.enhance_queryset(
+                model_class.objects.all(), prefetch_field_options=True
+            )._prefetch_related_lookups
+            if field_option_lookups:
+                # Only prefetches the related objects if they're not already set on
+                # the specific objects.
+                prefetch_related_objects(specifics, *field_option_lookups)
+
         for view in views:
             if not hasattr(view, "_prefetched_objects_cache"):
                 view._prefetched_objects_cache = {}
@@ -140,10 +160,6 @@ class RestrictedViewOwnershipType(ViewOwnershipType):
             if not field_options_check_result:
                 # Cache hidden field IDs to avoid repeated permission checks.
                 view_type = view_type_registry.get_by_model(view.specific_class)
-                # This could cause N number of queries, but if the views are fetched
-                # using the `ViewHandler::list_views`, which is used when listing the
-                # views via the API, it won't be a problem because everything is then
-                # prefetched.
                 hidden_field_ids = view_type.get_hidden_fields(view.specific)
                 view._hidden_field_ids = hidden_field_ids
 

--- a/enterprise/backend/src/baserow_enterprise/view_ownership_types.py
+++ b/enterprise/backend/src/baserow_enterprise/view_ownership_types.py
@@ -121,8 +121,8 @@ class RestrictedViewOwnershipType(ViewOwnershipType):
         )
 
         # The `view_type.get_hidden_fields` needs to have the field options in order
-        # to calculate the hidden fields. In order to keep things performant,
-        # they must be prefetched.
+        # to calculate the hidden fields. To keep things performant, they must be
+        # prefetched.
         specifics_by_class = defaultdict(list)
         for view in views:
             if not check_results[permission_checks[f"update_field_options{view.id}"]]:
@@ -131,13 +131,11 @@ class RestrictedViewOwnershipType(ViewOwnershipType):
 
         for model_class, specifics in specifics_by_class.items():
             view_type = view_type_registry.get_by_model(model_class)
-            field_option_lookups = view_type.enhance_queryset(
-                model_class.objects.all(), prefetch_field_options=True
-            )._prefetch_related_lookups
-            if field_option_lookups:
-                # Only prefetches the related objects if they're not already set on
-                # the specific objects.
-                prefetch_related_objects(specifics, *field_option_lookups)
+            if view_type.field_options_model_class is not None:
+                prefetch_name = (
+                    f"{view_type.field_options_model_class._meta.model_name}_set"
+                )
+                prefetch_related_objects(specifics, prefetch_name)
 
         for view in views:
             if not hasattr(view, "_prefetched_objects_cache"):

--- a/enterprise/backend/tests/baserow_enterprise_tests/views/test_restricted_view.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/views/test_restricted_view.py
@@ -19,6 +19,7 @@ from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.views.handler import ViewHandler
 from baserow.contrib.database.views.models import (
     GalleryViewFieldOptions,
+    GridView,
     GridViewFieldOptions,
     View,
     ViewDecoration,
@@ -2576,6 +2577,109 @@ def test_default_values_list_views_no_n_plus_one_queries(
 
     # The query count should be the same regardless of view count.
     assert three_views_query_count == baseline_query_count
+
+
+def _setup_prepare_views_field_options_test(enterprise_data_fixture, view_count=3):
+    enterprise_data_fixture.enable_enterprise()
+
+    admin = enterprise_data_fixture.create_user()
+    editor_user = enterprise_data_fixture.create_user()
+    workspace = enterprise_data_fixture.create_workspace(
+        user=admin, members=[editor_user]
+    )
+    database = enterprise_data_fixture.create_database_application(workspace=workspace)
+    table = enterprise_data_fixture.create_database_table(database=database)
+    visible_field = enterprise_data_fixture.create_text_field(table=table, primary=True)
+    hidden_field = enterprise_data_fixture.create_text_field(table=table)
+
+    no_access_role = Role.objects.get(uid="NO_ACCESS")
+    editor_role = Role.objects.get(uid="EDITOR")
+    RoleAssignmentHandler().assign_role(
+        editor_user, workspace, role=no_access_role, scope=workspace
+    )
+
+    views = []
+    for _ in range(view_count):
+        view = enterprise_data_fixture.create_grid_view(
+            table=table, ownership_type=RestrictedViewOwnershipType.type
+        )
+        _set_field_hidden(view, hidden_field, visible_fields=[visible_field])
+        RoleAssignmentHandler().assign_role(
+            editor_user,
+            workspace,
+            role=editor_role,
+            scope=View.objects.get(id=view.id),
+        )
+        views.append(view)
+
+    return editor_user, hidden_field, views
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_prepare_views_for_user_prefetches_field_options_in_bulk(
+    enterprise_data_fixture,
+):
+    editor_user, hidden_field, views = _setup_prepare_views_field_options_test(
+        enterprise_data_fixture
+    )
+
+    # Fetch the views without the field options prefetched, like the list views
+    # API endpoint does because it doesn't include them in the response.
+    views = list(GridView.objects.filter(id__in=[v.id for v in views]))
+    assert all(
+        "gridviewfieldoptions_set" not in getattr(v, "_prefetched_objects_cache", {})
+        for v in views
+    )
+
+    with CaptureQueriesContext(connection) as context:
+        prepared = RestrictedViewOwnershipType().prepare_views_for_user(
+            editor_user, views, includes=set()
+        )
+
+    field_option_queries = [
+        query["sql"]
+        for query in context.captured_queries
+        if "database_gridviewfieldoptions" in query["sql"]
+    ]
+    assert len(field_option_queries) == 1
+
+    # The hidden fields must have been computed correctly from the prefetched
+    # field options.
+    for view in prepared:
+        assert view._hidden_field_ids == {hidden_field.id}
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_prepare_views_for_user_does_not_refetch_prefetched_field_options(
+    enterprise_data_fixture,
+):
+    editor_user, hidden_field, views = _setup_prepare_views_field_options_test(
+        enterprise_data_fixture
+    )
+
+    views = list(
+        GridView.objects.filter(id__in=[v.id for v in views]).prefetch_related(
+            "gridviewfieldoptions_set"
+        )
+    )
+    assert all("gridviewfieldoptions_set" in v._prefetched_objects_cache for v in views)
+
+    with CaptureQueriesContext(connection) as context:
+        prepared = RestrictedViewOwnershipType().prepare_views_for_user(
+            editor_user, views, includes=set()
+        )
+
+    field_option_queries = [
+        query["sql"]
+        for query in context.captured_queries
+        if "database_gridviewfieldoptions" in query["sql"]
+    ]
+    assert len(field_option_queries) == 0
+
+    for view in prepared:
+        assert view._hidden_field_ids == {hidden_field.id}
 
 
 @pytest.mark.django_db

--- a/premium/backend/src/baserow_premium/views/view_types.py
+++ b/premium/backend/src/baserow_premium/views/view_types.py
@@ -294,8 +294,10 @@ class KanbanViewType(ViewType):
 
         return hidden_field_ids
 
-    def enhance_queryset(self, queryset):
-        return queryset.prefetch_related("kanbanviewfieldoptions_set")
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("kanbanviewfieldoptions_set")
+        return queryset
 
     def after_field_delete(self, field: Field) -> None:
         if isinstance(field, FileField):
@@ -546,8 +548,10 @@ class CalendarViewType(ViewType):
 
         return hidden_field_ids
 
-    def enhance_queryset(self, queryset):
-        return queryset.prefetch_related("calendarviewfieldoptions_set")
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("calendarviewfieldoptions_set")
+        return queryset
 
     def after_field_delete(self, field: Field) -> None:
         CalendarView.objects.filter(date_field_id=field.id).update(date_field_id=None)
@@ -887,7 +891,8 @@ class TimelineViewType(ViewType):
     def after_field_delete(self, field: Field) -> None:
         self._reset_views_with_incpompatible_fields(field)
 
-    def enhance_queryset(self, queryset):
-        return queryset.select_related(
-            "start_date_field", "end_date_field"
-        ).prefetch_related("timelineviewfieldoptions_set")
+    def enhance_queryset(self, queryset, prefetch_field_options=True):
+        queryset = queryset.select_related("start_date_field", "end_date_field")
+        if prefetch_field_options:
+            queryset = queryset.prefetch_related("timelineviewfieldoptions_set")
+        return queryset


### PR DESCRIPTION
### What is in this PR

This list views endpoint was prefetching all the field options, even though they were not needed in the response. If there were many views and many fields, it would have to fetch (views * fields =) objects, which could easily hit the 100k+. This was causing performance problems because it could slow down the endpoint significantly.

This PR makes a small change so that the field options are not prefetched in this case. A side effect of this is that the restricted view listing slows down because it does need the prefetched field options there to avoid N number of queries. I've made a small change so that only the field options of the restricted views are prefetched.

In my dev environment, I noticed the saw the endpoint going from 1s to 300ms in my dev environment. The impact in our production environment will be much better because it can take 9s in the current situation.

Before:

<img width="3314" height="590" alt="image" src="https://github.com/user-attachments/assets/f7617625-5408-4193-97f9-c1ae204d7a9f" />

After:

<img width="3314" height="590" alt="image" src="https://github.com/user-attachments/assets/fddeb92c-604b-43ee-8e28-bcc9fbfc4ed4" />


### How to test this PR

- Create a table with 200 views and 200 fields.
- Observe that the `http://localhost:8000/api/database/views/table/{table_id}/` is much faster than on the develop branch.
- Create a couple of restricted views. Confirm that there are no N number of queries when listing the views.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
