### PR TITLE
Fix multiple select field no value in row edit modal

### DIFF
--- a/changelog/entries/unreleased/bug/fix_multiple_select_no_value.json
+++ b/changelog/entries/unreleased/bug/fix_multiple_select_no_value.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fix multiple select field no value in row edit modal.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "builder",
+  "bullet_points": [],
+  "created_at": "2026-06-08"
+}

--- a/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldMultipleSelect.vue
@@ -2,7 +2,9 @@
   <div class="control__elements">
     <ul
       class="field-multiple-select__items"
-      :class="{ 'field-multiple-select__items--empty': value.length === 0 }"
+      :class="{
+        'field-multiple-select__items--empty': !value || value.length === 0,
+      }"
     >
       <li
         v-for="item in value"


### PR DESCRIPTION
### What is in this PR

Fixes a small bug where the value of a multiple select field is unavailable when the row edit modal closes. Related to https://baserow-eu.sentry.io/issues/124845652

Before:

https://github.com/user-attachments/assets/76f44f0b-7416-4efb-9ba0-f9988b78badc

### How to test this PR

- Create a table with multiple select field.
- Open the row edit modal of any row.
- Close the row edit modal.
- Observe that it does not give an error like on `develop`.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
