### PR TITLE
fix(web-frontend): correct link row "Add new" create modal behavior

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_link_row_add_new_modal_showing_premature_errors_and_cr.json
+++ b/changelog/entries/unreleased/bug/fixes_link_row_add_new_modal_showing_premature_errors_and_cr.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixes link row Add new modal showing premature errors and crashing on URL formula fields",
+  "issue_origin": "github",
+  "issue_number": 3940,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-08"
+}

--- a/web-frontend/modules/database/components/row/RowCreateModal.vue
+++ b/web-frontend/modules/database/components/row/RowCreateModal.vue
@@ -8,6 +8,7 @@
       </div>
       <Error :error="error" />
       <RowEditModalFieldsList
+        ref="visibleFieldsList"
         :primary-is-sortable="primaryIsSortable"
         :fields="visibleFields"
         :sortable="sortable"
@@ -19,6 +20,7 @@
         :database="database"
         :can-modify-fields="canModifyFields"
         :all-fields-in-table="allFieldsInTable"
+        :touched="touched"
         @field-updated="$emit('field-updated', $event)"
         @field-deleted="$emit('field-deleted')"
         @order-fields="$emit('order-fields', $event)"
@@ -33,6 +35,7 @@
         "
       >
         <RowEditModalFieldsList
+          ref="hiddenFieldsList"
           :primary-is-sortable="primaryIsSortable"
           :fields="hiddenFields"
           :sortable="false"
@@ -44,6 +47,7 @@
           :database="database"
           :can-modify-fields="canModifyFields"
           :all-fields-in-table="allFieldsInTable"
+          :touched="touched"
           @field-updated="$emit('field-updated', $event)"
           @field-deleted="$emit('field-deleted')"
           @toggle-field-visibility="$emit('toggle-field-visibility', $event)"
@@ -145,6 +149,7 @@ export default {
     return {
       row: {},
       loading: false,
+      touched: false,
     }
   },
   computed: {
@@ -208,6 +213,7 @@ export default {
       })
       Object.assign(row, defaults)
       this.row = row
+      this.touched = false
       return modal.methods.show.call(this, ...args)
     },
     update(event) {
@@ -215,6 +221,16 @@ export default {
       this.row[name] = event.value
     },
     create() {
+      this.touched = true
+
+      const valid = [this.$refs.visibleFieldsList, this.$refs.hiddenFieldsList]
+        .filter(Boolean)
+        .every((list) => list.isValid())
+
+      if (!valid) {
+        return
+      }
+
       this.loading = true
       this.$emit('created', {
         row: this.row,

--- a/web-frontend/modules/database/components/row/RowEditModalField.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalField.vue
@@ -168,11 +168,8 @@ export default {
       })
     },
     isValid() {
-      const component = this.$refs.field
-      if (!component || typeof component.isValid !== 'function') {
-        return true
-      }
-      return component.isValid()
+      // Fail open if not yet mounted.
+      return this.$refs.field?.isValid() ?? true
     },
   },
 }

--- a/web-frontend/modules/database/components/row/RowEditModalField.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalField.vue
@@ -59,7 +59,9 @@
       :row-is-created="!!row.id"
       :row="row"
       :all-fields-in-table="allFieldsInTable"
+      :touched="localTouched"
       @update="update"
+      @touched="localTouched = true"
       @refresh-row="$emit('refresh-row', row)"
     />
   </div>
@@ -125,6 +127,11 @@ export default {
       required: false,
       default: () => true,
     },
+    touched: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   emits: [
     'field-deleted',
@@ -133,6 +140,16 @@ export default {
     'toggle-field-visibility',
     'update',
   ],
+  data() {
+    return {
+      localTouched: this.touched,
+    }
+  },
+  watch: {
+    touched(value) {
+      this.localTouched = value
+    },
+  },
   methods: {
     isReadOnlyField(field) {
       return !this.$registry.get('field', field.type).canWriteFieldValues(field)
@@ -149,6 +166,13 @@ export default {
         value,
         oldValue,
       })
+    },
+    isValid() {
+      const component = this.$refs.field
+      if (!component || typeof component.isValid !== 'function') {
+        return true
+      }
+      return component.isValid()
     },
   },
 }

--- a/web-frontend/modules/database/components/row/RowEditModalFieldsList.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalFieldsList.vue
@@ -27,6 +27,7 @@
         :sortable="sortable && fieldIsSortable(field)"
         :can-modify-fields="canModifyFields"
         :all-fields-in-table="allFieldsInTable"
+        :touched="touched"
         @field-updated="$emit('field-updated', $event)"
         @field-deleted="$emit('field-deleted')"
         @update="$emit('update', $event)"
@@ -93,6 +94,11 @@ export default {
       type: Array,
       required: true,
     },
+    touched: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   emits: [
     'field-deleted',
@@ -105,6 +111,13 @@ export default {
   methods: {
     fieldIsSortable(field) {
       return this.sortable && (this.primaryIsSortable || !field.primary)
+    },
+    isValid() {
+      return this.fields.every((field) => {
+        const ref = this.$refs['field-' + field.id]
+        const component = Array.isArray(ref) ? ref[0] : ref
+        return component ? component.isValid() : true
+      })
     },
   },
 }

--- a/web-frontend/modules/database/components/row/SelectRowContent.vue
+++ b/web-frontend/modules/database/components/row/SelectRowContent.vue
@@ -437,6 +437,7 @@ export default {
       this.$refs.search?.focus()
     },
     async createRow({ row, callback }) {
+      let rowCreated
       try {
         const preparedRow = prepareRowForRequest(
           row,
@@ -444,42 +445,35 @@ export default {
           this.$registry
         )
 
-        const { data: rowCreated } = await RowService(this.$client).create(
+        const response = await RowService(this.$client).create(
           this.table.id,
           preparedRow
         )
+        rowCreated = response.data
 
         await this.fetch(this.page)
-
-        // When you create a new row from a linked row that links to its own table,the
-        // realtime update will be sent from you, and you won't receive it.Since you
-        // don't receive the realtime update we have to manually add the new row to the
-        // state. We can do that by using the same function that is used by the
-        // realtime update. (`viewType.rowCreated`)
-        const view = this.$store.getters['view/getSelected']
-
-        // The `view.type` check ensures that the Builder doesn't crash when
-        // creating a new row in the Data Source modal.
-        //
-        // In AB's Data Source modal, it is possible to create a new row for
-        // fields of the type "Link to table". Since there is no selected view,
-        // there is no view type.
-        callback()
-
-        if (view.type) {
-          const viewType = this.$registry.get('view', view.type)
-          viewType.rowCreated(
-            { store: this.$store },
-            this.table.id,
-            this.allFields,
-            rowCreated,
-            {},
-            'page/'
-          )
-          this.select(populateRow(rowCreated))
-        }
       } catch (error) {
         callback(error)
+        return
+      }
+
+      // Close before the selection below hides the parent modal, else it
+      // unmounts mid-close and loses its loading state.
+      callback()
+
+      // Self-referencing link rows don't receive their own realtime update.
+      const view = this.$store.getters['view/getSelected']
+      if (view.type) {
+        const viewType = this.$registry.get('view', view.type)
+        viewType.rowCreated(
+          { store: this.$store },
+          this.table.id,
+          this.allFields,
+          rowCreated,
+          {},
+          'page/'
+        )
+        this.select(populateRow(rowCreated))
       }
     },
     toggleFieldsContext() {

--- a/web-frontend/modules/database/components/row/SelectRowContent.vue
+++ b/web-frontend/modules/database/components/row/SelectRowContent.vue
@@ -464,6 +464,8 @@ export default {
         // In AB's Data Source modal, it is possible to create a new row for
         // fields of the type "Link to table". Since there is no selected view,
         // there is no view type.
+        callback()
+
         if (view.type) {
           const viewType = this.$registry.get('view', view.type)
           viewType.rowCreated(
@@ -476,8 +478,6 @@ export default {
           )
           this.select(populateRow(rowCreated))
         }
-
-        callback()
       } catch (error) {
         callback(error)
       }

--- a/web-frontend/modules/database/formula/formulaTypes.js
+++ b/web-frontend/modules/database/formula/formulaTypes.js
@@ -1180,7 +1180,7 @@ export class BaserowFormulaLinkType extends BaserowFormulaTypeDefinition {
     if (value?.label) {
       return `${value.label} (${value.url})`
     } else {
-      return value.url
+      return value?.url ?? ''
     }
   }
 
@@ -1248,7 +1248,7 @@ export class BaserowFormulaURLType extends mix(
     if (value?.label) {
       return `${value.label} (${value.url})`
     } else {
-      return value.url
+      return value?.url ?? ''
     }
   }
 

--- a/web-frontend/modules/database/formula/formulaTypes.js
+++ b/web-frontend/modules/database/formula/formulaTypes.js
@@ -1177,10 +1177,13 @@ export class BaserowFormulaLinkType extends BaserowFormulaTypeDefinition {
   }
 
   toHumanReadableString(field, value) {
-    if (value?.label) {
+    if (value == null) {
+      return ''
+    }
+    if (value.label) {
       return `${value.label} (${value.url})`
     } else {
-      return value?.url ?? ''
+      return value.url
     }
   }
 
@@ -1242,13 +1245,16 @@ export class BaserowFormulaURLType extends mix(
   }
 
   toHumanReadableString(field, value) {
+    if (value == null) {
+      return ''
+    }
     if (_.isString(value)) {
       return value
     }
-    if (value?.label) {
+    if (value.label) {
       return `${value.label} (${value.url})`
     } else {
-      return value?.url ?? ''
+      return value.url
     }
   }
 

--- a/web-frontend/test/unit/database/components/row/rowCreateModal.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowCreateModal.spec.js
@@ -1,0 +1,87 @@
+import { flushPromises } from '@vue/test-utils'
+
+import { TestApp } from '@baserow/test/helpers/testApp'
+import RowCreateModal from '@baserow/modules/database/components/row/RowCreateModal'
+import { populateField } from '@baserow/modules/database/store/field'
+
+describe('RowCreateModal', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const database = { id: 1, workspace: { id: 1 } }
+  const table = { id: 1 }
+
+  const buildFields = () => {
+    const registry = testApp.getRegistry()
+    return [
+      { id: 1, name: 'Name', type: 'text', primary: true, text_default: '' },
+      { id: 2, name: 'URL', type: 'url', primary: false },
+    ].map((field) => populateField(field, registry))
+  }
+
+  const mountModal = async () => {
+    const fields = buildFields()
+    const wrapper = await testApp.mount(RowCreateModal, {
+      props: {
+        database,
+        table,
+        view: null,
+        visibleFields: fields,
+        hiddenFields: [],
+        allFieldsInTable: fields,
+        canModifyFields: false,
+      },
+      global: { stubs: { FieldContext: true } },
+    })
+    await wrapper.vm.show()
+    await flushPromises()
+    return { wrapper, fields }
+  }
+
+  const getModalField = (wrapper, type) =>
+    wrapper
+      .findAllComponents({ name: 'RowEditModalField' })
+      .find((component) => component.props('field').type === type)
+
+  test('does not pre-validate fields when the modal is opened', async () => {
+    const { wrapper } = await mountModal()
+
+    const urlField = getModalField(wrapper, 'url')
+    expect(urlField).toBeDefined()
+    expect(urlField.find('.control__messages--error').exists()).toBe(false)
+  })
+
+  test('emits created when all field values are valid', async () => {
+    const { wrapper } = await mountModal()
+
+    wrapper.vm.create()
+    await flushPromises()
+
+    expect(wrapper.emitted('created')).toHaveLength(1)
+  })
+
+  test('shows the error and blocks creation for an invalid value', async () => {
+    const { wrapper } = await mountModal()
+
+    const urlField = getModalField(wrapper, 'url')
+    const input = urlField.find('input')
+    await input.trigger('focus')
+    await input.setValue('not a valid url')
+    await input.trigger('blur')
+    await flushPromises()
+
+    expect(urlField.find('.control__messages--error').exists()).toBe(true)
+
+    wrapper.vm.create()
+    await flushPromises()
+
+    expect(wrapper.emitted('created')).toBeUndefined()
+  })
+})

--- a/web-frontend/test/unit/database/formulaTypes.spec.js
+++ b/web-frontend/test/unit/database/formulaTypes.spec.js
@@ -1,0 +1,46 @@
+import {
+  BaserowFormulaURLType,
+  BaserowFormulaLinkType,
+} from '@baserow/modules/database/formula/formulaTypes'
+
+describe('formula URL types toHumanReadableString', () => {
+  const app = {}
+  const field = {}
+
+  describe.each([
+    ['BaserowFormulaURLType', new BaserowFormulaURLType({ app })],
+    ['BaserowFormulaLinkType', new BaserowFormulaLinkType({ app })],
+  ])('%s', (name, formulaType) => {
+    test('returns an empty string for a null value', () => {
+      expect(formulaType.toHumanReadableString(field, null)).toBe('')
+    })
+
+    test('returns an empty string for an undefined value', () => {
+      expect(formulaType.toHumanReadableString(field, undefined)).toBe('')
+    })
+
+    test('formats a value with a label and url', () => {
+      expect(
+        formulaType.toHumanReadableString(field, {
+          label: 'Baserow',
+          url: 'https://baserow.io',
+        })
+      ).toBe('Baserow (https://baserow.io)')
+    })
+
+    test('returns the url when there is no label', () => {
+      expect(
+        formulaType.toHumanReadableString(field, {
+          url: 'https://baserow.io',
+        })
+      ).toBe('https://baserow.io')
+    })
+  })
+
+  test('BaserowFormulaURLType returns a plain string value as-is', () => {
+    const formulaType = new BaserowFormulaURLType({ app })
+    expect(formulaType.toHumanReadableString(field, 'https://baserow.io')).toBe(
+      'https://baserow.io'
+    )
+  })
+})


### PR DESCRIPTION
### What is in this PR

Fixes the link row "Add new" create modal (#3940). Four things were broken when you opened that modal: fields showed validation errors before you typed anything, the Create button never showed a loading state, you could create a row with invalid input, and the modal crashed outright when the linked table's primary field was a URL-typed formula.

### Root cause

Four separate bugs in the same flow:

1. **Pre-validation on open.** `rowEditField.js` defaults `touched` to `true`, and the `touched` prop was never passed down through `RowCreateModal`, `RowEditModalFieldsList`, and `RowEditModalField`. So every field mounted already "touched" and immediately rendered its error chrome (`v-show="touched && !valid"`). The gallery modal avoided this only because it passes `cardFields` rather than every field.
2. **No loading state.** `SelectRowContent.createRow` called `this.select(...)` before `callback()`. `select()` emits `selected`, which hides the parent `SelectRowModal` and unmounts `RowCreateModal` before its `loading=true` state could render. The fix restructures `createRow`: the `try/catch` now wraps only the network create and fetch, and `callback()` runs exactly once on success before the new row is propagated and selected. The create modal now closes itself instead of being torn down by the parent.
3. **Create despite errors.** `RowCreateModal.create()` emitted `created` without first validating the rendered fields.
4. **Crash.** For a brand-new row, `RowCreateModal.heading` calls `toHumanReadableString(field, null)`. In `BaserowFormulaURLType.toHumanReadableString` (formulaTypes.js:1251, and the matching `BaserowFormulaLinkType` at :1183) that dereferenced `value.url` with no null check, throwing `Cannot read properties of null (reading 'url')`. The same method already guards the string case with `_.isString(value)`; the fix adds the missing null case.

### How to test this PR

#### Automated
```
just f yarn test:core --run test/unit/database/components/row/rowCreateModal.spec.js
just f yarn test:core --run test/unit/database/formulaTypes.spec.js
```
The `formulaTypes` null cases throw on `develop` and pass with the fix. The modal spec checks that no errors show on open, that an invalid value blocks submission, and that `created` only fires when the input is valid.

#### Manual
1. Table A: a URL field named `URL` plus a primary formula `field("URL")`.
2. Table B: a link row field pointing at Table A.
3. From a Table B row, open the link row modal and click **+ Add new**.
   - Before: the console throws on `value.url`, and the URL and formula fields show errors right away.
   - After: the modal opens cleanly with no premature errors.
4. Type an invalid URL and click **Create**. The modal stays open, the error shows, and no row is created.
5. Clear or fix the URL and click **Create**. The modal closes and the new row is created and linked. (The Create button shows its loading state while the request runs; on a local backend that is over quickly.)

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered

Closes #3940