### PR TITLE
fix: Ensure correct icon is shown when duplicating an application

### DIFF
--- a/changelog/entries/unreleased/bug/5483_fixed_the_application_icon_when_duplication_an_application.json
+++ b/changelog/entries/unreleased/bug/5483_fixed_the_application_icon_when_duplication_an_application.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed the application icon when duplication an application.",
+    "issue_origin": "github",
+    "issue_number": 5483,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-09"
+}

--- a/web-frontend/modules/core/components/sidebar/SidebarApplicationPendingJob.vue
+++ b/web-frontend/modules/core/components/sidebar/SidebarApplicationPendingJob.vue
@@ -26,7 +26,7 @@ export default {
       return this.$registry.get('job', this.job.type).getSidebarText(this.job)
     },
     jobIconClass() {
-      return this.$registry.get('job', this.job.type).getIconClass()
+      return this.$registry.get('job', this.job.type).getIconClass(this.job)
     },
   },
 }

--- a/web-frontend/modules/core/jobTypes.js
+++ b/web-frontend/modules/core/jobTypes.js
@@ -126,9 +126,14 @@ export class DuplicateApplicationJobType extends JobType {
     return 'duplicate_application'
   }
 
-  getIconClass() {
-    // TODO: This should be moved to a registry and in the database module.
-    return 'iconoir-db'
+  getIconClass(job) {
+    const applicationTypeName = job.original_application.type
+    if (!this.app.$registry.exists('application', applicationTypeName)) {
+      return 'iconoir-db'
+    }
+    return this.app.$registry
+      .get('application', applicationTypeName)
+      .getIconClass()
   }
 
   getName() {


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug when duplicating a Builder or Automation app.

Currently, duplicating a builder or automation app will cause the database app icon to be shown. In this PR, both Builder and Automation apps now show the correct app icon:
| Before | After |
| - | - |
| <img width="462" height="448" alt="image" src="https://github.com/user-attachments/assets/681d2508-ff9d-4160-b887-238892328850" /> | <img width="448" height="386" alt="image" src="https://github.com/user-attachments/assets/88a85e35-1d66-44f0-a79f-156a706347dd" /> |

Closes https://github.com/baserow/baserow/issues/5483

### How to test this PR
In your browser debug tools, throttle your network connection to something very slow (e.g. 3G).

Duplicate the Builder or Automation app. You'll see that the icon shown is the Database icon.

In this branch, all the apps should show the correct icon when duplicating.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
