### PR TITLE
fix(backend): MCP create_rows does not fail when table has rich text fields with @mentions

### DIFF
--- a/backend/src/baserow/contrib/database/mcp/services.py
+++ b/backend/src/baserow/contrib/database/mcp/services.py
@@ -461,7 +461,8 @@ def create_rows(
     table = get_table(user, workspace, table_id)
     model = table.get_model()
     rows_values = _map_user_field_names(model, rows)
-    created = CreateRowsActionType.do(user, table, rows_values, model=model)
+    with transaction.atomic():
+        created = CreateRowsActionType.do(user, table, rows_values, model=model)
     return list(serialize_rows_for_response(created, model, user_field_names=True))
 
 

--- a/backend/templates/all-fields.json
+++ b/backend/templates/all-fields.json
@@ -539,6 +539,14 @@
               "through_field_name": "Related",
               "target_field_id": 13020,
               "target_field_name": "URL"
+            },
+            {
+              "id": 43346,
+              "type": "long_text",
+              "name": "Rich text notes",
+              "order": 36,
+              "primary": false,
+              "long_text_enable_rich_text": true
             }
           ],
           "views": [
@@ -1203,7 +1211,8 @@
               "field_13017": null,
               "field_13019": null,
               "field_13022": null,
-              "field_13023": null
+              "field_13023": null,
+              "field_43346": ""
             }
           ]
         },

--- a/backend/tests/baserow/contrib/database/mcp/test_mcp_services.py
+++ b/backend/tests/baserow/contrib/database/mcp/test_mcp_services.py
@@ -354,6 +354,28 @@ def test_create_rows_with_user_field_names(data_fixture):
     assert created[1]["Name"] == "Bob"
 
 
+@pytest.mark.django_db(transaction=True)
+def test_create_rows_with_rich_text_mention(data_fixture):
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    db = data_fixture.create_database_application(workspace=workspace)
+    table = data_fixture.create_database_table(database=db)
+    data_fixture.create_text_field(name="Name", table=table, primary=True)
+    data_fixture.create_long_text_field(
+        name="Notes", table=table, long_text_enable_rich_text=True
+    )
+
+    created = services.create_rows(
+        user,
+        workspace,
+        table.id,
+        [{"Name": "Test", "Notes": f"Hello @{user.id} check this"}],
+    )
+    assert len(created) == 1
+    assert created[0]["Name"] == "Test"
+    assert f"@{user.id}" in created[0]["Notes"]
+
+
 @pytest.mark.django_db
 def test_create_rows_unknown_field_raises(data_fixture):
     user = data_fixture.create_user()

--- a/changelog/entries/unreleased/bug/5493_fix_for_mcp_create_rows_fails_when_table_has_rich_text_field.json
+++ b/changelog/entries/unreleased/bug/5493_fix_for_mcp_create_rows_fails_when_table_has_rich_text_field.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix for MCP create_rows fails when table has rich text fields with @mentions",
+    "issue_origin": "github",
+    "issue_number": 5493,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-10"
+}

--- a/changelog/entries/unreleased/bug/5493_fix_for_mcp_create_rows_fails_when_table_has_rich_text_field.json
+++ b/changelog/entries/unreleased/bug/5493_fix_for_mcp_create_rows_fails_when_table_has_rich_text_field.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Fix for MCP create_rows fails when table has rich text fields with @mentions",
+    "message": "Fix MCP create_rows failing when table has rich text fields with @mentions",
     "issue_origin": "github",
     "issue_number": 5493,
     "domain": "database",


### PR DESCRIPTION
Closes #5493 


### What is in this PR
This pr:

- fixes issue when MCP is called to create rows on table that contains rich text with mentions. 
- contains targeted unittest for this case
- adds rich text field to All fields template


### How to test this PR
- Set up MCP for baserow
- Create table with rich text or use "All fields" template (recommended)
- Ask MCP to create some rows and observe that no exception is thrown

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
