### PR TITLE
feat: option to exclude row ID and primary field columns in export

### DIFF
--- a/backend/src/baserow/contrib/database/api/export/serializers.py
+++ b/backend/src/baserow/contrib/database/api/export/serializers.py
@@ -146,6 +146,14 @@ class BaseExporterOptionsSerializer(serializers.Serializer):
         child=serializers.IntegerField(),
         help_text="List of field IDs that must be included in the export, in the desired order.",
     )
+    include_row_id = serializers.BooleanField(
+        default=True,
+        help_text="Whether or not to include the row id column in the export.",
+    )
+    include_primary_field = serializers.BooleanField(
+        default=True,
+        help_text="Whether or not to include the primary field column in the export.",
+    )
 
 
 class CsvExporterOptionsSerializer(BaseExporterOptionsSerializer):

--- a/backend/src/baserow/contrib/database/export/file_writer.py
+++ b/backend/src/baserow/contrib/database/export/file_writer.py
@@ -162,12 +162,30 @@ class QuerysetSerializer(abc.ABC):
 
     can_handle_rich_value = False
 
-    def __init__(self, queryset, ordered_field_objects):
+    def __init__(
+        self,
+        queryset,
+        ordered_field_objects,
+        include_row_id=True,
+        include_primary_field=True,
+    ):
         self.queryset = queryset
-        self.field_serializers = [lambda row: ("id", "id", row.id)]
+        self.include_row_id = include_row_id
+        self.include_primary_field = include_primary_field
+
+        if not include_primary_field:
+            ordered_field_objects = [
+                field_object
+                for field_object in ordered_field_objects
+                if not field_object["field"].primary
+            ]
         self.ordered_field_objects = ordered_field_objects
 
-        for field_object in ordered_field_objects:
+        self.field_serializers = []
+        if include_row_id:
+            self.field_serializers.append(lambda row: ("id", "id", row.id))
+
+        for field_object in self.ordered_field_objects:
             self.field_serializers.append(self._get_field_serializer(field_object))
 
     @abc.abstractmethod
@@ -180,20 +198,36 @@ class QuerysetSerializer(abc.ABC):
         """
 
     @classmethod
-    def for_table(cls, table) -> "QuerysetSerializer":
+    def for_table(
+        cls, table, include_row_id=True, include_primary_field=True
+    ) -> "QuerysetSerializer":
         """
         Generates a queryset serializer for the provided table.
         :param table: The table to serialize.
+        :param include_row_id: Whether to include the row id column in the export.
+        :param include_primary_field: Whether to include the primary field column
+            in the export.
         :return: A QuerysetSerializer ready to serialize the table.
         """
 
         model = table.get_model()
         qs = model.objects.all().enhance_by_fields()
         ordered_field_objects = model._field_objects.values()
-        return cls(qs, ordered_field_objects)
+        return cls(
+            qs,
+            ordered_field_objects,
+            include_row_id=include_row_id,
+            include_primary_field=include_primary_field,
+        )
 
     @classmethod
-    def for_view(cls, view, visible_field_ids_in_order=None) -> "QuerysetSerializer":
+    def for_view(
+        cls,
+        view,
+        visible_field_ids_in_order=None,
+        include_row_id=True,
+        include_primary_field=True,
+    ) -> "QuerysetSerializer":
         """
         Generates a queryset serializer for the provided view according to it's view
         type and any relevant view settings it might have (filters, sorts,
@@ -202,6 +236,9 @@ class QuerysetSerializer(abc.ABC):
         :param view: The view to serialize.
         :param visible_field_ids_in_order: Optionally provide a list of field IDs in
             the correct order. Only those fields will be included in the export.
+        :param include_row_id: Whether to include the row id column in the export.
+        :param include_primary_field: Whether to include the primary field column
+            in the export.
         :return: A QuerysetSerializer ready to serialize the table.
         """
 
@@ -223,7 +260,15 @@ class QuerysetSerializer(abc.ABC):
                 if field_id in field_map
             ]
         qs = ViewHandler().get_queryset(None, view, model=model)
-        return cls(qs, fields), visible_field_objects_in_view
+        return (
+            cls(
+                qs,
+                fields,
+                include_row_id=include_row_id,
+                include_primary_field=include_primary_field,
+            ),
+            visible_field_objects_in_view,
+        )
 
     def add_ad_hoc_filters_dict_to_queryset(self, filters_dict, only_by_field_ids=None):
         filters = AdHocFilters.from_dict(filters_dict)

--- a/backend/src/baserow/contrib/database/export/handler.py
+++ b/backend/src/baserow/contrib/database/export/handler.py
@@ -355,15 +355,24 @@ def _open_file_and_run_export(job: ExportJob) -> ExportJob:
     filters = job.export_options.pop("filters", None)
     order_by = job.export_options.pop("order_by", None)
     visible_fields_in_order = job.export_options.pop("fields", None)
+    include_row_id = job.export_options.pop("include_row_id", True)
+    include_primary_field = job.export_options.pop("include_primary_field", True)
     only_by_field_ids = None
 
     with _create_storage_dir_if_missing_and_open(storage_location) as file:
         queryset_serializer_class = exporter.queryset_serializer_class
         if job.view is None:
-            serializer = queryset_serializer_class.for_table(job.table)
+            serializer = queryset_serializer_class.for_table(
+                job.table,
+                include_row_id=include_row_id,
+                include_primary_field=include_primary_field,
+            )
         else:
             serializer, visible_fields_in_view = queryset_serializer_class.for_view(
-                job.view, visible_fields_in_order
+                job.view,
+                visible_fields_in_order,
+                include_row_id=include_row_id,
+                include_primary_field=include_primary_field,
             )
             only_by_field_ids = [f["field"].id for f in visible_fields_in_view]
 

--- a/backend/src/baserow/contrib/database/export/table_exporters/csv_table_exporter.py
+++ b/backend/src/baserow/contrib/database/export/table_exporters/csv_table_exporter.py
@@ -36,12 +36,14 @@ class CsvTableExporter(TableExporter):
 
 
 class CsvQuerysetSerializer(QuerysetSerializer):
-    def __init__(self, queryset, ordered_field_objects):
-        super().__init__(queryset, ordered_field_objects)
+    def __init__(self, queryset, ordered_field_objects, **kwargs):
+        super().__init__(queryset, ordered_field_objects, **kwargs)
 
-        self.headers = OrderedDict({"id": "id"})
+        self.headers = OrderedDict()
+        if self.include_row_id:
+            self.headers["id"] = "id"
 
-        for field_object in ordered_field_objects:
+        for field_object in self.ordered_field_objects:
             field_database_name = field_object["name"]
             field_display_name = field_object["field"].name
             self.headers[field_database_name] = field_display_name

--- a/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
+++ b/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
@@ -794,6 +794,72 @@ def test_can_export_csv_without_header(get_storage_mock, data_fixture):
 
 
 @pytest.mark.django_db
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_csv_without_row_id(get_storage_mock, data_fixture):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+
+    _, contents = setup_table_and_run_export_decoding_result(
+        data_fixture,
+        storage_mock,
+        options={"exporter_type": "csv", "include_row_id": False},
+    )
+    expected = (
+        "\ufeff"
+        "text_field,option_field,date_field,File,Price,Customer\r\n"
+        "atest,A,02/01/2020 01:23,,-10.20,linked_row_1\r\n"
+        'test,B,02/01/2020 01:23,,10.20,"linked_row_1,linked_row_2"\r\n'
+    )
+    assert expected == contents
+
+
+@pytest.mark.django_db
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_csv_without_primary_field(get_storage_mock, data_fixture):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+
+    _, contents = setup_table_and_run_export_decoding_result(
+        data_fixture,
+        storage_mock,
+        options={"exporter_type": "csv", "include_primary_field": False},
+    )
+    expected = (
+        "\ufeff"
+        "id,option_field,date_field,File,Price,Customer\r\n"
+        "2,A,02/01/2020 01:23,,-10.20,linked_row_1\r\n"
+        '1,B,02/01/2020 01:23,,10.20,"linked_row_1,linked_row_2"\r\n'
+    )
+    assert expected == contents
+
+
+@pytest.mark.django_db
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_csv_without_row_id_and_primary_field(
+    get_storage_mock, data_fixture
+):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+
+    _, contents = setup_table_and_run_export_decoding_result(
+        data_fixture,
+        storage_mock,
+        options={
+            "exporter_type": "csv",
+            "include_row_id": False,
+            "include_primary_field": False,
+        },
+    )
+    expected = (
+        "\ufeff"
+        "option_field,date_field,File,Price,Customer\r\n"
+        "A,02/01/2020 01:23,,-10.20,linked_row_1\r\n"
+        'B,02/01/2020 01:23,,10.20,"linked_row_1,linked_row_2"\r\n'
+    )
+    assert expected == contents
+
+
+@pytest.mark.django_db
 @pytest.mark.once_per_day_in_ci
 @patch("baserow.core.storage.get_default_storage")
 def test_can_export_csv_with_different_charsets(get_storage_mock, data_fixture):

--- a/changelog/entries/unreleased/feature/4680_adds_options_to_leave_out_the_row_id_and_primary_field_colum.json
+++ b/changelog/entries/unreleased/feature/4680_adds_options_to_leave_out_the_row_id_and_primary_field_colum.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Adds options to leave out the row ID and primary field columns when exporting data",
+    "issue_origin": "github",
+    "issue_number": 4680,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-10"
+}

--- a/premium/backend/src/baserow_premium/export/exporter_types.py
+++ b/premium/backend/src/baserow_premium/export/exporter_types.py
@@ -166,12 +166,14 @@ class XMLTableExporter(PremiumTableExporter):
 
 
 class ExcelQuerysetSerializer(QuerysetSerializer):
-    def __init__(self, queryset, ordered_field_objects):
-        super().__init__(queryset, ordered_field_objects)
+    def __init__(self, queryset, ordered_field_objects, **kwargs):
+        super().__init__(queryset, ordered_field_objects, **kwargs)
 
-        self.headers = OrderedDict({"id": "id"})
+        self.headers = OrderedDict()
+        if self.include_row_id:
+            self.headers["id"] = "id"
 
-        for field_object in ordered_field_objects:
+        for field_object in self.ordered_field_objects:
             field_database_name = field_object["name"]
             field_display_name = field_object["field"].name
             self.headers[field_database_name] = field_display_name

--- a/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
+++ b/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
@@ -1313,3 +1313,126 @@ def test_export_non_empty_files_group_by_row(premium_data_fixture, use_tmp_media
             assert f"row_{row_1.id}/{user_file_2.name}" in file_list
             assert f"row_{row_2.id}/{user_file_2.name}" in file_list
             assert f"row_{row_2.id}/{user_file_3.name}" in file_list
+
+
+def _setup_simple_premium_table(premium_data_fixture):
+    user = premium_data_fixture.create_user(has_active_premium_license=True)
+    table = premium_data_fixture.create_database_table(user=user)
+    primary_field = premium_data_fixture.create_text_field(
+        table=table, name="Name", primary=True
+    )
+    notes_field = premium_data_fixture.create_text_field(table=table, name="Notes")
+    grid_view = premium_data_fixture.create_grid_view(table=table)
+    RowHandler().create_row(
+        user,
+        table,
+        {f"field_{primary_field.id}": "Joe", f"field_{notes_field.id}": "hi"},
+    )
+    return user, table, grid_view
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_json_without_row_id_and_primary_field(
+    get_storage_mock, premium_data_fixture
+):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user, table, grid_view = _setup_simple_premium_table(premium_data_fixture)
+
+    _, contents = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "json",
+            "include_row_id": False,
+            "include_primary_field": False,
+        },
+    )
+    assert '"id":' not in contents
+    assert '"Name":' not in contents
+    assert '"Notes": "hi"' in contents
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_xml_without_row_id_and_primary_field(
+    get_storage_mock, premium_data_fixture
+):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user, table, grid_view = _setup_simple_premium_table(premium_data_fixture)
+
+    _, contents = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "xml",
+            "include_row_id": False,
+            "include_primary_field": False,
+        },
+    )
+    assert "<id>" not in contents
+    assert "<Name>" not in contents
+    assert "<Notes>hi</Notes>" in contents
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_excel_without_row_id_and_primary_field(
+    get_storage_mock, premium_data_fixture
+):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user, table, grid_view = _setup_simple_premium_table(premium_data_fixture)
+
+    _, wb_bytes = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "excel",
+            "export_charset": None,
+            "excel_include_header": True,
+            "include_row_id": False,
+            "include_primary_field": False,
+        },
+    )
+    workbook = load_workbook(filename=BytesIO(wb_bytes))
+    worksheet = workbook.active
+    header = [cell.value for cell in worksheet[1]]
+    assert header == ["Notes"]
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_can_export_excel_without_primary_field(get_storage_mock, premium_data_fixture):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user, table, grid_view = _setup_simple_premium_table(premium_data_fixture)
+
+    _, wb_bytes = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "excel",
+            "export_charset": None,
+            "excel_include_header": True,
+            "include_primary_field": False,
+        },
+    )
+    workbook = load_workbook(filename=BytesIO(wb_bytes))
+    worksheet = workbook.active
+    header = [cell.value for cell in worksheet[1]]
+    assert header == ["id", "Notes"]

--- a/premium/web-frontend/modules/baserow_premium/components/exporter/TableExcelExporter.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/exporter/TableExcelExporter.vue
@@ -6,10 +6,37 @@
           small-label
           :label="$t('tableExcelExporter.includeHeader')"
           required
+          class="margin-bottom-2"
         >
           <Checkbox v-model="values.excel_include_header" :disabled="loading">{{
             $t('common.yes')
           }}</Checkbox>
+        </FormGroup>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includeRowId')"
+          required
+        >
+          <Checkbox v-model="values.include_row_id" :disabled="loading">{{
+            $t('common.yes')
+          }}</Checkbox>
+        </FormGroup>
+      </div>
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includePrimaryField')"
+          required
+        >
+          <Checkbox
+            v-model="values.include_primary_field"
+            :disabled="loading"
+            >{{ $t('common.yes') }}</Checkbox
+          >
         </FormGroup>
       </div>
     </div>
@@ -32,6 +59,8 @@ export default {
     return {
       values: {
         excel_include_header: true,
+        include_row_id: true,
+        include_primary_field: true,
       },
     }
   },

--- a/premium/web-frontend/modules/baserow_premium/components/exporter/TableJSONExporter.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/exporter/TableJSONExporter.vue
@@ -13,6 +13,32 @@
         </FormGroup>
       </div>
     </div>
+    <div class="row">
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includeRowId')"
+          required
+        >
+          <Checkbox v-model="values.include_row_id" :disabled="loading">{{
+            $t('common.yes')
+          }}</Checkbox>
+        </FormGroup>
+      </div>
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includePrimaryField')"
+          required
+        >
+          <Checkbox
+            v-model="values.include_primary_field"
+            :disabled="loading"
+            >{{ $t('common.yes') }}</Checkbox
+          >
+        </FormGroup>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -34,6 +60,8 @@ export default {
     return {
       values: {
         export_charset: 'utf-8',
+        include_row_id: true,
+        include_primary_field: true,
       },
     }
   },

--- a/premium/web-frontend/modules/baserow_premium/components/exporter/TableXMLExporter.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/exporter/TableXMLExporter.vue
@@ -13,6 +13,32 @@
         </FormGroup>
       </div>
     </div>
+    <div class="row">
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includeRowId')"
+          required
+        >
+          <Checkbox v-model="values.include_row_id" :disabled="loading">{{
+            $t('common.yes')
+          }}</Checkbox>
+        </FormGroup>
+      </div>
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includePrimaryField')"
+          required
+        >
+          <Checkbox
+            v-model="values.include_primary_field"
+            :disabled="loading"
+            >{{ $t('common.yes') }}</Checkbox
+          >
+        </FormGroup>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -34,6 +60,8 @@ export default {
     return {
       values: {
         export_charset: 'utf-8',
+        include_row_id: true,
+        include_primary_field: true,
       },
     }
   },

--- a/web-frontend/modules/database/components/export/TableCSVExporter.vue
+++ b/web-frontend/modules/database/components/export/TableCSVExporter.vue
@@ -44,10 +44,37 @@
           small-label
           :label="$t('tableCSVExporter.includeHeader')"
           required
+          class="margin-bottom-2"
         >
           <Checkbox v-model="values.csv_include_header" :disabled="loading">{{
             $t('common.yes')
           }}</Checkbox>
+        </FormGroup>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includeRowId')"
+          required
+        >
+          <Checkbox v-model="values.include_row_id" :disabled="loading">{{
+            $t('common.yes')
+          }}</Checkbox>
+        </FormGroup>
+      </div>
+      <div class="col col-6">
+        <FormGroup
+          small-label
+          :label="$t('exportTableForm.includePrimaryField')"
+          required
+        >
+          <Checkbox
+            v-model="values.include_primary_field"
+            :disabled="loading"
+            >{{ $t('common.yes') }}</Checkbox
+          >
         </FormGroup>
       </div>
     </div>
@@ -76,6 +103,8 @@ export default {
         csv_include_header: true,
         export_charset: 'utf-8',
         csv_column_separator: ',',
+        include_row_id: true,
+        include_primary_field: true,
       },
     }
   },

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -766,7 +766,9 @@
   },
   "exportTableForm": {
     "viewLabel": "Select the view to export:",
-    "typeError": "No exporter type available please select a different view or entire table."
+    "typeError": "No exporter type available please select a different view or entire table.",
+    "includeRowId": "Include row ID",
+    "includePrimaryField": "Include primary field"
   },
   "exportTableLoadingBar": {
     "export": "Export",

--- a/web-frontend/test/unit/database/components/export/__snapshots__/exportTableModal.spec.js.snap
+++ b/web-frontend/test/unit/database/components/export/__snapshots__/exportTableModal.spec.js.snap
@@ -34,7 +34,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
               
               <label
                 class="control__label control__label--small"
-                for="v-0-0-6"
+                for="v-0-0-10"
               >
                 <span>
                   exportTableForm.viewLabel
@@ -55,7 +55,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                     
                     <div
                       class="dropdown"
-                      id="v-0-0-6"
+                      id="v-0-0-10"
                       role="list"
                       tabindex="0"
                     >
@@ -182,7 +182,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
               
               <label
                 class="control__label control__label--small"
-                for="v-0-0-7"
+                for="v-0-0-11"
               >
                 <span>
                   exporterTypeChoices.formatLabel
@@ -351,7 +351,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-8"
+                  for="v-0-0-12"
                 >
                   <span>
                     tableCSVExporter.columnSeparatorLabel
@@ -372,7 +372,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                       
                       <div
                         class="dropdown"
-                        id="v-0-0-8"
+                        id="v-0-0-12"
                         role="list"
                         tabindex="0"
                       >
@@ -611,7 +611,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-9"
+                  for="v-0-0-13"
                 >
                   <span>
                     tableCSVExporter.encodingLabel
@@ -632,7 +632,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                       
                       <div
                         class="dropdown"
-                        id="v-0-0-9"
+                        id="v-0-0-13"
                         role="list"
                         tabindex="0"
                       >
@@ -1625,13 +1625,13 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
               class="col col-6"
             >
               <div
-                class="control"
+                class="control margin-bottom-2"
                 data-form-error="false"
               >
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-10"
+                  for="v-0-0-14"
                 >
                   <span>
                     tableCSVExporter.includeHeader
@@ -1656,7 +1656,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                         <input
                           checked=""
                           class="checkbox__native"
-                          id="checkboxv-0-0-11"
+                          id="checkboxv-0-0-15"
                           type="checkbox"
                         />
                         <div
@@ -1671,7 +1671,7 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <g
-                              clip-path="url(#clipv-0-0-11)"
+                              clip-path="url(#clipv-0-0-15)"
                             >
                               <path
                                 d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
@@ -1683,7 +1683,231 @@ exports[`Preview exportTableModal > Modal with no view 1`] = `
                             </g>
                             <defs>
                               <clippath
-                                id="clipv-0-0-11"
+                                id="clipv-0-0-15"
+                              >
+                                <rect
+                                  fill="white"
+                                  height="8"
+                                  transform="translate(0.5)"
+                                  width="8"
+                                />
+                              </clippath>
+                            </defs>
+                          </svg>
+                          <svg
+                            class="checkbox__tick-indeterminate"
+                            fill="none"
+                            height="8"
+                            style="display: none;"
+                            viewBox="0 0 8 8"
+                            width="8"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 4L6.5 4"
+                              stroke="white"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                        <span
+                          class="checkbox__label"
+                        >
+                          
+                          common.yes
+                          
+                        </span>
+                      </label>
+                      
+                    </div>
+                    <!--v-if-->
+                    
+                    
+                  </div>
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col col-6"
+            >
+              <div
+                class="control"
+                data-form-error="false"
+              >
+                
+                <label
+                  class="control__label control__label--small"
+                  for="v-0-0-16"
+                >
+                  <span>
+                    exportTableForm.includeRowId
+                  </span>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </label>
+                <div
+                  class="control__wrapper"
+                >
+                  <div
+                    class="control__elements"
+                  >
+                    <div
+                      class="control__elements-wrapper"
+                    >
+                      
+                      <label
+                        class="checkbox checkbox--checked"
+                      >
+                        <input
+                          checked=""
+                          class="checkbox__native"
+                          id="checkboxv-0-0-17"
+                          type="checkbox"
+                        />
+                        <div
+                          class="checkbox__button"
+                        >
+                          <svg
+                            class="checkbox__tick"
+                            fill="none"
+                            height="8"
+                            viewBox="0 0 9 8"
+                            width="9"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g
+                              clip-path="url(#clipv-0-0-17)"
+                            >
+                              <path
+                                d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
+                                stroke="white"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </g>
+                            <defs>
+                              <clippath
+                                id="clipv-0-0-17"
+                              >
+                                <rect
+                                  fill="white"
+                                  height="8"
+                                  transform="translate(0.5)"
+                                  width="8"
+                                />
+                              </clippath>
+                            </defs>
+                          </svg>
+                          <svg
+                            class="checkbox__tick-indeterminate"
+                            fill="none"
+                            height="8"
+                            style="display: none;"
+                            viewBox="0 0 8 8"
+                            width="8"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 4L6.5 4"
+                              stroke="white"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                        <span
+                          class="checkbox__label"
+                        >
+                          
+                          common.yes
+                          
+                        </span>
+                      </label>
+                      
+                    </div>
+                    <!--v-if-->
+                    
+                    
+                  </div>
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+            <div
+              class="col col-6"
+            >
+              <div
+                class="control"
+                data-form-error="false"
+              >
+                
+                <label
+                  class="control__label control__label--small"
+                  for="v-0-0-18"
+                >
+                  <span>
+                    exportTableForm.includePrimaryField
+                  </span>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </label>
+                <div
+                  class="control__wrapper"
+                >
+                  <div
+                    class="control__elements"
+                  >
+                    <div
+                      class="control__elements-wrapper"
+                    >
+                      
+                      <label
+                        class="checkbox checkbox--checked"
+                      >
+                        <input
+                          checked=""
+                          class="checkbox__native"
+                          id="checkboxv-0-0-19"
+                          type="checkbox"
+                        />
+                        <div
+                          class="checkbox__button"
+                        >
+                          <svg
+                            class="checkbox__tick"
+                            fill="none"
+                            height="8"
+                            viewBox="0 0 9 8"
+                            width="9"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g
+                              clip-path="url(#clipv-0-0-19)"
+                            >
+                              <path
+                                d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
+                                stroke="white"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </g>
+                            <defs>
+                              <clippath
+                                id="clipv-0-0-19"
                               >
                                 <rect
                                   fill="white"
@@ -1811,7 +2035,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
               
               <label
                 class="control__label control__label--small"
-                for="v-0-0-6"
+                for="v-0-0-10"
               >
                 <span>
                   exportTableForm.viewLabel
@@ -1832,7 +2056,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                     
                     <div
                       class="dropdown"
-                      id="v-0-0-6"
+                      id="v-0-0-10"
                       role="list"
                       tabindex="0"
                     >
@@ -1961,7 +2185,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
               
               <label
                 class="control__label control__label--small"
-                for="v-0-0-7"
+                for="v-0-0-11"
               >
                 <span>
                   exporterTypeChoices.formatLabel
@@ -2130,7 +2354,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-8"
+                  for="v-0-0-12"
                 >
                   <span>
                     tableCSVExporter.columnSeparatorLabel
@@ -2151,7 +2375,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                       
                       <div
                         class="dropdown"
-                        id="v-0-0-8"
+                        id="v-0-0-12"
                         role="list"
                         tabindex="0"
                       >
@@ -2390,7 +2614,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-9"
+                  for="v-0-0-13"
                 >
                   <span>
                     tableCSVExporter.encodingLabel
@@ -2411,7 +2635,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                       
                       <div
                         class="dropdown"
-                        id="v-0-0-9"
+                        id="v-0-0-13"
                         role="list"
                         tabindex="0"
                       >
@@ -3404,13 +3628,13 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
               class="col col-6"
             >
               <div
-                class="control"
+                class="control margin-bottom-2"
                 data-form-error="false"
               >
                 
                 <label
                   class="control__label control__label--small"
-                  for="v-0-0-10"
+                  for="v-0-0-14"
                 >
                   <span>
                     tableCSVExporter.includeHeader
@@ -3435,7 +3659,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                         <input
                           checked=""
                           class="checkbox__native"
-                          id="checkboxv-0-0-11"
+                          id="checkboxv-0-0-15"
                           type="checkbox"
                         />
                         <div
@@ -3450,7 +3674,7 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                             xmlns="http://www.w3.org/2000/svg"
                           >
                             <g
-                              clip-path="url(#clipv-0-0-11)"
+                              clip-path="url(#clipv-0-0-15)"
                             >
                               <path
                                 d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
@@ -3462,7 +3686,231 @@ exports[`Preview exportTableModal > Modal with view 1`] = `
                             </g>
                             <defs>
                               <clippath
-                                id="clipv-0-0-11"
+                                id="clipv-0-0-15"
+                              >
+                                <rect
+                                  fill="white"
+                                  height="8"
+                                  transform="translate(0.5)"
+                                  width="8"
+                                />
+                              </clippath>
+                            </defs>
+                          </svg>
+                          <svg
+                            class="checkbox__tick-indeterminate"
+                            fill="none"
+                            height="8"
+                            style="display: none;"
+                            viewBox="0 0 8 8"
+                            width="8"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 4L6.5 4"
+                              stroke="white"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                        <span
+                          class="checkbox__label"
+                        >
+                          
+                          common.yes
+                          
+                        </span>
+                      </label>
+                      
+                    </div>
+                    <!--v-if-->
+                    
+                    
+                  </div>
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+          </div>
+          <div
+            class="row"
+          >
+            <div
+              class="col col-6"
+            >
+              <div
+                class="control"
+                data-form-error="false"
+              >
+                
+                <label
+                  class="control__label control__label--small"
+                  for="v-0-0-16"
+                >
+                  <span>
+                    exportTableForm.includeRowId
+                  </span>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </label>
+                <div
+                  class="control__wrapper"
+                >
+                  <div
+                    class="control__elements"
+                  >
+                    <div
+                      class="control__elements-wrapper"
+                    >
+                      
+                      <label
+                        class="checkbox checkbox--checked"
+                      >
+                        <input
+                          checked=""
+                          class="checkbox__native"
+                          id="checkboxv-0-0-17"
+                          type="checkbox"
+                        />
+                        <div
+                          class="checkbox__button"
+                        >
+                          <svg
+                            class="checkbox__tick"
+                            fill="none"
+                            height="8"
+                            viewBox="0 0 9 8"
+                            width="9"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g
+                              clip-path="url(#clipv-0-0-17)"
+                            >
+                              <path
+                                d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
+                                stroke="white"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </g>
+                            <defs>
+                              <clippath
+                                id="clipv-0-0-17"
+                              >
+                                <rect
+                                  fill="white"
+                                  height="8"
+                                  transform="translate(0.5)"
+                                  width="8"
+                                />
+                              </clippath>
+                            </defs>
+                          </svg>
+                          <svg
+                            class="checkbox__tick-indeterminate"
+                            fill="none"
+                            height="8"
+                            style="display: none;"
+                            viewBox="0 0 8 8"
+                            width="8"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M1.5 4L6.5 4"
+                              stroke="white"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </div>
+                        <span
+                          class="checkbox__label"
+                        >
+                          
+                          common.yes
+                          
+                        </span>
+                      </label>
+                      
+                    </div>
+                    <!--v-if-->
+                    
+                    
+                  </div>
+                  <!--v-if-->
+                </div>
+                
+              </div>
+            </div>
+            <div
+              class="col col-6"
+            >
+              <div
+                class="control"
+                data-form-error="false"
+              >
+                
+                <label
+                  class="control__label control__label--small"
+                  for="v-0-0-18"
+                >
+                  <span>
+                    exportTableForm.includePrimaryField
+                  </span>
+                  <!--v-if-->
+                  <!--v-if-->
+                  <!--v-if-->
+                </label>
+                <div
+                  class="control__wrapper"
+                >
+                  <div
+                    class="control__elements"
+                  >
+                    <div
+                      class="control__elements-wrapper"
+                    >
+                      
+                      <label
+                        class="checkbox checkbox--checked"
+                      >
+                        <input
+                          checked=""
+                          class="checkbox__native"
+                          id="checkboxv-0-0-19"
+                          type="checkbox"
+                        />
+                        <div
+                          class="checkbox__button"
+                        >
+                          <svg
+                            class="checkbox__tick"
+                            fill="none"
+                            height="8"
+                            viewBox="0 0 9 8"
+                            width="9"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <g
+                              clip-path="url(#clipv-0-0-19)"
+                            >
+                              <path
+                                d="M1.5179 4.4821L3.18211 6.18211L7.42475 2.15368"
+                                stroke="white"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                              />
+                            </g>
+                            <defs>
+                              <clippath
+                                id="clipv-0-0-19"
                               >
                                 <rect
                                   fill="white"


### PR DESCRIPTION
### What is in this PR
Adds two checkboxes to the export dialog: "Include row ID" and "Include primary field". Untick one and that column won't be in the exported file. Both are on by default, so existing exports don't change. Works for CSV, Excel, JSON, and XML.

Closes #4680.

### How to test
Open a table or grid view, click "Export view", and pick a format. Untick "Include row ID" and/or "Include primary field", run the export, and check the file: those columns should be gone. With both ticked, the output matches what you'd get before this change.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
