### PR TITLE
translations recipe partially broken for premium/enterprise dirs

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -442,11 +442,19 @@ make-translations: _check-dev
     #!/usr/bin/env bash
     set -euo pipefail
     {{ _load_env }}
+    # premium/enterprise ship partial .venvs without Django installed. If
+    # UV_PROJECT_ENVIRONMENT is a relative path (local dev sets `.venv` via
+    # .env.local), cd-ing into those package dirs makes uv resolve THEIR venv
+    # and `django-admin` can't be spawned. Anchor a relative path to an absolute
+    # one (cwd is backend/ here) so every package uses the backend env. Docker
+    # already sets an absolute UV_PROJECT_ENVIRONMENT, so this leaves it untouched.
+    case "${UV_PROJECT_ENVIRONMENT:-}" in
+        ""|/*) ;;
+        *) export UV_PROJECT_ENVIRONMENT="$(pwd)/$UV_PROJECT_ENVIRONMENT" ;;
+    esac
     for pkg_dir in ./ ../premium/backend/ ../enterprise/backend/; do
         echo "Processing $pkg_dir"
-        cd "$pkg_dir"
-        {{ uv_run }} django-admin makemessages -l en --ignore 'tests/*' || true
-        cd -
+        ( cd "$pkg_dir" && {{ uv_run }} django-admin makemessages -l en --ignore 'tests/*' ) || true
     done
 
 # =============================================================================

--- a/backend/src/baserow/contrib/database/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/contrib/database/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-20 15:44+0000\n"
+"POT-Creation-Date: 2026-06-12 08:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -516,153 +516,153 @@ msgstr ""
 msgid "View sortings priority changed"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1159
+#: src/baserow/contrib/database/views/actions.py:1157
 msgid "Order views"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1159
+#: src/baserow/contrib/database/views/actions.py:1157
 msgid "Views order changed"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1230
+#: src/baserow/contrib/database/views/actions.py:1228
 msgid "Update view field options"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1231
+#: src/baserow/contrib/database/views/actions.py:1229
 msgid "ViewFieldOptions updated"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1333
+#: src/baserow/contrib/database/views/actions.py:1331
 msgid "View slug URL updated"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1334
+#: src/baserow/contrib/database/views/actions.py:1332
 msgid "View changed public slug URL"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1407
+#: src/baserow/contrib/database/views/actions.py:1405
 msgid "Update view"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1408
+#: src/baserow/contrib/database/views/actions.py:1406
 #, python-format
 msgid "View \"%(view_name)s\" (%(view_id)s) updated"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1489
+#: src/baserow/contrib/database/views/actions.py:1487
 msgid "Create view"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1490
+#: src/baserow/contrib/database/views/actions.py:1488
 #, python-format
 msgid "View \"%(view_name)s\" (%(view_id)s) created"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1564
+#: src/baserow/contrib/database/views/actions.py:1562
 msgid "Duplicate view"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1566
+#: src/baserow/contrib/database/views/actions.py:1564
 #, python-format
 msgid ""
 "View \"%(view_name)s\" (%(view_id)s) duplicated from view "
 "\"%(original_view_name)s\" (%(original_view_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1640
+#: src/baserow/contrib/database/views/actions.py:1638
 msgid "Delete view"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1641
+#: src/baserow/contrib/database/views/actions.py:1639
 #, python-format
 msgid "View \"%(view_name)s\" (%(view_id)s) deleted"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1703
+#: src/baserow/contrib/database/views/actions.py:1701
 msgid "Create decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1704
+#: src/baserow/contrib/database/views/actions.py:1702
 #, python-format
 msgid "View decoration %(decorator_id)s created"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1808
+#: src/baserow/contrib/database/views/actions.py:1806
 msgid "Update decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1809
+#: src/baserow/contrib/database/views/actions.py:1807
 #, python-format
 msgid "View decoration %(decorator_id)s updated"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1946
+#: src/baserow/contrib/database/views/actions.py:1944
 msgid "Delete decoration"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:1947
+#: src/baserow/contrib/database/views/actions.py:1945
 #, python-format
 msgid "View decoration %(decorator_id)s deleted"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2043
+#: src/baserow/contrib/database/views/actions.py:2041
 msgid "Create a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2044
+#: src/baserow/contrib/database/views/actions.py:2042
 #, python-format
 msgid "View grouped on field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2149
+#: src/baserow/contrib/database/views/actions.py:2147
 msgid "Update a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2150
+#: src/baserow/contrib/database/views/actions.py:2148
 #, python-format
 msgid "View group by updated on field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2299
+#: src/baserow/contrib/database/views/actions.py:2297
 msgid "Delete a view group"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2300
+#: src/baserow/contrib/database/views/actions.py:2298
 #, python-format
 msgid "View group by deleted from field \"%(field_name)s\" (%(field_id)s)"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2398
+#: src/baserow/contrib/database/views/actions.py:2396
 msgid "Prioritize view group bys"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2399
+#: src/baserow/contrib/database/views/actions.py:2397
 msgid "View group bys priority changed"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2474
+#: src/baserow/contrib/database/views/actions.py:2472
 msgid "Submit form"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2475
+#: src/baserow/contrib/database/views/actions.py:2473
 #, python-format
 msgid "Row (%(row_id)s) created via form submission"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2632
+#: src/baserow/contrib/database/views/actions.py:2630
 msgid "Edit form row"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2633
+#: src/baserow/contrib/database/views/actions.py:2631
 #, python-format
 msgid "Row (%(row_id)s) updated via form edit"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2712
+#: src/baserow/contrib/database/views/actions.py:2710
 msgid "Update view default values"
 msgstr ""
 
-#: src/baserow/contrib/database/views/actions.py:2713
+#: src/baserow/contrib/database/views/actions.py:2711
 #, python-format
 msgid "Default row values updated for view (%(view_name)s)"
 msgstr ""

--- a/backend/src/baserow/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-18 18:56+0000\n"
+"POT-Creation-Date: 2026-06-12 08:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -210,23 +210,23 @@ msgstr ""
 msgid "Widget \"%(widget_title)s\" (%(widget_id)s) deleted"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1135
+#: src/baserow/contrib/integrations/core/service_types.py:1142
 msgid "Branch taken"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1140
+#: src/baserow/contrib/integrations/core/service_types.py:1147
 msgid "Label"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1142
+#: src/baserow/contrib/integrations/core/service_types.py:1149
 msgid "The label of the branch that matched the condition."
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1553
+#: src/baserow/contrib/integrations/core/service_types.py:1560
 msgid "Previous scheduled run"
 msgstr ""
 
-#: src/baserow/contrib/integrations/core/service_types.py:1557
+#: src/baserow/contrib/integrations/core/service_types.py:1564
 msgid "Next scheduled run"
 msgstr ""
 

--- a/enterprise/backend/src/baserow_enterprise/locale/en/LC_MESSAGES/django.po
+++ b/enterprise/backend/src/baserow_enterprise/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-18 18:56+0000\n"
+"POT-Creation-Date: 2026-06-12 08:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -229,46 +229,46 @@ msgstr ""
 msgid "Listing views in %(table_name)s..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:384
+#: src/baserow_enterprise/assistant/tools/database/tools.py:385
 #, python-format
 msgid "Creating table %(table_name)s..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:640
+#: src/baserow_enterprise/assistant/tools/database/tools.py:641
 #, python-format
 msgid "Updating field %(field_id)s..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:696
+#: src/baserow_enterprise/assistant/tools/database/tools.py:697
 #, python-format
 msgid "Deleting field %(field_id)s..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:754
+#: src/baserow_enterprise/assistant/tools/database/tools.py:755
 #, python-format
 msgid "Creating %(view_type)s view %(view_name)s"
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:833
+#: src/baserow_enterprise/assistant/tools/database/tools.py:834
 #, python-format
 msgid "Creating filters in %(view_name)s..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:909
+#: src/baserow_enterprise/assistant/tools/database/tools.py:910
 msgid "Generating formula..."
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:1037
+#: src/baserow_enterprise/assistant/tools/database/tools.py:1038
 #, python-format
 msgid "Creating rows in %(table_name)s "
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:1074
+#: src/baserow_enterprise/assistant/tools/database/tools.py:1075
 #, python-format
 msgid "Updating rows in %(table_name)s "
 msgstr ""
 
-#: src/baserow_enterprise/assistant/tools/database/tools.py:1110
+#: src/baserow_enterprise/assistant/tools/database/tools.py:1111
 #, python-format
 msgid "Deleting rows in %(table_name)s "
 msgstr ""


### PR DESCRIPTION
### What is in this PR

If you use `local-dev` provisioning locally, the `just b make-translations` backend recipe isn't working for the premium and enterprise directories. You will get:

```bash
picklepete@baserow baserow % just b make-translations                                                                                                                                                                                         
  Processing ./                                                                                                                                                                                                                                      
  DEBUG 2026-06-12 08:10:50,324 asyncio.__init__:64- Using selector: KqueueSelector                                                                                                                                                                  
  11817|2026-06-12 08:10:51.283|INFO|baserow.core.telemetry.telemetry:setup_logging:66 - Logger setup.                                                                                                                                               
  processing locale en                                                                                                                                                                                                                               
  /Users/picklepete/Baserow/baserow/backend                                                                                                                                                                                                          
  Processing ../premium/backend/                                                                                                                                                                                                                     
  error: Failed to spawn: `django-admin`                                                                                                                                                                                                             
    Caused by: No such file or directory (os error 2)                                                                                                                                                                                                
  /Users/picklepete/Baserow/baserow/backend                                                                                                                                                                                                          
  Processing ../enterprise/backend/                                                                                                                                                                                                                  
  error: Failed to spawn: `django-admin`                                                                                                                                                                                                             
    Caused by: No such file or directory (os error 2)                                                                                                                                                                                                
  /Users/picklepete/Baserow/baserow/backend 
```

`make-translations` loops over three packages, cd-ing into each one and running `uv run django-admin makemessages`. Letting `uv` re-resolve the environment from each new working directory is the trap.
  
In the local dev setup, `.env.local` sets `UV_PROJECT_ENVIRONMENT=.venv`, a relative path. The recipe sources `.env.local` at runtime, so as the loop cds into each dir, uv resolves a different `.venv` per directory:

- backend/ (backend/.venv): full env, has django-admin
- premium/backend/ (premium/backend/.venv): partial env, no Django
- enterprise/backend/ (enterprise/backend/.venv): partial env, no Django

The premium/enterprise venvs don't install Django themselves (they piggyback on the backend env), so `django-admin` isn't in them (hence the "Failed to spawn").

### How to test this PR

- In develop, after running `just dev up`: `just b make-translations` will fail.
- In this branch: try both `just dev up` (local dev) and `just dc-dev up -d` (docker dev) and the command will run.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
