### PR TITLE
fix: Escape backslash chars in formula field

### DIFF
--- a/backend/src/baserow/core/formula/parser/formula_execution_visitor.py
+++ b/backend/src/baserow/core/formula/parser/formula_execution_visitor.py
@@ -1,3 +1,5 @@
+import re
+
 from baserow.core.formula import BaserowFormula, BaserowFormulaVisitor
 from baserow.core.formula.parser.exceptions import (
     BaserowFormulaSyntaxError,
@@ -40,9 +42,9 @@ class BaserowFormulaExecutionVisitor(BaserowFormulaVisitor):
     def process_string(self, ctx):
         literal_without_outer_quotes = ctx.getText()[1:-1]
         if ctx.SINGLEQ_STRING_LITERAL() is not None:
-            literal = literal_without_outer_quotes.replace("\\'", "'")
+            literal = re.sub(r"\\(['\\])", r"\1", literal_without_outer_quotes)
         else:
-            literal = literal_without_outer_quotes.replace('\\"', '"')
+            literal = re.sub(r'\\(["\\])', r"\1", literal_without_outer_quotes)
         return literal
 
     def visitFunctionCall(self, ctx: BaserowFormula.FunctionCallContext):

--- a/backend/src/baserow/core/formula/parser/formula_validation_visitor.py
+++ b/backend/src/baserow/core/formula/parser/formula_validation_visitor.py
@@ -1,3 +1,4 @@
+import re
 from typing import TYPE_CHECKING, List, Optional
 
 from baserow.core.formula.exceptions import InvalidRuntimeFormula
@@ -84,9 +85,9 @@ class BaserowFormulaValidationVisitor(BaserowFormulaVisitor):
     def process_string(self, ctx):
         literal_without_outer_quotes = ctx.getText()[1:-1]
         if ctx.SINGLEQ_STRING_LITERAL() is not None:
-            literal = literal_without_outer_quotes.replace("\\'", "'")
+            literal = re.sub(r"\\(['\\])", r"\1", literal_without_outer_quotes)
         else:
-            literal = literal_without_outer_quotes.replace('\\"', '"')
+            literal = re.sub(r'\\(["\\])', r"\1", literal_without_outer_quotes)
         return literal
 
     def visitDecimalLiteral(self, ctx: BaserowFormula.DecimalLiteralContext):

--- a/changelog/entries/unreleased/bug/3720_fixed_a_bug_where_backslash_chars_couldnt_be_entered_into_th.json
+++ b/changelog/entries/unreleased/bug/3720_fixed_a_bug_where_backslash_chars_couldnt_be_entered_into_th.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a bug where backslash chars couldn't be entered into the formula field.",
+    "issue_origin": "github",
+    "issue_number": 3720,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-15"
+}

--- a/tests/cases/formula_visitor_cases.json
+++ b/tests/cases/formula_visitor_cases.json
@@ -41,6 +41,30 @@
             "formula": "get('a') + get('b')",
             "result": 4,
             "context": {"a":  1, "b":  3}
+        },
+        {
+            "formula": "'\\\\'",
+            "result": "\\",
+            "context": {},
+            "description": "An escaped backslash unescapes to a single backslash"
+        },
+        {
+            "formula": "'a\\\\b'",
+            "result": "a\\b",
+            "context": {},
+            "description": "An escaped backslash between text unescapes correctly"
+        },
+        {
+            "formula": "'\\\\\\''",
+            "result": "\\'",
+            "context": {},
+            "description": "An escaped backslash followed by an escaped quote unescapes correctly"
+        },
+        {
+            "formula": "\"a\\\\b\"",
+            "result": "a\\b",
+            "context": {},
+            "description": "An escaped backslash unescapes inside a double-quoted string"
         }
     ],
     "INVALID_FORMULA_EXECUTION_TESTS": [
@@ -61,6 +85,11 @@
         {
             "formula": "'test'",
             "context": {}
+        },
+        {
+            "formula": "'\\\\'",
+            "context": {},
+            "description": "A string containing an escaped backslash validates correctly"
         },
         {
             "formula": "get('test_data_provider.1')",

--- a/tests/cases/tip_tap_visitor_cases.json
+++ b/tests/cases/tip_tap_visitor_cases.json
@@ -23,6 +23,30 @@
     }
   },
   {
+    "formula": "'\\\\'",
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "wrapper",
+          "content": [{ "text": "\\", "type": "text" }]
+        }
+      ]
+    }
+  },
+  {
+    "formula": "'a\\\\b'",
+    "content": {
+      "type": "doc",
+      "content": [
+        {
+          "type": "wrapper",
+          "content": [{ "text": "a\\b", "type": "text" }]
+        }
+      ]
+    }
+  },
+  {
     "formula": "concat('hello', 'there')",
     "content": {
       "type": "doc",

--- a/web-frontend/modules/core/formula/parser/formulaExecutionVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaExecutionVisitor.js
@@ -42,9 +42,9 @@ export default class BaserowFormulaExecutionVisitor extends BaserowFormulaVisito
     const literalWithoutOuterQuotes = ctx.getText().slice(1, -1)
     let literal
     if (ctx.SINGLEQ_STRING_LITERAL() !== null) {
-      literal = literalWithoutOuterQuotes.replace(/\\'/g, "'")
+      literal = literalWithoutOuterQuotes.replace(/\\(['\\])/g, '$1')
     } else {
-      literal = literalWithoutOuterQuotes.replace(/\\"/g, '"')
+      literal = literalWithoutOuterQuotes.replace(/\\(["\\])/g, '$1')
     }
     return literal
   }

--- a/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
+++ b/web-frontend/modules/core/formula/parser/formulaValidationVisitor.js
@@ -105,9 +105,9 @@ export default class BaserowFormulaValidationVisitor extends BaserowFormulaVisit
     const literalWithoutOuterQuotes = ctx.getText().slice(1, -1)
     let literal
     if (ctx.SINGLEQ_STRING_LITERAL() !== null) {
-      literal = literalWithoutOuterQuotes.replace(/\\'/g, "'")
+      literal = literalWithoutOuterQuotes.replace(/\\(['\\])/g, '$1')
     } else {
-      literal = literalWithoutOuterQuotes.replace(/\\"/g, '"')
+      literal = literalWithoutOuterQuotes.replace(/\\(["\\])/g, '$1')
     }
     return literal
   }

--- a/web-frontend/modules/core/formula/tiptap/fromTipTapVisitor.js
+++ b/web-frontend/modules/core/formula/tiptap/fromTipTapVisitor.js
@@ -183,7 +183,10 @@ export class FromTipTapVisitor {
     const cleanText = node.text.replace(ZWS_REGEX, '')
 
     if (this.mode === 'simple') {
-      return `'${cleanText.replace(/'/g, "\\'")}'`
+      // Escape backslashes first, then single quotes. Order matters: a lone
+      // trailing backslash would otherwise escape the closing quote and produce
+      // an unterminated, invalid string literal (e.g. typing `\` -> `'\'`).
+      return `'${cleanText.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
     }
 
     // In advanced mode, we need to escape actual newlines in the text

--- a/web-frontend/modules/core/formula/tiptap/toTipTapVisitor.js
+++ b/web-frontend/modules/core/formula/tiptap/toTipTapVisitor.js
@@ -212,9 +212,9 @@ export class ToTipTapVisitor extends BaserowFormulaVisitor {
     let literal
 
     if (ctx.SINGLEQ_STRING_LITERAL() !== null) {
-      literal = literalWithoutOuterQuotes.replace(/\\'/g, "'")
+      literal = literalWithoutOuterQuotes.replace(/\\(['\\])/g, '$1')
     } else {
-      literal = literalWithoutOuterQuotes.replace(/\\"/g, '"')
+      literal = literalWithoutOuterQuotes.replace(/\\(["\\])/g, '$1')
     }
 
     return literal


### PR DESCRIPTION
# What is in this PR
This PR fixes a bug that prevents a literal `\` from being entered into a formula field.

Closes https://github.com/baserow/baserow/issues/3450
Closes https://github.com/baserow/baserow/issues/3720

### Context
In simple mode, when you type in a literal `\` char in the formula field, the following error is seen:
```
Invalid formula
Not a valid expert formula, please check the syntax.
```

This is because of this lexer rule for strings:
```
// file: BaserowFormulaLexer.g4
fragment SQUOTA_STRING                : '\'' ('\\'. | ~('\'' | '\\'))* '\'';
```

This rule requires that inside a string, a backslash must be escaped. Here is the flow of how the bug manifests:

- In simple mode, when we type in a literal `\` in the formula field, the `fromTipTapVisitor.js` encodes it to a formula string by wrapping it in single quotes, so it becomes `'\'`.
- The unescaped backslash causes the trailing `'` char to be consumed during parsing, and the formula string ends up being read as `'\`.
- The lexer rule mentioned above rejects this since it's an unterminated string.
- The "Invalid formula" error mentioned above is shown.

To fix this:
- The "from" tip tap visitor has been updated so that backslashes are escaped first, then single quotes are escaped second (currently only single quotes are escaped). The fix ensures that when typing in a literal `\`, the final stored formula string becomes `'\\'`.
- The "to" tip tap visitor is similarly updated to unescape backslashes.
- The formula execution/validation visitors have also been updated to also ensure that backslashes are unescaped correctly.

### How to test this PR
In `develop`, create a Heading element in Builder, and in the formula field type in a single `\` char. You'll see the "Invalid formula" error:
> <img width="328" height="186" alt="image" src="https://github.com/user-attachments/assets/443a8735-f51b-4d54-884a-b7095c580c10" />

In this branch, you should see that the `\` is accepted and correctly parsed:
```json
{
    "value": {
        "mode": "simple",
        "version": "0.1",
        "formula": "'\\'"
    }
}
```

Test that various permutation of `\` and `'` chars are accepted.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
