### PR TITLE
fix: data provider of array types throw an error with no items

### DIFF
--- a/web-frontend/modules/core/dataProviderTypes.js
+++ b/web-frontend/modules/core/dataProviderTypes.js
@@ -222,7 +222,7 @@ export class DataProviderType extends Registerable {
         order,
         icon: this.getIconForNode(schema),
         type: 'array',
-        node_type: schema.items.type,
+        node_type: schema.items?.type,
         nodes: schema.items
           ? this._toNode(applicationContext, [...pathParts, null], schema.items)
               .nodes


### PR DESCRIPTION
### What is in this PR

- Iterator node
    - Child within it

Will throw an error when you select the child and its schema has no `items` yet.

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
