### PR TITLE
Allow instance admins to manage users' 2FA state

### DIFF
--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.fields import CharField, EmailField
 from rest_framework.serializers import ModelSerializer
@@ -64,11 +65,15 @@ class UserAdminResponseSerializer(ModelSerializer):
         )
         extra_kwargs = _USER_ADMIN_SERIALIZER_API_DOC_KWARGS
 
+    @extend_schema_field(TwoFactorAuthSerializer)
     def get_two_factor_auth(self, object):
         try:
             provider = object.two_factor_auth_provider
         except User.two_factor_auth_provider.RelatedObjectDoesNotExist:
             provider = None
+
+        if provider is None:
+            return {}
 
         return TwoFactorAuthSerializer(provider).data
 

--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -25,6 +25,24 @@ _USER_ADMIN_SERIALIZER_API_DOC_KWARGS = {
 }
 
 
+# Raw OpenAPI schema for the ``two_factor_auth`` admin response field. A typed
+# serializer can't be used here because drf-spectacular marks its read-only
+# fields as always required, whereas this field is an empty object (``{}``) when
+# the user has no two factor auth provider configured. Omitting ``required``
+# documents the ``{type, is_enabled}`` shape while still allowing ``{}``.
+_USER_ADMIN_TWO_FACTOR_AUTH_FIELD_SCHEMA = {
+    "type": "object",
+    "description": (
+        "The user's two factor auth state. An empty object when no provider is "
+        "configured, otherwise the provider type and whether it is enabled."
+    ),
+    "properties": {
+        "type": {"type": "string", "readOnly": True},
+        "is_enabled": {"type": "boolean", "readOnly": True},
+    },
+}
+
+
 class UserAdminWorkspacesSerializer(ModelSerializer):
     id = serializers.IntegerField(source="workspace.id")
     name = serializers.CharField(source="workspace.name")
@@ -65,7 +83,7 @@ class UserAdminResponseSerializer(ModelSerializer):
         )
         extra_kwargs = _USER_ADMIN_SERIALIZER_API_DOC_KWARGS
 
-    @extend_schema_field(TwoFactorAuthSerializer)
+    @extend_schema_field(_USER_ADMIN_TWO_FACTOR_AUTH_FIELD_SCHEMA)
     def get_two_factor_auth(self, object):
         try:
             provider = object.two_factor_auth_provider

--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.fields import CharField, EmailField
 from rest_framework.serializers import ModelSerializer
 
 from baserow.api.mixins import UnknownFieldRaisesExceptionSerializerMixin
+from baserow.api.two_factor_auth.serializers import TwoFactorAuthSerializer
 from baserow.api.user.validators import password_validation
 from baserow.core.models import WorkspaceUser
 
@@ -46,6 +47,7 @@ class UserAdminResponseSerializer(ModelSerializer):
     name = CharField(source="first_name", max_length=150)
     username = EmailField()
     workspaces = UserAdminWorkspacesSerializer(source="workspaceuser_set", many=True)
+    two_factor_auth = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -58,8 +60,17 @@ class UserAdminResponseSerializer(ModelSerializer):
             "date_joined",
             "is_active",
             "is_staff",
+            "two_factor_auth",
         )
         extra_kwargs = _USER_ADMIN_SERIALIZER_API_DOC_KWARGS
+
+    def get_two_factor_auth(self, object):
+        try:
+            provider = object.two_factor_auth_provider
+        except User.two_factor_auth_provider.RelatedObjectDoesNotExist:
+            provider = None
+
+        return TwoFactorAuthSerializer(provider).data
 
 
 class UserAdminCreateSerializer(

--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -25,17 +25,19 @@ _USER_ADMIN_SERIALIZER_API_DOC_KWARGS = {
 }
 
 
-# Raw OpenAPI schema for the ``two_factor_auth`` admin response field. A typed
-# serializer can't be used here because drf-spectacular marks its read-only
-# fields as always required, whereas this field is an empty object (``{}``) when
-# the user has no two factor auth provider configured. Omitting ``required``
-# documents the ``{type, is_enabled}`` shape while still allowing ``{}``.
+# Raw OpenAPI schema for the ``two_factor_auth`` admin response field. It is
+# ``null`` when the user has no provider configured, otherwise the provider
+# ``{type, is_enabled}``. A raw dict (instead of ``TwoFactorAuthSerializer``)
+# is used so the field can be marked nullable, which drf-spectacular does not
+# infer for a serializer-typed SerializerMethodField.
 _USER_ADMIN_TWO_FACTOR_AUTH_FIELD_SCHEMA = {
     "type": "object",
+    "nullable": True,
     "description": (
-        "The user's two factor auth state. An empty object when no provider is "
-        "configured, otherwise the provider type and whether it is enabled."
+        "The user's two factor auth provider state, or null when no provider "
+        "is configured."
     ),
+    "required": ["type", "is_enabled"],
     "properties": {
         "type": {"type": "string", "readOnly": True},
         "is_enabled": {"type": "boolean", "readOnly": True},
@@ -91,7 +93,7 @@ class UserAdminResponseSerializer(ModelSerializer):
             provider = None
 
         if provider is None:
-            return {}
+            return None
 
         return TwoFactorAuthSerializer(provider).data
 

--- a/backend/src/baserow/api/admin/users/urls.py
+++ b/backend/src/baserow/api/admin/users/urls.py
@@ -2,6 +2,7 @@ from django.urls import re_path
 
 from baserow.api.admin.users.views import (
     UserAdminImpersonateView,
+    UserAdminTwoFactorAuthView,
     UserAdminView,
     UsersAdminView,
 )
@@ -12,4 +13,9 @@ urlpatterns = [
     re_path(r"^$", UsersAdminView.as_view(), name="list"),
     re_path(r"^impersonate/$", UserAdminImpersonateView.as_view(), name="impersonate"),
     re_path(r"^(?P<user_id>[0-9]+)/$", UserAdminView.as_view(), name="edit"),
+    re_path(
+        r"^(?P<user_id>[0-9]+)/two-factor-auth/$",
+        UserAdminTwoFactorAuthView.as_view(),
+        name="two_factor_auth",
+    ),
 ]

--- a/backend/src/baserow/api/admin/users/views.py
+++ b/backend/src/baserow/api/admin/users/views.py
@@ -259,6 +259,7 @@ class UserAdminTwoFactorAuthView(APIView):
                 ]
             ),
             401: None,
+            403: None,
         },
     )
     @map_exceptions(

--- a/backend/src/baserow/api/admin/users/views.py
+++ b/backend/src/baserow/api/admin/users/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.db.models import Prefetch
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -34,6 +35,8 @@ from baserow.core.admin.users.exceptions import (
     UserDoesNotExistException,
 )
 from baserow.core.admin.users.handler import UserAdminHandler
+from baserow.core.db import specific_queryset
+from baserow.core.two_factor_auth.models import TwoFactorAuthProviderModel
 from baserow.core.user.exceptions import DeactivatedUserException, UserAlreadyExist
 from baserow.core.user.utils import generate_session_tokens_for_user
 
@@ -57,7 +60,12 @@ class UsersAdminView(AdminListingView):
 
     def get_queryset(self, request):
         return User.objects.prefetch_related(
-            "workspaceuser_set", "workspaceuser_set__workspace"
+            "workspaceuser_set",
+            "workspaceuser_set__workspace",
+            Prefetch(
+                "two_factor_auth_provider",
+                queryset=specific_queryset(TwoFactorAuthProviderModel.objects.all()),
+            ),
         ).all()
 
     @extend_schema(

--- a/backend/src/baserow/api/admin/users/views.py
+++ b/backend/src/baserow/api/admin/users/views.py
@@ -26,9 +26,11 @@ from baserow.api.admin.views import AdminListingView
 from baserow.api.decorators import map_exceptions, validate_body
 from baserow.api.pagination import PageNumberPaginationWithApproximateCount
 from baserow.api.schemas import get_error_schema
+from baserow.api.two_factor_auth.errors import ERROR_TWO_FACTOR_AUTH_NOT_CONFIGURED
 from baserow.api.user.registries import member_data_registry
 from baserow.api.user.schemas import authenticate_user_schema
 from baserow.api.user.serializers import get_all_user_data_serialized
+from baserow.core.admin.users.actions import AdminDisableTwoFactorAuthActionType
 from baserow.core.admin.users.exceptions import (
     CannotDeactivateYourselfException,
     CannotDeleteYourselfException,
@@ -36,6 +38,7 @@ from baserow.core.admin.users.exceptions import (
 )
 from baserow.core.admin.users.handler import UserAdminHandler
 from baserow.core.db import specific_queryset
+from baserow.core.two_factor_auth.exceptions import TwoFactorAuthNotConfigured
 from baserow.core.two_factor_auth.models import TwoFactorAuthProviderModel
 from baserow.core.user.exceptions import DeactivatedUserException, UserAlreadyExist
 from baserow.core.user.utils import generate_session_tokens_for_user
@@ -221,6 +224,56 @@ class UserAdminView(APIView):
 
         handler = UserAdminHandler()
         handler.delete_user(request.user, user_id)
+
+        return Response(status=204)
+
+
+class UserAdminTwoFactorAuthView(APIView):
+    permission_classes = (IsAdminUser,)
+
+    @extend_schema(
+        tags=["Admin"],
+        operation_id="admin_disable_user_two_factor_auth",
+        description=(
+            "Removes the configured two-factor authentication of the specified "
+            "user, if the requesting user is staff. This can be used to restore "
+            "access for users that lost their two-factor device and backup "
+            "codes. The user will be able to log in with just their password "
+            "and can configure two-factor authentication again afterwards."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="user_id",
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.INT,
+                description="The id of the user whose two-factor authentication "
+                "must be removed.",
+            ),
+        ],
+        responses={
+            204: None,
+            400: get_error_schema(
+                [
+                    "USER_ADMIN_UNKNOWN_USER",
+                    "ERROR_TWO_FACTOR_AUTH_NOT_CONFIGURED",
+                ]
+            ),
+            401: None,
+        },
+    )
+    @map_exceptions(
+        {
+            UserDoesNotExistException: USER_ADMIN_UNKNOWN_USER,
+            TwoFactorAuthNotConfigured: ERROR_TWO_FACTOR_AUTH_NOT_CONFIGURED,
+        }
+    )
+    @transaction.atomic
+    def delete(self, request, user_id):
+        """
+        Removes the two-factor authentication of the specified user.
+        """
+
+        AdminDisableTwoFactorAuthActionType.do(request.user, int(user_id))
 
         return Response(status=204)
 

--- a/backend/src/baserow/core/admin/users/actions.py
+++ b/backend/src/baserow/core/admin/users/actions.py
@@ -1,0 +1,63 @@
+import dataclasses
+
+from django.contrib.auth.models import AbstractUser
+from django.utils.translation import gettext_lazy as _
+
+from baserow.core.action.registries import (
+    ActionScopeStr,
+    ActionType,
+    ActionTypeDescription,
+)
+from baserow.core.action.scopes import RootActionScopeType
+from baserow.core.admin.users.handler import UserAdminHandler
+
+
+class AdminDisableTwoFactorAuthActionType(ActionType):
+    type = "admin_disable_two_factor_auth"
+    description = ActionTypeDescription(
+        _("Admin disable two-factor authentication"),
+        _(
+            'Admin "%(user_email)s" (%(user_id)s) disabled two-factor '
+            'authentication of user "%(disabled_user_email)s" '
+            "(%(disabled_user_id)s)."
+        ),
+    )
+    analytics_params = [
+        "user_id",
+        "disabled_user_id",
+    ]
+
+    @dataclasses.dataclass
+    class Params:
+        user_id: int
+        user_email: str
+        disabled_user_id: int
+        disabled_user_email: str
+
+    @classmethod
+    def do(cls, requesting_user: AbstractUser, user_id: int) -> None:
+        """
+        Removes the two-factor authentication of the specified user on behalf
+        of an instance admin.
+
+        :param requesting_user: The staff user performing the action.
+        :param user_id: The id of the user whose two-factor authentication
+            must be removed.
+        """
+
+        user = UserAdminHandler().disable_user_two_factor_auth(requesting_user, user_id)
+
+        cls.register_action(
+            user=requesting_user,
+            params=cls.Params(
+                requesting_user.id,
+                requesting_user.email,
+                user.id,
+                user.email,
+            ),
+            scope=cls.scope(),
+        )
+
+    @classmethod
+    def scope(cls) -> ActionScopeStr:
+        return RootActionScopeType.value()

--- a/backend/src/baserow/core/admin/users/handler.py
+++ b/backend/src/baserow/core/admin/users/handler.py
@@ -12,6 +12,7 @@ from baserow.core.admin.users.exceptions import (
 )
 from baserow.core.exceptions import IsNotAdminError
 from baserow.core.signals import before_user_deleted
+from baserow.core.two_factor_auth.handler import TwoFactorAuthHandler
 from baserow.core.user.exceptions import (
     PasswordDoesNotMatchValidation,
     UserAlreadyExist,
@@ -165,6 +166,33 @@ class UserAdminHandler:
             user.delete()
         except User.DoesNotExist:
             raise UserDoesNotExistException()
+
+    def disable_user_two_factor_auth(self, requesting_user: User, user_id: int):
+        """
+        Removes the configured two-factor authentication of the specified user.
+        This can be used to restore access for users that lost their two-factor
+        device and backup codes.
+
+        :param requesting_user: The user who is making the request, the user
+            must be a staff member or else an exception will be raised.
+        :param user_id: The id of the user whose two-factor authentication must
+            be removed, if they do not exist raises a UserDoesNotExistException.
+        :raises TwoFactorAuthNotConfigured: If the user has no two-factor
+            authentication configured.
+        :return: The user whose two-factor authentication was removed.
+        """
+
+        self._raise_if_not_permitted(requesting_user)
+
+        # Unlike deactivating or deleting, an admin removing their own two-factor
+        # authentication can't lock them out, so self-removal is allowed here.
+        try:
+            user = User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            raise UserDoesNotExistException()
+
+        TwoFactorAuthHandler().disable_for_user(user)
+        return user
 
     @staticmethod
     def _raise_if_not_permitted(requesting_user):

--- a/backend/src/baserow/core/apps.py
+++ b/backend/src/baserow/core/apps.py
@@ -388,7 +388,13 @@ class CoreConfig(AppConfig):
         from baserow.core.admin.users.actions import (
             AdminDisableTwoFactorAuthActionType,
         )
+        from baserow.core.two_factor_auth.actions import (
+            ConfigureTwoFactorAuthActionType,
+            DisableTwoFactorAuthActionType,
+        )
 
+        action_type_registry.register(ConfigureTwoFactorAuthActionType())
+        action_type_registry.register(DisableTwoFactorAuthActionType())
         action_type_registry.register(AdminDisableTwoFactorAuthActionType())
 
         from baserow.core.action.scopes import (

--- a/backend/src/baserow/core/apps.py
+++ b/backend/src/baserow/core/apps.py
@@ -385,6 +385,12 @@ class CoreConfig(AppConfig):
         action_type_registry.register(SendChangeEmailConfirmationActionType())
         action_type_registry.register(ChangeEmailActionType())
 
+        from baserow.core.admin.users.actions import (
+            AdminDisableTwoFactorAuthActionType,
+        )
+
+        action_type_registry.register(AdminDisableTwoFactorAuthActionType())
+
         from baserow.core.action.scopes import (
             ApplicationActionScopeType,
             RootActionScopeType,

--- a/backend/src/baserow/core/two_factor_auth/handler.py
+++ b/backend/src/baserow/core/two_factor_auth/handler.py
@@ -104,7 +104,6 @@ class TwoFactorAuthHandler:
         :param user: The user for whom to disable the authentication.
         :param password: Password for confirmation.
         :raises WrongPassword: If the provided password doesn't match.
-        :raises TwoFactorAuthNotConfigured: If the user has no provider.
         """
 
         if not user.check_password(password):

--- a/backend/src/baserow/core/two_factor_auth/handler.py
+++ b/backend/src/baserow/core/two_factor_auth/handler.py
@@ -98,15 +98,29 @@ class TwoFactorAuthHandler:
 
     def disable(self, user: AbstractUser, password: str):
         """
-        Disables any configured provider for the user.
+        Disables any configured provider for the user after confirming
+        their password.
 
         :param user: The user for whom to disable the authentication.
         :param password: Password for confirmation.
         :raises WrongPassword: If the provided password doesn't match.
+        :raises TwoFactorAuthNotConfigured: If the user has no provider.
         """
 
         if not user.check_password(password):
             raise WrongPassword
+
+        self.disable_for_user(user)
+
+    def disable_for_user(self, user: AbstractUser):
+        """
+        Disables any configured provider for the user without a password
+        check. Used by instance admins to restore access for users that
+        lost their two-factor device and backup codes.
+
+        :param user: The user for whom to disable the authentication.
+        :raises TwoFactorAuthNotConfigured: If the user has no provider.
+        """
 
         provider = self.get_provider_for_update(user)
         if provider:

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -108,7 +108,7 @@ def test_admin_can_see_admin_users_endpoint(api_client, data_fixture):
                 "is_staff": True,
                 "is_active": True,
                 "last_login": None,
-                "two_factor_auth": {},
+                "two_factor_auth": None,
             }
         ],
     }
@@ -211,7 +211,7 @@ def test_admin_can_search_users(api_client, data_fixture):
                 "is_staff": False,
                 "is_active": True,
                 "last_login": None,
-                "two_factor_auth": {},
+                "two_factor_auth": None,
             }
         ],
     }
@@ -253,7 +253,7 @@ def test_admin_can_sort_users(api_client, data_fixture):
                 "is_staff": False,
                 "is_active": True,
                 "last_login": None,
-                "two_factor_auth": {},
+                "two_factor_auth": None,
             }
         ],
     }
@@ -544,7 +544,7 @@ def test_admin_can_create_user(api_client, data_fixture):
             "is_staff": True,
             "is_active": True,
             "last_login": None,
-            "two_factor_auth": {},
+            "two_factor_auth": None,
         }
 
     response = api_client.post(
@@ -586,7 +586,7 @@ def test_admin_can_patch_user(api_client, data_fixture):
         "is_staff": True,
         "is_active": True,
         "last_login": None,
-        "two_factor_auth": {},
+        "two_factor_auth": None,
     }
 
 
@@ -620,7 +620,7 @@ def test_admin_can_patch_user_without_providing_password(api_client, data_fixtur
         "is_staff": True,
         "is_active": True,
         "last_login": None,
-        "two_factor_auth": {},
+        "two_factor_auth": None,
     }
 
 
@@ -959,7 +959,7 @@ def test_admin_users_endpoint_includes_two_factor_auth(api_client, data_fixture)
 
     assert response.status_code == HTTP_200_OK
     results = {r["username"]: r for r in response.json()["results"]}
-    assert results["staff@test.nl"]["two_factor_auth"] == {}
+    assert results["staff@test.nl"]["two_factor_auth"] is None
     assert results["enabled@test.nl"]["two_factor_auth"] == {
         "type": "totp",
         "is_enabled": True,

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -21,6 +21,8 @@ from baserow.core.models import (
     WORKSPACE_USER_PERMISSION_ADMIN,
     WORKSPACE_USER_PERMISSION_MEMBER,
 )
+from baserow.core.two_factor_auth.handler import TwoFactorAuthHandler
+from baserow.core.two_factor_auth.models import TOTPUsedCode, TwoFactorAuthRecoveryCode
 
 User = get_user_model()
 invalid_passwords = [
@@ -995,3 +997,93 @@ def test_admin_users_two_factor_auth_does_not_add_n_plus_one_queries(
     assert len(queries_for_few.captured_queries) == len(
         queries_for_many.captured_queries
     )
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_can_disable_two_factor_auth_of_user(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+    user = data_fixture.create_user(email="user@test.nl")
+    data_fixture.configure_totp(user)
+    TOTPUsedCode.objects.create(
+        user=user,
+        used_at=datetime(2021, 4, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        code="hashed-code",
+    )
+    assert TwoFactorAuthRecoveryCode.objects.filter(user=user).count() > 0
+    assert TOTPUsedCode.objects.filter(user=user).count() > 0
+
+    response = api_client.delete(
+        reverse("api:admin:users:two_factor_auth", kwargs={"user_id": user.id}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert TwoFactorAuthHandler().get_provider(user) is None
+    assert TwoFactorAuthRecoveryCode.objects.filter(user=user).count() == 0
+    assert TOTPUsedCode.objects.filter(user=user).count() == 0
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_non_admin_cannot_disable_two_factor_auth_of_user(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token(
+        email="nonstaff@test.nl",
+        password="password",
+        is_staff=False,
+    )
+    user = data_fixture.create_user(email="user@test.nl")
+    data_fixture.configure_totp(user)
+
+    response = api_client.delete(
+        reverse("api:admin:users:two_factor_auth", kwargs={"user_id": user.id}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_403_FORBIDDEN
+    assert TwoFactorAuthHandler().get_provider(user) is not None
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_disable_two_factor_auth_unknown_user(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+
+    response = api_client.delete(
+        reverse("api:admin:users:two_factor_auth", kwargs={"user_id": 99999}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "USER_ADMIN_UNKNOWN_USER"
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_disable_two_factor_auth_not_configured(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+    user = data_fixture.create_user(email="user@test.nl")
+
+    response = api_client.delete(
+        reverse("api:admin:users:two_factor_auth", kwargs={"user_id": user.id}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_TWO_FACTOR_AUTH_NOT_CONFIGURED"

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -2,8 +2,9 @@ import json
 from datetime import datetime, timezone
 
 from django.contrib.auth import get_user_model
+from django.db import connection
 from django.shortcuts import reverse
-from django.test.utils import override_settings
+from django.test.utils import CaptureQueriesContext, override_settings
 
 import pytest
 from freezegun import freeze_time
@@ -105,6 +106,7 @@ def test_admin_can_see_admin_users_endpoint(api_client, data_fixture):
                 "is_staff": True,
                 "is_active": True,
                 "last_login": None,
+                "two_factor_auth": {},
             }
         ],
     }
@@ -207,6 +209,7 @@ def test_admin_can_search_users(api_client, data_fixture):
                 "is_staff": False,
                 "is_active": True,
                 "last_login": None,
+                "two_factor_auth": {},
             }
         ],
     }
@@ -248,6 +251,7 @@ def test_admin_can_sort_users(api_client, data_fixture):
                 "is_staff": False,
                 "is_active": True,
                 "last_login": None,
+                "two_factor_auth": {},
             }
         ],
     }
@@ -538,6 +542,7 @@ def test_admin_can_create_user(api_client, data_fixture):
             "is_staff": True,
             "is_active": True,
             "last_login": None,
+            "two_factor_auth": {},
         }
 
     response = api_client.post(
@@ -579,6 +584,7 @@ def test_admin_can_patch_user(api_client, data_fixture):
         "is_staff": True,
         "is_active": True,
         "last_login": None,
+        "two_factor_auth": {},
     }
 
 
@@ -612,6 +618,7 @@ def test_admin_can_patch_user_without_providing_password(api_client, data_fixtur
         "is_staff": True,
         "is_active": True,
         "last_login": None,
+        "two_factor_auth": {},
     }
 
 
@@ -771,7 +778,7 @@ def test_admin_getting_view_users_only_runs_two_queries_instead_of_n(
         first_name="Test1",
         is_staff=True,
     )
-    fixed_num_of_queries_unrelated_to_number_of_rows = 7
+    fixed_num_of_queries_unrelated_to_number_of_rows = 8
 
     for i in range(10):
         data_fixture.create_user_workspace()
@@ -927,3 +934,64 @@ def test_admin_impersonate_staff_or_superuser(api_client, data_fixture):
     assert response.status_code == HTTP_400_BAD_REQUEST
     response_json = response.json()
     assert response_json["user"][0].startswith("Invalid pk")
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_users_endpoint_includes_two_factor_auth(api_client, data_fixture):
+    staff_user, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+    user_with_enabled_2fa = data_fixture.create_user(email="enabled@test.nl")
+    data_fixture.configure_totp(user_with_enabled_2fa)
+    user_with_pending_2fa = data_fixture.create_user(email="pending@test.nl")
+    data_fixture.configure_base_totp(user_with_pending_2fa)
+
+    response = api_client.get(
+        reverse("api:admin:users:list"),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    results = {r["username"]: r for r in response.json()["results"]}
+    assert results["staff@test.nl"]["two_factor_auth"] == {}
+    assert results["enabled@test.nl"]["two_factor_auth"] == {
+        "type": "totp",
+        "is_enabled": True,
+    }
+    assert results["pending@test.nl"]["two_factor_auth"] == {
+        "type": "totp",
+        "is_enabled": False,
+    }
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_users_two_factor_auth_does_not_add_n_plus_one_queries(
+    api_client, data_fixture
+):
+    _, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+    first_user = data_fixture.create_user()
+    data_fixture.configure_totp(first_user)
+    url = reverse("api:admin:users:list")
+
+    with CaptureQueriesContext(connection) as queries_for_few:
+        api_client.get(url, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+
+    for i in range(3):
+        extra_user = data_fixture.create_user()
+        data_fixture.configure_totp(extra_user)
+
+    with CaptureQueriesContext(connection) as queries_for_many:
+        api_client.get(url, format="json", HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert len(queries_for_few.captured_queries) == len(
+        queries_for_many.captured_queries
+    )

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -1031,6 +1031,29 @@ def test_admin_can_disable_two_factor_auth_of_user(api_client, data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_admin_can_disable_their_own_two_factor_auth(api_client, data_fixture):
+    # Removing your own two-factor authentication can't lock you out, so unlike
+    # self-deactivate/self-delete it is intentionally allowed.
+    staff_user, token = data_fixture.create_user_and_token(
+        email="staff@test.nl",
+        password="password",
+        is_staff=True,
+    )
+    data_fixture.configure_totp(staff_user)
+    assert TwoFactorAuthHandler().get_provider(staff_user) is not None
+
+    response = api_client.delete(
+        reverse("api:admin:users:two_factor_auth", kwargs={"user_id": staff_user.id}),
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_204_NO_CONTENT
+    assert TwoFactorAuthHandler().get_provider(staff_user) is None
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_non_admin_cannot_disable_two_factor_auth_of_user(api_client, data_fixture):
     _, token = data_fixture.create_user_and_token(
         email="nonstaff@test.nl",

--- a/backend/tests/baserow/core/admin/users/test_user_admin_actions.py
+++ b/backend/tests/baserow/core/admin/users/test_user_admin_actions.py
@@ -1,9 +1,20 @@
 import pytest
 
+from baserow.core.action.registries import action_type_registry
 from baserow.core.action.signals import action_done
 from baserow.core.admin.users.actions import AdminDisableTwoFactorAuthActionType
 from baserow.core.two_factor_auth.exceptions import TwoFactorAuthNotConfigured
 from baserow.core.two_factor_auth.handler import TwoFactorAuthHandler
+
+
+def test_admin_disable_two_factor_auth_action_type_is_registered():
+    # The action type must be registered in apps.py so that it is exposed as a
+    # filterable choice in the enterprise audit log export and resolvable via the
+    # action type registry, like every other action type.
+    assert (
+        action_type_registry.get(AdminDisableTwoFactorAuthActionType.type).type
+        == AdminDisableTwoFactorAuthActionType.type
+    )
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/core/admin/users/test_user_admin_actions.py
+++ b/backend/tests/baserow/core/admin/users/test_user_admin_actions.py
@@ -1,0 +1,54 @@
+import pytest
+
+from baserow.core.action.signals import action_done
+from baserow.core.admin.users.actions import AdminDisableTwoFactorAuthActionType
+from baserow.core.two_factor_auth.exceptions import TwoFactorAuthNotConfigured
+from baserow.core.two_factor_auth.handler import TwoFactorAuthHandler
+
+
+@pytest.mark.django_db
+def test_admin_disable_two_factor_auth_action_disables_and_registers(data_fixture):
+    staff_user = data_fixture.create_user(is_staff=True)
+    user = data_fixture.create_user()
+    data_fixture.configure_totp(user)
+
+    received = []
+
+    def receiver(sender, user, action_type, action_params, **kwargs):
+        received.append((user, action_type, action_params))
+
+    action_done.connect(receiver)
+    try:
+        AdminDisableTwoFactorAuthActionType.do(staff_user, user.id)
+    finally:
+        action_done.disconnect(receiver)
+
+    assert TwoFactorAuthHandler().get_provider(user) is None
+    assert len(received) == 1
+    acting_user, action_type, params = received[0]
+    assert acting_user.id == staff_user.id
+    assert action_type.type == "admin_disable_two_factor_auth"
+    assert params["user_id"] == staff_user.id
+    assert params["user_email"] == staff_user.email
+    assert params["disabled_user_id"] == user.id
+    assert params["disabled_user_email"] == user.email
+
+
+@pytest.mark.django_db
+def test_admin_disable_two_factor_auth_action_not_registered_on_failure(data_fixture):
+    staff_user = data_fixture.create_user(is_staff=True)
+    user = data_fixture.create_user()
+
+    received = []
+
+    def receiver(sender, **kwargs):
+        received.append(kwargs)
+
+    action_done.connect(receiver)
+    try:
+        with pytest.raises(TwoFactorAuthNotConfigured):
+            AdminDisableTwoFactorAuthActionType.do(staff_user, user.id)
+    finally:
+        action_done.disconnect(receiver)
+
+    assert len(received) == 0

--- a/backend/tests/baserow/core/admin/users/test_user_admin_handler.py
+++ b/backend/tests/baserow/core/admin/users/test_user_admin_handler.py
@@ -10,6 +10,8 @@ from baserow.core.admin.users.exceptions import (
 )
 from baserow.core.admin.users.handler import UserAdminHandler
 from baserow.core.exceptions import IsNotAdminError
+from baserow.core.two_factor_auth.exceptions import TwoFactorAuthNotConfigured
+from baserow.core.two_factor_auth.handler import TwoFactorAuthHandler
 from baserow.core.user.exceptions import (
     PasswordDoesNotMatchValidation,
     UserAlreadyExist,
@@ -442,3 +444,47 @@ def test_does_not_raise_exception_when_changing_to_same_username(data_fixture):
         handler.update_user(admin_user, admin_user.id, username="test@test.nl").email
         == "test@test.nl"
     )
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_admin_can_disable_user_two_factor_auth(data_fixture):
+    staff_user = data_fixture.create_user(is_staff=True)
+    user = data_fixture.create_user()
+    data_fixture.configure_totp(user)
+
+    UserAdminHandler().disable_user_two_factor_auth(staff_user, user.id)
+
+    assert TwoFactorAuthHandler().get_provider(user) is None
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_non_admin_cant_disable_user_two_factor_auth(data_fixture):
+    non_staff_user = data_fixture.create_user(is_staff=False)
+    user = data_fixture.create_user()
+    data_fixture.configure_totp(user)
+
+    with pytest.raises(IsNotAdminError):
+        UserAdminHandler().disable_user_two_factor_auth(non_staff_user, user.id)
+
+    assert TwoFactorAuthHandler().get_provider(user) is not None
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_disable_user_two_factor_auth_unknown_user(data_fixture):
+    staff_user = data_fixture.create_user(is_staff=True)
+
+    with pytest.raises(UserDoesNotExistException):
+        UserAdminHandler().disable_user_two_factor_auth(staff_user, 99999)
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+def test_disable_user_two_factor_auth_not_configured(data_fixture):
+    staff_user = data_fixture.create_user(is_staff=True)
+    user = data_fixture.create_user()
+
+    with pytest.raises(TwoFactorAuthNotConfigured):
+        UserAdminHandler().disable_user_two_factor_auth(staff_user, user.id)

--- a/backend/tests/baserow/core/two_factor_auth/test_two_factor_handler.py
+++ b/backend/tests/baserow/core/two_factor_auth/test_two_factor_handler.py
@@ -155,3 +155,23 @@ def test_verify(data_fixture):
         assert (
             TwoFactorAuthHandler().verify("totp", email=user.email, code=code) is True
         )
+
+
+@pytest.mark.django_db
+def test_disable_for_user_disables_without_password(data_fixture):
+    user = data_fixture.create_user()
+    data_fixture.configure_totp(user)
+    handler = TwoFactorAuthHandler()
+    assert handler.get_provider(user) is not None
+
+    handler.disable_for_user(user)
+
+    assert handler.get_provider(user) is None
+
+
+@pytest.mark.django_db
+def test_disable_for_user_raises_when_not_configured(data_fixture):
+    user = data_fixture.create_user()
+
+    with pytest.raises(TwoFactorAuthNotConfigured):
+        TwoFactorAuthHandler().disable_for_user(user)

--- a/changelog/entries/unreleased/feature/5492_allow_instance_admins_to_manage_the_2fa_state_of_the_users.json
+++ b/changelog/entries/unreleased/feature/5492_allow_instance_admins_to_manage_the_2fa_state_of_the_users.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Show the 2FA status in the admin user list and allow instance admins to remove a user's two-factor authentication.",
+    "issue_origin": "github",
+    "issue_number": 5492,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-13"
+}

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/admin/users/test_admin_users_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/admin/users/test_admin_users_views.py
@@ -73,7 +73,7 @@ def test_admin_users_endpoint_contains_highest_role(
                 "is_staff": True,
                 "is_active": True,
                 "last_login": None,
-                "two_factor_auth": {},
+                "two_factor_auth": None,
             }
         ],
     }

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/admin/users/test_admin_users_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/admin/users/test_admin_users_views.py
@@ -73,6 +73,7 @@ def test_admin_users_endpoint_contains_highest_role(
                 "is_staff": True,
                 "is_active": True,
                 "last_login": None,
+                "two_factor_auth": {},
             }
         ],
     }

--- a/web-frontend/modules/core/assets/scss/components/user_admin.scss
+++ b/web-frontend/modules/core/assets/scss/components/user_admin.scss
@@ -49,3 +49,9 @@
   color: $color-error-500;
   font-size: 14px;
 }
+
+.user-admin-edit__remove-2fa {
+  color: $color-error-500;
+  font-size: 14px;
+  cursor: pointer;
+}

--- a/web-frontend/modules/core/assets/scss/components/user_admin.scss
+++ b/web-frontend/modules/core/assets/scss/components/user_admin.scss
@@ -50,8 +50,13 @@
   font-size: 14px;
 }
 
+.user-admin-edit__two-factor {
+  @include flex-align-items(12px);
+}
+
 .user-admin-edit__remove-2fa {
   color: $color-error-500;
-  font-size: 14px;
+  font-size: 13px;
+  line-height: 20px;
   cursor: pointer;
 }

--- a/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
+++ b/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
@@ -90,12 +90,7 @@ export default {
         new CrudTableColumn(
           'two_factor_auth',
           () => this.$t('usersAdminTable.twoFactorAuth'),
-          TwoFactorAuthField,
-          false,
-          false,
-          false,
-          {},
-          8
+          TwoFactorAuthField
         ),
         new CrudTableColumn('more', '', MoreField, false, false, true),
       ]

--- a/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
+++ b/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
@@ -90,7 +90,12 @@ export default {
         new CrudTableColumn(
           'two_factor_auth',
           () => this.$t('usersAdminTable.twoFactorAuth'),
-          TwoFactorAuthField
+          TwoFactorAuthField,
+          false,
+          false,
+          false,
+          {},
+          8
         ),
         new CrudTableColumn('more', '', MoreField, false, false, true),
       ]

--- a/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
+++ b/web-frontend/modules/core/components/admin/users/UsersAdminTable.vue
@@ -28,6 +28,7 @@ import CrudTable from '@baserow/modules/core/components/crudTable/CrudTable'
 import SimpleField from '@baserow/modules/core/components/crudTable/fields/SimpleField'
 import LocalDateField from '@baserow/modules/core/components/crudTable/fields/LocalDateField'
 import ActiveField from '@baserow/modules/core/components/admin/users/fields/ActiveField'
+import TwoFactorAuthField from '@baserow/modules/core/components/crudTable/fields/TwoFactorAuthField'
 import MoreField from '@baserow/modules/core/components/crudTable/fields/MoreField'
 import EditUserContext from '@baserow/modules/core/components/admin/users/contexts/EditUserContext'
 import CrudTableColumn from '@baserow/modules/core/crudTable/crudTableColumn'
@@ -85,6 +86,11 @@ export default {
           () => this.$t('user.active'),
           ActiveField,
           true
+        ),
+        new CrudTableColumn(
+          'two_factor_auth',
+          () => this.$t('usersAdminTable.twoFactorAuth'),
+          TwoFactorAuthField
         ),
         new CrudTableColumn('more', '', MoreField, false, false, true),
       ]

--- a/web-frontend/modules/core/components/admin/users/fields/ActiveField.vue
+++ b/web-frontend/modules/core/components/admin/users/fields/ActiveField.vue
@@ -1,17 +1,15 @@
 <template>
-  <div>
-    <div v-if="row[column.key]" class="user-admin-active">
-      <i
-        class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"
-      ></i>
-      {{ $t('user.active') }}
-    </div>
-    <div v-else>
-      <i
-        class="iconoir-cancel user-admin-active__icon user-admin-active__icon--deactivated"
-      ></i>
-      {{ $t('user.deactivated') }}
-    </div>
+  <div class="user-admin-active">
+    <i
+      v-if="row[column.key]"
+      v-tooltip="$t('user.active')"
+      class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"
+    ></i>
+    <i
+      v-else
+      v-tooltip="$t('user.deactivated')"
+      class="iconoir-cancel user-admin-active__icon user-admin-active__icon--deactivated"
+    ></i>
   </div>
 </template>
 

--- a/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
+++ b/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
@@ -96,6 +96,31 @@
       </template>
     </FormGroup>
 
+    <FormGroup
+      small-label
+      :label="$t('userForm.twoFactorAuth')"
+      required
+      class="margin-top-2"
+    >
+      <Badge
+        :color="twoFactorAuthEnabled ? 'green' : 'neutral'"
+        :rounded="true"
+      >
+        {{
+          twoFactorAuthEnabled
+            ? twoFactorAuthProviderName
+            : $t('twoFactorAuthField.disabled')
+        }}
+      </Badge>
+      <a
+        v-if="twoFactorAuthEnabled"
+        class="user-admin-edit__remove-2fa"
+        @click.prevent="$emit('remove-two-factor-auth')"
+      >
+        {{ $t('userForm.removeTwoFactorAuth') }}
+      </a>
+    </FormGroup>
+
     <div class="actions">
       <slot></slot>
       <div class="align-right">
@@ -132,6 +157,7 @@ export default {
       required: true,
     },
   },
+  emits: ['remove-two-factor-auth'],
   setup() {
     const values = reactive({
       values: {
@@ -167,6 +193,16 @@ export default {
     return {
       allowedValues: ['username', 'name', 'is_active', 'is_staff'],
     }
+  },
+  computed: {
+    twoFactorAuthEnabled() {
+      return Boolean(this.user.two_factor_auth?.is_enabled)
+    },
+    twoFactorAuthProviderName() {
+      const type = this.user.two_factor_auth?.type
+      const registered = this.$registry.getAll('twoFactorAuth')
+      return registered[type] ? registered[type].name : type
+    },
   },
 }
 </script>

--- a/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
+++ b/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
@@ -102,23 +102,25 @@
       required
       class="margin-top-2"
     >
-      <Badge
-        :color="twoFactorAuthEnabled ? 'green' : 'neutral'"
-        :rounded="true"
-      >
-        {{
-          twoFactorAuthEnabled
-            ? twoFactorAuthProviderName
-            : $t('twoFactorAuthField.disabled')
-        }}
-      </Badge>
-      <a
-        v-if="twoFactorAuthEnabled"
-        class="user-admin-edit__remove-2fa"
-        @click.prevent="$emit('remove-two-factor-auth')"
-      >
-        {{ $t('userForm.removeTwoFactorAuth') }}
-      </a>
+      <div class="user-admin-edit__two-factor">
+        <Badge
+          :color="twoFactorAuthEnabled ? 'green' : 'neutral'"
+          :rounded="true"
+        >
+          {{
+            twoFactorAuthEnabled
+              ? twoFactorAuthProviderName
+              : $t('twoFactorAuthField.disabled')
+          }}
+        </Badge>
+        <a
+          v-if="twoFactorAuthEnabled"
+          class="user-admin-edit__remove-2fa"
+          @click.prevent="$emit('remove-two-factor-auth')"
+        >
+          {{ $t('userForm.removeTwoFactorAuth') }}
+        </a>
+      </div>
     </FormGroup>
 
     <div class="actions">

--- a/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
+++ b/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
@@ -99,7 +99,6 @@
     <FormGroup
       small-label
       :label="$t('userForm.twoFactorAuth')"
-      required
       class="margin-top-2"
     >
       <div class="user-admin-edit__two-factor">

--- a/web-frontend/modules/core/components/admin/users/modals/DisableTwoFactorAuthModal.vue
+++ b/web-frontend/modules/core/components/admin/users/modals/DisableTwoFactorAuthModal.vue
@@ -1,0 +1,71 @@
+<template>
+  <Modal ref="modal">
+    <h2 class="box__title">
+      {{ $t('disableTwoFactorAuthModal.title') }}
+    </h2>
+    <Error :error="error"></Error>
+    <div>
+      <i18n-t keypath="disableTwoFactorAuthModal.confirmation" tag="p">
+        <template #name>
+          <strong class="user-admin-delete__strong">{{ user.username }}</strong>
+        </template>
+      </i18n-t>
+      <p>
+        {{ $t('disableTwoFactorAuthModal.comment') }}
+      </p>
+      <div class="actions">
+        <div class="align-right">
+          <Button
+            type="danger"
+            size="large"
+            full-width
+            :disabled="loading"
+            :loading="loading"
+            @click.prevent="disableTwoFactorAuth()"
+          >
+            {{ $t('disableTwoFactorAuthModal.remove') }}</Button
+          >
+        </div>
+      </div>
+    </div>
+  </Modal>
+</template>
+
+<script>
+import modal from '@baserow/modules/core/mixins/modal'
+import error from '@baserow/modules/core/mixins/error'
+import UserAdminService from '@baserow/modules/core/services/admin/users'
+
+export default {
+  name: 'DisableTwoFactorAuthModal',
+  mixins: [modal, error],
+  props: {
+    user: {
+      type: Object,
+      required: true,
+    },
+  },
+  emits: ['two-factor-auth-disabled'],
+  data() {
+    return {
+      loading: false,
+    }
+  },
+  methods: {
+    async disableTwoFactorAuth() {
+      this.hideError()
+      this.loading = true
+
+      try {
+        await UserAdminService(this.$client).disableTwoFactorAuth(this.user.id)
+        this.$emit('two-factor-auth-disabled')
+        this.hide()
+      } catch (error) {
+        this.handleError(error, 'application')
+      }
+
+      this.loading = false
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/core/components/admin/users/modals/EditUserModal.vue
+++ b/web-frontend/modules/core/components/admin/users/modals/EditUserModal.vue
@@ -77,7 +77,7 @@ export default {
       }
     },
     onTwoFactorAuthDisabled() {
-      this.$emit('update', { ...this.user, two_factor_auth: {} })
+      this.$emit('update', { ...this.user, two_factor_auth: null })
     },
   },
 }

--- a/web-frontend/modules/core/components/admin/users/modals/EditUserModal.vue
+++ b/web-frontend/modules/core/components/admin/users/modals/EditUserModal.vue
@@ -10,6 +10,7 @@
       :loading="loading"
       :default-values="user"
       @submitted="editUser"
+      @remove-two-factor-auth="$refs.disableTwoFactorAuthModal.show()"
     >
       <div class="align-left">
         <a
@@ -25,6 +26,11 @@
       :user="user"
       @delete-user="$emit('delete-user', $event)"
     ></DeleteUserModal>
+    <DisableTwoFactorAuthModal
+      ref="disableTwoFactorAuthModal"
+      :user="user"
+      @two-factor-auth-disabled="onTwoFactorAuthDisabled"
+    ></DisableTwoFactorAuthModal>
   </Modal>
 </template>
 
@@ -34,10 +40,11 @@ import error from '@baserow/modules/core/mixins/error'
 import UserAdminService from '@baserow/modules/core/services/admin/users'
 import UserForm from '@baserow/modules/core/components/admin/users/forms/UserForm'
 import DeleteUserModal from '@baserow/modules/core/components/admin/users/modals/DeleteUserModal'
+import DisableTwoFactorAuthModal from '@baserow/modules/core/components/admin/users/modals/DisableTwoFactorAuthModal'
 
 export default {
   name: 'EditUserModal',
-  components: { DeleteUserModal, UserForm },
+  components: { DeleteUserModal, DisableTwoFactorAuthModal, UserForm },
   mixins: [modal, error],
   props: {
     user: {
@@ -68,6 +75,9 @@ export default {
         this.loading = false
         this.handleError(error, 'application')
       }
+    },
+    onTwoFactorAuthDisabled() {
+      this.$emit('update', { ...this.user, two_factor_auth: {} })
     },
   },
 }

--- a/web-frontend/modules/core/components/crudTable/fields/TwoFactorAuthField.vue
+++ b/web-frontend/modules/core/components/crudTable/fields/TwoFactorAuthField.vue
@@ -1,9 +1,9 @@
 <template>
   <Badge
-    :color="row[column.key].is_enabled ? 'green' : 'neutral'"
+    :color="row[column.key]?.is_enabled ? 'green' : 'neutral'"
     :rounded="true"
   >
-    <span v-if="row[column.key].is_enabled">
+    <span v-if="row[column.key]?.is_enabled">
       {{ $t('twoFactorAuthField.enabled') }}
     </span>
     <span v-else>

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -1006,7 +1006,8 @@
     "workspaces": "Workspaces",
     "lastLogin": "Last login",
     "dateJoined": "Signed up",
-    "active": "Active"
+    "active": "Active",
+    "twoFactorAuth": "2FA"
   },
   "editUserContext": {
     "changePassword": "Change password",

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -1026,6 +1026,8 @@
     "fullName": "Full name",
     "email": "Email",
     "isActive": "Is active",
+    "twoFactorAuth": "Two-factor authentication",
+    "removeTwoFactorAuth": "Remove two-factor authentication",
     "warning": {
       "changeEmail": "Changing this users email address means when they sign in they must use the new email address to do so. This must be communicated with that user.",
       "inactiveUser": "When a user is marked as inactive they are prevented from signing in.",
@@ -1045,6 +1047,12 @@
     "comment1": "The user account will be deleted, however the workspaces that user is a member of will continue existing. The users workspace will not be deleted, even if this user is the last user in the workspace. Deleting the last user in a workspace prevents anyone being able to access that workspace.",
     "comment2": "After deleting a user it is possible for a new user to sign up again using the deleted users email address. To ensure they cannot sign up again instead deactivate the user and do not delete them.",
     "delete": "Delete user {username}"
+  },
+  "disableTwoFactorAuthModal": {
+    "title": "Remove two-factor authentication",
+    "confirmation": "Are you sure you want to remove two-factor authentication for {name}?",
+    "comment": "They will be able to sign in with just their password and can set up two-factor authentication again afterwards.",
+    "remove": "Remove two-factor authentication"
   },
   "editUserModal": {
     "delete": "Delete user",

--- a/web-frontend/modules/core/services/admin/users.js
+++ b/web-frontend/modules/core/services/admin/users.js
@@ -8,6 +8,9 @@ export default (client) => {
     delete(userId) {
       return client.delete(`/admin/users/${userId}/`)
     },
+    disableTwoFactorAuth(userId) {
+      return client.delete(`/admin/users/${userId}/two-factor-auth/`)
+    },
     impersonate(userId) {
       return client.post(`/admin/users/impersonate/`, {
         user: userId,

--- a/web-frontend/test/fixtures/user.js
+++ b/web-frontend/test/fixtures/user.js
@@ -13,6 +13,7 @@ export function aUser({
   dateJoined = '2021-04-21T12:04:27.379781Z',
   isActive = true,
   isStaff = true,
+  twoFactorAuth = {},
 }) {
   return {
     id,
@@ -23,6 +24,7 @@ export function aUser({
     date_joined: dateJoined,
     is_active: isActive,
     is_staff: isStaff,
+    two_factor_auth: twoFactorAuth,
   }
 }
 

--- a/web-frontend/test/fixtures/user.js
+++ b/web-frontend/test/fixtures/user.js
@@ -13,7 +13,7 @@ export function aUser({
   dateJoined = '2021-04-21T12:04:27.379781Z',
   isActive = true,
   isStaff = true,
-  twoFactorAuth = {},
+  twoFactorAuth = null,
 }) {
   return {
     id,

--- a/web-frontend/test/helpers/userAdminHelpers.js
+++ b/web-frontend/test/helpers/userAdminHelpers.js
@@ -13,7 +13,7 @@ export default class UserAdminUserHelpers {
     this.c = userAdminComponent
   }
 
-  findCells(numCellsExpected = 7) {
+  findCells(numCellsExpected = 8) {
     const cells = this.c.findAll('tbody .data-table__table-cell-content')
     expect(cells.length).toBe(numCellsExpected)
     return cells
@@ -22,11 +22,11 @@ export default class UserAdminUserHelpers {
   findUsernameColumnCellsText() {
     const cells = this.c.findAll('tbody .data-table__table-cell-content')
     const usernameCells = []
-    const numRows = cells.length / 7
+    const numRows = cells.length / 8
     for (let i = 0; i < numRows; i++) {
       usernameCells.push(
         cells
-          .at(i * 7 + 0)
+          .at(i * 8 + 0)
           .find('.user-admin-username__name')
           .text()
       )
@@ -35,7 +35,7 @@ export default class UserAdminUserHelpers {
   }
 
   getRow(cells, rowNumber) {
-    const offset = rowNumber * 7
+    const offset = rowNumber * 8
     return {
       usernameCell: cells.at(offset),
       nameCell: cells.at(offset + 1),
@@ -43,7 +43,8 @@ export default class UserAdminUserHelpers {
       lastLoginCell: cells.at(offset + 3),
       signedUpCell: cells.at(offset + 4),
       isActiveCell: cells.at(offset + 5),
-      moreCell: cells.at(offset + 6),
+      twoFactorAuthCell: cells.at(offset + 6),
+      moreCell: cells.at(offset + 7),
     }
   }
 

--- a/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
+++ b/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
@@ -77,7 +77,7 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
               </div>
             </div>
           </th>
-          <th style="--width: 8%;" class="data-table__table-cell data-table__table-cell--header">
+          <th style="" class="data-table__table-cell data-table__table-cell--header">
             <div class="data-table__table-cell-head">
               <div>usersAdminTable.twoFactorAuth
                 <!--v-if-->
@@ -137,9 +137,7 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
           </td>
           <td class="data-table__table-cell data-table__table-cell--is_active">
             <div class="data-table__table-cell-content">
-              <div>
-                <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
-              </div>
+              <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i></div>
             </div>
           </td>
           <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
@@ -248,7 +246,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
               </div>
             </div>
           </th>
-          <th style="--width: 8%;" class="data-table__table-cell data-table__table-cell--header">
+          <th style="" class="data-table__table-cell data-table__table-cell--header">
             <div class="data-table__table-cell-head">
               <div>usersAdminTable.twoFactorAuth
                 <!--v-if-->
@@ -308,9 +306,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
           </td>
           <td class="data-table__table-cell data-table__table-cell--is_active">
             <div class="data-table__table-cell-content">
-              <div>
-                <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
-              </div>
+              <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i></div>
             </div>
           </td>
           <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
@@ -369,9 +365,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
           </td>
           <td class="data-table__table-cell data-table__table-cell--is_active">
             <div class="data-table__table-cell-content">
-              <div>
-                <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
-              </div>
+              <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i></div>
             </div>
           </td>
           <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
@@ -430,9 +424,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
           </td>
           <td class="data-table__table-cell data-table__table-cell--is_active">
             <div class="data-table__table-cell-content">
-              <div>
-                <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
-              </div>
+              <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i></div>
             </div>
           </td>
           <td class="data-table__table-cell data-table__table-cell--two_factor_auth">

--- a/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
+++ b/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
@@ -77,7 +77,7 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
               </div>
             </div>
           </th>
-          <th style="" class="data-table__table-cell data-table__table-cell--header">
+          <th style="--width: 8%;" class="data-table__table-cell data-table__table-cell--header">
             <div class="data-table__table-cell-head">
               <div>usersAdminTable.twoFactorAuth
                 <!--v-if-->
@@ -248,7 +248,7 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
               </div>
             </div>
           </th>
-          <th style="" class="data-table__table-cell data-table__table-cell--header">
+          <th style="--width: 8%;" class="data-table__table-cell data-table__table-cell--header">
             <div class="data-table__table-cell-head">
               <div>usersAdminTable.twoFactorAuth
                 <!--v-if-->

--- a/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
+++ b/web-frontend/test/unit/core/admin/users/__snapshots__/userAdmin.spec.js.snap
@@ -77,6 +77,13 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
               </div>
             </div>
           </th>
+          <th style="" class="data-table__table-cell data-table__table-cell--header">
+            <div class="data-table__table-cell-head">
+              <div>usersAdminTable.twoFactorAuth
+                <!--v-if-->
+              </div>
+            </div>
+          </th>
           <th style="" class="data-table__table-cell data-table__table-cell--header data-table__table-cell--sticky-right">
             <div class="data-table__table-cell-head">
               <div>
@@ -132,6 +139,13 @@ exports[`User Admin Component Tests > A users attributes will be displayed 1`] =
             <div class="data-table__table-cell-content">
               <div>
                 <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
+              </div>
+            </div>
+          </td>
+          <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
+            <div class="data-table__table-cell-content">
+              <div class="badge badge--neutral badge--regular badge--rounded">
+                <!--v-if--><span class="badge__label"><span>twoFactorAuthField.disabled</span></span>
               </div>
             </div>
           </td>
@@ -234,6 +248,13 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
               </div>
             </div>
           </th>
+          <th style="" class="data-table__table-cell data-table__table-cell--header">
+            <div class="data-table__table-cell-head">
+              <div>usersAdminTable.twoFactorAuth
+                <!--v-if-->
+              </div>
+            </div>
+          </th>
           <th style="" class="data-table__table-cell data-table__table-cell--header data-table__table-cell--sticky-right">
             <div class="data-table__table-cell-head">
               <div>
@@ -292,6 +313,13 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
               </div>
             </div>
           </td>
+          <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
+            <div class="data-table__table-cell-content">
+              <div class="badge badge--neutral badge--regular badge--rounded">
+                <!--v-if--><span class="badge__label"><span>twoFactorAuthField.disabled</span></span>
+              </div>
+            </div>
+          </td>
           <td class="data-table__table-cell data-table__table-cell--sticky-right data-table__table-cell--more">
             <div class="data-table__table-cell-content">
               <div class="data-table__more-wrapper" column="[object Object]"><a class="data-table__more"><i class="data-table__more-icon baserow-icon-more-horizontal"></i></a></div>
@@ -346,6 +374,13 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
               </div>
             </div>
           </td>
+          <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
+            <div class="data-table__table-cell-content">
+              <div class="badge badge--neutral badge--regular badge--rounded">
+                <!--v-if--><span class="badge__label"><span>twoFactorAuthField.disabled</span></span>
+              </div>
+            </div>
+          </td>
           <td class="data-table__table-cell data-table__table-cell--sticky-right data-table__table-cell--more">
             <div class="data-table__table-cell-content">
               <div class="data-table__more-wrapper" column="[object Object]"><a class="data-table__more"><i class="data-table__more-icon baserow-icon-more-horizontal"></i></a></div>
@@ -397,6 +432,13 @@ exports[`User Admin Component Tests > you can sort by multiple columns which wil
             <div class="data-table__table-cell-content">
               <div>
                 <div class="user-admin-active"><i class="iconoir-check user-admin-active__icon user-admin-active__icon--activated"></i> user.active</div>
+              </div>
+            </div>
+          </td>
+          <td class="data-table__table-cell data-table__table-cell--two_factor_auth">
+            <div class="data-table__table-cell-content">
+              <div class="badge badge--neutral badge--regular badge--rounded">
+                <!--v-if--><span class="badge__label"><span>twoFactorAuthField.disabled</span></span>
               </div>
             </div>
           </td>

--- a/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
+++ b/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
@@ -93,8 +93,8 @@ describe('User Admin Component Tests', () => {
     expect(lastLoginCell.text()).toMatch(/^04\/26\/2021 \d+:50 (AM|PM)$/)
     expect(signedUpCell.text()).toMatch(/^04\/21\/2021 \d+:04 (AM|PM)$/)
 
-    // Shown as active
-    expect(isActiveCell.text()).toBe('user.active')
+    // Shown as active via the icon only (no text label)
+    expect(isActiveCell.find('.iconoir-check').exists()).toBe(true)
 
     // 2FA is shown as disabled when not configured
     expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.disabled')
@@ -207,7 +207,7 @@ describe('User Admin Component Tests', () => {
 
     const cells = ui.findCells()
     const { isActiveCell } = ui.getRow(cells, 0)
-    expect(isActiveCell.text()).toContain('user.deactivated')
+    expect(isActiveCell.find('.iconoir-cancel').exists()).toBe(true)
   })
 
   test('A deactivated user can be activated', async () => {
@@ -227,7 +227,7 @@ describe('User Admin Component Tests', () => {
 
     const cells = ui.findCells()
     const { isActiveCell } = ui.getRow(cells, 0)
-    expect(isActiveCell.text()).toContain('user.active')
+    expect(isActiveCell.find('.iconoir-check').exists()).toBe(true)
   })
 
   // eslint-disable-next-line vitest/expect-expect
@@ -674,9 +674,11 @@ describe('User Admin Component Tests', () => {
 
     let cells = ui.findCells()
     const { isActiveCell } = ui.getRow(cells, 0)
-    expect(isActiveCell.text()).toBe(
-      startingIsActive ? 'user.active' : 'user.deactivated'
-    )
+    expect(
+      isActiveCell
+        .find(startingIsActive ? '.iconoir-check' : '.iconoir-cancel')
+        .exists()
+    ).toBe(true)
 
     mockServer.expectUserUpdated(user, {
       is_active: !startingIsActive,
@@ -692,9 +694,11 @@ describe('User Admin Component Tests', () => {
 
     cells = ui.findCells()
     const { isActiveCell: updatedIsActiveCell } = ui.getRow(cells, 0)
-    expect(updatedIsActiveCell.text()).toBe(
-      startingIsActive ? 'user.deactivated' : 'user.active'
-    )
+    expect(
+      updatedIsActiveCell
+        .find(startingIsActive ? '.iconoir-cancel' : '.iconoir-check')
+        .exists()
+    ).toBe(true)
   }
 
   async function whenThereIsAUserAndYouOpenUserAdmin(userSetup = {}) {

--- a/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
+++ b/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
@@ -157,6 +157,37 @@ describe('User Admin Component Tests', () => {
     expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.disabled')
   })
 
+  test('a failed 2FA removal shows an error and leaves the row unchanged', async () => {
+    testApp.mock.onDelete(`/admin/users/1/two-factor-auth/`).reply(400, {
+      error: 'ERROR_TWO_FACTOR_AUTH_NOT_CONFIGURED',
+      detail: 'Two-factor authentication is not configured.',
+    })
+
+    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin({
+      twoFactorAuth: { type: 'totp', is_enabled: true },
+    })
+    testApp.dontFailOnErrorResponses()
+
+    const editUserContext = await ui.openFirstUserActionsMenu()
+    await ui.clickEditUser(editUserContext)
+
+    const userForm = ui.c.findComponent(UserForm)
+    await userForm.find('.user-admin-edit__remove-2fa').trigger('click')
+    await flushPromises()
+
+    const disableModal = ui.c.findComponent(DisableTwoFactorAuthModal)
+    await disableModal.find('button.button--danger').trigger('click')
+    await flushPromises()
+
+    // The error is surfaced inside the modal instead of silently swallowed.
+    expect(ui.getErrorText(disableModal).length).toBeGreaterThan(0)
+
+    // The optimistic clear must NOT be applied: the row still shows 2FA enabled.
+    const cells = ui.findCells()
+    const { twoFactorAuthCell } = ui.getRow(cells, 0)
+    expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.enabled')
+  })
+
   test('A user with no workspaces is displayed without any', async () => {
     const { user, ui } = await whenThereIsAUserAndYouOpenUserAdmin({
       workspaces: [],

--- a/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
+++ b/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
@@ -1,6 +1,7 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import UsersAdminTable from '@baserow/modules/core/components/admin/users/UsersAdminTable'
 import UserForm from '@baserow/modules/core/components/admin/users/forms/UserForm'
+import DisableTwoFactorAuthModal from '@baserow/modules/core/components/admin/users/modals/DisableTwoFactorAuthModal'
 import moment from '@baserow/modules/core/moment'
 import flushPromises from 'flush-promises'
 import UserAdminUserHelpers from '@baserow/test/helpers/userAdminHelpers'
@@ -107,6 +108,53 @@ describe('User Admin Component Tests', () => {
     const cells = ui.findCells()
     const { twoFactorAuthCell } = ui.getRow(cells, 0)
     expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.enabled')
+  })
+
+  test('edit user modal shows 2FA provider and remove option when enabled', async () => {
+    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin({
+      twoFactorAuth: { type: 'totp', is_enabled: true },
+    })
+
+    const editUserContext = await ui.openFirstUserActionsMenu()
+    await ui.clickEditUser(editUserContext)
+
+    const userForm = ui.c.findComponent(UserForm)
+    expect(userForm.find('.user-admin-edit__remove-2fa').exists()).toBe(true)
+  })
+
+  test('edit user modal hides remove 2FA option when disabled', async () => {
+    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin({})
+
+    const editUserContext = await ui.openFirstUserActionsMenu()
+    await ui.clickEditUser(editUserContext)
+
+    const userForm = ui.c.findComponent(UserForm)
+    expect(userForm.find('.user-admin-edit__remove-2fa').exists()).toBe(false)
+  })
+
+  test('admin can remove a users 2FA', async () => {
+    // whenThereIsAUserAndYouOpenUserAdmin creates the user with id 1 by
+    // default — register the delete mock for that id before opening the UI.
+    testApp.mock.onDelete(`/admin/users/1/two-factor-auth/`).reply(204)
+
+    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin({
+      twoFactorAuth: { type: 'totp', is_enabled: true },
+    })
+    const editUserContext = await ui.openFirstUserActionsMenu()
+    await ui.clickEditUser(editUserContext)
+
+    const userForm = ui.c.findComponent(UserForm)
+    await userForm.find('.user-admin-edit__remove-2fa').trigger('click')
+    await flushPromises()
+
+    const disableModal = ui.c.findComponent(DisableTwoFactorAuthModal)
+    // the danger button is the confirm action
+    await disableModal.find('button.button--danger').trigger('click')
+    await flushPromises()
+
+    const cells = ui.findCells()
+    const { twoFactorAuthCell } = ui.getRow(cells, 0)
+    expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.disabled')
   })
 
   test('A user with no workspaces is displayed without any', async () => {

--- a/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
+++ b/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
@@ -48,7 +48,7 @@ describe('User Admin Component Tests', () => {
     expect(userAdmin.html()).toMatchSnapshot()
 
     const cells = ui.findCells()
-    expect(cells.length).toBe(7)
+    expect(cells.length).toBe(8)
     const {
       usernameCell,
       nameCell,
@@ -56,6 +56,7 @@ describe('User Admin Component Tests', () => {
       lastLoginCell,
       signedUpCell,
       isActiveCell,
+      twoFactorAuthCell,
     } = ui.getRow(cells, 0)
 
     // Username matches with correct initials and has an admin icon
@@ -93,6 +94,19 @@ describe('User Admin Component Tests', () => {
 
     // Shown as active
     expect(isActiveCell.text()).toBe('user.active')
+
+    // 2FA is shown as disabled when not configured
+    expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.disabled')
+  })
+
+  test('A users 2FA enabled status is displayed', async () => {
+    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin({
+      twoFactorAuth: { type: 'totp', is_enabled: true },
+    })
+
+    const cells = ui.findCells()
+    const { twoFactorAuthCell } = ui.getRow(cells, 0)
+    expect(twoFactorAuthCell.text()).toBe('twoFactorAuthField.enabled')
   })
 
   test('A user with no workspaces is displayed without any', async () => {
@@ -103,7 +117,7 @@ describe('User Admin Component Tests', () => {
     await flushPromises()
 
     const cells = ui.findCells()
-    expect(cells.length).toBe(7)
+    expect(cells.length).toBe(8)
     const { usernameCell, workspacesCell } = ui.getRow(cells, 0)
 
     expect(usernameCell.text()).toContain(user.username)
@@ -467,7 +481,7 @@ describe('User Admin Component Tests', () => {
     const userAdmin = await testApp.mount(UsersAdminTable, {})
     const ui = new UserAdminUserHelpers(userAdmin)
 
-    const cells = ui.findCells(14)
+    const cells = ui.findCells(16)
     const { usernameCell: firstUsernameCell } = ui.getRow(cells, 0)
     expect(firstUsernameCell.text()).toContain('firstUser@example.com')
     const { usernameCell: secondUsernameCell } = ui.getRow(cells, 1)
@@ -498,7 +512,7 @@ describe('User Admin Component Tests', () => {
     const userAdmin = await testApp.mount(UsersAdminTable, {})
     const ui = new UserAdminUserHelpers(userAdmin)
 
-    const cells = ui.findCells(14)
+    const cells = ui.findCells(16)
     const { usernameCell: firstUsernameCell } = ui.getRow(cells, 0)
     expect(firstUsernameCell.text()).toContain('firstUser@example.com')
     const { usernameCell: secondUsernameCell } = ui.getRow(cells, 1)

--- a/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
+++ b/web-frontend/test/unit/core/admin/users/userAdmin.spec.js
@@ -244,49 +244,43 @@ describe('User Admin Component Tests', () => {
     await flushPromises()
   })
 
-  test('users password cant be changed if not entered the same twice', async () => {
-    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
+  test.each([
+    {
+      description: 'cant be changed if not entered the same twice',
+      password: '1'.repeat(8),
+      passwordConfirm: '1'.repeat(8) + 'DifferentFromFirst',
+      property: 'passwordConfirm',
+      validator: 'sameAsPassword',
+    },
+    {
+      description: 'cant be changed to less than 8 characters',
+      password: '1'.repeat(7),
+      passwordConfirm: '1'.repeat(7),
+      property: 'password',
+      validator: 'minLength',
+    },
+    {
+      description: 'cant be changed to more than 256 characters',
+      password: '1'.repeat(257),
+      passwordConfirm: '1'.repeat(257),
+      property: 'password',
+      validator: 'maxLength',
+    },
+  ])(
+    'a users password $description',
+    async ({ password, passwordConfirm, property, validator }) => {
+      const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
 
-    const validPassword = '1'.repeat(8)
+      const errors = await ui.attemptToChangePasswordReturningModalError(
+        password,
+        passwordConfirm
+      )
 
-    const errors = await ui.attemptToChangePasswordReturningModalError(
-      validPassword,
-      validPassword + 'DifferentFromFirst'
-    )
-    expect(errors.length).toBeGreaterThan(0)
-    const error = errors.find((obj) => obj.$property === 'passwordConfirm')
-    expect(error.$validator).toMatch('sameAsPassword')
-  })
-
-  test('users password cant be changed less than 8 characters', async () => {
-    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
-
-    const tooShortPassword = '1'.repeat(7)
-
-    const errors = await ui.attemptToChangePasswordReturningModalError(
-      tooShortPassword,
-      tooShortPassword
-    )
-
-    expect(errors.length).toBeGreaterThan(0)
-    const error = errors.find((obj) => obj.$property === 'password')
-    expect(error.$validator).toMatch('minLength')
-  })
-
-  test('users password cant be changed to more than 256 characters', async () => {
-    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
-
-    const tooLongPassword = '1'.repeat(257)
-
-    const errors = await ui.attemptToChangePasswordReturningModalError(
-      tooLongPassword,
-      tooLongPassword
-    )
-
-    expect(errors.length).toBeGreaterThan(0)
-    const error = errors.find((obj) => obj.$property === 'password')
-    expect(error.$validator).toMatch('maxLength')
-  })
+      expect(errors.length).toBeGreaterThan(0)
+      const error = errors.find((obj) => obj.$property === property)
+      expect(error.$validator).toMatch(validator)
+    }
+  )
 
   // eslint-disable-next-line vitest/expect-expect
   test('users password can be changed to 256 characters', async () => {
@@ -361,24 +355,23 @@ describe('User Admin Component Tests', () => {
     expect(ui.getErrorText(modal)).toBe('clientHandler.notCompletedDescription')
   })
 
-  test('a users full name cant be changed to less than 2 characters', async () => {
+  test.each([
+    {
+      description: 'cant be changed to less than 2 characters',
+      name: '1',
+      rule: 'minLength',
+    },
+    {
+      description: 'cant be changed to more than 150 characters',
+      name: '1'.repeat(151),
+      rule: 'maxLength',
+    },
+  ])('a users full name $description', async ({ name, rule }) => {
     const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
 
-    const tooShortFullName = '1'
-
-    const editUserModal = await ui.changeFullName(tooShortFullName)
+    const editUserModal = await ui.changeFullName(name)
     const userFormComponent = editUserModal.findComponent(UserForm)
-    expect(userFormComponent.vm.v$.values.name.minLength.$invalid).toBe(true)
-  })
-
-  test('a users full name cant be changed to more than 150 characters', async () => {
-    const { ui } = await whenThereIsAUserAndYouOpenUserAdmin()
-
-    const tooLongFullName = '1'.repeat(151)
-
-    const editUserModal = await ui.changeFullName(tooLongFullName)
-    const userFormComponent = editUserModal.findComponent(UserForm)
-    expect(userFormComponent.vm.v$.values.name.maxLength.$invalid).toBe(true)
+    expect(userFormComponent.vm.v$.values.name[rule].$invalid).toBe(true)
   })
 
   test('a users username be changed', async () => {


### PR DESCRIPTION
Closes #5492.

## What this does

Two changes to the instance admin users area at `/admin/users`:

1. A "2FA" column in the users table showing whether each user has two-factor authentication enabled, using the same Enabled/Disabled badge style as the workspace members list.
2. In the "Edit user" modal, the active 2FA provider is now shown (for example "Authenticator app") with a link to remove it. Removing it clears the user's configured provider, which lets them sign in again after losing their device and backup codes.

## How it works

A new `DELETE /api/admin/users/{id}/two-factor-auth/` endpoint removes a user's provider. It goes through the usual layers: `AdminDisableTwoFactorAuthActionType` records the removal, `UserAdminHandler.disable_user_two_factor_auth` checks staff permission and loads the target user, and `TwoFactorAuthHandler.disable_for_user` clears the provider. The action type is registered in `apps.py`, so the removal also appears as a filterable choice in the enterprise audit log. The users listing endpoint gained a `two_factor_auth` field, prefetched with the polymorphic provider model so the column does not add a query per row.

There are no database migrations. The change reuses the existing two-factor provider model and only adds a serializer field, an endpoint, and an action type.

Two design decisions:

- The removal is recorded as a new auditable action, so there is a trail of which admin reset whose 2FA.
- The affected user is not emailed when their 2FA is removed.

An admin can remove their own 2FA. Deactivating or deleting yourself is blocked because it locks you out of the admin area, but removing your own 2FA does not: you can still sign in with your password and set it up again.

## Access control

The whole surface is staff-only. The listing and removal endpoints both require `IsAdminUser`, and the `/admin/users` page uses the `staff` middleware, so a non-staff user never receives the `two_factor_auth` field and never reaches the page. Workspace roles (the "Highest Role" column) are separate from instance staff status and grant no access here.

## Testing

Backend covers the 2FA handler, the admin handler, the action (registration, the audit signal, and the no-provider failure path), and the API view, plus an enterprise audit-log test. Frontend covers the table column and the edit-modal remove flow, with the snapshot updated.

## Screenshots / Video

https://github.com/user-attachments/assets/21f66574-0c77-45f8-a257-b361456d2e27


Users table with the 2FA column:
<img width="1920" height="1080" alt="Screenshot 2026-06-16 at 09 32 14 (2)" src="https://github.com/user-attachments/assets/c0a91269-b097-4d4c-bb7d-2aef9a36fd48" />


Edit user modal with the provider badge and remove link:
<img width="1611" height="770" alt="Screenshot 2026-06-16 at 09 35 13" src="https://github.com/user-attachments/assets/3d42cd7a-2e60-464f-ac11-5412415aafad" />

Remove modal:

<img width="1454" height="705" alt="Screenshot 2026-06-16 at 09 35 20" src="https://github.com/user-attachments/assets/cfd7b2c1-4618-41d8-848a-d93f12af4c2b" />

