### PR TITLE
fix: Ensure Read a Row node returns null instead of raising

### DIFF
--- a/backend/src/baserow/contrib/automation/automation_dispatch_context.py
+++ b/backend/src/baserow/contrib/automation/automation_dispatch_context.py
@@ -118,6 +118,15 @@ class AutomationDispatchContext(DispatchContext):
         return None
 
     @property
+    def raise_when_no_row_found(self) -> bool:
+        """
+        When no matching row is found, the dispatch should not raise. The
+        user should use a subsequent node (i.e. Router) to decide the next step.
+        """
+
+        return False
+
+    @property
     def is_publicly_sortable(self) -> bool:
         return False
 

--- a/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
+++ b/backend/src/baserow/contrib/integrations/local_baserow/service_types.py
@@ -1698,7 +1698,15 @@ class LocalBaserowGetRowUserServiceType(
         # row by setting the right condition
         if "row_id" not in resolved_values:
             if not queryset.exists():
-                raise ServiceImproperlyConfiguredDispatchException(_("No rows found"))
+                if dispatch_context.raise_when_no_row_found:
+                    raise ServiceImproperlyConfiguredDispatchException(
+                        _("No rows found")
+                    )
+                return {
+                    "data": None,
+                    "baserow_table_model": table_model,
+                    "public_allowed_properties": only_field_names,
+                }
             return {
                 "data": queryset.first(),
                 "baserow_table_model": table_model,
@@ -1713,9 +1721,15 @@ class LocalBaserowGetRowUserServiceType(
                 "public_allowed_properties": only_field_names,
             }
         except table_model.DoesNotExist:
-            raise ServiceImproperlyConfiguredDispatchException(
-                _(f"Row {resolved_values['row_id']} does not exist.")
-            )
+            if dispatch_context.raise_when_no_row_found:
+                raise ServiceImproperlyConfiguredDispatchException(
+                    _(f"Row {resolved_values['row_id']} does not exist.")
+                )
+            return {
+                "data": None,
+                "baserow_table_model": table_model,
+                "public_allowed_properties": only_field_names,
+            }
 
     def dispatch_transform(self, dispatch_data: Dict[str, Any]) -> DispatchResult:
         """
@@ -1724,6 +1738,9 @@ class LocalBaserowGetRowUserServiceType(
         :param dispatch_data: The `dispatch_data` result.
         :return:
         """
+
+        if dispatch_data["data"] is None:
+            return DispatchResult(data=None)
 
         field_ids = (
             extract_field_ids_from_list(dispatch_data["public_allowed_properties"])

--- a/backend/src/baserow/core/services/dispatch_context.py
+++ b/backend/src/baserow/core/services/dispatch_context.py
@@ -81,6 +81,15 @@ class DispatchContext(RuntimeFormulaContext, ABC):
         return new_context
 
     @property
+    def raise_when_no_row_found(self) -> bool:
+        """
+        Default behavior is to raise during dispatch when a single-row
+        service finds no matching row.
+        """
+
+        return True
+
+    @property
     @abstractmethod
     def is_publicly_searchable(self) -> bool:
         """

--- a/backend/tests/baserow/contrib/automation/nodes/test_node_dispatch_async.py
+++ b/backend/tests/baserow/contrib/automation/nodes/test_node_dispatch_async.py
@@ -284,6 +284,70 @@ def test_dispatch_node_expected_error(mock_logger, mock_dispatch, data_fixture):
 
 
 @pytest.mark.django_db
+def test_dispatch_node_get_row_not_found_returns_none(data_fixture):
+    """
+    When a "Read a row" node doesn't find a row, it should return an empty
+    result instead of raising an error.
+    """
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    integration = data_fixture.create_local_baserow_integration(user=user)
+    database = data_fixture.create_database_application(workspace=workspace)
+    trigger_table = data_fixture.create_database_table(database=database)
+    trigger_table_field_a = data_fixture.create_text_field(table=trigger_table)
+    trigger_table_field_b = data_fixture.create_text_field(table=trigger_table)
+    # The action table is left empty so no row can ever match.
+    action_table = data_fixture.create_database_table(database=database)
+
+    workflow = data_fixture.create_automation_workflow(
+        user, trigger_type="local_baserow_rows_created"
+    )
+    trigger = workflow.get_trigger()
+    trigger_service = trigger.service.specific
+    trigger_service.table = trigger_table
+    trigger_service.integration = integration
+    trigger_service.save()
+
+    get_row_node = data_fixture.create_local_baserow_get_row_action_node(
+        workflow=workflow,
+        previous_node=trigger,
+        service=data_fixture.create_local_baserow_get_row_service(
+            table=action_table,
+            integration=integration,
+            row_id="'999'",
+        ),
+    )
+
+    workflow_history = create_workflow_history(
+        data_fixture, workflow, [trigger_table_field_a, trigger_table_field_b]
+    )
+
+    # Dispatch the trigger, then the Read a row node.
+    AutomationNodeHandler().dispatch_node(trigger.id, history_id=workflow_history.id)
+    result = AutomationNodeHandler().dispatch_node(
+        get_row_node.id, history_id=workflow_history.id
+    )
+    assert result is None
+
+    handle_workflow_dispatch_done(history_id=workflow_history.id)
+    workflow_history.refresh_from_db()
+    assert workflow_history.message == ""
+    assert workflow_history.status == HistoryStatusChoices.SUCCESS
+
+    node_history = AutomationNodeHistory.objects.get(
+        workflow_history=workflow_history, node=get_row_node
+    )
+    assert node_history.message == ""
+    assert node_history.status == HistoryStatusChoices.SUCCESS
+
+    # The dispatch returns `None` and the history layer normalizes to an
+    # empty dict.
+    node_result = AutomationNodeResult.objects.get(node_history=node_history)
+    assert node_result.result == {}
+
+
+@pytest.mark.django_db
 def test_dispatch_node_dispatches_trigger(data_fixture):
     data = create_workflow(data_fixture)
     trigger_node = data["trigger_node"]

--- a/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_get_row_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/service_types/test_get_row_service_type.py
@@ -3,6 +3,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from baserow.contrib.automation.automation_dispatch_context import (
+    AutomationDispatchContext,
+)
 from baserow.contrib.builder.data_sources.service import DataSourceService
 from baserow.contrib.builder.elements.registries import element_type_registry
 from baserow.contrib.builder.elements.service import ElementService
@@ -423,6 +426,78 @@ def test_local_baserow_get_row_service_dispatch_data_row_not_exist(data_fixture)
     dispatch_values = service_type.resolve_service_formulas(service, dispatch_context)
     with pytest.raises(ServiceImproperlyConfiguredDispatchException):
         service_type.dispatch_data(service, dispatch_values, dispatch_context)
+
+
+@pytest.mark.django_db
+def test_local_baserow_get_row_service_dispatch_data_row_does_not_exist(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table = data_fixture.create_database_table(user=user)
+    integration = data_fixture.create_local_baserow_integration(
+        application=page.builder, user=user
+    )
+
+    service = data_fixture.create_local_baserow_get_row_service(
+        integration=integration, table=table, row_id="'999'"
+    )
+    service_type = service.get_type()
+
+    # In an automation context, a missing row returns `None` instead of raising.
+    workflow = data_fixture.create_automation_workflow(user=user)
+    dispatch_context = AutomationDispatchContext(workflow, None)
+    dispatch_values = service_type.resolve_service_formulas(service, dispatch_context)
+
+    dispatch_data = service_type.dispatch_data(
+        service, dispatch_values, dispatch_context
+    )
+    assert dispatch_data["data"] is None
+
+    assert service_type.dispatch_transform(dispatch_data).data is None
+
+
+@pytest.mark.django_db
+def test_local_baserow_get_row_service_dispatch_data_filter_matches_no_rows(
+    data_fixture,
+):
+    # In an automation context, when the filters match no row, `None` is
+    # returned instead of raising.
+    user = data_fixture.create_user()
+    page = data_fixture.create_builder_page(user=user)
+    table, fields, _ = data_fixture.build_table(
+        user=user,
+        columns=[
+            ("Name", "text"),
+        ],
+        rows=[
+            ["BMW"],
+            ["Audi"],
+        ],
+    )
+    view = data_fixture.create_grid_view(user, table=table)
+    data_fixture.create_view_filter(
+        view=view, field=fields[0], type="contains", value="foo"
+    )
+    integration = data_fixture.create_local_baserow_integration(
+        application=page.builder, user=user
+    )
+
+    service = data_fixture.create_local_baserow_get_row_service(
+        integration=integration, view=view, table=table, row_id=""
+    )
+    service_type = service.get_type()
+
+    workflow = data_fixture.create_automation_workflow(user=user)
+    dispatch_context = AutomationDispatchContext(workflow, None)
+    dispatch_values = service_type.resolve_service_formulas(service, dispatch_context)
+
+    dispatch_data = service_type.dispatch_data(
+        service, dispatch_values, dispatch_context
+    )
+    assert dispatch_data["data"] is None
+
+    assert service_type.dispatch_transform(dispatch_data).data is None
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/feature/4512_read_a_row_node_now_returns_none_when_a_row_is_not_found.json
+++ b/changelog/entries/unreleased/feature/4512_read_a_row_node_now_returns_none_when_a_row_is_not_found.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Read a Row node now returns None when a row is not found.",
+    "issue_origin": "github",
+    "issue_number": 4512,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-06-16"
+}

--- a/changelog/entries/unreleased/refactor/4512_updated_local_baserow_get_row_service_type_to_conditionally_.json
+++ b/changelog/entries/unreleased/refactor/4512_updated_local_baserow_get_row_service_type_to_conditionally_.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Updated Local Baserow Get Row service type to conditionally return None if a row is not found.",
+    "issue_origin": "github",
+    "issue_number": 4512,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-16"
+}

--- a/web-frontend/modules/automation/components/form/SimulateDispatchNodeForm.vue
+++ b/web-frontend/modules/automation/components/form/SimulateDispatchNodeForm.vue
@@ -87,26 +87,25 @@ const isLoading = computed(() => {
 
 const nodeType = computed(() => $registry.get('node', props.node.type))
 
+const sample = computed(() => nodeType.value.getSampleData(props.node))
+
 const sampleData = computed(() => {
-  const sample = nodeType.value.getSampleData(props.node)
-
-  if (sample?._error) {
-    return sample._error
+  if (sample.value?._error) {
+    return sample.value._error
   }
-  if (nodeType.value.returnsList && sample?.data) {
-    return sample.data.results
+  if (nodeType.value.returnsList && sample.value?.data) {
+    return sample.value.data.results
   }
-  return sample?.data
+  return sample.value?.data
 })
 
-const hasSampleData = computed(() => {
-  return Boolean(sampleData.value)
-})
+// A node counts as tested once its service has a sample data envelope, even
+// when the dispatch returned no data (e.g. a Read-a-row that matched no row,
+// whose `data` is `null`). We therefore key this off the envelope's presence
+// rather than the truthiness of its `data`.
+const hasSampleData = computed(() => sample.value !== null)
 
-const isErrorSample = computed(() => {
-  const sample = nodeType.value.getSampleData(props.node)
-  return Boolean(sample?._error)
-})
+const isErrorSample = computed(() => Boolean(sample.value?._error))
 
 /**
  * All previous nodes must have been tested, i.e. they must have sample
@@ -143,7 +142,10 @@ const cantBeTestedReason = computed(() => {
       })
     }
 
-    if (!previousNodeType.getSampleData(previousNode)?.data) {
+    // The node is considered tested once it has a sample data envelope and
+    // didn't error, regardless of whether the dispatch returned any data.
+    const previousSample = previousNodeType.getSampleData(previousNode)
+    if (!previousSample || previousSample._error) {
       return $i18n.t('simulateDispatch.errorPreviousNodesNotTested', {
         node: nodeLabel,
       })

--- a/web-frontend/modules/core/components/SampleDataViewer.vue
+++ b/web-frontend/modules/core/components/SampleDataViewer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="sampleData" class="sample-data-viewer">
+  <div class="sample-data-viewer">
     <div
       :class="{
         'sample-data-viewer__sample--error': isError,


### PR DESCRIPTION
### What is in this PR
This PR refactors the Local Baserow Get Row service type to conditionally return `None` for the data, when a row isn't found. Previously, we would always raise an error. Now, based on the dispatch context, we either raise or return `None`.

We also updated the sample data logic in the Automations frontend, specifically the concept around knowing if "a node is tested". We previously just checked if `sample.data` is falsey, and if so, consider the node as not tested. Now that a Read a Row node can have `sample.data = null`, we check the envelope/wrapper instead. Here is how the sample data looks when a row is not found:
```python
{"data": null, "status": 200, "output_uid": ""}
```

So, to know whether a node is tested or not, we now check if `getSampleData()` itself returns `null`, as opposed to an object where the `data` field is `null`.

The main benefit of this change is to allow Automation uses to be able to decide what to do when a Read a row node doesn't find a row; they can use a Router node to take the next step. Previously, the workflow would just error and stop.

[This community member](https://community.baserow.io/t/the-best-method-logic-to-use-when-updating-rows-in-one-db-from-another/11695/13) would benefit immediately from this change.

Closes https://github.com/baserow/baserow/issues/4512

### How to test this PR
In `develop`, create a Read a row node that doesn't match any rows (an invalid row ID or a filter that forces no match), then test that node. You'll see the node errors, and if you test the workflow, it stops at this node.

In this branch, you can create a Router node that has a branch with this condition `is_empty(get('previous_node.42.id'))`. If you test the node, you'll see that this branch is reached when a row is not found, and no error is thrown.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
