### PR TITLE
fix: cancel MCP SSE listener on client disconnect

### DIFF
--- a/backend/src/baserow/core/mcp/sse.py
+++ b/backend/src/baserow/core/mcp/sse.py
@@ -153,12 +153,15 @@ class DjangoChannelsSseServerTransport:
             tg.start_soon(group_listener)
 
             async def response_wrapper(scope: Scope, receive: Receive, send: Send):
-                await EventSourceResponse(
-                    content=sse_stream_reader, data_sender_callable=sse_writer
-                )(scope, receive, send)
-                await read_stream_writer.aclose()
-                await write_stream_reader.aclose()
-                logger.debug(f"SSE client disconnected {session_id}")
+                try:
+                    await EventSourceResponse(
+                        content=sse_stream_reader, data_sender_callable=sse_writer
+                    )(scope, receive, send)
+                finally:
+                    await read_stream_writer.aclose()
+                    await write_stream_reader.aclose()
+                    tg.cancel_scope.cancel()
+                    logger.debug(f"SSE client disconnected {session_id}")
 
             logger.debug("Starting SSE response task")
             tg.start_soon(response_wrapper, scope, receive, send)

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -1,12 +1,15 @@
 from django.db import transaction
 
+import anyio
 import pytest
 from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from mcp.shared.memory import (
     create_connected_server_and_client_session as client_session,
 )
 
 from baserow.core.mcp import BaserowMCPServer, current_key
+from baserow.core.mcp.sse import DjangoChannelsSseServerTransport
 
 
 @pytest.mark.django_db
@@ -123,6 +126,61 @@ def test_list_tools_with_valid_endpoint_key(data_fixture):
             async_to_sync(inner)()
     finally:
         current_key.reset(key_token)
+
+
+def test_sse_listener_is_closed_when_connection_is_closed():
+    async def inner():
+        sse = DjangoChannelsSseServerTransport("/mcp/messages/")
+        channel_layer = get_channel_layer()
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/mcp/key/sse",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        client_disconnected = anyio.Event()
+
+        async def receive():
+            # Block until the test simulates the client closing the connection.
+            await client_disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            # We don't care about what is sent back to the client.
+            pass
+
+        def listener_group():
+            return next(
+                (g for g in channel_layer.groups if g.startswith("mcp_sse_")), None
+            )
+
+        # If the listener is never cancelled, the context manager below hangs
+        # forever waiting for it, so guard the whole scenario with a timeout.
+        with anyio.fail_after(10):
+            async with sse.connect_sse(scope, receive, send) as (
+                read_stream,
+                _write_stream,
+            ):
+                # Wait until the listener has joined the group, meaning it now holds
+                # an open client that waits for incoming messages.
+                while listener_group() is None:
+                    await anyio.sleep(0.01)
+
+                # Simulate the client closing the connection. Draining the read
+                # stream lets the SSE response finish and the transport tear down.
+                client_disconnected.set()
+                async for _ in read_stream:
+                    pass
+
+        # Once the connection is closed the listener must have been cancelled and
+        # discarded itself from the group. If it were still running, it would keep
+        # its blocking client open.
+        assert listener_group() is None
+
+    async_to_sync(inner)()
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/fix_mcp_server_not_closing_redis.json
+++ b/changelog/entries/unreleased/bug/fix_mcp_server_not_closing_redis.json
@@ -1,6 +1,6 @@
 {
   "type": "bug",
-  "message": "Close Redis connection when MCP connection is closed.",
+  "message": "Close the BZPOPMIN client when an MCP server connection is closed.",
   "issue_origin": "github",
   "issue_number": null,
   "domain": "database",

--- a/changelog/entries/unreleased/bug/fix_mcp_server_not_closing_redis.json
+++ b/changelog/entries/unreleased/bug/fix_mcp_server_not_closing_redis.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Close Redis connection when MCP connection is closed.",
+  "issue_origin": "github",
+  "issue_number": null,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-16"
+}


### PR DESCRIPTION
### What is in this PR

This PR fixes a bug where the Redis connection remains open when a MCP connection is made to Baserow. Even if the MCP endpoint connection closes, it keeps Redis connection open. This can overload the number of Redis connections if a lot of MCP connections are opened.

### How to test this PR

- Create a MCP endpoint.
- Run this command in the backend container while the gunicorn/dev server is active.

```
python -c 'import os; from redis import Redis; r=Redis(host=os.getenv("REDIS_HOST","redis"), port=int(os.getenv("REDIS_PORT","6379")), username=os.getenv("REDIS_USER","") or None, password=os.getenv("REDIS_PASSWORD","") or None, decode_responses=True, ssl=os.getenv("REDIS_PROTOCOL","redis")=="rediss", ssl_cert_reqs=os.getenv("REDIS_SSL_CERT_REQS","required"), ssl_ca_certs=os.getenv("REDIS_SSL_CA_CERTS","") or None); m=[c for c in r.client_list() if c.get("cmd")=="bzpopmin"]; print("bzpopmin:", len(m)); [print(c["addr"], c["age"], c["idle"], c["cmd"]) for c in m[:10]]'
```

- It should output something like `bzpopmin: 0`.
- Now open a couple of websocket connections with:

```
for i in $(seq 1 50); do
  curl -N 'http://localhost:8000/mcp/TpTZdxPCfCeKmXpgFepoNB610Jae8FcW/sse' >/tmp/mcp-sse-$i.log 2>&1 &
done
```

- Run the `bzpopmin` command in the backend container again. It should output something like `bzpopmin: 52`.
- Close the connections using `pkill -f "mcp"`.
- Run the `bzpopmin` command in the backend container again. It should output something like `bzpopmin: 0`.

Note that you can also open connections by using a real mcp client like `npx @modelcontextprotocol/inspector` and then connect to it via the browser. In that case, it should increase/decrease the `bzpopmin` with only one of course. The cURL command opens 50 connections.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
