### PR TITLE
fix(backend): Remove upsert_env

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -175,13 +175,6 @@ code-runtime:
 
     chmod +x "$RUNTIME_DIR/bin/wasmtime"
 
-    upsert_env \
-        "BASEROW_ENTERPRISE_CODE_RUNNER_WASMTIME_EXECUTABLE" \
-        "$RUNTIME_DIR/bin/wasmtime"
-    upsert_env \
-        "BASEROW_ENTERPRISE_CODE_RUNNER_QUICKJS_WASM_PATH" \
-        "$RUNTIME_DIR/lib/baserow/qjs.wasm"
-
     echo "Code runner runtime installed in $RUNTIME_DIR"
     echo "Add these vars to your env file to enable the code runner:"
     echo "BASEROW_ENTERPRISE_CODE_RUNNER_WASMTIME_EXECUTABLE=$RUNTIME_DIR/bin/wasmtime"


### PR DESCRIPTION
### What is in this PR

https://github.com/baserow/baserow/pull/5425/ introduced `upsert_env` in backend justfile that breaks `just backend install`

This PR removes `upsert_env` as it's confirmed not needed


### How to test this PR
Run `just backend install` and see it works
