### PR TITLE
fix: Ensure HTTP request service allows control characters in JSON payload

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -544,7 +544,13 @@ class CoreHTTPRequestServiceType(CoreServiceType):
 
         if service.body_type == BODY_TYPE.JSON:  # JSON payload
             try:
-                body_dict["json"] = json.loads(body_content) if body_content else None
+                # `strict=False` allows raw control characters (e.g. newlines,
+                # tabs, etc) inside JSON string values. This is necessary because
+                # the body can be the resolved output of a formula which contains
+                # control chars.
+                body_dict["json"] = (
+                    json.loads(body_content, strict=False) if body_content else None
+                )
             except json.JSONDecodeError as e:
                 raise ServiceImproperlyConfiguredDispatchException(
                     "The body is not a valid JSON"

--- a/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
@@ -198,6 +198,45 @@ def test_core_http_request_basic_body_json(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("control_char", ["\n", "\t", "\r"])
+def test_core_http_request_basic_body_json_with_control_characters(
+    data_fixture, control_char
+):
+    """
+    Raw control characters (e.g. newlines, tabs) inside JSON string values
+    should be accepted. The body can be the resolved output of a formula, so
+    such characters are legitimate content and shouldn't fail the request.
+    """
+
+    value = f"line1{control_char}line2"
+    service = data_fixture.create_core_http_request_service(
+        url="'http://example.notexist/'",
+        # A *raw* control character inside the JSON string (not an escaped
+        # `\n` sequence), which `json.loads` rejects unless `strict=False`.
+        body_content="'" + f'{{"test": "{value}"}}' + "'",
+        body_type=BODY_TYPE.JSON,
+    )
+    service_type = service.get_type()
+
+    dispatch_context = FakeDispatchContext()
+
+    # Use the patch context manager to mock `advocate.request`
+    with mock_advocate_request({"foo": "bar"}) as mock_request:
+        service_type.dispatch(service, dispatch_context)
+
+        mock_request.assert_called_once_with(
+            **{
+                "headers": {"user-agent": AnyStr()},
+                "json": {"test": value},
+                "method": HTTP_METHOD.GET,
+                "params": {},
+                "timeout": 30,
+                "url": "http://example.notexist/",
+            }
+        )
+
+
+@pytest.mark.django_db
 def test_core_http_request_with_formulas(
     data_fixture,
 ):

--- a/changelog/entries/unreleased/bug/3879_ensure_control_characters_are_allowed_in_the_json_payload_of.json
+++ b/changelog/entries/unreleased/bug/3879_ensure_control_characters_are_allowed_in_the_json_payload_of.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ensure control characters are allowed in the JSON payload of an HTTP request.",
+    "issue_origin": "github",
+    "issue_number": 3879,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-06-18"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug that prevents control chars from being included in the JSON payload of an HTTP Request service.

Closes https://github.com/baserow/baserow/issues/3879

### How to test this PR
In Automations, create a HTTP Request node with the body containing a raw control char:
```json
{"foo": "bar
baz", "ding1": "dong1"}
```

Note, it has to be a raw control char, not a literal `\n` string. You can also try to just use a formula string, e.g.:
```
concat('{\"foo\": \"bar', '\n', 'baz\", \"ding1\": \"dong1\"}')
```

In `develop`, when you test this node you'll see an error: `The body is not a valid JSON`.

In this branch, it should succeed, and the payload should be sent correctly. Here is webhook.site receiving the request:
> <img width="213" height="142" alt="image" src="https://github.com/user-attachments/assets/4014a08e-07e2-42e6-af33-3e771c342f15" />

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
