### PR TITLE
fix: Ensure user roles use locale-aware sorting

### DIFF
--- a/changelog/entries/unreleased/bug/5268_ensure_user_roles_use_localeaware_sorting.json
+++ b/changelog/entries/unreleased/bug/5268_ensure_user_roles_use_localeaware_sorting.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Ensure user roles use locale-aware sorting.",
+    "issue_origin": "github",
+    "issue_number": 5268,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-06-18"
+}

--- a/web-frontend/modules/builder/mixins/visibilityForm.js
+++ b/web-frontend/modules/builder/mixins/visibilityForm.js
@@ -1,4 +1,5 @@
 import UserSourceService from '@baserow/modules/core/services/userSource'
+import { collatedStringCompare } from '@baserow/modules/core/utils/string'
 
 import {
   DEFAULT_USER_ROLE_PREFIX,
@@ -149,7 +150,7 @@ export default {
             })
             .flat()
         )
-      ).sort()
+      ).sort((roleA, roleB) => collatedStringCompare(roleA, roleB, 'ASC'))
 
       // If noRole exists, prefix to array
       if (noRole) {

--- a/web-frontend/test/unit/core/utils/string.spec.js
+++ b/web-frontend/test/unit/core/utils/string.spec.js
@@ -9,6 +9,7 @@ import {
   isNumeric,
   isInteger,
   isSubstringOfStrings,
+  collatedStringCompare,
 } from '@baserow/modules/core/utils/string'
 
 describe('test string utils', () => {
@@ -222,5 +223,42 @@ describe('test string utils', () => {
     expect(isSubstringOfStrings(['hello', 'test'], 'hell')).toBe(true)
     expect(isSubstringOfStrings([], 'hell')).toBe(false)
     expect(isSubstringOfStrings(['hello'], '')).toBe(true)
+  })
+
+  test('collatedStringCompare does locale-aware sorting', () => {
+    const roles = [
+      'Editor',
+      'Admin',
+      'Viewer',
+      'Manager',
+      'Éditeur',
+      'Über-admin',
+      'Évaluateur',
+    ]
+
+    expect(
+      [...roles].sort((a, b) => collatedStringCompare(a, b, 'ASC'))
+    ).toStrictEqual([
+      'Admin',
+      'Éditeur',
+      'Editor',
+      'Évaluateur',
+      'Manager',
+      'Über-admin',
+      'Viewer',
+    ])
+
+    // DESC reverses the same locale-aware ordering.
+    expect(
+      [...roles].sort((a, b) => collatedStringCompare(a, b, 'DESC'))
+    ).toStrictEqual([
+      'Viewer',
+      'Über-admin',
+      'Manager',
+      'Évaluateur',
+      'Editor',
+      'Éditeur',
+      'Admin',
+    ])
   })
 })


### PR DESCRIPTION
### What is in this PR
This fixes an ordering bug in how User Roles are visible in the visibility form's role dropdown field.

Closes https://github.com/baserow/baserow/issues/5268

### How to test this PR
Create a users table that has the usual name, email, password and role fields. For the Role (single line text) field, use these values that are intentionally unsorted:
```
Editor_role
Admin_role
Manager_role
Viewer_role
Éditeur_role
Über-admin_role
Évaluateur_role
```

In Builder, create a User Source and point to your users table. In any element's visibility field, click the roles dropdown list.

In `develop` you'll notice that the ASCII roles are sorted first, followed by the unicode roles. In this branch, the roles are sorted with locale awareness.

The Data Source and the Table element's sorting feature, both correctly do local-aware sorting. This PR just aligns visibility roles to also be consistent with sorting.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
