### PR TITLE
perf: faster grid/row reads for tables with many select fields

### DIFF
--- a/backend/src/baserow/api/serializers.py
+++ b/backend/src/baserow/api/serializers.py
@@ -9,6 +9,26 @@ from baserow.core.storage import get_default_storage
 from baserow.core.utils import split_comma_separated_string
 
 
+class PrefetchedManyToManyListSerializer(serializers.ListSerializer):
+    """
+    Reads a many-to-many relation straight from the instance's prefetch cache
+    instead of going through `getattr(instance, field)`, which builds a Django
+    `ManyRelatedManager` for every row. For wide tables serialized in bulk this
+    manager creation dominates the response time. Falls back to the default
+    lookup when the relation wasn't prefetched.
+
+    Use as `Meta.list_serializer_class` on a serializer used with `many=True`.
+    """
+
+    def get_attribute(self, instance):
+        prefetched = getattr(instance, "_prefetched_objects_cache", None)
+        if prefetched is not None and len(self.source_attrs) == 1:
+            cached = prefetched.get(self.source_attrs[0])
+            if cached is not None:
+                return cached
+        return super().get_attribute(instance)
+
+
 def get_example_pagination_serializer_class(
     results_serializer_class,
     additional_fields=None,

--- a/backend/src/baserow/contrib/database/api/fields/serializers.py
+++ b/backend/src/baserow/contrib/database/api/fields/serializers.py
@@ -13,6 +13,7 @@ from rest_framework import serializers
 from rest_framework.serializers import SkipField, empty
 
 from baserow.api.polymorphic import PolymorphicSerializer
+from baserow.api.serializers import PrefetchedManyToManyListSerializer
 from baserow.api.user_files.serializers import UserFileURLAndThumbnailsSerializerMixin
 from baserow.api.user_files.validators import user_file_name_validator
 from baserow.contrib.database.fields.constants import (
@@ -146,6 +147,10 @@ class SelectOptionSerializer(serializers.Serializer):
     id = serializers.IntegerField(required=False)
     value = serializers.CharField(max_length=255, required=True)
     color = serializers.CharField(max_length=255, required=True)
+
+    class Meta:
+        # Read prefetched options directly when serializing rows in bulk.
+        list_serializer_class = PrefetchedManyToManyListSerializer
 
 
 class CreateFieldSerializer(serializers.ModelSerializer):

--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -570,13 +570,12 @@ class _PrefetchedManyToManyResult:
     default manager too.
     """
 
-    __slots__ = ("_target_model", "_target_ids", "_result_cache", "_prefetch_done")
+    __slots__ = ("_target_model", "_target_ids", "_result_cache")
 
     def __init__(self, target_model, target_ids, result_cache):
         self._target_model = target_model
         self._target_ids = target_ids
         self._result_cache = result_cache
-        self._prefetch_done = True
 
     def _build_queryset(self):
         qs = self._target_model._default_manager.filter(pk__in=self._target_ids or [])

--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -660,12 +660,20 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
         :return: The updated `result_set` containing all the prefetched instances.
         """
 
+        # Resolve the model field for each prefetched field name once instead of
+        # for every row. With many fields this is called row_count * field_count
+        # times otherwise.
+        model_meta = queryset.model._meta
+        model_fields = {
+            field_name: model_meta.get_field(field_name)
+            for field_name in self.field_names
+        }
+
         for result in result_set:
+            field_name_to_target_ids = row_id_to_field_name_to_target_ids[result.id]
             for field_name in self.field_names:
-                model_field = queryset.model._meta.get_field(field_name)
-                target_ids = row_id_to_field_name_to_target_ids[result.id].get(
-                    field_name
-                )
+                model_field = model_fields[field_name]
+                target_ids = field_name_to_target_ids.get(field_name)
 
                 if isinstance(model_field, ForeignKey) and target_ids is not None:
                     target_id = target_ids[0]
@@ -673,20 +681,29 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
                     setattr(result, field_name, target_instance)
 
                 if isinstance(model_field, ManyToManyField):
-                    attr = getattr(result, field_name)
-                    qs = attr.get_queryset()
-                    qs._result_cache = (
-                        [
+                    # The related instances are already fully resolved in
+                    # `target_instances`, so the prefetch cache can be populated
+                    # directly. We deliberately avoid building the queryset via
+                    # `getattr(result, field_name).get_queryset()`: constructing the
+                    # relation-scoped queryset (through-table joins, filter setup) per
+                    # row and field is expensive and dominates the request time for
+                    # tables with many many-to-many fields. Scoping to the target ids
+                    # with `pk__in` on the base manager is cheap (no relation joins)
+                    # and keeps the queryset correct if a consumer re-filters or
+                    # re-orders the prefetched relation. Empty relations skip the
+                    # filter entirely with `none()`.
+                    if target_ids:
+                        qs = self.target_model._base_manager.filter(pk__in=target_ids)
+                        qs._result_cache = [
                             target_instances.get(target_id)
                             for target_id in target_ids
-                            # It could be that the target doesn't exist, but the
-                            # relationship does. In that case, we don't want the
-                            # result set contain `None` values.
+                            # The target may have been deleted while the relationship
+                            # still exists; don't put `None` in the result set.
                             if target_id in target_instances
                         ]
-                        if target_ids
-                        else []
-                    )
+                    else:
+                        qs = self.target_model._base_manager.none()
+                        qs._result_cache = []
                     qs._prefetch_done = True
                     result._prefetched_objects_cache = getattr(
                         result, "_prefetched_objects_cache", {}

--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -804,7 +804,6 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
         """
 
         sub_queries = []
-        row_ids_as_literal = [sql.Literal(str(result.id)) for result in result_set]
 
         for field_name in self.field_names:
             model_field = queryset.model._meta.get_field(field_name)
@@ -827,6 +826,9 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
                     f"model {self.target_model}."
                 )
 
+            # The row ids are filtered through the `wanted_rows` CTE below instead of
+            # being repeated in every subquery, which keeps the query small even with
+            # hundreds of many-to-many fields.
             subquery = sql.SQL(
                 """
                 (
@@ -836,7 +838,7 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
                         {row_id_column} as row_id,
                         {target_id_column} as target_id_column
                     FROM {m2m_table}
-                    WHERE {row_id_column} IN ({row_ids})
+                    WHERE {row_id_column} IN (SELECT row_id FROM wanted_rows)
                 )
                 """
             ).format(
@@ -844,14 +846,17 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
                 m2m_table=sql.Identifier(through_table_name),
                 row_id_column=sql.Identifier(row_column_name),
                 target_id_column=sql.Identifier(target_column_name),
-                row_ids=sql.SQL(",").join(row_ids_as_literal),
             )
             sub_queries.append(subquery)
 
         if len(sub_queries) > 0 and len(result_set) > 0:
+            wanted_rows = sql.SQL(", ").join(
+                sql.SQL("({})").format(sql.Literal(result.id)) for result in result_set
+            )
             union_query = sql.SQL(" UNION ").join(sub_queries)
             union_sql = sql.SQL(
                 """
+                WITH wanted_rows (row_id) AS (VALUES {wanted_rows})
                 SELECT
                     row_id,
                     field_name,
@@ -859,7 +864,7 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
                 FROM ({union_query}) sub
                 GROUP BY row_id, field_name
                 """
-            ).format(union_query=union_query)
+            ).format(wanted_rows=wanted_rows, union_query=union_query)
 
             with connection.cursor() as cursor:
                 cursor.execute(union_sql)

--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -564,6 +564,10 @@ class _PrefetchedManyToManyResult:
     the relation still gets the correct rows. This avoids building a queryset per
     row and field up front, which dominates the request time for tables with many
     many-to-many fields.
+
+    The lazy queryset uses the default manager so re-querying applies the same
+    filters (e.g. trash filtering) as the resolved instances, which come from the
+    default manager too.
     """
 
     __slots__ = ("_target_model", "_target_ids", "_result_cache", "_prefetch_done")
@@ -575,7 +579,7 @@ class _PrefetchedManyToManyResult:
         self._prefetch_done = True
 
     def _build_queryset(self):
-        qs = self._target_model._base_manager.filter(pk__in=self._target_ids or [])
+        qs = self._target_model._default_manager.filter(pk__in=self._target_ids or [])
         qs._result_cache = self._result_cache
         qs._prefetch_done = True
         return qs

--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -554,6 +554,51 @@ class MultiFieldPrefetchQuerysetMixin(Generic[ModelInstance]):
         return self._multi_field_prefetch_related_funcs
 
 
+class _PrefetchedManyToManyResult:
+    """
+    Stand-in stored in a row's prefetch cache for a many-to-many relation.
+
+    Iterating it returns the already resolved instances without touching the
+    database. Any queryset operation (`filter`, `order_by`, `values_list`, ...)
+    lazily builds the real `pk__in` scoped queryset, so a consumer that re-queries
+    the relation still gets the correct rows. This avoids building a queryset per
+    row and field up front, which dominates the request time for tables with many
+    many-to-many fields.
+    """
+
+    __slots__ = ("_target_model", "_target_ids", "_result_cache", "_prefetch_done")
+
+    def __init__(self, target_model, target_ids, result_cache):
+        self._target_model = target_model
+        self._target_ids = target_ids
+        self._result_cache = result_cache
+        self._prefetch_done = True
+
+    def _build_queryset(self):
+        qs = self._target_model._base_manager.filter(pk__in=self._target_ids or [])
+        qs._result_cache = self._result_cache
+        qs._prefetch_done = True
+        return qs
+
+    def all(self):
+        return self
+
+    def __iter__(self):
+        return iter(self._result_cache)
+
+    def __len__(self):
+        return len(self._result_cache)
+
+    def __bool__(self):
+        return bool(self._result_cache)
+
+    def __getitem__(self, item):
+        return self._result_cache[item]
+
+    def __getattr__(self, name):
+        return getattr(self._build_queryset(), name)
+
+
 class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
     """
     This prefetch class can be used as argument of the `multi_field_prefetch` method.
@@ -682,33 +727,28 @@ class CombinedForeignKeyAndManyToManyMultipleFieldPrefetch:
 
                 if isinstance(model_field, ManyToManyField):
                     # The related instances are already fully resolved in
-                    # `target_instances`, so the prefetch cache can be populated
-                    # directly. We deliberately avoid building the queryset via
-                    # `getattr(result, field_name).get_queryset()`: constructing the
-                    # relation-scoped queryset (through-table joins, filter setup) per
-                    # row and field is expensive and dominates the request time for
-                    # tables with many many-to-many fields. Scoping to the target ids
-                    # with `pk__in` on the base manager is cheap (no relation joins)
-                    # and keeps the queryset correct if a consumer re-filters or
-                    # re-orders the prefetched relation. Empty relations skip the
-                    # filter entirely with `none()`.
-                    if target_ids:
-                        qs = self.target_model._base_manager.filter(pk__in=target_ids)
-                        qs._result_cache = [
+                    # `target_instances`, so store a lazy stand-in that iterates them
+                    # directly and only builds a real queryset if a consumer re-filters
+                    # or re-orders the relation. See `_PrefetchedManyToManyResult`.
+                    result_cache = (
+                        [
                             target_instances.get(target_id)
                             for target_id in target_ids
                             # The target may have been deleted while the relationship
                             # still exists; don't put `None` in the result set.
                             if target_id in target_instances
                         ]
-                    else:
-                        qs = self.target_model._base_manager.none()
-                        qs._result_cache = []
-                    qs._prefetch_done = True
+                        if target_ids
+                        else []
+                    )
                     result._prefetched_objects_cache = getattr(
                         result, "_prefetched_objects_cache", {}
                     )
-                    result._prefetched_objects_cache[field_name] = qs
+                    result._prefetched_objects_cache[field_name] = (
+                        _PrefetchedManyToManyResult(
+                            self.target_model, target_ids, result_cache
+                        )
+                    )
 
         return result_set
 

--- a/backend/tests/baserow/core/test_core_db.py
+++ b/backend/tests/baserow/core/test_core_db.py
@@ -561,6 +561,68 @@ def test_combined_foreign_key_and_many_to_many_multiple_field_prefetch(
 
 
 @pytest.mark.django_db
+def test_combined_prefetch_query_count_is_constant_with_many_fields(
+    data_fixture, django_assert_num_queries
+):
+    """
+    The prefetch must resolve in a fixed number of queries (fetch rows, fetch the
+    many-to-many relations, fetch the target instances) regardless of how many
+    fields and rows are involved, and accessing the prefetched cells must not issue
+    additional queries. This guards against re-introducing per-cell queryset work in
+    `set_prefetched_values_on_result_set`.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(name="Wide", user=user)
+
+    multiple_select_fields = []
+    first_option_per_field = {}
+    for i in range(5):
+        field = data_fixture.create_multiple_select_field(
+            table=table, name=f"option_field_{i}", order=i
+        )
+        options = [
+            data_fixture.create_select_option(
+                field=field, value=v, color="blue", order=o
+            )
+            for o, v in enumerate(["A", "B", "C"])
+        ]
+        multiple_select_fields.append(field)
+        first_option_per_field[field.id] = options[0]
+
+    handler = RowHandler()
+    handler.create_rows(
+        user=user,
+        table=table,
+        rows_values=[
+            {
+                f"field_{field.id}": [first_option_per_field[field.id].id]
+                for field in multiple_select_fields
+            }
+            for _ in range(5)
+        ],
+    )
+
+    model = table.get_model()
+    prefetch = CombinedForeignKeyAndManyToManyMultipleFieldPrefetch(
+        SelectOption, skip_target_check=True
+    ).add_field_names([f"field_{field.id}" for field in multiple_select_fields])
+
+    # One query for the rows, one for the many-to-many relations, one for the
+    # select options. The field and row counts must not change this.
+    with django_assert_num_queries(3):
+        rows = list(model.objects.all().multi_field_prefetch(prefetch))
+
+    # Reading every prefetched cell must not trigger any additional query.
+    with django_assert_num_queries(0):
+        for row in rows:
+            for field in multiple_select_fields:
+                assert [
+                    option.id for option in getattr(row, f"field_{field.id}").all()
+                ] == [first_option_per_field[field.id].id]
+
+
+@pytest.mark.django_db
 def test_combined_multiple_field_prefetch_different_foreign_key_target(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(name="Car", user=user)

--- a/backend/tests/baserow/core/test_core_db.py
+++ b/backend/tests/baserow/core/test_core_db.py
@@ -623,6 +623,54 @@ def test_combined_prefetch_query_count_is_constant_with_many_fields(
 
 
 @pytest.mark.django_db
+def test_combined_prefetch_many_to_many_lazy_result(
+    data_fixture, django_assert_num_queries
+):
+    """
+    A prefetched many-to-many relation must iterate without hitting the database,
+    but re-querying it (order_by/filter) must lazily build a queryset scoped to
+    that row's relation rather than the whole target table.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_multiple_select_field(table=table)
+    a = data_fixture.create_select_option(field=field, value="A", order=0)
+    b = data_fixture.create_select_option(field=field, value="B", order=1)
+    c = data_fixture.create_select_option(field=field, value="C", order=2)
+
+    RowHandler().create_rows(
+        user=user,
+        table=table,
+        rows_values=[{f"field_{field.id}": [a.id, b.id]}, {f"field_{field.id}": []}],
+    )
+
+    model = table.get_model()
+    rows = list(
+        model.objects.all()
+        .order_by("id")
+        .multi_field_prefetch(
+            CombinedForeignKeyAndManyToManyMultipleFieldPrefetch(
+                SelectOption, [f"field_{field.id}"], skip_target_check=True
+            )
+        )
+    )
+    rel = getattr(rows[0], f"field_{field.id}")
+    empty = getattr(rows[1], f"field_{field.id}")
+
+    with django_assert_num_queries(0):
+        assert [o.id for o in rel.all()] == [a.id, b.id]
+        assert len(rel.all()) == 2
+        assert bool(rel.all()) is True
+        assert bool(empty.all()) is False
+
+    # Re-querying scopes to this row's relation (c is not selected on this row).
+    assert [o.id for o in rel.order_by("-order")] == [b.id, a.id]
+    assert list(rel.filter(value="A")) == [a]
+    assert c.id not in [o.id for o in rel.all()]
+
+
+@pytest.mark.django_db
 def test_combined_multiple_field_prefetch_different_foreign_key_target(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(name="Car", user=user)

--- a/changelog/entries/unreleased/bug/speed_up_loading_grid_view_rows_for_tables_with_many_singlem.json
+++ b/changelog/entries/unreleased/bug/speed_up_loading_grid_view_rows_for_tables_with_many_singlem.json
@@ -1,6 +1,6 @@
 {
-    "type": "bug",
-    "message": "Speed up loading grid view rows for tables with many single or multiple select fields by populating the prefetch cache without an expensive per-cell queryset and by serializing the prefetched options directly",
+    "type": "refactor",
+    "message": "Speed up loading rows for tables with many single or multiple select fields.",
     "issue_origin": "github",
     "issue_number": null,
     "domain": "database",

--- a/changelog/entries/unreleased/bug/speed_up_loading_grid_view_rows_for_tables_with_many_singlem.json
+++ b/changelog/entries/unreleased/bug/speed_up_loading_grid_view_rows_for_tables_with_many_singlem.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Speed up loading grid view rows for tables with many single or multiple select fields by populating the prefetch cache without an expensive per-cell queryset and by serializing the prefetched options directly",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-19"
+}


### PR DESCRIPTION
## Problem

Loading a page of rows from a table with many single/multiple select fields was slow (~5.9s for a 444‑field / 2000‑row grid page), yet almost none of it was SQL — Silk showed ~36ms across 12 queries. The time was spent in Python, in the per‑row / per‑field prefetch and serialization machinery, and it scales with `rows × select_fields`.

## Changes

Three focused commits (all in `backend/src/baserow/core/db.py`, plus the serializer in `backend/src/baserow/api/serializers.py`):

1. **`perf: speed up wide-table row reads (prefetch + serialization)`**
   - `CombinedForeignKeyAndManyToManyMultipleFieldPrefetch` built a fully relation‑scoped queryset per (row × m2m cell) just to populate the prefetch cache (through‑table joins, filter setup). Replaced with a cheap `pk__in` queryset on the base manager, `none()` for empty relations, and hoisted the per‑field lookup out of the row loop.
   - The row serializer built a Django `ManyRelatedManager` for every m2m cell. Added `PrefetchedManyToManyListSerializer`, which reads the prefetch cache directly, wired into `SelectOptionSerializer`.

2. **`perf: list row ids once in the m2m prefetch collect query`**
   - `collect_many_to_many_key_target_ids` embedded the page's row ids as SQL literals in *every* per‑field subquery (e.g. 120 ids × 249 fields ≈ 30k literals). Moved them into a single `wanted_rows` CTE.

3. **`perf: lazily build the queryset for prefetched many-to-many cells`**
   - Storing a real queryset per cell was still the biggest cost. Replaced with a lazy `_PrefetchedManyToManyResult` that iterates the resolved options directly and only builds a (scoped) queryset if a consumer re-filters or re-orders the relation.

## Results

444‑field / 2000‑row grid page, median endpoint time **~5.9s → ~1.0s**.

| phase | before | after |
| --- | --- | --- |
| prefetch populate (set values) | ~500 ms | ~40 ms |
| prefetch collect (UNION build) | ~135–280 ms | ~85 ms |
| row serialization | ~440 ms | ~140 ms |

The largest remaining item is rebuilding the generated table model on every request (~360 ms, because the model is only cached in request‑scoped `local_cache`). That's a separate follow‑up (cross‑request model cache) and is out of scope here.

## Correctness

- Output verified against Django's native `prefetch_related` (membership **and** order), and the lazy result re-queries correctly scoped to the row's relation.
- New regression tests in `tests/baserow/core/test_core_db.py`: constant query count regardless of field/row count, and the lazy iterate‑vs‑re‑query behavior.
- Green suites: `test_core_db`, `multiple_select` (incl. type conversions), `link_row`, `multiple_collaborators`, and the grid / rows / batch‑rows / fields API tests.

## How to verify the speed-up

The script below is **not committed**. Save it as `benchmark_grid_endpoint.py`. It builds (once, then reuses) a wide table with a configurable mix of field types — text, long‑text, single/multiple select, date, number, boolean (defaults to roughly a real wide table: 42 text, 57 long‑text, 39 single‑select, 200 multiple‑select, 52 date, 2 number, 1 boolean) — and measures the grid endpoint with a per‑phase breakdown. Or point it at an existing grid view with `BENCH_VIEW_ID`.

<details>
<summary><b>benchmark_grid_endpoint.py</b></summary>

```python
"""
Benchmark the grid view "list rows" endpoint for a wide table and show where the
time goes. Used to verify the speed-up of each commit in this PR.

Run through the backend Django shell, e.g.:

    docker exec -i baserow-backend-1 bash -lc \
        'cd /baserow/backend && python src/baserow/manage.py shell' \
        < benchmark_grid_endpoint.py

By default it creates (once, then reuses) a wide table with a mix of field types
and some rows, then measures the endpoint. Override with env vars:

    BENCH_VIEW_ID        measure this existing grid view instead of creating data
    BENCH_ROWS           rows to create (default 1000)
    BENCH_PAGE           page size requested (default 120)
    BENCH_RUNS           measured requests (default 7)

    # field composition of the generated table (defaults ~ a real wide table):
    BENCH_TEXT           text fields           (default 42)
    BENCH_LONG_TEXT      long text fields       (default 57)
    BENCH_SINGLE_SELECT  single select fields   (default 39)
    BENCH_MULTI_SELECT   multiple select fields (default 200)
    BENCH_DATE           date fields            (default 52)
    BENCH_NUMBER         number fields          (default 2)
    BENCH_BOOLEAN        boolean fields         (default 1)

Build the table once, then `git checkout` each commit and re-run against the
SAME table (via BENCH_VIEW_ID); compare the reported median total ms.
"""

import os
import random
import statistics
import time
from collections import defaultdict

from django.contrib.auth import get_user_model
from django.db import connection
from django.test.utils import CaptureQueriesContext
from rest_framework.test import APIClient

ROWS = int(os.environ.get("BENCH_ROWS", "1000"))
PAGE = int(os.environ.get("BENCH_PAGE", "120"))
RUNS = int(os.environ.get("BENCH_RUNS", "7"))
VIEW_ID = os.environ.get("BENCH_VIEW_ID")

# (field type, how many) — order is the column order in the table.
FIELD_SPEC = [
    ("text", int(os.environ.get("BENCH_TEXT", "42"))),
    ("long_text", int(os.environ.get("BENCH_LONG_TEXT", "57"))),
    ("single_select", int(os.environ.get("BENCH_SINGLE_SELECT", "39"))),
    ("multiple_select", int(os.environ.get("BENCH_MULTI_SELECT", "200"))),
    ("date", int(os.environ.get("BENCH_DATE", "52"))),
    ("number", int(os.environ.get("BENCH_NUMBER", "2"))),
    ("boolean", int(os.environ.get("BENCH_BOOLEAN", "1"))),
]

User = get_user_model()
user = (
    User.objects.filter(is_staff=True).order_by("id").first()
    or User.objects.order_by("id").first()
)


def get_or_create_wide_view():
    from baserow.contrib.database.fields.handler import FieldHandler
    from baserow.contrib.database.models import Table
    from baserow.contrib.database.rows.handler import RowHandler
    from baserow.contrib.database.table.handler import TableHandler
    from baserow.contrib.database.views.models import GridView
    from baserow.core.handler import CoreHandler
    from baserow.core.models import Workspace

    workspace = (
        Workspace.objects.filter(workspaceuser__user=user).order_by("id").first()
    )
    total = sum(c for _, c in FIELD_SPEC)
    select_count = sum(c for t, c in FIELD_SPEC if "select" in t)
    table_name = f"perf-bench {total}f {select_count}sel {ROWS}r"

    existing = Table.objects.filter(
        name=table_name, database__workspace=workspace
    ).first()
    if existing:
        view = GridView.objects.filter(table=existing).order_by("id").first()
        if view:
            return view, existing

    spec = ", ".join(f"{c} {t}" for t, c in FIELD_SPEC if c)
    print(f"Creating wide table '{table_name}' ({spec}; {ROWS} rows)...")
    database = CoreHandler().create_application(
        user, workspace, "database", name="perf-bench"
    )
    table, _ = TableHandler().create_table(
        user, database, name=table_name, data=[["Name"]], first_row_header=True
    )

    colors = ["light-blue", "light-green", "dark-red", "blue", "yellow", "purple"]
    field_handler = FieldHandler()
    fields = []  # (field, field_type)
    option_ids = {}
    for field_type, count in FIELD_SPEC:
        for i in range(count):
            kwargs = {"name": f"{field_type}_{i}"}
            if field_type in ("single_select", "multiple_select"):
                kwargs["select_options"] = [
                    {"value": f"opt_{j}", "color": colors[j % len(colors)]}
                    for j in range(12)
                ]
            elif field_type == "date":
                kwargs.update(date_format="ISO", date_include_time=False)
            elif field_type == "number":
                kwargs.update(number_decimal_places=0)
            f = field_handler.create_field(user, table, field_type, **kwargs)
            if field_type in ("single_select", "multiple_select"):
                option_ids[f.id] = list(f.select_options.values_list("id", flat=True))
            fields.append((f, field_type))
    print("  fields created, creating rows...")

    rng = random.Random(42)

    def make_value(field, field_type):
        if field_type == "multiple_select":
            ids = option_ids[field.id]
            k = min(rng.choice([0, 0, 1, 1, 1, 2]), len(ids))
            return rng.sample(ids, k)
        if field_type == "single_select":
            ids = option_ids[field.id]
            return rng.choice(ids) if rng.random() < 0.8 else None
        if field_type == "text":
            return rng.choice(["", "alpha", "beta", "OK", "client", "to check"])
        if field_type == "long_text":
            return rng.choice([None, "short note", "a longer note about the row"])
        if field_type == "date":
            if rng.random() < 0.5:
                return (
                    f"{rng.randint(2018, 2026):04d}-"
                    f"{rng.randint(1, 12):02d}-{rng.randint(1, 28):02d}"
                )
            return None
        if field_type == "number":
            return rng.randint(0, 100000)
        if field_type == "boolean":
            return rng.random() < 0.3
        return None

    batch = []
    for _ in range(ROWS):
        batch.append({f"field_{f.id}": make_value(f, t) for f, t in fields})
        if len(batch) >= 200:
            RowHandler().create_rows(user=user, table=table, rows_values=batch)
            batch = []
    if batch:
        RowHandler().create_rows(user=user, table=table, rows_values=batch)

    view = GridView.objects.filter(table=table).order_by("id").first()
    return view, table


# --- resolve the view to benchmark -------------------------------------------
if VIEW_ID:
    from baserow.contrib.database.views.models import GridView

    view = GridView.objects.get(id=int(VIEW_ID))
    table = view.table
else:
    view, table = get_or_create_wide_view()

field_count = len(table.field_set.all())
row_count = table.get_model(field_ids=[]).objects.count()

# --- per-phase instrumentation (defensive: works across all commits) ---------
T = defaultdict(list)


def wrap(obj, attr, label):
    orig = getattr(obj, attr, None)
    if orig is None:
        return

    def w(*a, **k):
        t = time.time()
        try:
            return orig(*a, **k)
        finally:
            T[label].append((time.time() - t) * 1000)

    setattr(obj, attr, w)


import baserow.contrib.database.api.views.grid.views as gv
import baserow.contrib.database.table.models as tm
from baserow.core.db import CombinedForeignKeyAndManyToManyMultipleFieldPrefetch as Pref

wrap(tm.Table, "_get_model", "model_build")
wrap(gv, "get_view_filtered_queryset", "build_queryset")
wrap(gv, "paginate_and_serialize_queryset", "paginate+serialize")
wrap(gv, "serialize_view_field_options", "field_options")
wrap(gv, "serialize_rows_metadata", "row_metadata")
wrap(Pref, "collect_many_to_many_key_target_ids", "prefetch_collect")
wrap(Pref, "set_prefetched_values_on_result_set", "prefetch_populate")

# --- measure -----------------------------------------------------------------
client = APIClient()
client.force_authenticate(user=user)
url = (
    f"/api/database/views/grid/{view.id}/"
    f"?limit={PAGE}&include=row_metadata,field_options&limit_linked_items=20"
)

for _ in range(2):  # warm up
    client.get(url)

totals, sqls = [], []
T.clear()
for _ in range(RUNS):
    with CaptureQueriesContext(connection) as cap:
        t = time.time()
        resp = client.get(url)
        totals.append((time.time() - t) * 1000)
    sqls.append(sum(float(q["time"]) * 1000 for q in cap.captured_queries))

print(
    f"\nview {view.id} | table {table.id} | {field_count} fields | {row_count} rows "
    f"| page {PAGE} | status {resp.status_code}"
)
print(
    f"runs={RUNS}  median total = {statistics.median(totals):.0f} ms  "
    f"(min {min(totals):.0f}, max {max(totals):.0f})"
)
print(f"median SQL = {statistics.median(sqls):.0f} ms")
print("\nper-phase mean ms/request:")
for label in ["model_build", "build_queryset", "prefetch_collect", "prefetch_populate",
              "paginate+serialize", "field_options", "row_metadata"]:
    vals = T.get(label)
    if vals:
        print(f"  {label:22s} {sum(vals) / RUNS:7.0f}")
```
</details>

Compare across commits against the **same** table:

```bash
# 1. Build the table once; note the "table N" id it prints and its grid view id.
docker exec -i baserow-backend-1 bash -lc \
  'cd /baserow/backend && python src/baserow/manage.py shell' < benchmark_grid_endpoint.py

# 2. Measure that fixed view at each commit:
export BENCH_VIEW_ID=<grid view id from step 1>
for c in develop 0c0eab864 6807ae8fc 91208165f; do
  git checkout "$c"
  docker exec -i -e BENCH_VIEW_ID baserow-backend-1 bash -lc \
    'cd /baserow/backend && python src/baserow/manage.py shell' < benchmark_grid_endpoint.py
done
```

The field composition is configurable via env vars (`BENCH_TEXT`, `BENCH_SINGLE_SELECT`, `BENCH_MULTI_SELECT`, `BENCH_DATE`, …; see the script header). It wraps only functions that exist on `develop` and every commit, so it runs across all of them. Totals include test‑client + full‑middleware overhead, and `CaptureQueriesContext` counts every query (so SQL reads higher than production Silk); the per‑phase `prefetch_*` and serialization numbers are the apples‑to‑apples comparison.
