### PR TITLE
feat: Add from_json() and to_json() expressions

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -58,6 +58,7 @@ from baserow.contrib.integrations.core.models import (
 )
 from baserow.contrib.integrations.core.utils import calculate_next_periodic_run
 from baserow.contrib.integrations.utils import get_http_request_function
+from baserow.core.formula.registries import formula_runtime_function_registry
 from baserow.core.formula.types import BaserowFormulaObject
 from baserow.core.formula.validator import (
     ensure_array,
@@ -84,8 +85,11 @@ from baserow.core.services.registries import (
 from baserow.core.services.types import DispatchResult, FormulaToResolve, ServiceDict
 from baserow.version import VERSION as BASEROW_VERSION
 
-# Matches any runtime formula function calls, e.g. `get(`, `concat(`, etc.
-RE_FORMULA_FUNCTION = re.compile(r"\b[a-z_]+\s*\(")
+# Captures potential runtime formula function calls, e.g. `get(`, `concat(`, etc.
+# The captured name is checked against the runtime function registry so that
+# literal text like `foo(` (which isn't a real function) doesn't match. Function
+# names are case-insensitive, so the name is lowercased before the lookup.
+RE_FORMULA_FUNCTION = re.compile(r"\b([a-zA-Z_]+)\s*\(")
 
 
 class CoreServiceType(ServiceType):
@@ -546,7 +550,11 @@ class CoreHTTPRequestServiceType(CoreServiceType):
 
         formula = (service.body_content or {}).get("formula") or ""
 
-        return bool(RE_FORMULA_FUNCTION.search(formula))
+        registered_functions = set(formula_runtime_function_registry.get_types())
+        return any(
+            match.group(1).lower() in registered_functions
+            for match in RE_FORMULA_FUNCTION.finditer(formula)
+        )
 
     def dispatch_data(
         self,

--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -85,7 +85,7 @@ from baserow.core.services.types import DispatchResult, FormulaToResolve, Servic
 from baserow.version import VERSION as BASEROW_VERSION
 
 # Matches any runtime formula function calls, e.g. `get(`, `concat(`, etc.
-RE_DYNAMIC_FORMULA = re.compile(r"\b[a-z_]+\s*\(")
+RE_FORMULA_FUNCTION = re.compile(r"\b[a-z_]+\s*\(")
 
 
 class CoreServiceType(ServiceType):
@@ -551,7 +551,7 @@ class CoreHTTPRequestServiceType(CoreServiceType):
         else:
             formula = body_content or ""
 
-        return bool(RE_DYNAMIC_FORMULA.search(formula))
+        return bool(RE_FORMULA_FUNCTION.search(formula))
 
     def dispatch_data(
         self,

--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+import re
 import socket
 import uuid
 from datetime import datetime
@@ -82,6 +83,9 @@ from baserow.core.services.registries import (
 )
 from baserow.core.services.types import DispatchResult, FormulaToResolve, ServiceDict
 from baserow.version import VERSION as BASEROW_VERSION
+
+# Matches any runtime formula function calls, e.g. `get(`, `concat(`, etc.
+RE_DYNAMIC_FORMULA = re.compile(r"\b[a-z_]+\s*\(")
 
 
 class CoreServiceType(ServiceType):
@@ -531,6 +535,24 @@ class CoreHTTPRequestServiceType(CoreServiceType):
 
         return formulas
 
+    def _body_has_formula(self, service: CoreHTTPRequestService) -> bool:
+        """
+        Returns True if the JSON body is built from a formula that interpolates a
+        runtime value, e.g. a data source via `get(...)` or a function like `now()`.
+
+        This is used to customize the JSON validation error with a more specific
+        error message.
+        """
+
+        body_content = service.body_content
+
+        if isinstance(body_content, dict):
+            formula = body_content.get("formula") or ""
+        else:
+            formula = body_content or ""
+
+        return bool(RE_DYNAMIC_FORMULA.search(formula))
+
     def dispatch_data(
         self,
         service: CoreHTTPRequestService,
@@ -554,9 +576,14 @@ class CoreHTTPRequestServiceType(CoreServiceType):
                     json.loads(body_content, strict=False) if body_content else None
                 )
             except json.JSONDecodeError as e:
-                raise ServiceImproperlyConfiguredDispatchException(
-                    "The body is not a valid JSON"
-                ) from e
+                message = "The body is not a valid JSON"
+                if self._body_has_formula(service):
+                    message += (
+                        ". If the body includes a value from a formula, wrap "
+                        "it with to_json() so it is correctly quoted and "
+                        "escaped, e.g. concat('{\"value\": ', to_json(get('...')), '}')."
+                    )
+                raise ServiceImproperlyConfiguredDispatchException(message) from e
         elif service.body_type == BODY_TYPE.FORM:  # Form multipart payload
             body_dict["data"] = {
                 f.key: resolved_values[f"form_data_{f.id}"]

--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -544,12 +544,7 @@ class CoreHTTPRequestServiceType(CoreServiceType):
         error message.
         """
 
-        body_content = service.body_content
-
-        if isinstance(body_content, dict):
-            formula = body_content.get("formula") or ""
-        else:
-            formula = body_content or ""
+        formula = (service.body_content or {}).get("formula") or ""
 
         return bool(RE_FORMULA_FUNCTION.search(formula))
 

--- a/backend/src/baserow/core/apps.py
+++ b/backend/src/baserow/core/apps.py
@@ -49,6 +49,7 @@ class CoreConfig(AppConfig):
             RuntimeDivide,
             RuntimeDurationFormat,
             RuntimeEqual,
+            RuntimeFromJson,
             RuntimeGenerateUUID,
             RuntimeGet,
             RuntimeGetProperty,
@@ -88,6 +89,7 @@ class CoreConfig(AppConfig):
             RuntimeToDatetime,
             RuntimeToday,
             RuntimeToDuration,
+            RuntimeToJson,
             RuntimeUpper,
             RuntimeYear,
         )
@@ -141,6 +143,8 @@ class CoreConfig(AppConfig):
         formula_runtime_function_registry.register(RuntimeAt())
         formula_runtime_function_registry.register(RuntimeToArray())
         formula_runtime_function_registry.register(RuntimeRange())
+        formula_runtime_function_registry.register(RuntimeToJson())
+        formula_runtime_function_registry.register(RuntimeFromJson())
         formula_runtime_function_registry.register(RuntimeNull())
         formula_runtime_function_registry.register(RuntimeNumberFormat())
         formula_runtime_function_registry.register(RuntimeToDuration())

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -35,9 +35,10 @@ from baserow.core.formula.registries import RuntimeFormulaFunction
 from baserow.core.formula.types import FormulaArg, FormulaArgs, FormulaContext
 from baserow.core.formula.utils.date import convert_date_format_moment_to_python
 from baserow.core.formula.validator import (
-    BaserowFormulaJSONEncoder,
     ensure_array,
     ensure_datetime,
+    ensure_deserialized_json,
+    ensure_json_serializable,
     ensure_string,
 )
 from baserow.core.utils import to_path
@@ -796,13 +797,15 @@ class RuntimeToJson(RuntimeFormulaFunction):
     args = [AnyBaserowRuntimeFormulaArgumentType()]
 
     def execute(self, context: FormulaContext, args: FormulaArgs):
+        try:
+            serializable = ensure_json_serializable(args[0])
+        except ValidationError as exc:
+            raise BaserowFormulaSyntaxError(
+                "The 'to_json' function received a value that cannot be "
+                "converted to JSON."
+            ) from exc
         # Compact separators are used to match the frontend's `JSON.stringify` output.
-        return json.dumps(
-            args[0],
-            cls=BaserowFormulaJSONEncoder,
-            allow_nan=False,
-            separators=(",", ":"),
-        )
+        return json.dumps(serializable, separators=(",", ":"))
 
 
 class RuntimeFromJson(RuntimeFormulaFunction):
@@ -814,8 +817,8 @@ class RuntimeFromJson(RuntimeFormulaFunction):
         # Parse a JSON-encoded string back into a value. Returns `None` when the
         # input isn't valid JSON.
         try:
-            return json.loads(args[0])
-        except (TypeError, ValueError):
+            return ensure_deserialized_json(args[0], strict=True)
+        except ValidationError:
             return None
 
 

--- a/backend/src/baserow/core/formula/runtime_formula_types.py
+++ b/backend/src/baserow/core/formula/runtime_formula_types.py
@@ -1,3 +1,4 @@
+import json
 import random
 import uuid
 from datetime import datetime, timedelta
@@ -33,7 +34,12 @@ from baserow.core.formula.argument_types import (
 from baserow.core.formula.registries import RuntimeFormulaFunction
 from baserow.core.formula.types import FormulaArg, FormulaArgs, FormulaContext
 from baserow.core.formula.utils.date import convert_date_format_moment_to_python
-from baserow.core.formula.validator import ensure_array, ensure_datetime, ensure_string
+from baserow.core.formula.validator import (
+    BaserowFormulaJSONEncoder,
+    ensure_array,
+    ensure_datetime,
+    ensure_string,
+)
 from baserow.core.utils import to_path
 
 
@@ -782,6 +788,35 @@ class RuntimeRange(RuntimeFormulaFunction):
             )
 
         return list(result)
+
+
+class RuntimeToJson(RuntimeFormulaFunction):
+    type = "to_json"
+
+    args = [AnyBaserowRuntimeFormulaArgumentType()]
+
+    def execute(self, context: FormulaContext, args: FormulaArgs):
+        # Compact separators are used to match the frontend's `JSON.stringify` output.
+        return json.dumps(
+            args[0],
+            cls=BaserowFormulaJSONEncoder,
+            allow_nan=False,
+            separators=(",", ":"),
+        )
+
+
+class RuntimeFromJson(RuntimeFormulaFunction):
+    type = "from_json"
+
+    args = [TextBaserowRuntimeFormulaArgumentType()]
+
+    def execute(self, context: FormulaContext, args: FormulaArgs):
+        # Parse a JSON-encoded string back into a value. Returns `None` when the
+        # input isn't valid JSON.
+        try:
+            return json.loads(args[0])
+        except (TypeError, ValueError):
+            return None
 
 
 class RuntimeNull(RuntimeFormulaFunction):

--- a/backend/src/baserow/core/formula/validator.py
+++ b/backend/src/baserow/core/formula/validator.py
@@ -324,20 +324,28 @@ class BaserowFormulaJSONEncoder(DjangoJSONEncoder):
         return super().default(obj)
 
 
-def ensure_deserialized_json(value: Any) -> Any:
+def ensure_deserialized_json(value: Any, strict: bool = False) -> Any:
     """
     Decode a JSON string if possible, otherwise return the value unchanged.
 
+    Values that are not strings are already deserialized and are returned as-is,
+    even when `strict` is True.
+
     :param value: The value to decode if it is a valid JSON string.
+    :param strict: If True, raise a ValidationError when `value` is a string that
+        cannot be decoded as JSON, instead of returning it unchanged.
     :return: The decoded JSON value if `value` is a valid JSON string, otherwise
         `value`.
+    :raises ValidationError: If `strict` is True and `value` is a string that is
+        not valid JSON.
     """
 
     if isinstance(value, str):
         try:
             return json.loads(value)
-        except (TypeError, JSONDecodeError):
-            pass
+        except (TypeError, JSONDecodeError) as exc:
+            if strict:
+                raise ValidationError("Value is not valid JSON.") from exc
 
     return value
 

--- a/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_core_http_request_service_type.py
@@ -7,7 +7,10 @@ from requests import exceptions as request_exceptions
 
 from baserow.contrib.integrations.core.models import BODY_TYPE, HTTP_METHOD
 from baserow.contrib.integrations.core.service_types import CoreHTTPRequestServiceType
-from baserow.core.services.exceptions import UnexpectedDispatchException
+from baserow.core.services.exceptions import (
+    ServiceImproperlyConfiguredDispatchException,
+    UnexpectedDispatchException,
+)
 from baserow.core.services.handler import ServiceHandler
 from baserow.test_utils.helpers import AnyInt, AnyStr
 from baserow.test_utils.pytest_conftest import FakeDispatchContext
@@ -189,6 +192,106 @@ def test_core_http_request_basic_body_json(
             **{
                 "headers": {"user-agent": AnyStr()},
                 "json": {"test": "2"},
+                "method": HTTP_METHOD.GET,
+                "params": {},
+                "timeout": 30,
+                "url": "http://example.notexist/",
+            }
+        )
+
+
+@pytest.mark.django_db
+def test_core_http_request_body_json_invalid_static_body(data_fixture):
+    """
+    A static body that isn't valid JSON should fail with the plain error
+    message, without the extra hint.
+    """
+
+    service = data_fixture.create_core_http_request_service(
+        url="'http://example.notexist/'",
+        # `{"value1": }` is missing a value, so it's invalid JSON.
+        body_content="""'{"value1": }'""",
+        body_type=BODY_TYPE.JSON,
+    )
+    service_type = service.get_type()
+
+    with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
+        service_type.dispatch(service, FakeDispatchContext())
+
+    assert str(exc.value) == "The body is not a valid JSON"
+
+
+@pytest.mark.django_db
+def test_core_http_request_body_json_invalid_with_data_provider_hint(data_fixture):
+    """
+    When the body interpolates a formula value without `to_json(...)` and
+    the result isn't valid JSON, the error should hint at wrapping the value.
+    """
+
+    service = data_fixture.create_core_http_request_service(
+        url="'http://example.notexist/'",
+        # The value isn't wrapped in quotes/`to_json`, so a string value
+        # produces invalid JSON, e.g. `{"value1": hello}`.
+        body_content="""concat('{"value1": ', get('page_parameter.id'), '}')""",
+        body_type=BODY_TYPE.JSON,
+    )
+    service_type = service.get_type()
+    dispatch_context = FakeDispatchContext(context={"page_parameter": {"id": "hello"}})
+
+    with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
+        service_type.dispatch(service, dispatch_context)
+
+    assert "The body is not a valid JSON" in str(exc.value)
+    assert "to_json(" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_core_http_request_body_json_invalid_with_formula_function_hint(data_fixture):
+    """
+    The hint should also be shown for formula functions as well (e.g. `now()`).
+    """
+
+    service = data_fixture.create_core_http_request_service(
+        url="'http://example.notexist/'",
+        # `now()` produces an unquoted value, e.g. `{"id":  2026-06-22 03:52:07.130000+00:00}`.
+        body_content="""concat('{"id": ', now(), '}')""",
+        body_type=BODY_TYPE.JSON,
+    )
+    service_type = service.get_type()
+
+    with pytest.raises(ServiceImproperlyConfiguredDispatchException) as exc:
+        service_type.dispatch(service, FakeDispatchContext())
+
+    assert "The body is not a valid JSON" in str(exc.value)
+    assert "wrap it with to_json()" in str(exc.value)
+
+
+@pytest.mark.django_db
+def test_core_http_request_body_json_with_to_json_escapes_data_source(data_fixture):
+    """
+    Wrapping a data source value with `to_json(...)` produces a valid JSON body
+    even when the value contains characters that would otherwise break it.
+    """
+
+    service = data_fixture.create_core_http_request_service(
+        url="'http://example.notexist/'",
+        body_content=(
+            """concat('{"value1": ', to_json(get('page_parameter.id')), '}')"""
+        ),
+        body_type=BODY_TYPE.JSON,
+    )
+    service_type = service.get_type()
+    dispatch_context = FakeDispatchContext(
+        context={"page_parameter": {"id": 'foo "bar"'}}
+    )
+
+    with mock_advocate_request({"foo": "bar"}) as mock_request:
+        service_type.dispatch(service, dispatch_context)
+
+        mock_request.assert_called_once_with(
+            **{
+                "headers": {"user-agent": AnyStr()},
+                "json": {"value1": 'foo "bar"'},
                 "method": HTTP_METHOD.GET,
                 "params": {},
                 "timeout": 30,

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -20,6 +20,7 @@ from baserow.core.formula.runtime_formula_types import (
     RuntimeDivide,
     RuntimeDurationFormat,
     RuntimeEqual,
+    RuntimeFromJson,
     RuntimeGenerateUUID,
     RuntimeGet,
     RuntimeGetProperty,
@@ -59,6 +60,7 @@ from baserow.core.formula.runtime_formula_types import (
     RuntimeToDatetime,
     RuntimeToday,
     RuntimeToDuration,
+    RuntimeToJson,
     RuntimeUpper,
     RuntimeYear,
 )
@@ -2507,6 +2509,91 @@ def test_runtime_range_validate_type_of_args(args, expected):
 )
 def test_runtime_range_validate_number_of_args(args, expected):
     result = RuntimeRange().validate_number_of_args(args)
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["foo"], '"foo"'),
+        ([123], "123"),
+        ([True], "true"),
+        ([None], "null"),
+        ([{"a": 1}], '{"a":1}'),
+        ([[1, 2]], "[1,2]"),
+        # Quotes, backslashes and control characters are escaped so the result
+        # is safe to embed inside a larger JSON document.
+        ([r'foo "bar"'], r'"foo \"bar\""'),
+        (["a\nb"], r'"a\nb"'),
+    ],
+)
+def test_runtime_to_json_execute(args, expected):
+    parsed_args = RuntimeToJson().parse_args(args)
+    result = RuntimeToJson().execute({}, parsed_args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([123], []),
+        (["foo"], []),
+        ([{"a": 1}], []),
+    ],
+)
+def test_runtime_to_json_validate_type_of_args(args, expected):
+    result = RuntimeToJson().validate_type_of_args(args)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], False),
+        (["foo"], True),
+        (["foo", "bar"], False),
+    ],
+)
+def test_runtime_to_json_validate_number_of_args(args, expected):
+    result = RuntimeToJson().validate_number_of_args(args)
+    assert result is expected
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["[1, 2, 3]"], [1, 2, 3]),
+        (['{"a": 1}'], {"a": 1}),
+        (['"foo"'], "foo"),
+        (["123"], 123),
+        # Invalid JSON degrades gracefully to None instead of raising.
+        (["not json"], None),
+        ([""], None),
+    ],
+)
+def test_runtime_from_json_execute(args, expected):
+    parsed_args = RuntimeFromJson().parse_args(args)
+    result = RuntimeFromJson().execute({}, parsed_args)
+    assert result == expected
+
+
+def test_runtime_to_json_from_json_round_trip():
+    value = {"value1": 'foo "bar"\nbaz'}
+    dumped = RuntimeToJson().execute({}, RuntimeToJson().parse_args([value]))
+    result = RuntimeFromJson().execute({}, RuntimeFromJson().parse_args([dumped]))
+    assert result == value
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], False),
+        (["foo"], True),
+        (["foo", "bar"], False),
+    ],
+)
+def test_runtime_from_json_validate_number_of_args(args, expected):
+    result = RuntimeFromJson().validate_number_of_args(args)
     assert result is expected
 
 

--- a/backend/tests/baserow/core/formula/test_runtime_formula_types.py
+++ b/backend/tests/baserow/core/formula/test_runtime_formula_types.py
@@ -2533,6 +2533,14 @@ def test_runtime_to_json_execute(args, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), object()])
+def test_runtime_to_json_raises_for_non_serializable_value(value):
+    parsed_args = RuntimeToJson().parse_args([value])
+    with pytest.raises(BaserowFormulaSyntaxError) as exc_info:
+        RuntimeToJson().execute({}, parsed_args)
+    assert "cannot be" in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "args,expected",
     [

--- a/backend/tests/baserow/core/formula/test_validator.py
+++ b/backend/tests/baserow/core/formula/test_validator.py
@@ -225,6 +225,21 @@ def test_ensure_deserialized_json_returns_value_unchanged_when_json_is_invalid()
     assert ensure_deserialized_json({"name": "Ada"}) == {"name": "Ada"}
 
 
+def test_ensure_deserialized_json_strict_raises_for_invalid_json_strings():
+    with pytest.raises(ValidationError) as exc:
+        ensure_deserialized_json("not json", strict=True)
+    assert exc.value.args[0] == "Value is not valid JSON."
+
+    with pytest.raises(ValidationError):
+        ensure_deserialized_json("", strict=True)
+
+
+def test_ensure_deserialized_json_strict_keeps_non_strings_unchanged():
+    assert ensure_deserialized_json({"name": "Ada"}, strict=True) == {"name": "Ada"}
+    assert ensure_deserialized_json(42, strict=True) == 42
+    assert ensure_deserialized_json(None, strict=True) is None
+
+
 @pytest.mark.parametrize(
     "value,expected",
     [

--- a/changelog/entries/unreleased/feature/3879_add_to_json_and_from_json_expressions.json
+++ b/changelog/entries/unreleased/feature/3879_add_to_json_and_from_json_expressions.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add to_json() and from_json() expressions.",
+    "issue_origin": "github",
+    "issue_number": 3879,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-22"
+}

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -701,6 +701,8 @@
     "atDescription": "Returns the item in the first argument at the index specified by the second argument.",
     "toArrayDescription": "Converts a comma-delimited string into an array.",
     "rangeDescription": "Returns an array of numbers. Provide range(stop), range(start, stop), or range(start, stop, step).",
+    "toJsonDescription": "Serializes a value into a JSON-encoded string, escaping quotes, backslashes and control characters so it can be safely embedded inside a JSON document.",
+    "fromJsonDescription": "Parses a JSON-encoded string into a value such as an object, array or number. Returns null if the string is not valid JSON.",
     "nullDescription": "Returns null, which can be used as a value or for comparison",
     "numberFormatDescription": "Formats a number as a string with configurable decimal places, thousand separator, and decimal separator.",
     "toDatetimeDescription": "Parses a string into a datetime object. An optional second argument specifies the format (e.g. 'DD/MM/YYYY'). If omitted, ISO 8601 format is assumed.",

--- a/web-frontend/modules/core/plugin.js
+++ b/web-frontend/modules/core/plugin.js
@@ -120,7 +120,8 @@ import {
   RuntimeAvg,
   RuntimeAt,
   RuntimeToArray,
-  RuntimeRange,
+  RuntimeToJson,
+  RuntimeFromJson,
   RuntimeToDatetime,
 } from '@baserow/modules/core/runtimeFormulaTypes'
 
@@ -303,6 +304,8 @@ export default defineNuxtPlugin({
     registry.register('runtimeFormulaFunction', new RuntimeAt(context))
     registry.register('runtimeFormulaFunction', new RuntimeToArray(context))
     registry.register('runtimeFormulaFunction', new RuntimeRange(context))
+    registry.register('runtimeFormulaFunction', new RuntimeToJson(context))
+    registry.register('runtimeFormulaFunction', new RuntimeFromJson(context))
     registry.register('runtimeFormulaFunction', new RuntimeNull(context))
     registry.register(
       'runtimeFormulaFunction',

--- a/web-frontend/modules/core/plugin.js
+++ b/web-frontend/modules/core/plugin.js
@@ -119,6 +119,7 @@ import {
   RuntimeSum,
   RuntimeAvg,
   RuntimeAt,
+  RuntimeRange,
   RuntimeToArray,
   RuntimeToJson,
   RuntimeFromJson,

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -28,6 +28,8 @@ import {
   ensureString,
   ensureArray,
   ensureDateTime,
+  ensureJsonSerializable,
+  ensureDeserializedJson,
 } from '@baserow/modules/core/utils/validator'
 import {
   formatValueWithDurationFormat,
@@ -2799,7 +2801,7 @@ export class RuntimeToJson extends RuntimeFormulaFunction {
 
   execute(context, [arg]) {
     try {
-      return JSON.stringify(arg)
+      return JSON.stringify(ensureJsonSerializable(arg))
     } catch {
       return null
     }
@@ -2839,7 +2841,7 @@ export class RuntimeFromJson extends RuntimeFormulaFunction {
 
   execute(context, [arg]) {
     try {
-      return JSON.parse(arg)
+      return ensureDeserializedJson(arg, { strict: true })
     } catch {
       return null
     }

--- a/web-frontend/modules/core/runtimeFormulaTypes.js
+++ b/web-frontend/modules/core/runtimeFormulaTypes.js
@@ -2780,6 +2780,86 @@ export class RuntimeRange extends RuntimeFormulaFunction {
   }
 }
 
+export class RuntimeToJson extends RuntimeFormulaFunction {
+  static getType() {
+    return 'to_json'
+  }
+
+  static getFormulaType() {
+    return FORMULA_TYPE.FUNCTION
+  }
+
+  static getCategoryType() {
+    return FORMULA_CATEGORY.UTILITY
+  }
+
+  get args() {
+    return [new AnyBaserowRuntimeFormulaArgumentType()]
+  }
+
+  execute(context, [arg]) {
+    try {
+      return JSON.stringify(arg)
+    } catch {
+      return null
+    }
+  }
+
+  getDescription() {
+    const { $i18n: i18n } = this.app
+    return i18n.t('runtimeFormulaTypes.toJsonDescription')
+  }
+
+  getExamples() {
+    return [
+      {
+        formula: "concat('{\"value\": ', to_json('foo \"bar\"'), '}')",
+        result: '\'{"value": "foo \\"bar\\""}\'',
+      },
+    ]
+  }
+}
+
+export class RuntimeFromJson extends RuntimeFormulaFunction {
+  static getType() {
+    return 'from_json'
+  }
+
+  static getFormulaType() {
+    return FORMULA_TYPE.FUNCTION
+  }
+
+  static getCategoryType() {
+    return FORMULA_CATEGORY.UTILITY
+  }
+
+  get args() {
+    return [new TextBaserowRuntimeFormulaArgumentType()]
+  }
+
+  execute(context, [arg]) {
+    try {
+      return JSON.parse(arg)
+    } catch {
+      return null
+    }
+  }
+
+  getDescription() {
+    const { $i18n: i18n } = this.app
+    return i18n.t('runtimeFormulaTypes.fromJsonDescription')
+  }
+
+  getExamples() {
+    return [
+      {
+        formula: "from_json('[1, 2, 3]')",
+        result: '[1, 2, 3]',
+      },
+    ]
+  }
+}
+
 export class RuntimeNull extends RuntimeFormulaFunction {
   static getType() {
     return 'null'

--- a/web-frontend/modules/core/utils/validator.js
+++ b/web-frontend/modules/core/utils/validator.js
@@ -322,3 +322,56 @@ export const ensureDuration = (value) => {
 
   throw new TypeError('Value cannot be converted to a duration.')
 }
+
+/**
+ * Normalizes a value into a JSON-serializable counterpart, mirroring the
+ * backend `ensure_json_serializable`. Special runtime types are converted to
+ * the same representation the backend uses, so `to_json` produces identical
+ * output on both sides: a `Timedelta` becomes its number of seconds. Arrays and
+ * plain objects are normalized recursively; every other value is returned
+ * unchanged so native JSON types pass through untouched.
+ *
+ * @param {*} value - The value to normalize.
+ * @returns {*} The JSON-serializable value.
+ */
+export const ensureJsonSerializable = (value) => {
+  if (value instanceof Timedelta) {
+    return Math.floor(value.ms / 1000)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => ensureJsonSerializable(item))
+  }
+
+  if (_.isPlainObject(value)) {
+    return _.mapValues(value, (item) => ensureJsonSerializable(item))
+  }
+
+  return value
+}
+
+/**
+ * Decodes a JSON string if possible, otherwise returns the value unchanged,
+ * mirroring the backend `ensure_deserialized_json`. Values that are not strings
+ * are already deserialized and are returned as-is, even when `strict` is true.
+ *
+ * @param {*} value - The value to decode if it is a valid JSON string.
+ * @param {Boolean} strict - If true, throw when `value` is a string that cannot
+ *   be decoded as JSON, instead of returning it unchanged.
+ * @returns {*} The decoded JSON value, or `value` when it is not a JSON string.
+ * @throws {Error} If `strict` is true and `value` is a string that is not valid
+ *   JSON.
+ */
+export const ensureDeserializedJson = (value, { strict = false } = {}) => {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value)
+    } catch (e) {
+      if (strict) {
+        throw new Error('Value is not valid JSON.', { cause: e })
+      }
+    }
+  }
+
+  return value
+}

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -50,6 +50,8 @@ import {
   RuntimeAt,
   RuntimeToArray,
   RuntimeRange,
+  RuntimeToJson,
+  RuntimeFromJson,
   RuntimeNull,
   RuntimeNumberFormat,
   RuntimeToDatetime,
@@ -2228,6 +2230,63 @@ describe('RuntimeRange', () => {
       0, 1, 2, 3, 4,
     ])
     expect(formulaType.execute({}, formulaType.parseArgs([0, 6]))).toBeNull()
+  })
+})
+
+describe('RuntimeToJson', () => {
+  test.each([
+    { args: ['foo'], expected: '"foo"' },
+    { args: [123], expected: '123' },
+    { args: [true], expected: 'true' },
+    { args: [null], expected: 'null' },
+    { args: [{ a: 1 }], expected: '{"a":1}' },
+    { args: [[1, 2]], expected: '[1,2]' },
+    // Quotes and control characters are escaped so the result is safe to embed
+    // inside a larger JSON document.
+    { args: ['foo "bar"'], expected: '"foo \\"bar\\""' },
+    { args: ['a\nb'], expected: '"a\\nb"' },
+  ])('execute returns expected value', ({ args, expected }) => {
+    const formulaType = new RuntimeToJson()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toEqual(expected)
+  })
+
+  test.each([
+    { args: [], expected: false },
+    { args: ['foo'], expected: true },
+    { args: ['foo', 'bar'], expected: false },
+  ])('validates number of args', ({ args, expected }) => {
+    const formulaType = new RuntimeToJson()
+    const result = formulaType.validateNumberOfArgs(args)
+    expect(result).toStrictEqual(expected)
+  })
+})
+
+describe('RuntimeFromJson', () => {
+  test.each([
+    { args: ['[1, 2, 3]'], expected: [1, 2, 3] },
+    { args: ['{"a": 1}'], expected: { a: 1 } },
+    { args: ['"foo"'], expected: 'foo' },
+    { args: ['123'], expected: 123 },
+    // Invalid JSON degrades gracefully to null instead of throwing.
+    { args: ['not json'], expected: null },
+    { args: [''], expected: null },
+  ])('execute returns expected value', ({ args, expected }) => {
+    const formulaType = new RuntimeFromJson()
+    const parsedArgs = formulaType.parseArgs(args)
+    const result = formulaType.execute({}, parsedArgs)
+    expect(result).toEqual(expected)
+  })
+
+  test.each([
+    { args: [], expected: false },
+    { args: ['foo'], expected: true },
+    { args: ['foo', 'bar'], expected: false },
+  ])('validates number of args', ({ args, expected }) => {
+    const formulaType = new RuntimeFromJson()
+    const result = formulaType.validateNumberOfArgs(args)
+    expect(result).toStrictEqual(expected)
   })
 })
 

--- a/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
+++ b/web-frontend/test/unit/core/formula/runtimeFormulaTypes.spec.js
@@ -2245,6 +2245,16 @@ describe('RuntimeToJson', () => {
     // inside a larger JSON document.
     { args: ['foo "bar"'], expected: '"foo \\"bar\\""' },
     { args: ['a\nb'], expected: '"a\\nb"' },
+    // A Timedelta is normalized to its number of seconds, matching the
+    // backend's `to_json` output (e.g. `3600`, not `{"ms":3600000}`).
+    { args: [new Timedelta(3600 * 1000)], expected: '3600' },
+    { args: [new Timedelta(5400 * 1000)], expected: '5400' },
+    // Timedeltas nested inside arrays and objects are normalized recursively.
+    { args: [[new Timedelta(1800 * 1000)]], expected: '[1800]' },
+    {
+      args: [{ a: new Timedelta(3600 * 1000), b: [1, 2] }],
+      expected: '{"a":3600,"b":[1,2]}',
+    },
   ])('execute returns expected value', ({ args, expected }) => {
     const formulaType = new RuntimeToJson()
     const parsedArgs = formulaType.parseArgs(args)


### PR DESCRIPTION
# What is in this PR
This PR adds two new expressions: `to_json()` and `from_json()`.

It also improves the error message of the HTTP Request service when the payload contains a data provider/expression value that hasn't been escaped correctly.

### 1. `to_json()`
The new `to_json()` expression can be used to coerce a value to a valid JSON string, e.g.: `{"foo": "bar"}` becomes `"{\"foo\": \"bar\"}"`.

It will correctly escape any special chars inside, e.g. `to_json('{"foo", "bar"baz"}')` becomes `"{\"foo\", \"bar\"baz\"}"`.

### 2. `from_json()`
This is the opposite of `to_json()`. It take a JSON string and converts it to an object, array, or scalar.

E.g. `from_json('[1,2,3]')` returns `[1, 2, 3]`.

### 3. HTTP Request service improvement
When a data provider value is included in the HTTP Request's JSON body, the formula is saved as part of the `body_content`. E.g. when updating the Body content field with `{"foo": <data source value>}`, this is what gets sent to the backend:
```
{
    "formula": "concat('{\"foo\": ', get('previous_node.36.0.field_7715'), '}')",
    "mode": "simple",
    "version": "0.1"
}
```

During the service type's `dispatch()`, the `get('previous_node.36.0.field_7715')` is resolved first, which might be `b"ar` (notice the single instance of a double-quote char). This turns the entire payload to:
```
{
    "foo": b"ar
}
```

And that's invalid due to the value being unquoted. In `develop`, we just show the generic `"The body is not a valid JSON"` error. In this branch, if the JSON can't be decoded and the Body content uses a data provider/expression, we show an enhanced message:
> <img width="673" height="227" alt="image" src="https://github.com/user-attachments/assets/feff6df3-d88f-48dd-bd1a-27215a7bc2f4" />

#### 3.1. Context
We can't escape the entire JSON, because it's already one string. So the solution is to use the new `to_json()` expression to wrap the data source, i.e. you'd update the Body content field so that it looks like `{"foo": to_json(<data source value>)}`, which would eventually become the payload:
```
{
    "foo": "b\"ar"
}
```

Here is another example. Suppose you have this Body content: `{"foo": now()}`. When this gets resolved, we end up with `{"foo": 2026-06-22 03:52:07.130000+00:00}`. Notice that this is a literal timestamp (via concat -> ensure_string). This would fail because it's not valid JSON.

To fix this, we just use `to_json()`, i.e. `{"foo": to_json(now())}`, which ends up being converted to `{"foo": "2026-06-22 03:52:07.130000+00:00"}` which is valid JSON.

# How to test this PR
Test the new `to_json()` and `from_json()` expressions.

For the HTTP Request service improvement, in `develop`, first try:
- Using a Database field formula in your JSON payload.
- Try using control chars, literal double-quotes, etc in your database field and make sure the `to_json()` still works.
- Try directly using an expression (e.g. `now()`, `generate_uuid()`, etc) in the Body content payload.

These should all fail with the generic error `The body is not a valid JSON`.

In this branch, you should see an enhanced error. If you then wrap the formula part with `to_json()`, you should no longer see an error.

Here are some examples you can test:
```
# using a data provider
concat('{"foo": ', to_json(get('previous_node.36.0.field_7715')), '}')
# using a formula function
concat('{"foo": ', to_json(now()), '}')
```

# Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
