### PR TITLE
fix(web-frontend): remove empty option from link-to-table dropdown in form view

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_an_empty_option_showing_at_the_top_of_linktotable_drop.json
+++ b/changelog/entries/unreleased/bug/fixes_an_empty_option_showing_at_the_top_of_linktotable_drop.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Fixes an empty option showing at the top of link-to-table dropdowns in forms",
+  "issue_origin": "github",
+  "issue_number": 5549,
+  "domain": "database",
+  "bullet_points": [],
+  "created_at": "2026-06-23"
+}

--- a/web-frontend/modules/database/components/view/form/FormViewFieldLinkRow.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewFieldLinkRow.vue
@@ -3,6 +3,7 @@
     <PaginatedDropdown
       :fetch-page="fetchPage"
       :value="dropdownValue"
+      :add-empty-item="false"
       :initial-display-name="initialDisplayName"
       :error="touched && !valid"
       :fetch-on-open="lazyLoad"

--- a/web-frontend/modules/database/components/view/form/FormViewFieldLinkRow.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewFieldLinkRow.vue
@@ -3,7 +3,7 @@
     <PaginatedDropdown
       :fetch-page="fetchPage"
       :value="dropdownValue"
-      :add-empty-item="false"
+      :add-empty-item="!required"
       :initial-display-name="initialDisplayName"
       :error="touched && !valid"
       :fetch-on-open="lazyLoad"

--- a/web-frontend/modules/database/components/view/form/FormViewFieldMultipleLinkRow.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewFieldMultipleLinkRow.vue
@@ -9,6 +9,7 @@
         <PaginatedDropdown
           :fetch-page="fetchPage"
           :value="value[index].id"
+          :add-empty-item="false"
           :initial-display-name="rowDisplayName(value[index])"
           :error="touched && !valid && isInvalidValue(value[index])"
           :fetch-on-open="lazyLoad"

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldLinkRow.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldLinkRow.spec.js
@@ -3,6 +3,7 @@ import flushPromises from 'flush-promises'
 
 import FormViewFieldLinkRow from '@baserow/modules/database/components/view/form/FormViewFieldLinkRow'
 import FormViewFieldMultipleLinkRow from '@baserow/modules/database/components/view/form/FormViewFieldMultipleLinkRow'
+import PaginatedDropdown from '@baserow/modules/core/components/PaginatedDropdown'
 import ViewService from '@baserow/modules/database/services/view'
 import { LinkRowFieldType } from '@baserow/modules/database/fieldTypes'
 
@@ -176,6 +177,15 @@ describe('FormViewFieldLinkRow', () => {
     const wrapper = await mountComponent({ value: [], required: false })
     expect(wrapper.vm.getValidationError(wrapper.vm.value)).toBeNull()
   })
+
+  test('does not render the empty option at the top of the dropdown', async () => {
+    const wrapper = await mountComponent({ value: [] })
+    // The blank entry that PaginatedDropdown adds by default must be suppressed,
+    // otherwise an empty option shows up at the top of the link-row dropdown.
+    expect(wrapper.findComponent(PaginatedDropdown).props('addEmptyItem')).toBe(
+      false
+    )
+  })
 })
 
 describe('FormViewFieldMultipleLinkRow', () => {
@@ -340,5 +350,14 @@ describe('FormViewFieldMultipleLinkRow', () => {
   test('non-required + empty array passes validation', async () => {
     const wrapper = await mountComponent({ value: [], required: false })
     expect(wrapper.vm.getValidationError(wrapper.vm.value)).toBeNull()
+  })
+
+  test('does not render the empty option in any slot dropdown', async () => {
+    const wrapper = await mountComponent({ value: [{ id: 42, value: '' }] })
+    // Each slot's PaginatedDropdown must suppress the default blank entry; slots
+    // are cleared with the bin button, not an empty option in the list.
+    expect(wrapper.findComponent(PaginatedDropdown).props('addEmptyItem')).toBe(
+      false
+    )
   })
 })

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldLinkRow.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldLinkRow.spec.js
@@ -4,6 +4,7 @@ import flushPromises from 'flush-promises'
 import FormViewFieldLinkRow from '@baserow/modules/database/components/view/form/FormViewFieldLinkRow'
 import FormViewFieldMultipleLinkRow from '@baserow/modules/database/components/view/form/FormViewFieldMultipleLinkRow'
 import PaginatedDropdown from '@baserow/modules/core/components/PaginatedDropdown'
+import DropdownItem from '@baserow/modules/core/components/DropdownItem'
 import ViewService from '@baserow/modules/database/services/view'
 import { LinkRowFieldType } from '@baserow/modules/database/fieldTypes'
 
@@ -17,6 +18,15 @@ const mockLinkRowFieldLookup = (rows) => {
     .mockResolvedValue({ data: { results: rows, count: rows.length } })
   ViewService.mockReturnValue({ linkRowFieldLookup })
   return linkRowFieldLookup
+}
+
+const renderedOptionValues = async (wrapper) => {
+  const dropdown = wrapper.findComponent(PaginatedDropdown)
+  await dropdown.vm.fetch()
+  await flushPromises()
+  return dropdown
+    .findAllComponents(DropdownItem)
+    .map((item) => item.props('value'))
 }
 
 const linkRowField = {
@@ -178,13 +188,22 @@ describe('FormViewFieldLinkRow', () => {
     expect(wrapper.vm.getValidationError(wrapper.vm.value)).toBeNull()
   })
 
-  test('does not render the empty option at the top of the dropdown', async () => {
-    const wrapper = await mountComponent({ value: [] })
-    // The blank entry that PaginatedDropdown adds by default must be suppressed,
-    // otherwise an empty option shows up at the top of the link-row dropdown.
-    expect(wrapper.findComponent(PaginatedDropdown).props('addEmptyItem')).toBe(
-      false
-    )
+  test('required field lists the real rows without the blank option', async () => {
+    mockLinkRowFieldLookup([{ id: 43, value: 'Real name' }])
+    const wrapper = await mountComponent({ value: [], required: true })
+    const values = await renderedOptionValues(wrapper)
+    expect(values).toContain(43)
+    expect(values).not.toContain(null)
+  })
+
+  test('non-required field keeps the blank option so a value can be reset', async () => {
+    mockLinkRowFieldLookup([{ id: 43, value: 'Real name' }])
+    const wrapper = await mountComponent({ value: [], required: false })
+    const values = await renderedOptionValues(wrapper)
+    expect(values).toContain(43)
+    // Without a clear button, the blank entry is the only way to unset an
+    // optional field, so it must remain available.
+    expect(values).toContain(null)
   })
 })
 
@@ -352,12 +371,16 @@ describe('FormViewFieldMultipleLinkRow', () => {
     expect(wrapper.vm.getValidationError(wrapper.vm.value)).toBeNull()
   })
 
-  test('does not render the empty option in any slot dropdown', async () => {
-    const wrapper = await mountComponent({ value: [{ id: 42, value: '' }] })
-    // Each slot's PaginatedDropdown must suppress the default blank entry; slots
-    // are cleared with the bin button, not an empty option in the list.
-    expect(wrapper.findComponent(PaginatedDropdown).props('addEmptyItem')).toBe(
-      false
-    )
+  test('a slot dropdown lists the real rows without the blank option', async () => {
+    mockLinkRowFieldLookup([{ id: 43, value: 'Real name' }])
+    const wrapper = await mountComponent({
+      value: [{ id: false, value: '' }],
+      required: false,
+    })
+    const values = await renderedOptionValues(wrapper)
+    expect(values).toContain(43)
+    // no blank entry appears, even on an optional field: a slot is
+    // cleared with the bin button, not by picking an empty option.
+    expect(values).not.toContain(null)
   })
 })


### PR DESCRIPTION
### What is in this PR

Link-to-table fields in a Form View showed a blank empty option at the top of their selection dropdown. This suppresses that option on both the single and multiple link-row form components.

### Root cause

The form-view link-row components mount `PaginatedDropdown` without overriding its `addEmptyItem` prop. That prop defaults to `true` with an empty `emptyItemDisplayName` (`web-frontend/modules/core/mixins/paginatedDropdown.js`), so the dropdown always renders a nameless `DropdownItem` (value `null`) at the top of the list (`PaginatedDropdown.vue`).

The canonical sibling, `FormViewFieldSingleSelectRadios.vue`, renders no empty option. The established suppress pattern — `:add-empty-item="false"` — is already used by `FieldDateSubForm.vue` and `ManualLicenseSeatForm.vue`. The fix applies the same to:

- `FormViewFieldLinkRow.vue` (single)
- `FormViewFieldMultipleLinkRow.vue` (each slot; slots are cleared via the existing bin button)


### How to test this PR
1. Create a Form View containing a Link-to-table field.
2. Open the form and open the field's dropdown.
3. Before: a blank option appears at the top. After: only the real rows are listed, no empty option.

<img width="1134" height="643" alt="Screenshot 2026-06-23 at 12 11 44" src="https://github.com/user-attachments/assets/39d14bcb-d5b3-4345-bb8d-2b8821b870c5" />


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered

Closes #5549