### PR TITLE
Fix Vuex store state isolation during SSR

### DIFF
--- a/web-frontend/modules/automation/store/automationHistory.js
+++ b/web-frontend/modules/automation/store/automationHistory.js
@@ -1,12 +1,12 @@
 import { useNuxtApp } from '#app'
 import AutomationHistoryService from '@baserow/modules/automation/services/history'
 
-const state = {
+const state = () => ({
   // Holds the value of which workflow history is currently selected
   workflowHistory: {},
   nodeHistoriesByWorkflowHistory: {},
   nodeResults: {},
-}
+})
 
 const mutations = {
   SET_WORKFLOW_HISTORY(state, { data }) {

--- a/web-frontend/modules/automation/store/automationWorkflow.js
+++ b/web-frontend/modules/automation/store/automationWorkflow.js
@@ -20,7 +20,7 @@ export function populateAutomationWorkflow(workflow) {
   }
 }
 
-const state = {
+const state = () => ({
   // Holds the value of which workflow is currently selected
   selected: {},
   // A job object that tracks the progress of a workflow duplication currently running
@@ -29,7 +29,7 @@ const state = {
   // `null` (side panel is closed), `history` (view workflow run history) and
   // `node` (trigger and action node edit forms).
   activeSidePanel: null,
-}
+})
 
 const mutations = {
   ADD_ITEM(state, { automation, workflow }) {

--- a/web-frontend/modules/automation/store/automationWorkflowNode.js
+++ b/web-frontend/modules/automation/store/automationWorkflowNode.js
@@ -6,10 +6,10 @@ import { clone } from '@baserow/modules/core/utils/object'
 
 import NodeGraphHandler from '@baserow/modules/automation/utils/nodeGraphHandler'
 
-const state = {
+const state = () => ({
   selectedNodeId: null,
   draggingNodeId: null,
-}
+})
 
 const updateContext = {
   updateTimeout: null,

--- a/web-frontend/modules/builder/store/builderWorkflowAction.js
+++ b/web-frontend/modules/builder/store/builderWorkflowAction.js
@@ -20,7 +20,7 @@ export function populateWorkflowAction(workflowAction) {
   }
 }
 
-const state = {}
+const state = () => ({})
 
 const mutations = {
   ADD_ITEM(state, { page, workflowAction }) {

--- a/web-frontend/modules/builder/store/dataSource.js
+++ b/web-frontend/modules/builder/store/dataSource.js
@@ -1,7 +1,7 @@
 import DataSourceService from '@baserow/modules/builder/services/dataSource'
 import PublishedBuilderService from '@baserow/modules/builder/services/publishedBuilder'
 
-const state = {}
+const state = () => ({})
 
 const updateContext = {
   updateTimeout: null,

--- a/web-frontend/modules/builder/store/dataSourceContent.js
+++ b/web-frontend/modules/builder/store/dataSourceContent.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import DataSourceService from '@baserow/modules/builder/services/dataSource'
 import PublishedBuilderService from '@baserow/modules/builder/services/publishedBuilder'
 
-const state = {}
+const state = () => ({})
 
 const fetchTimeoutPerPage = {}
 

--- a/web-frontend/modules/builder/store/domain.js
+++ b/web-frontend/modules/builder/store/domain.js
@@ -10,9 +10,9 @@ const populateDomain = (domain) => {
   return domain
 }
 
-const state = {
+const state = () => ({
   domains: [],
-}
+})
 
 const mutations = {
   SET_ITEMS(state, { domains }) {

--- a/web-frontend/modules/builder/store/element.js
+++ b/web-frontend/modules/builder/store/element.js
@@ -25,7 +25,7 @@ const populateElement = (element, registry) => {
   return element
 }
 
-const state = {}
+const state = () => ({})
 
 const updateContext = {
   updateTimeout: null,

--- a/web-frontend/modules/builder/store/elementContent.js
+++ b/web-frontend/modules/builder/store/elementContent.js
@@ -3,7 +3,7 @@ import PublishedBuilderService from '@baserow/modules/builder/services/published
 import { rangeDiff } from '@baserow/modules/core/utils/range'
 import axios from 'axios'
 
-const state = {}
+const state = () => ({})
 
 const queriesInProgress = {}
 

--- a/web-frontend/modules/builder/store/formData.js
+++ b/web-frontend/modules/builder/store/formData.js
@@ -4,7 +4,7 @@ import {
   setValueAtPath,
 } from '@baserow/modules/core/utils/object'
 
-const state = {}
+const state = () => ({})
 
 /**
  * Responsible for setting a form entry at a given path in the form data of a page in

--- a/web-frontend/modules/builder/store/page.js
+++ b/web-frontend/modules/builder/store/page.js
@@ -25,7 +25,7 @@ export function populatePage(page) {
   }
 }
 
-const state = {
+const state = () => ({
   // Holds the value of which page is currently selected
   selected: {},
   // By default, the device type will be desktop. This will be overridden
@@ -35,7 +35,7 @@ const state = {
   deviceTypeSelected: 'desktop',
   // A job object that tracks the progress of a page duplication currently running
   duplicateJob: null,
-}
+})
 
 const mutations = {
   ADD_ITEM(state, { builder, page }) {

--- a/web-frontend/modules/builder/store/pageParameter.js
+++ b/web-frontend/modules/builder/store/pageParameter.js
@@ -1,4 +1,4 @@
-const state = {}
+const state = () => ({})
 
 const mutations = {
   SET_PARAMETER(state, { page, name, value }) {

--- a/web-frontend/modules/builder/store/publicBuilder.js
+++ b/web-frontend/modules/builder/store/publicBuilder.js
@@ -1,6 +1,6 @@
 import PublishedBuilderService from '@baserow/modules/builder/services/publishedBuilder'
 
-const state = {}
+const state = () => ({})
 
 const mutations = {}
 

--- a/web-frontend/modules/builder/store/theme.js
+++ b/web-frontend/modules/builder/store/theme.js
@@ -1,7 +1,7 @@
 import ThemeService from '@baserow/modules/builder/services/theme'
 import { clone } from '@baserow/modules/core/utils/object'
 
-const state = {}
+const state = () => ({})
 
 let patchRequestTimeout = null
 let patchRequestResolve = null

--- a/web-frontend/modules/core/store/integration.js
+++ b/web-frontend/modules/core/store/integration.js
@@ -1,6 +1,6 @@
 import IntegrationService from '@baserow/modules/core/services/integration'
 
-const state = {}
+const state = () => ({})
 
 const updateContext = {
   updateTimeout: null,

--- a/web-frontend/modules/core/store/userSource.js
+++ b/web-frontend/modules/core/store/userSource.js
@@ -1,7 +1,7 @@
 import UserSourceService from '@baserow/modules/core/services/userSource'
 import _ from 'lodash'
 
-const state = {}
+const state = () => ({})
 
 const updateContext = {
   updateTimeout: null,


### PR DESCRIPTION
## Summary

- Convert Vuex module initial state declarations from module-scope objects to factory functions in builder, automation, and affected core frontend stores.

## Problem

Several frontend Vuex modules were declaring initial state as plain module-scope objects, for example `const state = { ... }`.

Vuex initializes module state with:

```js
this.state = (typeof rawState === 'function' ? rawState() : rawState) || {}
```

During SSR, Baserow creates a new Vuex store per request, but the imported module definitions are cached and reused by the same Node process. When `state` is a plain object, Vuex reuses that object reference across store instances. That means one server-side request can mutate module state that is then visible to another request handled by the same process.

Using `state = () => ({ ... })` makes Vuex allocate fresh module state every time the store module is initialized.

## Verification

```bash
just f yarn test:core --run test/unit/builder/store/ssrStatePollution.spec.js
```

Result: 1 test file passed, 3 tests passed.

## Proof: ssrStatePollution.spec.js

<details>
<summary>Attached proof spec</summary>

```js
import { describe, expect, test } from 'vitest'
import { createStore } from 'vuex'

import domainStore from '@baserow/modules/builder/store/domain'

// A Vuex module whose `state` is a plain object leaks state across stores.
// Under SSR, `core/plugins/store.js` runs `createStore({ modules })` once per
// request, but every request reuses the same imported module objects. Creating
// two stores from one module definition here reproduces two concurrent SSR
// requests sharing one Node process. See the Vuex Module constructor:
//   this.state = (typeof rawState === 'function' ? rawState() : rawState) || {}
// Object form means shared reference. Function form means fresh object per
// store.

const makeListModule = (stateDef) => ({
  namespaced: true,
  state: stateDef,
  mutations: {
    ADD(state, item) {
      state.items.push(item)
    },
  },
})

describe('Vuex SSR cross-request state pollution', () => {
  test('plain-object state is shared by reference across stores', () => {
    const moduleDef = makeListModule({ items: [] })

    const requestA = createStore({ modules: { m: moduleDef } })
    const requestB = createStore({ modules: { m: moduleDef } })

    requestA.commit('m/ADD', 'request-a-value')

    expect(requestB.state.m.items).toEqual(['request-a-value'])
    expect(requestA.state.m.items).toBe(requestB.state.m.items)
  })

  test('factory-function state is isolated per store', () => {
    const moduleDef = makeListModule(() => ({ items: [] }))

    const requestA = createStore({ modules: { m: moduleDef } })
    const requestB = createStore({ modules: { m: moduleDef } })

    requestA.commit('m/ADD', 'request-a-value')

    expect(requestA.state.m.items).toEqual(['request-a-value'])
    expect(requestB.state.m.items).toEqual([])
    expect(requestA.state.m.items).not.toBe(requestB.state.m.items)
  })

  test('the Baserow domain store state is isolated per store', () => {
    const requestA = createStore({ modules: { domain: domainStore } })
    const requestB = createStore({ modules: { domain: domainStore } })

    requestA.commit('domain/ADD_ITEM', {
      domain: { id: 1, domain_name: 'tenant-a.example.com' },
    })

    expect(requestA.state.domain.domains.map((d) => d.domain_name)).toEqual([
      'tenant-a.example.com',
    ])
    expect(requestB.state.domain.domains).toEqual([])
    expect(requestA.state.domain.domains).not.toBe(
      requestB.state.domain.domains
    )
  })
})
```

</details>
