### PR TITLE
bug: fix custom favicon support in application builder

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_custom_favicons_from_appearin.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_custom_favicons_from_appearin.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented custom favicons from appearing in previewed and published applications.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-06-24"
+}

--- a/web-frontend/modules/builder/components/PublicPageContent.vue
+++ b/web-frontend/modules/builder/components/PublicPageContent.vue
@@ -25,6 +25,7 @@ import ApplicationBuilderFormulaInput from '@baserow/modules/builder/components/
 import _ from 'lodash'
 import { prefixInternalResolvedUrl } from '@baserow/modules/builder/utils/urlResolution'
 import { userCanViewPage } from '@baserow/modules/builder/utils/visibility'
+import { getCustomFaviconLinks } from '@baserow/modules/builder/utils/favicon'
 
 import {
   userSourceCookieTokenName,
@@ -131,18 +132,7 @@ const isAuthenticated = computed(() =>
   store.getters['userSourceUser/isAuthenticated'](props.builder)
 )
 
-const faviconLink = computed(() => {
-  if (props.builder.favicon_file?.url) {
-    return {
-      rel: 'icon',
-      type: props.builder.favicon_file.mime_type,
-      href: props.builder.favicon_file.url,
-      sizes: '128x128',
-      hid: true,
-    }
-  }
-  return null
-})
+const faviconLinks = computed(() => getCustomFaviconLinks(props.builder))
 
 const themeConfigBlocks = computed(() =>
   $registry.getOrderedList('themeConfigBlock')
@@ -169,8 +159,8 @@ const headConfig = computed(() => {
     style: [{ innerHTML: `:root { ${cssVars} }`, type: 'text/css' }],
   }
 
-  if (faviconLink.value) {
-    header.link = [faviconLink.value]
+  if (faviconLinks.value) {
+    header.link = faviconLinks.value
   }
 
   const pluginHeaders = $registry.getList('plugin').map((plugin) =>

--- a/web-frontend/modules/builder/utils/favicon.js
+++ b/web-frontend/modules/builder/utils/favicon.js
@@ -1,0 +1,39 @@
+import head from '@baserow/modules/core/head'
+
+/**
+ * The `key` values of the default favicon `<link>` tags defined in
+ * `core/head.js`. unhead dedupes `link` tags by `key`, so reusing these keys is
+ * what lets a builder's custom favicon override the defaults instead of being
+ * appended alongside them. Deriving the keys from `head.js` (rather than
+ * hardcoding them here) guarantees the two stay in sync.
+ *
+ * @returns {string[]} the `key` of every default favicon link.
+ */
+export const getDefaultFaviconKeys = () =>
+  head.link.filter((link) => link.rel === 'icon').map((link) => link.key)
+
+/**
+ * Returns the favicon `<link>` tags for a builder application.
+ *
+ * When the builder has a custom favicon uploaded, one overriding link is
+ * returned per default favicon key, all pointing at the custom file, so the
+ * custom favicon wins regardless of which size the browser decides to use.
+ *
+ * When no custom favicon is set, `null` is returned so that the defaults from
+ * `core/head.js` remain in place untouched.
+ *
+ * @param {object} builder the builder application.
+ * @returns {object[]|null} the override favicon links, or `null` to keep the
+ *   defaults.
+ */
+export const getCustomFaviconLinks = (builder) => {
+  if (!builder.favicon_file?.url) {
+    return null
+  }
+  return getDefaultFaviconKeys().map((key) => ({
+    key,
+    rel: 'icon',
+    type: builder.favicon_file.mime_type,
+    href: builder.favicon_file.url,
+  }))
+}

--- a/web-frontend/modules/core/head.js
+++ b/web-frontend/modules/core/head.js
@@ -13,34 +13,37 @@ export default {
       content: 'telephone=no, email=no, address=no, date=no',
     },
   ],
+  // The `key` on each favicon is what allows other parts of the app (e.g. the
+  // application builder's custom favicon) to override these defaults. unhead
+  // dedupes `link` tags by `key`.
   link: [
     {
       rel: 'icon',
       type: 'image/png',
       href: '/img/favicon_16.png',
       sizes: '16x16',
-      hid: true,
+      key: 'favicon-16',
     },
     {
       rel: 'icon',
       type: 'image/png',
       href: '/img/favicon_32.png',
       sizes: '32x32',
-      hid: true,
+      key: 'favicon-32',
     },
     {
       rel: 'icon',
       type: 'image/png',
       href: '/img/favicon_48.png',
       sizes: '64x64',
-      hid: true,
+      key: 'favicon-64',
     },
     {
       rel: 'icon',
       type: 'image/png',
       href: '/img/favicon_192.png',
       sizes: '192x192',
-      hid: true,
+      key: 'favicon-192',
     },
   ],
 }

--- a/web-frontend/test/unit/builder/utils/favicon.spec.js
+++ b/web-frontend/test/unit/builder/utils/favicon.spec.js
@@ -1,0 +1,64 @@
+import head from '@baserow/modules/core/head'
+import {
+  getCustomFaviconLinks,
+  getDefaultFaviconKeys,
+} from '@baserow/modules/builder/utils/favicon'
+
+describe('Builder favicon util tests', () => {
+  describe('getDefaultFaviconKeys', () => {
+    test('returns the key of every default favicon link in head.js', () => {
+      const keys = getDefaultFaviconKeys()
+
+      // There should be at least one default favicon, and every one must
+      // expose a key (otherwise unhead cannot dedupe and the builder's custom
+      // favicon could never override it).
+      expect(keys.length).toBeGreaterThan(0)
+      keys.forEach((key) => expect(typeof key).toBe('string'))
+
+      // The keys must exactly match the favicon links declared in head.js.
+      const expected = head.link
+        .filter((link) => link.rel === 'icon')
+        .map((link) => link.key)
+      expect(keys).toStrictEqual(expected)
+    })
+  })
+
+  describe('getCustomFaviconLinks', () => {
+    test('returns null when no custom favicon is uploaded, keeping the defaults', () => {
+      expect(getCustomFaviconLinks({})).toBe(null)
+      expect(getCustomFaviconLinks({ favicon_file: null })).toBe(null)
+      // A favicon_file without a usable url should also fall back to defaults.
+      expect(getCustomFaviconLinks({ favicon_file: {} })).toBe(null)
+    })
+
+    test('overrides every default favicon with the custom one', () => {
+      const builder = {
+        favicon_file: {
+          url: 'https://example.com/media/custom-favicon.png',
+          mime_type: 'image/png',
+        },
+      }
+
+      const links = getCustomFaviconLinks(builder)
+
+      // One override link is produced per default favicon...
+      expect(links).toHaveLength(getDefaultFaviconKeys().length)
+
+      // ...and the keys exactly match the defaults so unhead replaces them
+      // rather than appending alongside them.
+      expect(links.map((link) => link.key)).toStrictEqual(
+        getDefaultFaviconKeys()
+      )
+
+      // Every override points at the uploaded custom favicon.
+      links.forEach((link) => {
+        expect(link).toStrictEqual({
+          key: link.key,
+          rel: 'icon',
+          type: 'image/png',
+          href: 'https://example.com/media/custom-favicon.png',
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
### What is in this PR

This fixes a bug that [a community user](https://community.baserow.io/t/application-builder-favicon-wont-change/12591) discovered. Likely since the nuxt3 upgrade, custom favicon support has been broken.

### How to test this PR

- Try favicon support in `develop` or in SaaS. It won't display, because we add all default `<link>` alongside the custom one. The custom one never gets selected.
- In this branch: try it again, in preview/published, and it'll work.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
