### PR TITLE
fix(backend): set hard time_limit on run_periodic_fields_updates

### DIFF
--- a/backend/src/baserow/contrib/database/fields/tasks.py
+++ b/backend/src/baserow/contrib/database/fields/tasks.py
@@ -49,6 +49,9 @@ def filter_distinct_workspace_ids_per_fields(
     bind=True,
     queue=settings.PERIODIC_FIELD_UPDATE_QUEUE_NAME,
     soft_time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60,
+    # Keep the hard limit above the soft one, else the global CELERY_TASK_TIME_LIMIT
+    # (shorter) kills the task before the soft limit can fire.
+    time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60 + 60,
 )
 def run_periodic_fields_updates(
     self, workspace_id: Optional[int] = None, update_now: bool = True

--- a/backend/src/baserow/contrib/database/fields/tasks.py
+++ b/backend/src/baserow/contrib/database/fields/tasks.py
@@ -50,8 +50,10 @@ def filter_distinct_workspace_ids_per_fields(
     queue=settings.PERIODIC_FIELD_UPDATE_QUEUE_NAME,
     soft_time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60,
     # Keep the hard limit above this task's soft_time_limit, otherwise a shorter
-    # global/default CELERY_TASK_TIME_LIMIT could kill the task before the soft limit fires.
-    time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60 + 60,
+    # global/default CELERY_TASK_TIME_LIMIT could kill the task before the soft limit
+    # fires. The 30s margin stays under the task's run interval to avoid overlapping
+    # with the next run.
+    time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60 + 30,
 )
 def run_periodic_fields_updates(
     self, workspace_id: Optional[int] = None, update_now: bool = True

--- a/backend/src/baserow/contrib/database/fields/tasks.py
+++ b/backend/src/baserow/contrib/database/fields/tasks.py
@@ -49,8 +49,8 @@ def filter_distinct_workspace_ids_per_fields(
     bind=True,
     queue=settings.PERIODIC_FIELD_UPDATE_QUEUE_NAME,
     soft_time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60,
-    # Keep the hard limit above the soft one, else the global CELERY_TASK_TIME_LIMIT
-    # (shorter) kills the task before the soft limit can fire.
+    # Keep the hard limit above this task's soft_time_limit, otherwise a shorter
+    # global/default CELERY_TASK_TIME_LIMIT could kill the task before the soft limit fires.
     time_limit=settings.PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60 + 60,
 )
 def run_periodic_fields_updates(

--- a/changelog/entries/unreleased/bug/fixes_periodic_field_updates_being_stopped_before_they_finis.json
+++ b/changelog/entries/unreleased/bug/fixes_periodic_field_updates_being_stopped_before_they_finis.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes periodic field updates being stopped before they finish",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-25"
+}


### PR DESCRIPTION
### What is in this PR
Sets an explicit hard `time_limit` on the `run_periodic_fields_updates` Celery task so it is no longer killed before its intended runtime.

### Root cause
`run_periodic_fields_updates` (`backend/src/baserow/contrib/database/fields/tasks.py:48`) declared a 9-minute `soft_time_limit` (`PERIODIC_FIELD_UPDATE_TIMEOUT_MINUTES * 60 = 540s`) but **no hard `time_limit`**. It therefore inherited the global default `CELERY_TASK_TIME_LIMIT = CELERY_TASK_SOFT_TIME_LIMIT + 60 = 360s` (`config/settings/base.py:196`). Because the hard limit (360s) is shorter than the task's soft limit (540s), the hard limit always fires first — `billiard` force-kills the task at 360s, raising `TimeLimitExceeded(360)`, and the soft limit never triggers. Every other task that sets `soft_time_limit` in this repo also sets a matching hard `time_limit` (search, usage, export, data_scanner, premium fields); this task was the only one missing it.

The two Sentry issues are the same event seen from two sides:
- `BASEROW-SAAS-BACKEND-3Z` — Celery request log: `Hard time limit (360s) exceeded for ...run_periodic_fields_updates`
- `BASEROW-SAAS-BACKEND-40` — worker pool exception: `TimeLimitExceeded(360)` in `billiard/pool.py:on_hard_timeout`

The fix adds `time_limit = soft + 60s` (600s), mirroring the global `CELERY_TASK_TIME_LIMIT = CELERY_TASK_SOFT_TIME_LIMIT + 60` convention so the soft limit can fire gracefully before the hard kill.

### How to test this PR
#### Manual
Inspect the registered task config:
```python
from baserow.contrib.database.fields.tasks import run_periodic_fields_updates
assert run_periodic_fields_updates.time_limit > run_periodic_fields_updates.soft_time_limit
```
On `develop` `time_limit` is `None` (inherits the 360s global); with this PR it is `600` while the soft limit is `540`.

### Out of scope
*Why* the task can run longer than 6 minutes is a separate performance question. This PR stops the premature kill; if the task later exceeds the new 600s hard limit, that warrants a separate performance investigation.

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered

Closes [BASEROW-SAAS-BACKEND-3Z](https://baserow-eu.sentry.io/issues/97212098)
Closes [BASEROW-SAAS-BACKEND-40](https://baserow-eu.sentry.io/issues/97212102)
