### PR TITLE
feat [1/2]: group aggregations in grouped grid views 

### DIFF
--- a/backend/src/baserow/contrib/database/api/views/grid/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/serializers.py
@@ -90,6 +90,14 @@ class GridViewGroupByDataGroupSerializer(serializers.Serializer):
             "grouped row order."
         )
     )
+    aggregations = serializers.DictField(
+        required=False,
+        help_text=(
+            "Per-group aggregation values keyed by field db_column, mirroring the "
+            "grid view field-aggregations response. Only present for visible fields "
+            "that have a scalar aggregation configured."
+        ),
+    )
 
 
 class GridViewGroupByDataPageSerializer(serializers.Serializer):

--- a/backend/src/baserow/contrib/database/api/views/grid/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/serializers.py
@@ -75,20 +75,30 @@ class GridViewGroupByDataGroupSerializer(serializers.Serializer):
         help_text="Zero-based depth of this group in the group-by hierarchy."
     )
     row_count = serializers.IntegerField(
-        help_text="Number of leaf rows descending from this group."
+        required=False,
+        help_text=(
+            "Number of leaf rows descending from this group. Omitted in "
+            "`aggregations_only` mode, which returns no windowed layout."
+        ),
     )
     children_count = serializers.IntegerField(
         required=False,
         help_text="Number of immediate sub-groups. Omitted at leaf depth.",
     )
     sibling_index = serializers.IntegerField(
-        help_text="Zero-based index of this group among its siblings."
+        required=False,
+        help_text=(
+            "Zero-based index of this group among its siblings. Omitted in "
+            "`aggregations_only` mode, which returns no windowed layout."
+        ),
     )
     row_offset = serializers.IntegerField(
+        required=False,
         help_text=(
             "Absolute offset of this group's first descendant row in the full "
-            "grouped row order."
-        )
+            "grouped row order. Omitted in `aggregations_only` mode, which returns "
+            "no windowed layout."
+        ),
     )
     aggregations = serializers.DictField(
         required=False,
@@ -117,5 +127,13 @@ class GridViewGroupByDataSerializer(serializers.Serializer):
         help_text=(
             "Whether descendant loading stopped early because the response page or "
             "group cap was reached."
+        ),
+    )
+    aggregations = serializers.DictField(
+        required=False,
+        help_text=(
+            "Table-level field aggregation totals keyed by field db_column, "
+            "mirroring the grid view field-aggregations response. Only present when "
+            "`include_totals=true` was requested."
         ),
     )

--- a/backend/src/baserow/contrib/database/api/views/grid/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/utils.py
@@ -439,6 +439,8 @@ def get_group_by_data_pages(
     include_descendants: bool = False,
     descendant_limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
     row_budget: int = GROUP_BY_DATA_DESCENDANT_MAX_GROUPS,
+    aggregations: Optional[List[Tuple[Field, str]]] = None,
+    aggregations_only: bool = False,
 ) -> Tuple[List[Dict[str, Any]], bool]:
     """
     **Parent mode.** Returns bounded group-by pages for the requested parents.
@@ -494,6 +496,8 @@ def get_group_by_data_pages(
                 offset=request["offset"],
                 limit=request["limit"],
                 parent_row_offset=request.get("parent_row_offset"),
+                aggregations=aggregations,
+                aggregations_only=aggregations_only,
             )
             page["parent"] = parent
             group_count += len(page.get("groups", []))
@@ -564,6 +568,7 @@ def get_group_by_data_pages(
                 depth,
                 offset=offset,
                 per_parent_limit=limit,
+                aggregations=aggregations,
             )
 
             # Split the batched groups into one page per parent, making each group's
@@ -646,12 +651,40 @@ def get_group_by_data_pages(
     return pages, truncated
 
 
+def get_grid_view_group_by_aggregations(view, view_type) -> List[Tuple[Field, str]]:
+    """
+    Resolves the per-group aggregations to compute for a grid view's group-by data.
+
+    Reuses the column footer aggregation configuration
+    (``GridViewFieldOptions.aggregation_raw_type``) so a single "Summarize" choice
+    drives both the grid footer and the per-group header values.
+
+    :param view: The grid view to resolve the configured aggregations for.
+    :param view_type: The resolved view type of ``view``.
+    :return: The configured ``(field, aggregation_raw_type)`` pairs, or an empty
+        list when the view type does not support field aggregations.
+    """
+
+    if not getattr(view_type, "can_aggregate_field", False):
+        return []
+    visible_field_ids = {
+        option.field_id for option in view_type.get_visible_field_options_in_order(view)
+    }
+    return [
+        (field.specific, raw_type)
+        for field, raw_type in view_type.get_aggregations(view)
+        if field.id in visible_field_ids
+    ]
+
+
 def build_group_by_data_response(
     view_handler: ViewHandler,
     request: Request,
     queryset: QuerySet,
     view_group_bys: List[ViewGroupBy],
     group_by_fields: List[Field],
+    aggregations: Optional[List[Tuple[Field, str]]] = None,
+    totals: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     **Entry point.** Builds the serialized group-by data response for a grid view.
@@ -666,9 +699,13 @@ def build_group_by_data_response(
     :param queryset: The filtered/searched rows queryset to group.
     :param view_group_bys: The view group-by configuration rows.
     :param group_by_fields: The ordered group-by fields configured on the view.
+    :param totals: The optional table-level aggregations to bundle top-level (when
+        ``include_totals`` was requested), so the client can update the footer from
+        the same request.
     :return: The serialized group-by data response.
     """
 
+    aggregations_only = str_to_bool(str(request.GET.get("aggregations_only")))
     offset = parse_non_negative_int(request.GET.get("offset"), 0)
     limit = min(
         parse_non_negative_int(request.GET.get("limit"), GROUP_BY_DATA_DEFAULT_LIMIT),
@@ -692,6 +729,7 @@ def build_group_by_data_response(
             depth=depth,
             offset=offset,
             limit=limit,
+            aggregations=aggregations,
         )
         pages = split_group_by_depth_page_by_parent(depth_page, group_by_fields)
         truncated = False
@@ -728,6 +766,13 @@ def build_group_by_data_response(
                     if include_descendants
                     else GROUP_BY_DATA_DESCENDANT_MAX_GROUPS
                 ),
+                aggregations=aggregations,
+                aggregations_only=aggregations_only,
             )
 
-    return serialize_group_by_data_pages(pages, group_by_fields, truncated=truncated)
+    response = serialize_group_by_data_pages(
+        pages, group_by_fields, truncated=truncated
+    )
+    if totals is not None:
+        response["aggregations"] = totals
+    return response

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -17,6 +17,7 @@ from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.schemas import get_error_schema
 from baserow.api.search.serializers import SearchQueryParamSerializer
 from baserow.api.serializers import get_example_pagination_serializer_class
+from baserow.config.settings.utils import str_to_bool
 from baserow.contrib.database.api.constants import (
     ADHOC_FILTERS_API_PARAMS,
     ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
@@ -108,6 +109,7 @@ from .serializers import GridViewFilterSerializer, GridViewGroupByDataSerializer
 from .utils import (
     build_group_by_data_response,
     empty_group_by_data_page,
+    get_grid_view_group_by_aggregations,
     parse_adhoc_view_group_bys,
 )
 
@@ -557,9 +559,32 @@ class GridViewGroupByDataView(APIView):
             )
 
         group_by_fields = view_handler.get_group_by_fields(queryset, view_group_bys)
+        aggregations = get_grid_view_group_by_aggregations(view, view_type)
+
+        totals = None
+        if aggregations and str_to_bool(str(request.GET.get("include_totals"))):
+            totals = view_handler.get_view_field_aggregations(
+                request.user,
+                view,
+                search=query_params.get("search"),
+                search_mode=query_params.get("search_mode"),
+                adhoc_filters=adhoc_filters,
+            )
+            totals = {
+                field: (
+                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
+                )
+                for field, value in totals.items()
+            }
 
         response_data = build_group_by_data_response(
-            view_handler, request, queryset, view_group_bys, group_by_fields
+            view_handler,
+            request,
+            queryset,
+            view_group_bys,
+            group_by_fields,
+            aggregations,
+            totals=totals,
         )
 
         return Response(response_data)
@@ -992,9 +1017,15 @@ class PublicGridViewGroupByDataView(APIView):
             )
 
         group_by_fields = view_handler.get_group_by_fields(queryset, view_group_bys)
+        aggregations = get_grid_view_group_by_aggregations(view, view_type)
 
         response_data = build_group_by_data_response(
-            view_handler, request, queryset, view_group_bys, group_by_fields
+            view_handler,
+            request,
+            queryset,
+            view_group_bys,
+            group_by_fields,
+            aggregations,
         )
 
         return Response(response_data)

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from drf_spectacular.openapi import OpenApiParameter, OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -63,6 +61,7 @@ from baserow.contrib.database.api.views.utils import (
     get_public_view_authorization_token,
     get_public_view_filtered_queryset,
     get_view_filtered_queryset,
+    json_safe_aggregation_value,
     paginate_and_serialize_queryset,
     serialize_group_by_data_pages,
     serialize_group_by_fields_metadata,
@@ -571,9 +570,7 @@ class GridViewGroupByDataView(APIView):
                 adhoc_filters=adhoc_filters,
             )
             totals = {
-                field: (
-                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
-                )
+                field: json_safe_aggregation_value(value)
                 for field, value in totals.items()
             }
 
@@ -691,12 +688,9 @@ class GridViewFieldAggregationsView(APIView):
             adhoc_filters=adhoc_filters,
         )
 
-        # Decimal("NaN") can't be serialized, therefore we have to replace it
-        # with its literal string representation
-        nan_replacement_value = "NaN"
-        for field in result:
-            if isinstance(result[field], Decimal) and result[field].is_nan():
-                result[field] = nan_replacement_value
+        result = {
+            field: json_safe_aggregation_value(value) for field, value in result.items()
+        }
 
         return Response(result)
 
@@ -800,12 +794,9 @@ class PublicGridViewFieldAggregationsView(APIView):
             skip_perm_check=True,
         )
 
-        # Decimal("NaN") can't be serialized, therefore we have to replace it
-        # with its literal string representation
-        nan_replacement_value = "NaN"
-        for field in result:
-            if isinstance(result[field], Decimal) and result[field].is_nan():
-                result[field] = nan_replacement_value
+        result = {
+            field: json_safe_aggregation_value(value) for field, value in result.items()
+        }
 
         return Response(result)
 

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -170,6 +170,29 @@ GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM = OpenApiParameter(
         "request limit and is capped by the total group budget."
     ),
 )
+GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM = OpenApiParameter(
+    name="aggregations_only",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.BOOL,
+    required=False,
+    description=(
+        "When true, returns a lean values-only page: each group carries only its "
+        "`path` (plus `children_count` and per-group `aggregations`) and omits the "
+        "windowed layout fields (`row_count`, `sibling_index`, `row_offset`). Used "
+        "to refresh aggregation values in place without rebuilding the layout."
+    ),
+)
+GROUP_BY_DATA_INCLUDE_TOTALS_API_PARAM = OpenApiParameter(
+    name="include_totals",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.BOOL,
+    required=False,
+    description=(
+        "When true, the response also includes a top-level `aggregations` object "
+        "with the view's table-level field aggregation totals, mirroring the grid "
+        "view field-aggregations response."
+    ),
+)
 
 
 class GridViewView(APIView):
@@ -465,6 +488,8 @@ class GridViewGroupByDataView(APIView):
             GROUP_BY_DATA_INCLUDE_DESCENDANTS_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_LIMIT_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM,
+            GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM,
+            GROUP_BY_DATA_INCLUDE_TOTALS_API_PARAM,
             OpenApiParameter("offset", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter("limit", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter(
@@ -927,6 +952,7 @@ class PublicGridViewGroupByDataView(APIView):
             GROUP_BY_DATA_INCLUDE_DESCENDANTS_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_LIMIT_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM,
+            GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM,
             OpenApiParameter("offset", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter("limit", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter(

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -422,6 +422,16 @@ def _resolve_group_by_display_lists(
     return display_lists_per_page
 
 
+def json_safe_aggregation_value(value: Any) -> Any:
+    # Decimal("NaN") isn't JSON-serializable (it renders as the invalid JSON `NaN`
+    # token), so it's substituted with its string form. Ideally each field type would
+    # own how its aggregated value is represented; this single helper keeps that
+    # concern in one place until that field-type-level refactor is worth doing.
+    if isinstance(value, Decimal) and value.is_nan():
+        return "NaN"
+    return value
+
+
 def serialize_group_by_data(
     page: Dict[str, Any],
     group_by_fields: List[Field],
@@ -508,12 +518,8 @@ def serialize_group_by_data(
         if display:
             out_group["display"] = display
         if "aggregations" in group:
-            # Mirror the grid footer: raw values, with Decimal("NaN") replaced by
-            # its literal string since it can't be JSON-serialized.
             out_group["aggregations"] = {
-                db_column: (
-                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
-                )
+                db_column: json_safe_aggregation_value(value)
                 for db_column, value in group["aggregations"].items()
             }
         groups.append(out_group)

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Type
 
 from django.conf import settings
@@ -491,16 +492,30 @@ def serialize_group_by_data(
         out_group = {
             "path": serialize_path(group["path"]),
             "depth": group["depth"],
-            "row_count": group["row_count"],
-            "sibling_index": group["sibling_index"],
-            "row_offset": group["row_offset"],
         }
+        # Layout keys are omitted in the lean "aggregations only" mode, so only
+        # copy the ones the handler provided.
+        for layout_key in (
+            "row_count",
+            "sibling_index",
+            "row_offset",
+            "children_count",
+        ):
+            if layout_key in group:
+                out_group[layout_key] = group[layout_key]
         # `containers[0]` is the parent, so the groups start at index 1.
         display = serialize_display(group_index + 1)
         if display:
             out_group["display"] = display
-        if "children_count" in group:
-            out_group["children_count"] = group["children_count"]
+        if "aggregations" in group:
+            # Mirror the grid footer: raw values, with Decimal("NaN") replaced by
+            # its literal string since it can't be JSON-serialized.
+            out_group["aggregations"] = {
+                db_column: (
+                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
+                )
+                for db_column, value in group["aggregations"].items()
+            }
         groups.append(out_group)
 
     return {

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -4034,6 +4034,8 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         offset: int = 0,
         limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
         parent_row_offset: Optional[int] = None,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
+        aggregations_only: bool = False,
     ) -> Dict[str, Any]:
         """
         Returns one paginated page of group-by sibling groups.
@@ -4050,6 +4052,9 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :param limit: The maximum number of siblings to return.
         :param parent_row_offset: The optional precomputed absolute row offset of
             the parent group.
+        :param aggregations_only: When ``True`` only ``path`` + ``aggregations`` are
+            returned, skipping the window-function layout (row count, sibling index,
+            row offset). Used by the lean values-only refresh.
         :return: The paginated group-by data response.
         """
 
@@ -4074,15 +4079,25 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
                 "group_count": 0,
             }
 
+        grouped_queryset = self._get_group_by_data_level_queryset(
+            group_by_levels,
+            base_queryset,
+            parent_depth,
+            parent_path,
+            aggregations=aggregations,
+        )
+
+        if aggregations_only:
+            return self._build_aggregations_only_page(
+                grouped_queryset, fields, parent_depth, offset, limit, aggregations
+            )
+
         if parent_row_offset is None:
             parent_row_offset = self._get_group_by_path_row_offset(
                 group_by_levels,
                 base_queryset,
                 parent_path,
             )
-        grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, parent_depth, parent_path
-        )
         page = self._execute_group_by_data_windowed_query(
             grouped_queryset, parent_row_offset, offset=offset, limit=limit
         )
@@ -4106,6 +4121,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return {
@@ -4122,6 +4141,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         offset: int = 0,
         limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> Dict[str, Any]:
         """
         Returns one paginated page of group-by groups at a global depth.
@@ -4149,7 +4169,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
 
         grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, depth, {}
+            group_by_levels, base_queryset, depth, {}, aggregations=aggregations
         )
         page = self._execute_group_by_data_depth_windowed_query(
             grouped_queryset, fields, depth, offset=offset, limit=limit
@@ -4178,6 +4198,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return {
@@ -4747,6 +4771,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         offset: int = 0,
         per_parent_limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Returns the children of several parents at one depth in a single query.
@@ -4772,7 +4797,12 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             return []
 
         grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, depth, {}, parent_paths=parents
+            group_by_levels,
+            base_queryset,
+            depth,
+            {},
+            parent_paths=parents,
+            aggregations=aggregations,
         )
         rows = self._execute_group_by_data_level_windowed_query(
             grouped_queryset, fields, depth, offset, per_parent_limit
@@ -4797,6 +4827,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return groups
@@ -4808,6 +4842,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         parent_path: Dict[str, Any],
         parent_paths: Optional[List[Dict[str, Any]]] = None,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> QuerySet:
         """
         Builds the grouped queryset for a single group-by level under one or more parents.
@@ -4889,6 +4924,12 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
                 output_field=IntegerField(),
             )
 
+        if aggregations:
+            queryset, aggregation_annotations = self._apply_group_by_data_aggregations(
+                queryset, aggregations, base_queryset.model
+            )
+            annotations.update(aggregation_annotations)
+
         queryset = (
             queryset.values(*field_names, *order_key_names)
             .annotate(**annotations)
@@ -4899,6 +4940,121 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             queryset = queryset.with_cte(cte_with)
 
         return queryset
+
+    @staticmethod
+    def _group_by_data_aggregation_alias(field: Field, raw_type: str) -> str:
+        """
+        Returns the query alias for a per-group aggregation annotation.
+
+        The alias is namespaced to avoid clashing with the group-by columns,
+        ``row_count``/``children_count``, and the order-key annotations.
+        """
+
+        return f"agg_{field.id}_{raw_type}"
+
+    def _apply_group_by_data_aggregations(
+        self,
+        queryset: QuerySet,
+        aggregations: List[Tuple[Field, str]],
+        model: Type[GeneratedTableModel],
+    ) -> Tuple[QuerySet, Dict[str, Any]]:
+        """
+        Builds the per-group aggregation annotations for the grouped level query.
+
+        Each configured aggregation that resolves to a single scalar aggregate is
+        computed once per group, in the same grouped query as ``row_count``.
+        ``AnnotatedAggregation`` aggregations (e.g. empty/not-empty count on
+        link-row fields) require a pre-annotation on the row queryset before the
+        grouping, mirroring the grid footer aggregation handling. Aggregations that
+        are not a single scalar value (``DistributionAggregation`` and the dict-based
+        ``range``) are skipped; they remain available as footer aggregations.
+
+        :param queryset: The row queryset that is about to be grouped.
+        :param aggregations: The configured ``(field, aggregation_raw_type)`` pairs.
+        :param model: The table model the aggregations are computed against.
+        :return: The (possibly pre-annotated) queryset and the mapping of
+            aggregation alias to its aggregate expression.
+        """
+
+        annotations: Dict[str, Any] = {}
+        for field, raw_type in aggregations:
+            aggregation_type = view_aggregation_type_registry.get(raw_type)
+            model_field = model._meta.get_field(field.db_column)
+            aggregation = aggregation_type.get_aggregation(
+                field.db_column, model_field, field
+            )
+            if isinstance(aggregation, (DistributionAggregation, dict)):
+                continue
+            if isinstance(aggregation, AnnotatedAggregation):
+                queryset = queryset.annotate(**aggregation.annotations)
+                aggregation = aggregation.aggregation
+            annotations[self._group_by_data_aggregation_alias(field, raw_type)] = (
+                aggregation
+            )
+        return queryset, annotations
+
+    def _extract_group_by_aggregations(
+        self,
+        entry: Dict[str, Any],
+        aggregations: List[Tuple[Field, str]],
+    ) -> Dict[str, Any]:
+        """
+        Extracts the per-group aggregation values from a grouped query row.
+
+        Only aggregations that were actually computed in the grouped query (and so
+        produced a column in ``entry``) are included, which transparently skips the
+        aggregations dropped by :meth:`_apply_group_by_data_aggregations`.
+
+        :param entry: A single grouped row returned by the windowed query.
+        :param aggregations: The configured ``(field, aggregation_raw_type)`` pairs.
+        :return: A mapping of field ``db_column`` to the group's aggregation value,
+            matching the shape of the grid view footer aggregations response.
+        """
+
+        result: Dict[str, Any] = {}
+        for field, raw_type in aggregations:
+            alias = self._group_by_data_aggregation_alias(field, raw_type)
+            if alias in entry:
+                result[field.db_column] = entry[alias]
+        return result
+
+    def _build_aggregations_only_page(
+        self,
+        grouped_queryset: QuerySet,
+        fields: List[Field],
+        depth: int,
+        offset: int,
+        limit: int,
+        aggregations: Optional[List[Tuple[Field, str]]],
+    ) -> Dict[str, Any]:
+        """
+        Builds a lean group page with only ``path`` (+ ``children_count``) and
+        ``aggregations``, skipping the window-function layout (row count, sibling
+        index, row offset). The grouped query runs without the windowed wrapper, so
+        the values-only refresh doesn't recompute layout it already has.
+        ``children_count`` is kept so the descendant fan-out can still recurse.
+        """
+
+        entries = list(grouped_queryset[offset : offset + limit])
+        groups = []
+        for entry in entries:
+            path = {
+                field.db_column: entry[field.db_column] for field in fields[: depth + 1]
+            }
+            group: Dict[str, Any] = {"path": path, "depth": depth}
+            if "children_count" in entry:
+                group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
+            groups.append(group)
+        return {
+            "groups": groups,
+            "offset": offset,
+            "limit": limit,
+            "group_count": len(groups),
+        }
 
     def _add_group_by_data_order_key_annotations(
         self, queryset: QuerySet, order_by_args: List[Any]

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -5053,6 +5053,8 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             "groups": groups,
             "offset": offset,
             "limit": limit,
+            # Values-only refresh: the client keys values onto groups by path and
+            # never paginates off this response, so the slice size suffices.
             "group_count": len(groups),
         }
 

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
@@ -31,6 +31,484 @@ def _get_page_by_parent(response_json, parent):
 
 
 @pytest.mark.django_db
+def test_get_group_by_data_computes_per_group_aggregations(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    group_by = data_fixture.create_view_group_by(view=grid, field=color)
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Blue", f"field_{amount.id}": 5})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    result = ViewHandler().get_group_by_data(
+        model.objects.all(),
+        [group_by],
+        aggregations=[(amount, "sum")],
+    )
+
+    groups = {group["path"][f"field_{color.id}"]: group for group in result["groups"]}
+    assert groups["Blue"]["aggregations"] == {f"field_{amount.id}": 5}
+    assert groups["Green"]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_for_depth_computes_per_group_aggregations(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    size = data_fixture.create_text_field(table=table, name="Size")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    color_group = data_fixture.create_view_group_by(view=grid, field=color)
+    size_group = data_fixture.create_view_group_by(view=grid, field=size)
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "S",
+            f"field_{amount.id}": 10,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "S",
+            f"field_{amount.id}": 20,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "L",
+            f"field_{amount.id}": 100,
+        }
+    )
+
+    handler = ViewHandler()
+    aggregations = [(amount, "sum")]
+
+    top = handler.get_group_by_data_for_depth(
+        model.objects.all(),
+        [color_group, size_group],
+        depth=0,
+        aggregations=aggregations,
+    )
+    top_groups = {g["path"][f"field_{color.id}"]: g for g in top["groups"]}
+    assert top_groups["Green"]["aggregations"] == {f"field_{amount.id}": 130}
+
+    leaf = handler.get_group_by_data_for_depth(
+        model.objects.all(),
+        [color_group, size_group],
+        depth=1,
+        aggregations=aggregations,
+    )
+    leaf_groups = {g["path"][f"field_{size.id}"]: g for g in leaf["groups"]}
+    assert leaf_groups["S"]["aggregations"] == {f"field_{amount.id}": 30}
+    assert leaf_groups["L"]["aggregations"] == {f"field_{amount.id}": 100}
+
+
+@pytest.mark.django_db
+def test_group_by_data_endpoint_returns_per_group_aggregations(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Blue", f"field_{amount.id}": 5})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    groups = {g["path"][f"field_{color.id}"]: g for g in page["groups"]}
+    assert groups["Blue"]["aggregations"] == {f"field_{amount.id}": 5}
+    assert groups["Green"]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_omits_distribution_aggregation(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    label = data_fixture.create_text_field(table=table, name="Label")
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"},
+            label.id: {
+                "aggregation_type": "distribution",
+                "aggregation_raw_type": "distribution",
+            },
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{amount.id}": 10,
+            f"field_{label.id}": "a",
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{amount.id}": 20,
+            f"field_{label.id}": "b",
+        }
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # The distribution aggregation isn't a scalar, so it's omitted per group while
+    # the scalar sum is still returned.
+    assert group["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_computes_link_row_not_empty_count_aggregation(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    related_table = data_fixture.create_database_table(
+        user=user, database=table.database
+    )
+    color = data_fixture.create_text_field(table=table, name="Color")
+    link = data_fixture.create_link_row_field(
+        table=table, link_row_table=related_table, name="Link"
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            link.id: {
+                "aggregation_type": "not_empty_count",
+                "aggregation_raw_type": "not_empty_count",
+            }
+        },
+    )
+
+    related_model = related_table.get_model()
+    related_row = related_model.objects.create()
+    model = table.get_model()
+    linked = model.objects.create(**{f"field_{color.id}": "Green"})
+    getattr(linked, f"field_{link.id}").set([related_row.id])
+    model.objects.create(**{f"field_{color.id}": "Green"})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # 1 of the 2 "Green" rows has a linked relation (link-row uses the
+    # AnnotatedAggregation path).
+    assert group["aggregations"] == {f"field_{link.id}": 1}
+
+
+@pytest.mark.django_db
+def test_group_by_data_excludes_aggregations_for_hidden_fields(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    visible_amount = data_fixture.create_number_field(
+        table=table, name="Visible", number_decimal_places=0
+    )
+    hidden_amount = data_fixture.create_number_field(
+        table=table, name="Hidden", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            visible_amount.id: {
+                "aggregation_type": "sum",
+                "aggregation_raw_type": "sum",
+            },
+            hidden_amount.id: {
+                "hidden": True,
+                "aggregation_type": "sum",
+                "aggregation_raw_type": "sum",
+            },
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{visible_amount.id}": 10,
+            f"field_{hidden_amount.id}": 99,
+        }
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    # The hidden field's aggregation is not exposed, matching the grid footer.
+    assert page["groups"][0]["aggregations"] == {f"field_{visible_amount.id}": 10}
+
+
+@pytest.mark.django_db
+def test_public_group_by_data_returns_per_group_aggregations(api_client, data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table, public=True)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse(
+        "api:database:views:grid:public-group-by-data", kwargs={"slug": grid.slug}
+    )
+    response = api_client.get(url)
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    assert page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_respect_view_filters(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+    data_fixture.create_view_filter(
+        view=grid, field=amount, type="higher_than", value="15"
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 30})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # Only rows with amount > 15 are counted, matching row_count: 20 + 30 = 50.
+    assert group["row_count"] == 2
+    assert group["aggregations"] == {f"field_{amount.id}": 50}
+
+
+@pytest.mark.django_db
+def test_group_by_data_average_aggregation_returns_decimal(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=2
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {
+                "aggregation_type": "average",
+                "aggregation_raw_type": "average",
+            }
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 30})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    assert page["groups"][0]["aggregations"][f"field_{amount.id}"] == 20
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_only_skips_layout(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(
+        url, {"aggregations_only": "true"}, HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    assert group["path"] == {f"field_{color.id}": "Green"}
+    assert group["aggregations"] == {f"field_{amount.id}": 30}
+    # The expensive window-function layout is skipped in lean mode.
+    assert "row_count" not in group
+    assert "sibling_index" not in group
+    assert "row_offset" not in group
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_only_with_descendants(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    size = data_fixture.create_number_field(
+        table=table, name="Size", number_decimal_places=0
+    )
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    data_fixture.create_view_group_by(view=grid, field=size)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 10}
+    )
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 20}
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    # Lean mode skips the layout, so descendant fan-out must not rely on row_offset.
+    response = api_client.get(
+        url,
+        {"aggregations_only": "true", "include_descendants": "true"},
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    root_page = _get_page_by_parent(response.json(), {})
+    assert root_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+    blue_page = _get_page_by_parent(response.json(), {f"field_{color.id}": "Blue"})
+    assert blue_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_include_totals_bundles_table_totals(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Red", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(
+        url, {"include_totals": "true"}, HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert response.status_code == HTTP_200_OK
+    # The cached table-level total is bundled top-level so the frontend updates the
+    # footer from the same request.
+    assert response.json()["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
 def test_returns_empty_group_by_data_when_view_has_no_group_by(
     api_client, data_fixture
 ):

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_utils.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_utils.py
@@ -386,6 +386,7 @@ class _LevelGroupByDataHandler:
         depth,
         offset=0,
         per_parent_limit=40,
+        aggregations=None,
     ):
         self.level_calls.append((depth, [dict(parent) for parent in parents]))
         groups = []

--- a/backend/tests/baserow/ws/test_ws_realtime_events.py
+++ b/backend/tests/baserow/ws/test_ws_realtime_events.py
@@ -1676,6 +1676,20 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     user, token = await sync_to_async(data_fixture.create_user_and_token)()
     await sync_to_async(data_fixture.create_workspace)(user=user)
 
+    # Last-seen event cleaned by retention while a newer one survives: replay can't
+    # anchor, so it must force a refresh. Capture the real id — the sequence isn't
+    # reset between transactional tests.
+    stale_last_seen_id = await sync_to_async(_record_event)(
+        "users",
+        {
+            "type": "broadcast_to_users",
+            "user_ids": [user.id],
+            "send_to_all_users": False,
+            "payload": {"type": "stale"},
+            "ignore_web_socket_id": "ws-other",
+        },
+    )
+    await sync_to_async(RealtimeEvent.objects.filter(id=stale_last_seen_id).delete)()
     await sync_to_async(_record_event)(
         "users",
         {
@@ -1696,12 +1710,10 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     assert connected is True
     await communicator.receive_json_from()
 
-    # last_seen_id=1 does not exist — retention cleaned it (simulated by
-    # never having created id=1). Replay can't proceed — client must refresh.
     await communicator.send_json_to(
         {
             "type": "replay_events",
-            "last_seen_id": 1,
+            "last_seen_id": stale_last_seen_id,
         }
     )
 

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -816,6 +816,32 @@ flat/group-by runs, the same way filters and sorts do.
 - New nested group banners and their counters are visible after the refresh.
 - Total row count is unchanged.
 
+### 7.3.1 Group headers show per-column aggregation summaries
+
+Behind the `group_by_aggregations` feature flag.
+
+- When a column has a "Summarize" aggregation configured, each group header shows
+  that column's aggregation computed over that group's rows, column-aligned under
+  the field, at every group-by depth.
+- The summary is visible whether the group is collapsed or expanded.
+- It respects the view's filters and search, the same scope as the group row count.
+- A column set to the `distribution` aggregation shows no value in group headers;
+  its bottom-footer value is unaffected.
+- The bottom footer still shows the overall total for the column.
+
+### 7.3.2 Hovering a group header to pick or change an aggregation
+
+Behind the `group_by_aggregations` feature flag.
+
+- Hovering a group-by header reveals, per column, the aggregation value or a
+  `+ Summarize` affordance on the hovered column (only the hovered column).
+- Clicking it opens the aggregation menu; choosing a function sets it for the
+  column, so the bottom footer and every group's header show that function
+  together (shared column setting).
+- After choosing — and after editing a row — the affected group values show a
+  brief loading spinner and update in place. The group layout (rows, counts,
+  offsets) is not rebuilt; only the aggregation values change.
+
 ## Search
 
 ### 8.1.1 Search in highlight mode

--- a/web-frontend/modules/core/assets/scss/components/views/grid.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/grid.scss
@@ -546,13 +546,56 @@
   }
 }
 
-.grid-view__group-by-banner-primary {
+.grid-view__group-by-banner-field {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 12px;
   box-sizing: border-box;
+  min-width: 0;
+  overflow: hidden;
+  container-type: inline-size;
+}
+
+.grid-view__group-by-banner-field--primary {
+  gap: 12px;
   padding: 0 12px;
+}
+
+.grid-view-aggregation.grid-view__group-by-banner-aggregation {
+  @extend %ellipsis;
+
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+  color: $palette-neutral-900;
+}
+
+@container (max-width: 130px) {
+  .grid-view__group-by-banner-aggregation .grid-view-aggregation__generic-name {
+    display: none;
+  }
+}
+
+.grid-view__group-by-banner-aggregation
+  .grid-view-aggregation__generic-value--loading {
+  color: transparent;
+}
+
+.grid-view__group-by-banner-aggregation-loading {
+  @include loading(14px);
+
+  margin-left: auto;
+}
+
+.grid-view__group-by-banner-aggregation-empty {
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.grid-view__group-by-banner-field:hover
+  .grid-view__group-by-banner-aggregation-empty,
+.grid-view__group-by-banner-aggregation-empty.grid-view-aggregation__empty--active {
+  opacity: 1;
 }
 
 .grid-view__group-by-banner-stack {

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -101,6 +101,14 @@ export default {
     return { pendingValueUpdate: false }
   },
   computed: {
+    // Group headers reuse this column's config, but only when the flag is on.
+    groupAggregationsEnabled() {
+      return (
+        typeof this.$featureFlagIsEnabled === 'function' &&
+        this.$featureFlagIsEnabled('group_by_aggregations') &&
+        this.$store.getters[this.storePrefix + 'view/grid/isGroupByMode']
+      )
+    },
     userCanMakeAggregations() {
       return this.$hasPermission(
         'database.table.view.update_field_options',
@@ -207,6 +215,15 @@ export default {
         values.aggregation_raw_type = selectedAggregation.getRawType()
       }
 
+      const syncGroups = this.groupAggregationsEnabled
+      if (syncGroups && values.aggregation_type) {
+        // Spin before the optimistic change so the new label never shows the old value.
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+          { fieldId: this.field.id }
+        )
+      }
+
       // Prevent the watcher to trigger while value is not yet saved on server
       this.pendingValueUpdate = true
       try {
@@ -218,8 +235,27 @@ export default {
             readOnly: !this.userCanMakeAggregations,
           }
         )
+      } catch (error) {
+        if (syncGroups) {
+          this.$store.dispatch(
+            this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+            { loading: false }
+          )
+        }
+        throw error
       } finally {
         this.pendingValueUpdate = false
+      }
+
+      if (syncGroups) {
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/refreshGroupByAggregations',
+          {
+            view: this.view,
+            fields: this.$store.getters['field/getAll'],
+            fieldId: this.field.id,
+          }
+        )
       }
     },
   },

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -1,0 +1,220 @@
+<template>
+  <div
+    v-if="hasValue || editable"
+    ref="anchor"
+    class="grid-view-aggregation grid-view__group-by-banner-aggregation"
+    :class="{ 'read-only': !editable }"
+    :title="titleText"
+    @click.prevent="
+      editable && $refs.context.toggle($refs.anchor, 'top', 'right', 10)
+    "
+  >
+    <component
+      :is="viewAggregationType.getComponent()"
+      v-if="hasValue"
+      :aggregation-type="viewAggregationType"
+      :value="value"
+      :field="field"
+      :loading="loading"
+    />
+    <div
+      v-else-if="loading && viewAggregationType"
+      class="grid-view__group-by-banner-aggregation-loading"
+    ></div>
+    <div
+      v-else
+      class="grid-view-aggregation__empty grid-view__group-by-banner-aggregation-empty"
+      :class="{
+        'grid-view-aggregation__empty--active':
+          $refs.context && $refs.context.isOpen(),
+      }"
+    >
+      <i class="grid-view-aggregation__empty-icon iconoir-plus"></i>
+      {{ $t('common.summarize') }}
+    </div>
+    <Context ref="context">
+      <ul class="select__items">
+        <li
+          class="select__item select__item--no-options"
+          :class="{ active: !viewAggregationType }"
+        >
+          <a class="select__item-link" @click="selectAggregation('none')">
+            <div class="select__item-name">
+              <span class="select__item-name-text">{{
+                $t('common.none')
+              }}</span>
+            </div>
+          </a>
+          <i
+            v-if="!viewAggregationType"
+            class="select__item-active-icon iconoir-check"
+          ></i>
+        </li>
+        <li
+          v-for="viewAggregation in viewAggregationTypes"
+          :key="viewAggregation.getType()"
+          class="select__item select__item--no-options"
+          :class="{ active: viewAggregation === viewAggregationType }"
+        >
+          <a
+            class="select__item-link"
+            @click="selectAggregation(viewAggregation.getType())"
+          >
+            <div class="select__item-name">
+              <span class="select__item-name-text">{{
+                viewAggregation.getName()
+              }}</span>
+            </div>
+          </a>
+          <i
+            v-if="viewAggregation === viewAggregationType"
+            class="select__item-active-icon iconoir-check"
+          ></i>
+        </li>
+      </ul>
+    </Context>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GridViewGroupByAggregation',
+  props: {
+    view: {
+      type: Object,
+      required: true,
+    },
+    workspaceId: {
+      type: null,
+      default: null,
+    },
+    field: {
+      type: Object,
+      required: true,
+    },
+    storePrefix: {
+      type: String,
+      required: true,
+    },
+    // The raw, server-computed aggregation value for this group, or undefined when
+    // the field has no per-group value (e.g. an unsupported aggregation type).
+    rawValue: {
+      type: null,
+      default: undefined,
+    },
+    // This group's row count, used as the percentage/total context, mirroring the
+    // grid footer.
+    rowCount: {
+      type: Number,
+      default: 0,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['change'],
+  computed: {
+    fieldOptions() {
+      return this.$store.getters[
+        this.storePrefix + 'view/grid/getAllFieldOptions'
+      ]
+    },
+    aggregationType() {
+      return this.fieldOptions[this.field.id]?.aggregation_type
+    },
+    viewAggregationType() {
+      if (!this.aggregationType) {
+        return null
+      }
+      try {
+        return this.$registry.get('viewAggregation', this.aggregationType)
+      } catch (_) {
+        return null
+      }
+    },
+    viewAggregationTypes() {
+      return this.$registry
+        .getOrderedList('viewAggregation')
+        .filter(
+          (agg) => agg.fieldIsCompatible(this.field) && agg.isAllowedInView()
+        )
+    },
+    fieldType() {
+      return this.$registry.get('field', this.field.type)
+    },
+    editable() {
+      return this.$hasPermission(
+        'database.table.view.update_field_options',
+        this.view,
+        this.workspaceId
+      )
+    },
+    hasValue() {
+      return this.viewAggregationType !== null && this.rawValue !== undefined
+    },
+    // Full "Label value" tooltip so no information is lost when a narrow column
+    // hides the label (see the container query in grid.scss).
+    titleText() {
+      if (!this.hasValue) {
+        return null
+      }
+      return `${this.viewAggregationType.getShortName()} ${this.value}`
+    },
+    value() {
+      if (!this.viewAggregationType) {
+        return undefined
+      }
+      return this.viewAggregationType.getValue(this.rawValue, {
+        rowCount: this.rowCount,
+        field: this.field,
+        fieldType: this.fieldType,
+      })
+    },
+  },
+  methods: {
+    async selectAggregation(newType) {
+      this.$refs.context.hide()
+
+      const values = {
+        aggregation_type: '',
+        aggregation_raw_type: '',
+      }
+
+      if (newType !== 'none') {
+        const selectedAggregation = this.$registry.get(
+          'viewAggregation',
+          newType
+        )
+        values.aggregation_type = newType
+        values.aggregation_raw_type = selectedAggregation.getRawType()
+      }
+
+      // Spin before the optimistic change so the new label never shows the old value.
+      this.$store.dispatch(
+        this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+        { fieldId: this.field.id }
+      )
+      try {
+        await this.$store.dispatch(
+          this.storePrefix + 'view/grid/updateFieldOptionsOfField',
+          {
+            field: this.field,
+            values,
+            readOnly: !this.editable,
+          }
+        )
+      } catch (error) {
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+          { loading: false }
+        )
+        throw error
+      }
+      // The aggregation values are computed server-side, so the visible group tree
+      // must be refetched to reflect the new function.
+      this.$emit('change')
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -21,8 +21,10 @@
       v-else-if="loading && viewAggregationType"
       class="grid-view__group-by-banner-aggregation-loading"
     ></div>
+    <!-- Only unconfigured columns offer the picker; a configured column with no
+    per-group value (e.g. distribution) shows nothing. -->
     <div
-      v-else
+      v-else-if="!viewAggregationType"
       class="grid-view-aggregation__empty grid-view__group-by-banner-aggregation-empty"
       :class="{
         'grid-view-aggregation__empty--active':

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -12,42 +12,45 @@
     }"
     :data-collapsed="item.collapsed ? 'true' : 'false'"
   >
-    <template v-if="includeRowDetails">
-      <div
-        class="grid-view__group-by-banner-chevron-lane"
-        :style="{
-          width: rowDetailsWidth + 'px',
-          paddingLeft: indentPx + 'px',
-        }"
+    <div
+      v-if="includeRowDetails"
+      class="grid-view__group-by-banner-chevron-lane"
+      :style="{
+        width: rowDetailsWidth + 'px',
+        paddingLeft: indentPx + 'px',
+      }"
+    >
+      <button
+        type="button"
+        class="grid-view__group-by-banner-toggle"
+        :aria-expanded="!item.collapsed"
+        :aria-label="
+          item.collapsed
+            ? $t('gridViewGroupByBanner.expandGroup')
+            : $t('gridViewGroupByBanner.collapseGroup')
+        "
+        @click="$emit('toggle', item.path)"
       >
-        <button
-          type="button"
-          class="grid-view__group-by-banner-toggle"
-          :aria-expanded="!item.collapsed"
-          :aria-label="
+        <i
+          :class="
             item.collapsed
-              ? $t('gridViewGroupByBanner.expandGroup')
-              : $t('gridViewGroupByBanner.collapseGroup')
+              ? 'iconoir-nav-arrow-right'
+              : 'iconoir-nav-arrow-down'
           "
-          @click="$emit('toggle', item.path)"
-        >
-          <i
-            :class="
-              item.collapsed
-                ? 'iconoir-nav-arrow-right'
-                : 'iconoir-nav-arrow-down'
-            "
-          />
-        </button>
-      </div>
-      <div
-        v-if="primaryFieldWidth > 0"
-        class="grid-view__group-by-banner-primary"
-        :style="{
-          width: primaryFieldWidth + 'px',
-          paddingLeft: indentPx + 'px',
-        }"
-      >
+        />
+      </button>
+    </div>
+    <div
+      v-for="(field, index) in visibleFields"
+      :key="field.id"
+      class="grid-view__group-by-banner-field"
+      :class="{
+        'grid-view__group-by-banner-field--primary':
+          includeRowDetails && index === 0,
+      }"
+      :style="bannerFieldStyle(field, index)"
+    >
+      <template v-if="includeRowDetails && index === 0">
         <div class="grid-view__group-by-banner-stack">
           <div class="grid-view__group-by-banner-label">
             {{ fieldNameLabel }}
@@ -74,22 +77,29 @@
         <div class="grid-view__group-by-banner-count">
           {{ item.rowCount }}
         </div>
-      </div>
-    </template>
-    <div
-      v-for="(position, index) in separatorPositions"
-      :key="'separator-' + index"
-      class="grid-view__group-by-banner-separator"
-      :style="{ left: position - 1 + 'px' }"
-    />
+      </template>
+      <GridViewGroupByAggregation
+        v-else-if="aggregationsEnabled"
+        :view="view"
+        :workspace-id="workspaceId"
+        :field="field"
+        :store-prefix="storePrefix"
+        :raw-value="aggregationValueFor(field)"
+        :row-count="item.rowCount"
+        :loading="aggregationLoadingFor(field.id)"
+        @change="$emit('aggregation-changed', field.id)"
+      />
+    </div>
   </div>
 </template>
 
 <script>
 import { groupBannerIndentPx } from '@baserow/modules/database/utils/gridGroupByRender'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
 
 export default {
   name: 'GridViewGroupByBanner',
+  components: { GridViewGroupByAggregation },
   props: {
     item: {
       type: Object,
@@ -103,10 +113,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    primaryFieldWidth: {
-      type: Number,
-      default: 0,
-    },
     rowDetailsWidth: {
       type: Number,
       default: 72,
@@ -115,17 +121,45 @@ export default {
       type: null,
       default: null,
     },
-    separatorPositions: {
-      type: Array,
-      default: () => [],
-    },
     width: {
       type: Number,
       required: true,
     },
+    visibleFields: {
+      type: Array,
+      default: () => [],
+    },
+    fieldWidths: {
+      type: Object,
+      default: () => ({}),
+    },
+    view: {
+      type: Object,
+      default: null,
+    },
+    storePrefix: {
+      type: String,
+      default: '',
+    },
   },
-  emits: ['toggle'],
+  emits: ['toggle', 'aggregation-changed'],
   computed: {
+    aggregationsEnabled() {
+      return (
+        this.storePrefix !== '' &&
+        this.view !== null &&
+        typeof this.$featureFlagIsEnabled === 'function' &&
+        this.$featureFlagIsEnabled('group_by_aggregations')
+      )
+    },
+    aggregationLoadingFor() {
+      if (this.storePrefix === '') {
+        return () => false
+      }
+      return this.$store.getters[
+        this.storePrefix + 'view/grid/getGroupByAggregationsLoading'
+      ]
+    },
     groupByField() {
       return this.groupByFields[this.item.depth]
     },
@@ -223,6 +257,22 @@ export default {
         return JSON.stringify(value)
       }
       return String(value)
+    },
+  },
+  methods: {
+    aggregationValueFor(field) {
+      if (!this.item.aggregations) {
+        return undefined
+      }
+      return this.item.aggregations[`field_${field.id}`]
+    },
+    bannerFieldStyle(field, index) {
+      const style = { width: (this.fieldWidths[field.id] || 0) + 'px' }
+      if (this.includeRowDetails && index === 0) {
+        // Indent the field-name block in lockstep with the chevron.
+        style.paddingLeft = this.indentPx + 'px'
+      }
+      return style
     },
   },
 }

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
@@ -6,12 +6,15 @@
         :item="item"
         :group-by-fields="groupByFields"
         :include-row-details="includeRowDetails"
-        :primary-field-width="primaryFieldWidth"
         :row-details-width="gridViewRowDetailsWidth"
         :workspace-id="workspaceId"
-        :separator-positions="bannerSeparatorPositions"
         :width="sectionWidth"
+        :visible-fields="visibleFields"
+        :field-widths="fieldWidths"
+        :view="view"
+        :store-prefix="storePrefix"
         @toggle="toggleGroup"
+        @aggregation-changed="onAggregationChanged"
       />
       <div
         v-else-if="item.type === 'row' && shouldRenderRows"
@@ -220,28 +223,6 @@ export default {
       })
       return positions
     },
-    /**
-     * Vertical cell separators inside the group banner, at every internal field
-     * boundary. Only the scrollable-right section gets them: the section edge
-     * already draws the outer border, and the left section's banner content
-     * (chevron, label, count) flows across its columns.
-     */
-    bannerSeparatorPositions() {
-      if (this.includeRowDetails) {
-        return []
-      }
-      const positions = []
-      let x = 0
-      this.visibleFields.slice(0, -1).forEach((field) => {
-        x += this.getFieldWidth(field)
-        positions.push(x)
-      })
-      return positions
-    },
-    primaryFieldWidth() {
-      const primaryField = this.visibleFields[0]
-      return primaryField ? this.getFieldWidth(primaryField) : 0
-    },
     shouldRenderRows() {
       return this.includeRowDetails || this.visibleFields.length > 0
     },
@@ -306,6 +287,20 @@ export default {
             path,
             view: this.view,
             fields: this.allFieldsInTable,
+          }
+        )
+      } catch (error) {
+        notifyIf(error, 'view')
+      }
+    },
+    async onAggregationChanged(fieldId) {
+      try {
+        await this.$store.dispatch(
+          this.storePrefix + 'view/grid/refreshGroupByAggregations',
+          {
+            view: this.view,
+            fields: this.allFieldsInTable,
+            fieldId,
           }
         )
       } catch (error) {

--- a/web-frontend/modules/database/services/view/grid.js
+++ b/web-frontend/modules/database/services/view/grid.js
@@ -157,6 +157,8 @@ export default (client) => {
       descendantLimit = null,
       descendantRowBudget = null,
       groupBy = '',
+      aggregationsOnly = false,
+      includeTotals = false,
     }) {
       const params = new URLSearchParams()
       params.append('offset', offset)
@@ -166,6 +168,12 @@ export default (client) => {
       }
       if (includeDescendants) {
         params.append('include_descendants', 'true')
+      }
+      if (aggregationsOnly) {
+        params.append('aggregations_only', 'true')
+      }
+      if (includeTotals) {
+        params.append('include_totals', 'true')
       }
       if (descendantLimit !== null) {
         params.append('descendant_limit', descendantLimit)

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -125,6 +125,9 @@ function getEmptyGroupByState() {
     absoluteRows: {},
     revision: 0,
     generation: 0,
+    // True while a lean values-only aggregation refresh is in flight, so the group
+    // header cells show a loading spinner without rebuilding the layout.
+    aggregationsLoading: false,
     collapse: { mode: 'expand', paths: [] },
     collapseInitialized: false,
     sectionRows: {},
@@ -1048,6 +1051,37 @@ export const mutations = {
       ...rowsByOffset,
     }
   },
+  SET_GROUP_BY_AGGREGATIONS_LOADING(state, value) {
+    state.groupBy.aggregationsLoading = value
+  },
+  // Updates only the loaded group nodes' `aggregations` from a lean response,
+  // matched by path so it survives sibling-order changes. Layout untouched.
+  UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES(state, { pages, fields }) {
+    const aggregationsByPath = {}
+    for (const page of pages) {
+      for (const group of page.groups || []) {
+        aggregationsByPath[pathKey(group.path, fields)] =
+          group.aggregations || {}
+      }
+    }
+
+    const applyTo = (node) => {
+      const aggregations = aggregationsByPath[pathKey(node.path, fields)]
+      return aggregations !== undefined ? { ...node, aggregations } : node
+    }
+
+    const newPages = {}
+    for (const [pageKey, page] of Object.entries(state.groupBy.pages || {})) {
+      const newNodes = {}
+      for (const [index, node] of Object.entries(page.nodes || {})) {
+        newNodes[index] = applyTo(node)
+      }
+      newPages[pageKey] = { ...page, nodes: newNodes }
+    }
+    state.groupBy.pages = newPages
+    state.groupBy.treeNodes = (state.groupBy.treeNodes || []).map(applyTo)
+    state.groupBy.revision = (state.groupBy.revision || 0) + 1
+  },
   UPDATE_GROUP_BY_TREE_PATH_COUNT(
     state,
     { path, fields, delta, registry, display = null }
@@ -1631,6 +1665,68 @@ const activeGroupByRowsRequests = new Map()
 const lastAggregationRequest = { request: null, controller: null }
 
 export const actions = {
+  // Toggles per-group aggregation loading. A `fieldId` spins one column; omitting it
+  // spins all (a row edit can change any value).
+  setGroupByAggregationsLoading(
+    { commit },
+    { fieldId = null, loading = true }
+  ) {
+    commit(
+      'SET_GROUP_BY_AGGREGATIONS_LOADING',
+      loading ? (fieldId !== null ? [fieldId] : true) : false
+    )
+  },
+  // Lean values-only refresh: refetches per-group values + bundled totals and updates
+  // them in place without rebuilding the layout. Used after an aggregation or row change.
+  async refreshGroupByAggregations(
+    { commit, getters, rootGetters },
+    { view, fields, fieldId = null }
+  ) {
+    const { $client, $config } = this
+    if (!getters.isGroupByMode) {
+      return
+    }
+    const groupByFields = getGroupByFieldsFromActiveGroupBys(
+      getters.getActiveGroupBys,
+      fields
+    )
+    if (groupByFields.length === 0) {
+      return
+    }
+    const gridId = getters.getLastGridId
+    commit(
+      'SET_GROUP_BY_AGGREGATIONS_LOADING',
+      fieldId !== null ? [fieldId] : true
+    )
+    try {
+      const { data } = await GridService($client).fetchGroupByData({
+        gridId,
+        search: getters.getServerSearchTerm,
+        searchMode: getDefaultSearchModeFromEnv($config),
+        publicUrl: rootGetters['page/view/public/getIsPublic'],
+        publicAuthToken: rootGetters['page/view/public/getAuthToken'],
+        filters: getFilters(view, getters.getAdhocFiltering),
+        offset: 0,
+        limit: getters.getBufferRequestSize,
+        includeDescendants: true,
+        descendantLimit: getters.getBufferRequestSize,
+        aggregationsOnly: true,
+        includeTotals: true,
+      })
+      commit('UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES', {
+        pages: data.pages || [],
+        fields: groupByFields,
+      })
+      for (const [fieldKey, value] of Object.entries(data.aggregations || {})) {
+        const fieldId = parseInt(fieldKey.replace('field_', ''), 10)
+        if (!isNaN(fieldId)) {
+          commit('SET_FIELD_AGGREGATION_DATA', { fieldId, value })
+        }
+      }
+    } finally {
+      commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+    }
+  },
   async fetchGroupByData(
     { commit, getters, rootGetters, state },
     {
@@ -6062,6 +6158,18 @@ export const getters = {
   // per-call fields array would be a new reference every time and defeat the cache.
   getGroupByLayout(state) {
     return getGroupByLayoutFromState(state)
+  },
+  getGroupByAggregationsLoading(state) {
+    const loading = state.groupBy.aggregationsLoading
+    return (fieldId = null) => {
+      if (loading === true) {
+        return true
+      }
+      if (Array.isArray(loading)) {
+        return fieldId !== null && loading.includes(fieldId)
+      }
+      return false
+    }
   },
   getGroupBySectionRowsMap: (state) => {
     return makeSectionRowsMap(state.groupBy.sectionRows)

--- a/web-frontend/modules/database/utils/gridGroupByRender.js
+++ b/web-frontend/modules/database/utils/gridGroupByRender.js
@@ -161,6 +161,7 @@ export function buildLayout({
       height: HEADER_HEIGHT,
       collapsed,
       gapAbove,
+      aggregations: node.aggregations ?? null,
     })
     y += HEADER_HEIGHT
 
@@ -381,6 +382,7 @@ function buildPagedLayout({
         height: HEADER_HEIGHT,
         collapsed,
         gapAbove,
+        aggregations: node.aggregations ?? null,
       })
       y += HEADER_HEIGHT
 
@@ -614,6 +616,7 @@ export function renderViewport({
         height: item.height,
         collapsed: item.collapsed,
         gapAbove: item.gapAbove,
+        aggregations: item.aggregations ?? null,
       })
       continue
     }

--- a/web-frontend/modules/database/viewTypes.js
+++ b/web-frontend/modules/database/viewTypes.js
@@ -802,6 +802,28 @@ export class GridViewType extends ViewType {
     )
   }
 
+  // In grouped mode (flag on), refresh per-group values via a lean request that keeps
+  // the layout; otherwise refresh the footer aggregations as before.
+  refreshAggregationsAfterRowChange(store, fields, storePrefix) {
+    const view = store.getters['view/getSelected']
+    const groupAggregations =
+      typeof this.app.$featureFlagIsEnabled === 'function' &&
+      this.app.$featureFlagIsEnabled('group_by_aggregations')
+    if (
+      groupAggregations &&
+      store.getters[storePrefix + 'view/grid/isGroupByMode']
+    ) {
+      store.dispatch(storePrefix + 'view/grid/refreshGroupByAggregations', {
+        view,
+        fields,
+      })
+    } else {
+      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
+        view,
+      })
+    }
+  }
+
   async rowCreated(
     { store },
     tableId,
@@ -821,9 +843,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 
@@ -865,9 +885,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 
@@ -882,9 +900,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
@@ -16,6 +16,7 @@ describe('Field footer component', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
     await testApp.afterEach()
   })
 
@@ -168,5 +169,45 @@ describe('Field footer component', () => {
     ).toEqual({ 3: { loading: false, value: 10 } })
 
     expect(wrapper.element).toMatchSnapshot()
+  })
+
+  const mountGroupedFooter = (flagEnabled) => {
+    store.commit('page/view/grid/SET_LAST_GRID_ID', 2)
+    store.commit('page/view/grid/SET_ACTIVE_GROUP_BYS', [{ field: 1 }])
+    return testApp.mount(GridViewFieldFooter, {
+      propsData: {
+        view: { id: 2 },
+        database: { id: 1, workspace: { id: 1 } },
+        field: { id: 3, type: 'text' },
+        storePrefix: 'page/',
+      },
+      global: { mocks: { $featureFlagIsEnabled: () => flagEnabled } },
+    })
+  }
+
+  test('changing the aggregation refreshes the group headers in grouped mode', async () => {
+    const wrapper = await mountGroupedFooter(true)
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await selectValue(wrapper, 2)
+    await flushPromises()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/refreshGroupByAggregations',
+      expect.objectContaining({ fieldId: 3 })
+    )
+  })
+
+  test('changing the aggregation leaves group headers untouched when the flag is off', async () => {
+    const wrapper = await mountGroupedFooter(false)
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await selectValue(wrapper, 2)
+    await flushPromises()
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      'page/view/grid/refreshGroupByAggregations',
+      expect.anything()
+    )
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -102,6 +102,17 @@ describe('GridViewGroupByAggregation', () => {
     expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
   })
 
+  test('never shows the summarize affordance for a configured field without a per-group value', async () => {
+    // A non-scalar aggregation (e.g. distribution) is configured but the backend
+    // returns no per-group value, so the field must not look unconfigured.
+    await configureSum()
+
+    const wrapper = await mountCell({ rawValue: undefined })
+
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('30')
+  })
+
   test('renders nothing for a read-only user when nothing is configured', async () => {
     const wrapper = await mountCell(
       { rawValue: undefined },

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -1,0 +1,134 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
+import Context from '@baserow/modules/core/components/Context'
+import flushPromises from 'flush-promises'
+
+describe('GridViewGroupByAggregation', () => {
+  let testApp = null
+  let store = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    store = testApp.store
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const field = { id: 2, name: 'Amount', type: 'number' }
+
+  const mountCell = (props = {}, mocks = {}) =>
+    testApp.mount(GridViewGroupByAggregation, {
+      propsData: {
+        view: { id: 1 },
+        workspaceId: 1,
+        field,
+        storePrefix: 'page/',
+        rawValue: 30,
+        rowCount: 2,
+        ...props,
+      },
+      global: { mocks },
+    })
+
+  const configureSum = () =>
+    store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      2: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
+    })
+
+  test('renders the per-group aggregation value for a configured field', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell()
+
+    expect(wrapper.find('.grid-view-aggregation').exists()).toBe(true)
+    expect(wrapper.text()).toContain('30')
+  })
+
+  test('keeps the label but hides the value behind the spinner while loading', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell({ loading: true })
+
+    // Label stays; the value gets the modifier that hides it and shows the spinner.
+    expect(wrapper.find('.grid-view-aggregation__generic-name').exists()).toBe(
+      true
+    )
+    expect(
+      wrapper.find('.grid-view-aggregation__generic-value--loading').exists()
+    ).toBe(true)
+  })
+
+  test('shows a spinner while loading the first value (none to aggregation)', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell({ rawValue: undefined, loading: true })
+
+    expect(
+      wrapper.find('.grid-view__group-by-banner-aggregation-loading').exists()
+    ).toBe(true)
+  })
+
+  test('starts the spinner as the aggregation changes, before the refresh', async () => {
+    await configureSum()
+    const wrapper = await mountCell()
+    const realDispatch = store.dispatch.bind(store)
+    vi.spyOn(store, 'dispatch').mockImplementation((action, payload) => {
+      if (action.endsWith('updateFieldOptionsOfField')) {
+        return Promise.resolve(undefined)
+      }
+      return realDispatch(action, payload)
+    })
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const context = wrapper.findComponent(Context)
+    await context
+      .find('.select__items > .select__item:nth-child(2)')
+      .find('.select__item-link')
+      .trigger('click')
+    await flushPromises()
+
+    // Loading is set as part of the change, so the old value never flashes.
+    expect(
+      store.getters['page/view/grid/getGroupByAggregationsLoading'](field.id)
+    ).toBe(true)
+  })
+
+  test('renders a summarize affordance when nothing is configured yet', async () => {
+    const wrapper = await mountCell({ rawValue: undefined })
+
+    // The empty state lets an editable user set an aggregation from the group.
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
+  })
+
+  test('renders nothing for a read-only user when nothing is configured', async () => {
+    const wrapper = await mountCell(
+      { rawValue: undefined },
+      { $hasPermission: () => false }
+    )
+
+    expect(wrapper.find('.grid-view-aggregation').exists()).toBe(false)
+  })
+
+  test('selecting an aggregation updates the shared field option and emits change', async () => {
+    await configureSum()
+    const wrapper = await mountCell()
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const context = wrapper.findComponent(Context)
+    // The second item is the first aggregation function after "None".
+    await context
+      .find('.select__items > .select__item:nth-child(2)')
+      .find('.select__item-link')
+      .trigger('click')
+    await flushPromises()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/updateFieldOptionsOfField',
+      expect.objectContaining({ field })
+    )
+    expect(wrapper.emitted('change')).toBeTruthy()
+  })
+})

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
@@ -1,5 +1,6 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import GridViewGroupByBanner from '@baserow/modules/database/components/view/grid/GridViewGroupByBanner'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
 
 describe('GridViewGroupByBanner component', () => {
   let testApp = null
@@ -17,6 +18,7 @@ describe('GridViewGroupByBanner component', () => {
       props: {
         groupByFields: [field],
         item: {
+          type: 'header',
           depth: 0,
           path,
           display,
@@ -26,7 +28,8 @@ describe('GridViewGroupByBanner component', () => {
           height: 48,
         },
         includeRowDetails: true,
-        primaryFieldWidth: 200,
+        visibleFields: [field],
+        fieldWidths: { [field.id]: 200 },
         width: 300,
         workspaceId: null,
       },
@@ -52,34 +55,6 @@ describe('GridViewGroupByBanner component', () => {
     })
 
     expect(wrapper.text()).toContain('Row A')
-  })
-
-  test('renders a cell separator at each provided position', async () => {
-    const field = { id: 1, type: 'text', name: 'Name' }
-    const wrapper = await testApp.mount(GridViewGroupByBanner, {
-      props: {
-        groupByFields: [field],
-        item: {
-          depth: 0,
-          path: { field_1: 'A' },
-          display: {},
-          rowCount: 1,
-          collapsed: false,
-          y: 0,
-          height: 48,
-        },
-        includeRowDetails: false,
-        primaryFieldWidth: 0,
-        separatorPositions: [200, 350],
-        width: 500,
-        workspaceId: null,
-      },
-    })
-
-    const separators = wrapper.findAll('.grid-view__group-by-banner-separator')
-    expect(separators).toHaveLength(2)
-    expect(separators.at(0).element.style.left).toBe('199px')
-    expect(separators.at(1).element.style.left).toBe('349px')
   })
 
   test('renders the single select value from the backend display value', async () => {
@@ -165,7 +140,8 @@ describe('GridViewGroupByBanner component', () => {
           height: 48,
         },
         includeRowDetails: true,
-        primaryFieldWidth: 200,
+        visibleFields: [{ id: 1, type: 'text', name: 'Field 1' }],
+        fieldWidths: { 1: 200 },
         rowDetailsWidth,
         width: 300,
         workspaceId: null,
@@ -198,10 +174,134 @@ describe('GridViewGroupByBanner component', () => {
   test('indents the field-name block in lockstep with its chevron', async () => {
     const subGroup = await mountAtDepth(2, 1)
     const labelPadding = parseFloat(
-      subGroup.find('.grid-view__group-by-banner-primary').element.style
+      subGroup.find('.grid-view__group-by-banner-field--primary').element.style
         .paddingLeft
     )
     expect(labelPadding).toBe(chevronPadding(subGroup))
     expect(labelPadding).toBeGreaterThan(12)
+  })
+})
+
+describe('GridViewGroupByBanner aggregations', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const colorField = { id: 1, name: 'Color', type: 'text' }
+  const amountField = { id: 2, name: 'Amount', type: 'number' }
+  const sizeField = { id: 3, name: 'Size', type: 'number' }
+
+  const header = (aggregations) => ({
+    type: 'header',
+    depth: 0,
+    path: { field_1: 'Green' },
+    rowCount: 2,
+    y: 0,
+    height: 48,
+    collapsed: false,
+    aggregations,
+  })
+
+  const mountBanner = (item, featureEnabled = true) =>
+    testApp.mount(GridViewGroupByBanner, {
+      propsData: {
+        item,
+        groupByFields: [colorField],
+        includeRowDetails: false,
+        width: 200,
+        workspaceId: 1,
+        visibleFields: [amountField],
+        fieldWidths: { [amountField.id]: 200 },
+        view: { id: 1 },
+        storePrefix: 'page/',
+      },
+      global: {
+        mocks: { $featureFlagIsEnabled: () => featureEnabled },
+        stubs: { GridViewGroupByAggregation: true },
+      },
+    })
+
+  test('renders an aggregation cell per visible field with the group value when enabled', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    const cell = wrapper.findComponent(GridViewGroupByAggregation)
+    expect(cell.exists()).toBe(true)
+    expect(cell.props('rawValue')).toBe(30)
+    expect(cell.props('rowCount')).toBe(2)
+    expect(cell.props('field')).toEqual(amountField)
+  })
+
+  test('renders no aggregation cell when the feature flag is disabled', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }), false)
+
+    expect(wrapper.findComponent(GridViewGroupByAggregation).exists()).toBe(
+      false
+    )
+  })
+
+  test('passes an undefined raw value when the group has no value for the field', async () => {
+    const wrapper = await mountBanner(header({}))
+
+    const cell = wrapper.findComponent(GridViewGroupByAggregation)
+    expect(cell.exists()).toBe(true)
+    expect(cell.props('rawValue')).toBeUndefined()
+  })
+
+  const mountTwoFieldBanner = (aggregations) =>
+    testApp.mount(GridViewGroupByBanner, {
+      propsData: {
+        item: header(aggregations),
+        groupByFields: [colorField],
+        includeRowDetails: false,
+        width: 400,
+        workspaceId: 1,
+        visibleFields: [amountField, sizeField],
+        fieldWidths: { [amountField.id]: 200, [sizeField.id]: 200 },
+        view: { id: 1 },
+        storePrefix: 'page/',
+      },
+      global: {
+        mocks: { $featureFlagIsEnabled: () => true },
+        stubs: { GridViewGroupByAggregation: true },
+      },
+    })
+
+  test('spins only the changed field when a single aggregation is refreshing', async () => {
+    testApp.store.commit('page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING', [
+      amountField.id,
+    ])
+    const wrapper = await mountTwoFieldBanner({ field_2: 30, field_3: 5 })
+
+    const cells = wrapper.findAllComponents(GridViewGroupByAggregation)
+    expect(cells[0].props('field')).toEqual(amountField)
+    expect(cells[0].props('loading')).toBe(true)
+    expect(cells[1].props('field')).toEqual(sizeField)
+    expect(cells[1].props('loading')).toBe(false)
+  })
+
+  test('spins every field when all aggregations are refreshing after a row edit', async () => {
+    testApp.store.commit(
+      'page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING',
+      true
+    )
+    const wrapper = await mountTwoFieldBanner({ field_2: 30, field_3: 5 })
+
+    const cells = wrapper.findAllComponents(GridViewGroupByAggregation)
+    expect(cells[0].props('loading')).toBe(true)
+    expect(cells[1].props('loading')).toBe(true)
+  })
+
+  test('forwards the changed field id with the aggregation-changed event', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    wrapper.findComponent(GridViewGroupByAggregation).vm.$emit('change')
+
+    expect(wrapper.emitted('aggregation-changed')[0]).toEqual([amountField.id])
   })
 })

--- a/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
+++ b/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
@@ -212,6 +212,53 @@ describe('gridGroupByRender', () => {
     expect(pagedAddRow.y).toBe(HEADER_HEIGHT + 2 * rowHeight)
   })
 
+  test('buildLayout carries per-group aggregations onto header items', () => {
+    const fields = [textField(1)]
+    const layout = buildLayout({
+      nodes: [
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 2,
+          aggregations: { field_2: 30 },
+        },
+        { path: { field_1: 'B' }, depth: 0, row_count: 1 },
+      ],
+      collapse: { mode: 'expand', paths: [] },
+      fields,
+    })
+
+    const headers = layout.items.filter((item) => item.type === 'header')
+    expect(headers[0].aggregations).toStrictEqual({ field_2: 30 })
+    expect(headers[1].aggregations).toBe(null)
+  })
+
+  test('renderViewport preserves header aggregations', () => {
+    const fields = [textField(1)]
+    const layout = buildLayout({
+      nodes: [
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 1,
+          aggregations: { field_2: 5 },
+        },
+      ],
+      collapse: { mode: 'expand', paths: [] },
+      fields,
+    })
+
+    const items = renderViewport({
+      layout,
+      sectionRows: new Map(),
+      viewport: { scrollTop: 0, clientHeight: 1000 },
+      fields,
+    })
+
+    const header = items.find((item) => item.type === 'header')
+    expect(header.aggregations).toStrictEqual({ field_2: 5 })
+  })
+
   test('buildLayout skips collapsed descendants', () => {
     const fields = [textField(1), textField(2)]
     const layout = buildLayout({


### PR DESCRIPTION
## Group aggregations in grouped grid views

When a grid view is grouped, each **group header** now shows the column's configured "Summarize" value computed over that group's rows — column-aligned, at every group-by depth, and visible whether the group is collapsed or expanded. The value uses the same formatting as the grid footer, with the group's own row count as the percentage/total context.

It reuses the column's existing footer aggregation config: one "Summarize" choice drives both the footer total and every group header. You can also set or change a column's aggregation directly from a group header via an inline picker; unconfigured columns show a hover **+ Summarize** affordance.

Gated behind the `group_by_aggregations` frontend feature flag — with the flag off, behaviour is unchanged. The backend computes the values inside the existing single-pass group-by-data query (no new endpoint, no N+1).

### Not in this PR (follow-ups)
- **Realtime updates** — live propagation of group aggregations to other viewers over websockets.
- **Performance & caching** — per-group aggregation caching and scale tuning for wide/deep trees.
- **Endpoint consolidation** — grouped views currently still issue two aggregate requests (`group-by-data` and the footer `/aggregations/`); these may be merged into a single request for grouped views.

### How to test
- Verify nothing changes in the UI with the FF disabled
- Verify it's possible to pick and see an aggregation at group-by level

NOTE: Some additional fixes have been implemented in #5602, so it's okay to perform full functional testing there and approve this PR, as long as it doesn't affect the application when the FF is disabled and the initial code and UI for the aggregations are sound.

---
Stacked on #5470 (collapsible group-by grid view).
