### PR TITLE
bug: SaaS exports with generative AI can be self-hoster imported

### DIFF
--- a/backend/src/baserow/contrib/integrations/ai/service_types.py
+++ b/backend/src/baserow/contrib/integrations/ai/service_types.py
@@ -106,6 +106,30 @@ class AIAgentServiceType(ServiceType):
         ai_prompt: str
         ai_choices: List[str]
 
+    def import_serialized(
+        self,
+        parent: Any,
+        serialized_values: Dict[str, Any],
+        id_mapping: Dict[str, Dict[int, int]],
+        *args,
+        **kwargs,
+    ) -> AIAgentService:
+        # The app might have been exported from another instance (e.g. Baserow
+        # SaaS), where a generative AI model type can exist that isn't registered
+        # here. In that case there's nothing valid to use, so clear the provider
+        # and model rather than importing a dangling reference.
+        ai_type = serialized_values.get("ai_generative_ai_type")
+        if ai_type:
+            try:
+                generative_ai_model_type_registry.get(ai_type)
+            except GenerativeAITypeDoesNotExist:
+                serialized_values["ai_generative_ai_type"] = None
+                serialized_values["ai_generative_ai_model"] = None
+
+        return super().import_serialized(
+            parent, serialized_values, id_mapping, *args, **kwargs
+        )
+
     def prepare_values(
         self,
         values: Dict[str, Any],

--- a/backend/tests/baserow/contrib/integrations/ai/test_ai_agent_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/ai/test_ai_agent_service_type.py
@@ -605,6 +605,57 @@ def test_ai_agent_service_export_import(data_fixture, settings):
 
 
 @pytest.mark.django_db
+def test_ai_agent_service_import_unregistered_ai_type(data_fixture, settings):
+    """
+    An app exported from another instance (e.g. Baserow SaaS) can reference a
+    generative AI model type that isn't registered here. On import the provider
+    and model should be cleared rather than importing a dangling reference.
+    """
+
+    settings.BASEROW_OPENAI_API_KEY = "sk-test"
+    settings.BASEROW_OPENAI_MODELS = ["gpt-4"]
+
+    user = data_fixture.create_user()
+    application = data_fixture.create_builder_application(user=user)
+
+    integration_type = AIIntegrationType()
+    integration = (
+        IntegrationService()
+        .create_integration(user, integration_type, application=application)
+        .specific
+    )
+
+    serialized = {
+        "id": 1,
+        "integration_id": integration.id,
+        "sample_data": None,
+        "type": "ai_agent",
+        "ai_generative_ai_type": "Baserow",
+        "ai_generative_ai_model": "baserow-model",
+        "ai_output_type": "text",
+        "ai_temperature": 0.5,
+        "ai_prompt": {
+            "formula": "'Tell me a joke'",
+            "mode": "simple",
+            "version": "0.1",
+        },
+        "ai_choices": [],
+    }
+
+    service_type = AIAgentServiceType()
+    new_service = service_type.import_serialized(
+        None, serialized, {integration.id: integration}, lambda x, d: x
+    )
+
+    assert new_service.ai_generative_ai_type is None
+    assert new_service.ai_generative_ai_model is None
+    # The rest of the configuration is preserved.
+    assert new_service.ai_output_type == "text"
+    assert new_service.ai_temperature == 0.5
+    assert new_service.ai_prompt["formula"] == "'Tell me a joke'"
+
+
+@pytest.mark.django_db
 def test_ai_agent_service_dispatch_in_published_workflow(data_fixture, settings):
     """
     Test that AI agent services work correctly when a workflow is published.

--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_workspace_exports_from_basero.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_workspace_exports_from_basero.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented workspace exports from Baserow cloud to be imported into self-hosted environments if a specific generative AI model was chosen.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-06-26"
+}


### PR DESCRIPTION
### What is in this PR

If you export a workspace in SaaS which contains a node/element configured with a generative AI model, and that model is "Baserow", then importing that export locally will fail. You'll first notice it in the frontend with:

> The type "Baserow" is not found under namespace "generativeAIModel" in the registry. Available types are: openai, anthropic, mistral, ollama, openrouter.   

But it'll also fail during dispatch, since the instance doesn't exist in the registry. We'll fix this by ensuring on import we nuke `ai_generative_ai_type` and `ai_generative_ai_model` if the type doesn't exist.

### How to test this PR

Ask me for a workspace export.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
