### PR TITLE
feat: Group-by aggregations

### DIFF
--- a/backend/src/baserow/contrib/database/api/views/grid/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/serializers.py
@@ -77,8 +77,10 @@ class GridViewGroupByDataGroupSerializer(serializers.Serializer):
     row_count = serializers.IntegerField(
         required=False,
         help_text=(
-            "Number of leaf rows descending from this group. Omitted in "
-            "`aggregations_only` mode, which returns no windowed layout."
+            "Number of leaf rows descending from this group. In "
+            "`aggregations_only` mode, this is still returned so derived "
+            "aggregation values can be formatted without using optimistic "
+            "client-side counts."
         ),
     )
     children_count = serializers.IntegerField(

--- a/backend/src/baserow/contrib/database/api/views/grid/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/serializers.py
@@ -90,6 +90,14 @@ class GridViewGroupByDataGroupSerializer(serializers.Serializer):
             "grouped row order."
         )
     )
+    aggregations = serializers.DictField(
+        required=False,
+        help_text=(
+            "Per-group aggregation values keyed by field db_column, mirroring the "
+            "grid view field-aggregations response. Only present for visible fields "
+            "that have a scalar aggregation configured."
+        ),
+    )
 
 
 class GridViewGroupByDataPageSerializer(serializers.Serializer):

--- a/backend/src/baserow/contrib/database/api/views/grid/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/serializers.py
@@ -75,20 +75,30 @@ class GridViewGroupByDataGroupSerializer(serializers.Serializer):
         help_text="Zero-based depth of this group in the group-by hierarchy."
     )
     row_count = serializers.IntegerField(
-        help_text="Number of leaf rows descending from this group."
+        required=False,
+        help_text=(
+            "Number of leaf rows descending from this group. Omitted in "
+            "`aggregations_only` mode, which returns no windowed layout."
+        ),
     )
     children_count = serializers.IntegerField(
         required=False,
         help_text="Number of immediate sub-groups. Omitted at leaf depth.",
     )
     sibling_index = serializers.IntegerField(
-        help_text="Zero-based index of this group among its siblings."
+        required=False,
+        help_text=(
+            "Zero-based index of this group among its siblings. Omitted in "
+            "`aggregations_only` mode, which returns no windowed layout."
+        ),
     )
     row_offset = serializers.IntegerField(
+        required=False,
         help_text=(
             "Absolute offset of this group's first descendant row in the full "
-            "grouped row order."
-        )
+            "grouped row order. Omitted in `aggregations_only` mode, which returns "
+            "no windowed layout."
+        ),
     )
     aggregations = serializers.DictField(
         required=False,
@@ -117,5 +127,13 @@ class GridViewGroupByDataSerializer(serializers.Serializer):
         help_text=(
             "Whether descendant loading stopped early because the response page or "
             "group cap was reached."
+        ),
+    )
+    aggregations = serializers.DictField(
+        required=False,
+        help_text=(
+            "Table-level field aggregation totals keyed by field db_column, "
+            "mirroring the grid view field-aggregations response. Only present when "
+            "`include_totals=true` was requested."
         ),
     )

--- a/backend/src/baserow/contrib/database/api/views/grid/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/utils.py
@@ -439,6 +439,8 @@ def get_group_by_data_pages(
     include_descendants: bool = False,
     descendant_limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
     row_budget: int = GROUP_BY_DATA_DESCENDANT_MAX_GROUPS,
+    aggregations: Optional[List[Tuple[Field, str]]] = None,
+    aggregations_only: bool = False,
 ) -> Tuple[List[Dict[str, Any]], bool]:
     """
     **Parent mode.** Returns bounded group-by pages for the requested parents.
@@ -494,6 +496,8 @@ def get_group_by_data_pages(
                 offset=request["offset"],
                 limit=request["limit"],
                 parent_row_offset=request.get("parent_row_offset"),
+                aggregations=aggregations,
+                aggregations_only=aggregations_only,
             )
             page["parent"] = parent
             group_count += len(page.get("groups", []))
@@ -564,6 +568,7 @@ def get_group_by_data_pages(
                 depth,
                 offset=offset,
                 per_parent_limit=limit,
+                aggregations=aggregations,
             )
 
             # Split the batched groups into one page per parent, making each group's
@@ -646,12 +651,40 @@ def get_group_by_data_pages(
     return pages, truncated
 
 
+def get_grid_view_group_by_aggregations(view, view_type) -> List[Tuple[Field, str]]:
+    """
+    Resolves the per-group aggregations to compute for a grid view's group-by data.
+
+    Reuses the column footer aggregation configuration
+    (``GridViewFieldOptions.aggregation_raw_type``) so a single "Summarize" choice
+    drives both the grid footer and the per-group header values.
+
+    :param view: The grid view to resolve the configured aggregations for.
+    :param view_type: The resolved view type of ``view``.
+    :return: The configured ``(field, aggregation_raw_type)`` pairs, or an empty
+        list when the view type does not support field aggregations.
+    """
+
+    if not getattr(view_type, "can_aggregate_field", False):
+        return []
+    visible_field_ids = {
+        option.field_id for option in view_type.get_visible_field_options_in_order(view)
+    }
+    return [
+        (field.specific, raw_type)
+        for field, raw_type in view_type.get_aggregations(view)
+        if field.id in visible_field_ids
+    ]
+
+
 def build_group_by_data_response(
     view_handler: ViewHandler,
     request: Request,
     queryset: QuerySet,
     view_group_bys: List[ViewGroupBy],
     group_by_fields: List[Field],
+    aggregations: Optional[List[Tuple[Field, str]]] = None,
+    totals: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     **Entry point.** Builds the serialized group-by data response for a grid view.
@@ -666,9 +699,13 @@ def build_group_by_data_response(
     :param queryset: The filtered/searched rows queryset to group.
     :param view_group_bys: The view group-by configuration rows.
     :param group_by_fields: The ordered group-by fields configured on the view.
+    :param totals: The optional table-level aggregations to bundle top-level (when
+        ``include_totals`` was requested), so the client can update the footer from
+        the same request.
     :return: The serialized group-by data response.
     """
 
+    aggregations_only = str_to_bool(str(request.GET.get("aggregations_only")))
     offset = parse_non_negative_int(request.GET.get("offset"), 0)
     limit = min(
         parse_non_negative_int(request.GET.get("limit"), GROUP_BY_DATA_DEFAULT_LIMIT),
@@ -692,6 +729,7 @@ def build_group_by_data_response(
             depth=depth,
             offset=offset,
             limit=limit,
+            aggregations=aggregations,
         )
         pages = split_group_by_depth_page_by_parent(depth_page, group_by_fields)
         truncated = False
@@ -728,6 +766,13 @@ def build_group_by_data_response(
                     if include_descendants
                     else GROUP_BY_DATA_DESCENDANT_MAX_GROUPS
                 ),
+                aggregations=aggregations,
+                aggregations_only=aggregations_only,
             )
 
-    return serialize_group_by_data_pages(pages, group_by_fields, truncated=truncated)
+    response = serialize_group_by_data_pages(
+        pages, group_by_fields, truncated=truncated
+    )
+    if totals is not None:
+        response["aggregations"] = totals
+    return response

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -953,6 +953,7 @@ class PublicGridViewGroupByDataView(APIView):
             GROUP_BY_DATA_DESCENDANT_LIMIT_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM,
             GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM,
+            GROUP_BY_DATA_INCLUDE_TOTALS_API_PARAM,
             OpenApiParameter("offset", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter("limit", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter(
@@ -1036,6 +1037,24 @@ class PublicGridViewGroupByDataView(APIView):
         group_by_fields = view_handler.get_group_by_fields(queryset, view_group_bys)
         aggregations = get_grid_view_group_by_aggregations(view, view_type)
 
+        totals = None
+        if aggregations and str_to_bool(str(request.GET.get("include_totals"))):
+            # Public visitors can't change the view, so skip the perm check and
+            # combine ad hoc + view filters, like the public aggregations endpoint.
+            totals = view_handler.get_view_field_aggregations(
+                request.user,
+                view,
+                search=query_params.get("search"),
+                search_mode=query_params.get("search_mode"),
+                adhoc_filters=AdHocFilters.from_request(request),
+                combine_filters=True,
+                skip_perm_check=True,
+            )
+            totals = {
+                field: json_safe_aggregation_value(value)
+                for field, value in totals.items()
+            }
+
         response_data = build_group_by_data_response(
             view_handler,
             request,
@@ -1043,6 +1062,7 @@ class PublicGridViewGroupByDataView(APIView):
             view_group_bys,
             group_by_fields,
             aggregations,
+            totals=totals,
         )
 
         return Response(response_data)

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -17,6 +17,7 @@ from baserow.api.errors import ERROR_USER_NOT_IN_GROUP
 from baserow.api.schemas import get_error_schema
 from baserow.api.search.serializers import SearchQueryParamSerializer
 from baserow.api.serializers import get_example_pagination_serializer_class
+from baserow.config.settings.utils import str_to_bool
 from baserow.contrib.database.api.constants import (
     ADHOC_FILTERS_API_PARAMS,
     ADHOC_FILTERS_API_PARAMS_NO_COMBINE,
@@ -108,6 +109,7 @@ from .serializers import GridViewFilterSerializer, GridViewGroupByDataSerializer
 from .utils import (
     build_group_by_data_response,
     empty_group_by_data_page,
+    get_grid_view_group_by_aggregations,
     parse_adhoc_view_group_bys,
 )
 
@@ -557,9 +559,32 @@ class GridViewGroupByDataView(APIView):
             )
 
         group_by_fields = view_handler.get_group_by_fields(queryset, view_group_bys)
+        aggregations = get_grid_view_group_by_aggregations(view, view_type)
+
+        totals = None
+        if aggregations and str_to_bool(str(request.GET.get("include_totals"))):
+            totals = view_handler.get_view_field_aggregations(
+                request.user,
+                view,
+                search=query_params.get("search"),
+                search_mode=query_params.get("search_mode"),
+                adhoc_filters=adhoc_filters,
+            )
+            totals = {
+                field: (
+                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
+                )
+                for field, value in totals.items()
+            }
 
         response_data = build_group_by_data_response(
-            view_handler, request, queryset, view_group_bys, group_by_fields
+            view_handler,
+            request,
+            queryset,
+            view_group_bys,
+            group_by_fields,
+            aggregations,
+            totals=totals,
         )
 
         return Response(response_data)
@@ -992,9 +1017,15 @@ class PublicGridViewGroupByDataView(APIView):
             )
 
         group_by_fields = view_handler.get_group_by_fields(queryset, view_group_bys)
+        aggregations = get_grid_view_group_by_aggregations(view, view_type)
 
         response_data = build_group_by_data_response(
-            view_handler, request, queryset, view_group_bys, group_by_fields
+            view_handler,
+            request,
+            queryset,
+            view_group_bys,
+            group_by_fields,
+            aggregations,
         )
 
         return Response(response_data)

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from drf_spectacular.openapi import OpenApiParameter, OpenApiTypes
 from drf_spectacular.utils import extend_schema
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -63,6 +61,7 @@ from baserow.contrib.database.api.views.utils import (
     get_public_view_authorization_token,
     get_public_view_filtered_queryset,
     get_view_filtered_queryset,
+    json_safe_aggregation_value,
     paginate_and_serialize_queryset,
     serialize_group_by_data_pages,
     serialize_group_by_fields_metadata,
@@ -571,9 +570,7 @@ class GridViewGroupByDataView(APIView):
                 adhoc_filters=adhoc_filters,
             )
             totals = {
-                field: (
-                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
-                )
+                field: json_safe_aggregation_value(value)
                 for field, value in totals.items()
             }
 
@@ -691,12 +688,9 @@ class GridViewFieldAggregationsView(APIView):
             adhoc_filters=adhoc_filters,
         )
 
-        # Decimal("NaN") can't be serialized, therefore we have to replace it
-        # with its literal string representation
-        nan_replacement_value = "NaN"
-        for field in result:
-            if isinstance(result[field], Decimal) and result[field].is_nan():
-                result[field] = nan_replacement_value
+        result = {
+            field: json_safe_aggregation_value(value) for field, value in result.items()
+        }
 
         return Response(result)
 
@@ -800,12 +794,9 @@ class PublicGridViewFieldAggregationsView(APIView):
             skip_perm_check=True,
         )
 
-        # Decimal("NaN") can't be serialized, therefore we have to replace it
-        # with its literal string representation
-        nan_replacement_value = "NaN"
-        for field in result:
-            if isinstance(result[field], Decimal) and result[field].is_nan():
-                result[field] = nan_replacement_value
+        result = {
+            field: json_safe_aggregation_value(value) for field, value in result.items()
+        }
 
         return Response(result)
 

--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -170,6 +170,29 @@ GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM = OpenApiParameter(
         "request limit and is capped by the total group budget."
     ),
 )
+GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM = OpenApiParameter(
+    name="aggregations_only",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.BOOL,
+    required=False,
+    description=(
+        "When true, returns a lean values-only page: each group carries only its "
+        "`path` (plus `children_count` and per-group `aggregations`) and omits the "
+        "windowed layout fields (`row_count`, `sibling_index`, `row_offset`). Used "
+        "to refresh aggregation values in place without rebuilding the layout."
+    ),
+)
+GROUP_BY_DATA_INCLUDE_TOTALS_API_PARAM = OpenApiParameter(
+    name="include_totals",
+    location=OpenApiParameter.QUERY,
+    type=OpenApiTypes.BOOL,
+    required=False,
+    description=(
+        "When true, the response also includes a top-level `aggregations` object "
+        "with the view's table-level field aggregation totals, mirroring the grid "
+        "view field-aggregations response."
+    ),
+)
 
 
 class GridViewView(APIView):
@@ -465,6 +488,8 @@ class GridViewGroupByDataView(APIView):
             GROUP_BY_DATA_INCLUDE_DESCENDANTS_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_LIMIT_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM,
+            GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM,
+            GROUP_BY_DATA_INCLUDE_TOTALS_API_PARAM,
             OpenApiParameter("offset", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter("limit", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter(
@@ -927,6 +952,7 @@ class PublicGridViewGroupByDataView(APIView):
             GROUP_BY_DATA_INCLUDE_DESCENDANTS_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_LIMIT_API_PARAM,
             GROUP_BY_DATA_DESCENDANT_ROW_BUDGET_API_PARAM,
+            GROUP_BY_DATA_AGGREGATIONS_ONLY_API_PARAM,
             OpenApiParameter("offset", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter("limit", OpenApiTypes.INT, OpenApiParameter.QUERY),
             OpenApiParameter(

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -422,6 +422,16 @@ def _resolve_group_by_display_lists(
     return display_lists_per_page
 
 
+def json_safe_aggregation_value(value: Any) -> Any:
+    # Decimal("NaN") isn't JSON-serializable (it renders as the invalid JSON `NaN`
+    # token), so it's substituted with its string form. Ideally each field type would
+    # own how its aggregated value is represented; this single helper keeps that
+    # concern in one place until that field-type-level refactor is worth doing.
+    if isinstance(value, Decimal) and value.is_nan():
+        return "NaN"
+    return value
+
+
 def serialize_group_by_data(
     page: Dict[str, Any],
     group_by_fields: List[Field],
@@ -508,12 +518,8 @@ def serialize_group_by_data(
         if display:
             out_group["display"] = display
         if "aggregations" in group:
-            # Mirror the grid footer: raw values, with Decimal("NaN") replaced by
-            # its literal string since it can't be JSON-serialized.
             out_group["aggregations"] = {
-                db_column: (
-                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
-                )
+                db_column: json_safe_aggregation_value(value)
                 for db_column, value in group["aggregations"].items()
             }
         groups.append(out_group)

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Type
 
 from django.conf import settings
@@ -491,16 +492,30 @@ def serialize_group_by_data(
         out_group = {
             "path": serialize_path(group["path"]),
             "depth": group["depth"],
-            "row_count": group["row_count"],
-            "sibling_index": group["sibling_index"],
-            "row_offset": group["row_offset"],
         }
+        # Layout keys are omitted in the lean "aggregations only" mode, so only
+        # copy the ones the handler provided.
+        for layout_key in (
+            "row_count",
+            "sibling_index",
+            "row_offset",
+            "children_count",
+        ):
+            if layout_key in group:
+                out_group[layout_key] = group[layout_key]
         # `containers[0]` is the parent, so the groups start at index 1.
         display = serialize_display(group_index + 1)
         if display:
             out_group["display"] = display
-        if "children_count" in group:
-            out_group["children_count"] = group["children_count"]
+        if "aggregations" in group:
+            # Mirror the grid footer: raw values, with Decimal("NaN") replaced by
+            # its literal string since it can't be JSON-serialized.
+            out_group["aggregations"] = {
+                db_column: (
+                    "NaN" if isinstance(value, Decimal) and value.is_nan() else value
+                )
+                for db_column, value in group["aggregations"].items()
+            }
         groups.append(out_group)
 
     return {

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -7333,7 +7333,7 @@ class MultipleCollaboratorsFieldType(
                 JSONBAgg(
                     get_collaborator_extractor(db_column, model_field),
                     filter=Q(**{f"{db_column}__isnull": False}),
-                    order=f"{db_column}__id",
+                    order_by=f"{db_column}__id",
                 ),
                 Value([], output_field=JSONField()),
             )
@@ -7342,7 +7342,7 @@ class MultipleCollaboratorsFieldType(
                 wrap_in_subquery(
                     JSONBAgg(
                         get_collaborator_extractor(db_column, model_field),
-                        order=f"{db_column}__id",
+                        order_by=f"{db_column}__id",
                     ),
                     db_column,
                     model_field.model,

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -11,7 +11,11 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
-from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.exceptions import (
+    EmptyResultSet,
+    FieldDoesNotExist,
+    ValidationError,
+)
 from django.db import OperationalError, connection, transaction
 from django.db import models as django_models
 from django.db.models import (
@@ -4464,7 +4468,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
 
     def _prepare_group_by_data_window_query(
         self, queryset: QuerySet
-    ) -> Tuple[str, Tuple[Any, ...], sql.Composable, Tuple[Any, ...]]:
+    ) -> Optional[Tuple[str, Tuple[Any, ...], sql.Composable, Tuple[Any, ...]]]:
         """
         Compiles the inner grouped query and its window ``ORDER BY`` clause.
 
@@ -4472,13 +4476,17 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         same grouped query but project different window columns.
 
         :param queryset: The grouped queryset to wrap with window metadata.
-        :return: The inner query SQL, its params, the window ``ORDER BY`` clause,
-            and the params that clause expects on each use.
+        :return: The inner query SQL, its params, the window ``ORDER BY`` clause and
+            its params, or ``None`` when the queryset compiles to an empty result (a
+            filter reducing to an always-false ``WHERE``) and callers return no rows.
         """
 
-        query_sql, query_params = queryset.query.get_compiler(
-            connection=connection
-        ).as_sql()
+        try:
+            query_sql, query_params = queryset.query.get_compiler(
+                connection=connection
+            ).as_sql()
+        except EmptyResultSet:
+            return None
         order_by_sql, order_by_params = self._get_group_by_data_window_order_sql(
             queryset
         )
@@ -4526,12 +4534,15 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :return: A list of grouped rows with window metadata.
         """
 
+        prepared = self._prepare_group_by_data_window_query(queryset)
+        if prepared is None:
+            return []
         (
             query_sql,
             query_params,
             window_order_sql,
             order_by_params,
-        ) = self._prepare_group_by_data_window_query(queryset)
+        ) = prepared
         row_count_identifier = sql.Identifier("grouped_data", "row_count")
         where_clause = (
             sql.SQL("WHERE {}").format(where_sql) if where_sql else sql.SQL("")
@@ -4607,12 +4618,15 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :return: A list of grouped rows with global depth and sibling metadata.
         """
 
+        prepared = self._prepare_group_by_data_window_query(queryset)
+        if prepared is None:
+            return []
         (
             query_sql,
             query_params,
             window_order_sql,
             order_by_params,
-        ) = self._prepare_group_by_data_window_query(queryset)
+        ) = prepared
         parent_fields = fields[:depth]
         if parent_fields:
             parent_identifiers = [
@@ -4700,12 +4714,15 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :return: Grouped rows with per-parent sibling metadata.
         """
 
+        prepared = self._prepare_group_by_data_window_query(queryset)
+        if prepared is None:
+            return []
         (
             query_sql,
             query_params,
             window_order_sql,
             order_by_params,
-        ) = self._prepare_group_by_data_window_query(queryset)
+        ) = prepared
         parent_fields = fields[:depth]
         if parent_fields:
             parent_identifiers = [

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -4052,9 +4052,9 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :param limit: The maximum number of siblings to return.
         :param parent_row_offset: The optional precomputed absolute row offset of
             the parent group.
-        :param aggregations_only: When ``True`` only ``path`` + ``aggregations`` are
-            returned, skipping the window-function layout (row count, sibling index,
-            row offset). Used by the lean values-only refresh.
+        :param aggregations_only: When ``True`` only ``path`` + ``row_count`` +
+            ``aggregations`` are returned, skipping the window-function layout
+            (sibling index and row offset). Used by the lean values-only refresh.
         :return: The paginated group-by data response.
         """
 
@@ -5028,10 +5028,11 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         aggregations: Optional[List[Tuple[Field, str]]],
     ) -> Dict[str, Any]:
         """
-        Builds a lean group page with only ``path`` (+ ``children_count``) and
-        ``aggregations``, skipping the window-function layout (row count, sibling
-        index, row offset). The grouped query runs without the windowed wrapper, so
-        the values-only refresh doesn't recompute layout it already has.
+        Builds a lean group page with only ``path``, ``row_count``
+        (+ ``children_count``) and ``aggregations``, skipping the window-function
+        layout (sibling index and row offset). The grouped query runs without the
+        windowed wrapper, so the values-only refresh doesn't recompute layout it
+        already has.
         ``children_count`` is kept so the descendant fan-out can still recurse.
         """
 
@@ -5041,7 +5042,11 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             path = {
                 field.db_column: entry[field.db_column] for field in fields[: depth + 1]
             }
-            group: Dict[str, Any] = {"path": path, "depth": depth}
+            group: Dict[str, Any] = {
+                "path": path,
+                "depth": depth,
+                "row_count": entry["row_count"],
+            }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
             if aggregations:

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -4034,6 +4034,8 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         offset: int = 0,
         limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
         parent_row_offset: Optional[int] = None,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
+        aggregations_only: bool = False,
     ) -> Dict[str, Any]:
         """
         Returns one paginated page of group-by sibling groups.
@@ -4050,6 +4052,9 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         :param limit: The maximum number of siblings to return.
         :param parent_row_offset: The optional precomputed absolute row offset of
             the parent group.
+        :param aggregations_only: When ``True`` only ``path`` + ``aggregations`` are
+            returned, skipping the window-function layout (row count, sibling index,
+            row offset). Used by the lean values-only refresh.
         :return: The paginated group-by data response.
         """
 
@@ -4074,15 +4079,25 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
                 "group_count": 0,
             }
 
+        grouped_queryset = self._get_group_by_data_level_queryset(
+            group_by_levels,
+            base_queryset,
+            parent_depth,
+            parent_path,
+            aggregations=aggregations,
+        )
+
+        if aggregations_only:
+            return self._build_aggregations_only_page(
+                grouped_queryset, fields, parent_depth, offset, limit, aggregations
+            )
+
         if parent_row_offset is None:
             parent_row_offset = self._get_group_by_path_row_offset(
                 group_by_levels,
                 base_queryset,
                 parent_path,
             )
-        grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, parent_depth, parent_path
-        )
         page = self._execute_group_by_data_windowed_query(
             grouped_queryset, parent_row_offset, offset=offset, limit=limit
         )
@@ -4106,6 +4121,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return {
@@ -4122,6 +4141,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         offset: int = 0,
         limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> Dict[str, Any]:
         """
         Returns one paginated page of group-by groups at a global depth.
@@ -4149,7 +4169,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
 
         grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, depth, {}
+            group_by_levels, base_queryset, depth, {}, aggregations=aggregations
         )
         page = self._execute_group_by_data_depth_windowed_query(
             grouped_queryset, fields, depth, offset=offset, limit=limit
@@ -4178,6 +4198,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return {
@@ -4747,6 +4771,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         offset: int = 0,
         per_parent_limit: int = GROUP_BY_DATA_DEFAULT_LIMIT,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Returns the children of several parents at one depth in a single query.
@@ -4772,7 +4797,12 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             return []
 
         grouped_queryset = self._get_group_by_data_level_queryset(
-            group_by_levels, base_queryset, depth, {}, parent_paths=parents
+            group_by_levels,
+            base_queryset,
+            depth,
+            {},
+            parent_paths=parents,
+            aggregations=aggregations,
         )
         rows = self._execute_group_by_data_level_windowed_query(
             grouped_queryset, fields, depth, offset, per_parent_limit
@@ -4797,6 +4827,10 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             }
             if "children_count" in entry:
                 group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
             groups.append(group)
 
         return groups
@@ -4808,6 +4842,7 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
         depth: int,
         parent_path: Dict[str, Any],
         parent_paths: Optional[List[Dict[str, Any]]] = None,
+        aggregations: Optional[List[Tuple[Field, str]]] = None,
     ) -> QuerySet:
         """
         Builds the grouped queryset for a single group-by level under one or more parents.
@@ -4889,6 +4924,12 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
                 output_field=IntegerField(),
             )
 
+        if aggregations:
+            queryset, aggregation_annotations = self._apply_group_by_data_aggregations(
+                queryset, aggregations, base_queryset.model
+            )
+            annotations.update(aggregation_annotations)
+
         queryset = (
             queryset.values(*field_names, *order_key_names)
             .annotate(**annotations)
@@ -4899,6 +4940,121 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             queryset = queryset.with_cte(cte_with)
 
         return queryset
+
+    @staticmethod
+    def _group_by_data_aggregation_alias(field: Field, raw_type: str) -> str:
+        """
+        Returns the query alias for a per-group aggregation annotation.
+
+        The alias is namespaced to avoid clashing with the group-by columns,
+        ``row_count``/``children_count``, and the order-key annotations.
+        """
+
+        return f"agg_{field.id}_{raw_type}"
+
+    def _apply_group_by_data_aggregations(
+        self,
+        queryset: QuerySet,
+        aggregations: List[Tuple[Field, str]],
+        model: Type[GeneratedTableModel],
+    ) -> Tuple[QuerySet, Dict[str, Any]]:
+        """
+        Builds the per-group aggregation annotations for the grouped level query.
+
+        Each configured aggregation that resolves to a single scalar aggregate is
+        computed once per group, in the same grouped query as ``row_count``.
+        ``AnnotatedAggregation`` aggregations (e.g. empty/not-empty count on
+        link-row fields) require a pre-annotation on the row queryset before the
+        grouping, mirroring the grid footer aggregation handling. Aggregations that
+        are not a single scalar value (``DistributionAggregation`` and the dict-based
+        ``range``) are skipped; they remain available as footer aggregations.
+
+        :param queryset: The row queryset that is about to be grouped.
+        :param aggregations: The configured ``(field, aggregation_raw_type)`` pairs.
+        :param model: The table model the aggregations are computed against.
+        :return: The (possibly pre-annotated) queryset and the mapping of
+            aggregation alias to its aggregate expression.
+        """
+
+        annotations: Dict[str, Any] = {}
+        for field, raw_type in aggregations:
+            aggregation_type = view_aggregation_type_registry.get(raw_type)
+            model_field = model._meta.get_field(field.db_column)
+            aggregation = aggregation_type.get_aggregation(
+                field.db_column, model_field, field
+            )
+            if isinstance(aggregation, (DistributionAggregation, dict)):
+                continue
+            if isinstance(aggregation, AnnotatedAggregation):
+                queryset = queryset.annotate(**aggregation.annotations)
+                aggregation = aggregation.aggregation
+            annotations[self._group_by_data_aggregation_alias(field, raw_type)] = (
+                aggregation
+            )
+        return queryset, annotations
+
+    def _extract_group_by_aggregations(
+        self,
+        entry: Dict[str, Any],
+        aggregations: List[Tuple[Field, str]],
+    ) -> Dict[str, Any]:
+        """
+        Extracts the per-group aggregation values from a grouped query row.
+
+        Only aggregations that were actually computed in the grouped query (and so
+        produced a column in ``entry``) are included, which transparently skips the
+        aggregations dropped by :meth:`_apply_group_by_data_aggregations`.
+
+        :param entry: A single grouped row returned by the windowed query.
+        :param aggregations: The configured ``(field, aggregation_raw_type)`` pairs.
+        :return: A mapping of field ``db_column`` to the group's aggregation value,
+            matching the shape of the grid view footer aggregations response.
+        """
+
+        result: Dict[str, Any] = {}
+        for field, raw_type in aggregations:
+            alias = self._group_by_data_aggregation_alias(field, raw_type)
+            if alias in entry:
+                result[field.db_column] = entry[alias]
+        return result
+
+    def _build_aggregations_only_page(
+        self,
+        grouped_queryset: QuerySet,
+        fields: List[Field],
+        depth: int,
+        offset: int,
+        limit: int,
+        aggregations: Optional[List[Tuple[Field, str]]],
+    ) -> Dict[str, Any]:
+        """
+        Builds a lean group page with only ``path`` (+ ``children_count``) and
+        ``aggregations``, skipping the window-function layout (row count, sibling
+        index, row offset). The grouped query runs without the windowed wrapper, so
+        the values-only refresh doesn't recompute layout it already has.
+        ``children_count`` is kept so the descendant fan-out can still recurse.
+        """
+
+        entries = list(grouped_queryset[offset : offset + limit])
+        groups = []
+        for entry in entries:
+            path = {
+                field.db_column: entry[field.db_column] for field in fields[: depth + 1]
+            }
+            group: Dict[str, Any] = {"path": path, "depth": depth}
+            if "children_count" in entry:
+                group["children_count"] = entry["children_count"]
+            if aggregations:
+                group["aggregations"] = self._extract_group_by_aggregations(
+                    entry, aggregations
+                )
+            groups.append(group)
+        return {
+            "groups": groups,
+            "offset": offset,
+            "limit": limit,
+            "group_count": len(groups),
+        }
 
     def _add_group_by_data_order_key_annotations(
         self, queryset: QuerySet, order_by_args: List[Any]

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -5053,6 +5053,8 @@ class ViewHandler(metaclass=baserow_trace_methods(tracer)):
             "groups": groups,
             "offset": offset,
             "limit": limit,
+            # Values-only refresh: the client keys values onto groups by path and
+            # never paginates off this response, so the slice size suffices.
             "group_count": len(groups),
         }
 

--- a/backend/src/baserow/contrib/database/views/view_aggregations.py
+++ b/backend/src/baserow/contrib/database/views/view_aggregations.py
@@ -17,6 +17,10 @@ from django.db.models import (
 )
 
 from baserow.contrib.database.db.aggregations import Percentile
+from baserow.contrib.database.fields.field_filters import (
+    AnnotatedQ,
+    OptionallyAnnotatedQ,
+)
 from baserow.contrib.database.fields.field_types import (
     AutonumberFieldType,
     BooleanFieldType,
@@ -69,6 +73,23 @@ def get_has_relations_annotation(field_name: str, model_field: Field) -> Dict:
     reversed_field = through_model._meta.get_fields()[1].name
     subquery = through_model.objects.filter(**{f"{reversed_field}_id": OuterRef("pk")})
     return {f"has_relations_{field_name}": Exists(subquery)}
+
+
+def count_distinct_filtered_by(filter_q: OptionallyAnnotatedQ):
+    """
+    Builds a distinct ``Count`` filtered by a ``Q``/``AnnotatedQ``.
+
+    Array/lookup fields express their empty filter as an ``AnnotatedQ``; a plain
+    ``Count(filter=AnnotatedQ)`` is invalid, so those are wrapped in an
+    ``AnnotatedAggregation`` (like the M2M branch) which callers already unwrap.
+    """
+
+    if isinstance(filter_q, AnnotatedQ):
+        return AnnotatedAggregation(
+            annotations=filter_q.annotation,
+            aggregation=Count("id", distinct=True, filter=filter_q.q),
+        )
+    return Count("id", distinct=True, filter=filter_q)
 
 
 class CountViewAggregationType(ViewAggregationType):
@@ -169,10 +190,8 @@ class EmptyCountViewAggregationType(ViewAggregationType):
                 ),
             )
         else:
-            return Count(
-                "id",
-                distinct=True,
-                filter=field_type.empty_query(field_name, model_field, field),
+            return count_distinct_filtered_by(
+                field_type.empty_query(field_name, model_field, field)
             )
 
 
@@ -198,10 +217,8 @@ class NotEmptyCountViewAggregationType(EmptyCountViewAggregationType):
                 ),
             )
         else:
-            return Count(
-                "id",
-                distinct=True,
-                filter=~field_type.empty_query(field_name, model_field, field),
+            return count_distinct_filtered_by(
+                ~field_type.empty_query(field_name, model_field, field)
             )
 
 

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
@@ -509,6 +509,82 @@ def test_group_by_data_include_totals_bundles_table_totals(api_client, data_fixt
 
 
 @pytest.mark.django_db
+def test_group_by_data_parents_chain_aggregations_only_with_totals(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    size = data_fixture.create_number_field(
+        table=table, name="Size", number_decimal_places=0
+    )
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    data_fixture.create_view_group_by(view=grid, field=size)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 10}
+    )
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 20}
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": 5,
+            f"field_{amount.id}": 100,
+        }
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    # Mirror the frontend targeted refetch for a row changed in Blue > 1: the root page
+    # (the Blue group) plus the Blue parent page (the size groups under Blue).
+    parents = [
+        {"parent": {}, "offset": 0, "limit": 40},
+        {"parent": {f"field_{color.id}": "Blue"}, "offset": 0, "limit": 40},
+    ]
+    response = api_client.get(
+        url,
+        {
+            "parents": json.dumps(parents),
+            "aggregations_only": "true",
+            "include_totals": "true",
+        },
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    body = response.json()
+    root_page = _get_page_by_parent(body, {})
+    blue_group = next(
+        group
+        for group in root_page["groups"]
+        if group["path"] == {f"field_{color.id}": "Blue"}
+    )
+    assert blue_group["aggregations"] == {f"field_{amount.id}": 30}
+    # Lean mode omits the window-function layout.
+    assert "row_offset" not in blue_group
+    blue_page = _get_page_by_parent(body, {f"field_{color.id}": "Blue"})
+    assert blue_page["groups"][0]["path"] == {
+        f"field_{color.id}": "Blue",
+        f"field_{size.id}": "1",
+    }
+    assert blue_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+    # Footer total bundled in the same request.
+    assert body["aggregations"] == {f"field_{amount.id}": 130}
+
+
+@pytest.mark.django_db
 def test_returns_empty_group_by_data_when_view_has_no_group_by(
     api_client, data_fixture
 ):

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
@@ -425,9 +425,9 @@ def test_group_by_data_aggregations_only_skips_layout(api_client, data_fixture):
     page = _get_only_page(response)
     group = page["groups"][0]
     assert group["path"] == {f"field_{color.id}": "Green"}
+    assert group["row_count"] == 2
     assert group["aggregations"] == {f"field_{amount.id}": 30}
     # The expensive window-function layout is skipped in lean mode.
-    assert "row_count" not in group
     assert "sibling_index" not in group
     assert "row_offset" not in group
 
@@ -571,6 +571,7 @@ def test_group_by_data_parents_chain_aggregations_only_with_totals(
         for group in root_page["groups"]
         if group["path"] == {f"field_{color.id}": "Blue"}
     )
+    assert blue_group["row_count"] == 2
     assert blue_group["aggregations"] == {f"field_{amount.id}": 30}
     # Lean mode omits the window-function layout.
     assert "row_offset" not in blue_group
@@ -579,6 +580,7 @@ def test_group_by_data_parents_chain_aggregations_only_with_totals(
         f"field_{color.id}": "Blue",
         f"field_{size.id}": "1",
     }
+    assert blue_page["groups"][0]["row_count"] == 2
     assert blue_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
     # Footer total bundled in the same request.
     assert body["aggregations"] == {f"field_{amount.id}": 130}

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
@@ -31,6 +31,484 @@ def _get_page_by_parent(response_json, parent):
 
 
 @pytest.mark.django_db
+def test_get_group_by_data_computes_per_group_aggregations(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    group_by = data_fixture.create_view_group_by(view=grid, field=color)
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Blue", f"field_{amount.id}": 5})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    result = ViewHandler().get_group_by_data(
+        model.objects.all(),
+        [group_by],
+        aggregations=[(amount, "sum")],
+    )
+
+    groups = {group["path"][f"field_{color.id}"]: group for group in result["groups"]}
+    assert groups["Blue"]["aggregations"] == {f"field_{amount.id}": 5}
+    assert groups["Green"]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_for_depth_computes_per_group_aggregations(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    size = data_fixture.create_text_field(table=table, name="Size")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    color_group = data_fixture.create_view_group_by(view=grid, field=color)
+    size_group = data_fixture.create_view_group_by(view=grid, field=size)
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "S",
+            f"field_{amount.id}": 10,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "S",
+            f"field_{amount.id}": 20,
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{size.id}": "L",
+            f"field_{amount.id}": 100,
+        }
+    )
+
+    handler = ViewHandler()
+    aggregations = [(amount, "sum")]
+
+    top = handler.get_group_by_data_for_depth(
+        model.objects.all(),
+        [color_group, size_group],
+        depth=0,
+        aggregations=aggregations,
+    )
+    top_groups = {g["path"][f"field_{color.id}"]: g for g in top["groups"]}
+    assert top_groups["Green"]["aggregations"] == {f"field_{amount.id}": 130}
+
+    leaf = handler.get_group_by_data_for_depth(
+        model.objects.all(),
+        [color_group, size_group],
+        depth=1,
+        aggregations=aggregations,
+    )
+    leaf_groups = {g["path"][f"field_{size.id}"]: g for g in leaf["groups"]}
+    assert leaf_groups["S"]["aggregations"] == {f"field_{amount.id}": 30}
+    assert leaf_groups["L"]["aggregations"] == {f"field_{amount.id}": 100}
+
+
+@pytest.mark.django_db
+def test_group_by_data_endpoint_returns_per_group_aggregations(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Blue", f"field_{amount.id}": 5})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    groups = {g["path"][f"field_{color.id}"]: g for g in page["groups"]}
+    assert groups["Blue"]["aggregations"] == {f"field_{amount.id}": 5}
+    assert groups["Green"]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_omits_distribution_aggregation(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    label = data_fixture.create_text_field(table=table, name="Label")
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"},
+            label.id: {
+                "aggregation_type": "distribution",
+                "aggregation_raw_type": "distribution",
+            },
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{amount.id}": 10,
+            f"field_{label.id}": "a",
+        }
+    )
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{amount.id}": 20,
+            f"field_{label.id}": "b",
+        }
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # The distribution aggregation isn't a scalar, so it's omitted per group while
+    # the scalar sum is still returned.
+    assert group["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_computes_link_row_not_empty_count_aggregation(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    related_table = data_fixture.create_database_table(
+        user=user, database=table.database
+    )
+    color = data_fixture.create_text_field(table=table, name="Color")
+    link = data_fixture.create_link_row_field(
+        table=table, link_row_table=related_table, name="Link"
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            link.id: {
+                "aggregation_type": "not_empty_count",
+                "aggregation_raw_type": "not_empty_count",
+            }
+        },
+    )
+
+    related_model = related_table.get_model()
+    related_row = related_model.objects.create()
+    model = table.get_model()
+    linked = model.objects.create(**{f"field_{color.id}": "Green"})
+    getattr(linked, f"field_{link.id}").set([related_row.id])
+    model.objects.create(**{f"field_{color.id}": "Green"})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # 1 of the 2 "Green" rows has a linked relation (link-row uses the
+    # AnnotatedAggregation path).
+    assert group["aggregations"] == {f"field_{link.id}": 1}
+
+
+@pytest.mark.django_db
+def test_group_by_data_excludes_aggregations_for_hidden_fields(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    visible_amount = data_fixture.create_number_field(
+        table=table, name="Visible", number_decimal_places=0
+    )
+    hidden_amount = data_fixture.create_number_field(
+        table=table, name="Hidden", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            visible_amount.id: {
+                "aggregation_type": "sum",
+                "aggregation_raw_type": "sum",
+            },
+            hidden_amount.id: {
+                "hidden": True,
+                "aggregation_type": "sum",
+                "aggregation_raw_type": "sum",
+            },
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{
+            f"field_{color.id}": "Green",
+            f"field_{visible_amount.id}": 10,
+            f"field_{hidden_amount.id}": 99,
+        }
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    # The hidden field's aggregation is not exposed, matching the grid footer.
+    assert page["groups"][0]["aggregations"] == {f"field_{visible_amount.id}": 10}
+
+
+@pytest.mark.django_db
+def test_public_group_by_data_returns_per_group_aggregations(api_client, data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table, public=True)
+    data_fixture.create_view_group_by(view=grid, field=color)
+
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse(
+        "api:database:views:grid:public-group-by-data", kwargs={"slug": grid.slug}
+    )
+    response = api_client.get(url)
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    assert page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_respect_view_filters(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+    data_fixture.create_view_filter(
+        view=grid, field=amount, type="higher_than", value="15"
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 30})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    # Only rows with amount > 15 are counted, matching row_count: 20 + 30 = 50.
+    assert group["row_count"] == 2
+    assert group["aggregations"] == {f"field_{amount.id}": 50}
+
+
+@pytest.mark.django_db
+def test_group_by_data_average_aggregation_returns_decimal(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=2
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {
+                "aggregation_type": "average",
+                "aggregation_raw_type": "average",
+            }
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 30})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    assert page["groups"][0]["aggregations"][f"field_{amount.id}"] == 20
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_only_skips_layout(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(
+        url, {"aggregations_only": "true"}, HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    group = page["groups"][0]
+    assert group["path"] == {f"field_{color.id}": "Green"}
+    assert group["aggregations"] == {f"field_{amount.id}": 30}
+    # The expensive window-function layout is skipped in lean mode.
+    assert "row_count" not in group
+    assert "sibling_index" not in group
+    assert "row_offset" not in group
+
+
+@pytest.mark.django_db
+def test_group_by_data_aggregations_only_with_descendants(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    size = data_fixture.create_number_field(
+        table=table, name="Size", number_decimal_places=0
+    )
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    data_fixture.create_view_group_by(view=grid, field=size)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 10}
+    )
+    model.objects.create(
+        **{f"field_{color.id}": "Blue", f"field_{size.id}": 1, f"field_{amount.id}": 20}
+    )
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    # Lean mode skips the layout, so descendant fan-out must not rely on row_offset.
+    response = api_client.get(
+        url,
+        {"aggregations_only": "true", "include_descendants": "true"},
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    root_page = _get_page_by_parent(response.json(), {})
+    assert root_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+    blue_page = _get_page_by_parent(response.json(), {f"field_{color.id}": "Blue"})
+    assert blue_page["groups"][0]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_group_by_data_include_totals_bundles_table_totals(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Red", f"field_{amount.id}": 20})
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(
+        url, {"include_totals": "true"}, HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+
+    assert response.status_code == HTTP_200_OK
+    # The cached table-level total is bundled top-level so the frontend updates the
+    # footer from the same request.
+    assert response.json()["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
 def test_returns_empty_group_by_data_when_view_has_no_group_by(
     api_client, data_fixture
 ):

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_data.py
@@ -13,6 +13,7 @@ from rest_framework.status import (
 )
 
 from baserow.contrib.database.api.views.grid import utils as grid_view_utils
+from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.views.handler import ViewHandler
 
 
@@ -55,6 +56,51 @@ def test_get_group_by_data_computes_per_group_aggregations(data_fixture):
     groups = {group["path"][f"field_{color.id}"]: group for group in result["groups"]}
     assert groups["Blue"]["aggregations"] == {f"field_{amount.id}": 5}
     assert groups["Green"]["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
+def test_get_group_by_data_empty_count_aggregation_on_array_field(data_fixture):
+    # empty_count on a lookup-of-file field filters by an AnnotatedQ; its annotation
+    # must be applied or Django can't resolve it as an aggregate filter (500).
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    related_table = data_fixture.create_database_table(user=user, database=database)
+    related_primary = data_fixture.create_text_field(
+        table=related_table, name="Name", primary=True
+    )
+    related_file = data_fixture.create_file_field(table=related_table, name="File")
+    related_row = related_table.get_model().objects.create(
+        **{f"field_{related_primary.id}": "r"}
+    )
+
+    table = data_fixture.create_database_table(user=user, database=database)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    link = data_fixture.create_link_row_field(
+        name="Link", table=table, link_row_table=related_table
+    )
+    lookup = data_fixture.create_lookup_field(
+        table=table,
+        through_field=link,
+        target_field=related_file,
+        through_field_name=link.name,
+        target_field_name=related_file.name,
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    group_by = data_fixture.create_view_group_by(view=grid, field=color)
+
+    RowHandler().create_row(
+        user, table, {f"field_{color.id}": "Blue", f"field_{link.id}": [related_row.id]}
+    )
+    RowHandler().create_row(user, table, {f"field_{color.id}": "Blue"})
+
+    result = ViewHandler().get_group_by_data(
+        table.get_model().objects.all(),
+        [group_by],
+        aggregations=[(lookup, "empty_count")],
+    )
+
+    groups = {group["path"][f"field_{color.id}"]: group for group in result["groups"]}
+    assert groups["Blue"]["aggregations"] == {f"field_{lookup.id}": 2}
 
 
 @pytest.mark.django_db
@@ -509,6 +555,40 @@ def test_group_by_data_include_totals_bundles_table_totals(api_client, data_fixt
 
 
 @pytest.mark.django_db
+def test_public_group_by_data_include_totals_bundles_table_totals(
+    api_client, data_fixture
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    color = data_fixture.create_text_field(table=table, name="Color")
+    amount = data_fixture.create_number_field(
+        table=table, name="Amount", number_decimal_places=0
+    )
+    grid = data_fixture.create_grid_view(table=table, public=True)
+    data_fixture.create_view_group_by(view=grid, field=color)
+    ViewHandler().update_field_options(
+        view=grid,
+        field_options={
+            amount.id: {"aggregation_type": "sum", "aggregation_raw_type": "sum"}
+        },
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{color.id}": "Green", f"field_{amount.id}": 10})
+    model.objects.create(**{f"field_{color.id}": "Red", f"field_{amount.id}": 20})
+
+    url = reverse(
+        "api:database:views:grid:public-group-by-data", kwargs={"slug": grid.slug}
+    )
+    response = api_client.get(url, {"include_totals": "true"})
+
+    assert response.status_code == HTTP_200_OK
+    # The publicly shared grouped view must bundle the footer totals the same way the
+    # private endpoint does, otherwise its footer aggregations stay empty.
+    assert response.json()["aggregations"] == {f"field_{amount.id}": 30}
+
+
+@pytest.mark.django_db
 def test_group_by_data_parents_chain_aggregations_only_with_totals(
     api_client, data_fixture
 ):
@@ -635,6 +715,42 @@ def test_returns_empty_root_page_with_descendants_when_no_rows_match(
     # The empty root page must still be reported, otherwise the client cannot
     # tell a loaded-empty tree apart from an unloaded one (and would render no
     # add-row line).
+    assert response.status_code == HTTP_200_OK
+    page = _get_only_page(response)
+    assert page["parent"] == {}
+    assert page["groups"] == []
+    assert page["group_count"] == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query_params",
+    [
+        {"include_descendants": "true"},
+        {"depth": "0"},
+        {},
+    ],
+)
+def test_returns_empty_page_when_filter_compiles_to_empty_result_set(
+    api_client, data_fixture, query_params
+):
+    # An unparseable `single_select_is_any_of` filter compiles to an always-false
+    # WHERE; the eager .as_sql() must catch EmptyResultSet instead of 500ing.
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    single_select = data_fixture.create_single_select_field(table=table, name="Status")
+    grid = data_fixture.create_grid_view(table=table)
+    data_fixture.create_view_group_by(view=grid, field=single_select)
+    data_fixture.create_view_filter(
+        view=grid, field=single_select, type="single_select_is_any_of", value="abc"
+    )
+
+    model = table.get_model()
+    model.objects.create()
+
+    url = reverse("api:database:views:grid:group-by-data", kwargs={"view_id": grid.id})
+    response = api_client.get(url, query_params, HTTP_AUTHORIZATION=f"JWT {token}")
+
     assert response.status_code == HTTP_200_OK
     page = _get_only_page(response)
     assert page["parent"] == {}

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_utils.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_group_by_utils.py
@@ -386,6 +386,7 @@ class _LevelGroupByDataHandler:
         depth,
         offset=0,
         per_parent_limit=40,
+        aggregations=None,
     ):
         self.level_calls.append((depth, [dict(parent) for parent in parents]))
         groups = []

--- a/backend/tests/baserow/contrib/database/view/test_view_aggregations.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_aggregations.py
@@ -7,6 +7,7 @@ from faker import Faker
 from baserow.contrib.database.fields.exceptions import FieldNotInTable
 from baserow.contrib.database.fields.field_types import SingleSelectFieldType
 from baserow.contrib.database.fields.handler import FieldHandler
+from baserow.contrib.database.rows.handler import RowHandler
 from baserow.contrib.database.views.exceptions import FieldAggregationNotSupported
 from baserow.contrib.database.views.handler import ViewHandler
 from baserow.contrib.database.views.registries import view_aggregation_type_registry
@@ -113,6 +114,49 @@ def test_view_empty_count_aggregation(data_fixture):
     )
 
     assert result[f"total"] == 4
+
+
+@pytest.mark.django_db
+def test_view_empty_count_aggregation_on_array_field(data_fixture):
+    # empty/not-empty count on a lookup-of-file field filters by an AnnotatedQ; its
+    # annotation must be applied or Django can't resolve it as a footer aggregate.
+    user = data_fixture.create_user()
+    database = data_fixture.create_database_application(user=user)
+    related_table = data_fixture.create_database_table(user=user, database=database)
+    related_primary = data_fixture.create_text_field(
+        table=related_table, name="Name", primary=True
+    )
+    related_file = data_fixture.create_file_field(table=related_table, name="File")
+    related_row = related_table.get_model().objects.create(
+        **{f"field_{related_primary.id}": "r"}
+    )
+
+    table = data_fixture.create_database_table(user=user, database=database)
+    link = data_fixture.create_link_row_field(
+        name="Link", table=table, link_row_table=related_table
+    )
+    lookup = data_fixture.create_lookup_field(
+        table=table,
+        through_field=link,
+        target_field=related_file,
+        through_field_name=link.name,
+        target_field_name=related_file.name,
+    )
+    grid_view = data_fixture.create_grid_view(table=table)
+
+    RowHandler().create_row(user, table, {f"field_{link.id}": [related_row.id]})
+    RowHandler().create_row(user, table, {})
+
+    view_handler = ViewHandler()
+    empty = view_handler.get_field_aggregations(
+        user, grid_view, [(lookup, "empty_count")]
+    )
+    not_empty = view_handler.get_field_aggregations(
+        user, grid_view, [(lookup, "not_empty_count")]
+    )
+
+    # Both aggregations must resolve (no AnnotatedQ crash) and partition the 2 rows.
+    assert empty[lookup.db_column] + not_empty[lookup.db_column] == 2
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/ws/test_ws_realtime_events.py
+++ b/backend/tests/baserow/ws/test_ws_realtime_events.py
@@ -1676,12 +1676,20 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     user, token = await sync_to_async(data_fixture.create_user_and_token)()
     await sync_to_async(data_fixture.create_workspace)(user=user)
 
-    # The client's last seen event was cleaned up by retention.
-    expired_id = await sync_to_async(_record_user_broadcast)(
-        user.id, {"type": "expired"}
+    # Last-seen event cleaned by retention while a newer one survives: replay can't
+    # anchor, so it must force a refresh. Capture the real id — the sequence isn't
+    # reset between transactional tests.
+    stale_last_seen_id = await sync_to_async(_record_event)(
+        "users",
+        {
+            "type": "broadcast_to_users",
+            "user_ids": [user.id],
+            "send_to_all_users": False,
+            "payload": {"type": "stale"},
+            "ignore_web_socket_id": "ws-other",
+        },
     )
-    await sync_to_async(RealtimeEvent.objects.filter(id=expired_id).delete)()
-
+    await sync_to_async(RealtimeEvent.objects.filter(id=stale_last_seen_id).delete)()
     await sync_to_async(_record_event)(
         "users",
         {
@@ -1702,12 +1710,10 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     assert connected is True
     await communicator.receive_json_from()
 
-    # The expired id no longer exists, so replay can't anchor against it —
-    # the client must refresh.
     await communicator.send_json_to(
         {
             "type": "replay_events",
-            "last_seen_id": expired_id,
+            "last_seen_id": stale_last_seen_id,
         }
     )
 

--- a/docs/technical/collapsible-grid-group-by.md
+++ b/docs/technical/collapsible-grid-group-by.md
@@ -2,15 +2,16 @@
 
 The collapsible grid group-by view renders and scrolls a large grouped table
 without loading every group or every row. The design goal is to keep the flat
-grid's `offset`/`limit` row-windowing behavior, but apply it to a tree of groups
-so both rows and groups can scale far beyond what a fully loaded grouped row list
-can handle in the browser.
+grid's row-windowing behavior — fetch rows by absolute offset and limit — but
+apply it to a tree of groups, so both rows and groups can scale far beyond what
+a fully loaded grouped row list can handle in the browser.
 
-This document intentionally describes the stable contract and the principles the
-implementation follows. It avoids repeating function names, component names, and
-store internals that are better read from the code directly. To find the current
-implementation, search the codebase for the stable API concepts documented here,
-especially `group-by-data`, `row_offset`, `sibling_index`, and `truncated`.
+This document describes the stable approach and the tradeoffs behind it. It
+deliberately avoids endpoint shapes, parameter lists, field-by-field schemas,
+function names, and store internals: those drift and are better read from the
+code. To find the current implementation, search the codebase for the durable
+concepts named here, especially `group-by-data`, `row_offset`, `sibling_index`,
+and `truncated`.
 
 ## Core Principles
 
@@ -18,12 +19,12 @@ especially `group-by-data`, `row_offset`, `sibling_index`, and `truncated`.
 
 The feature is built from two data layers:
 
-1. **Group metadata layer** - the `group-by-data` endpoint returns pages of
-   groups, not rows. Each group tells the client how many rows it contains, where
-   it sits among its siblings, whether it has child groups, and where its first
+1. **Group metadata layer** - a dedicated endpoint returns pages of groups, not
+   rows. Each group tells the client how many rows it contains, where it sits
+   among its siblings, whether it has child groups, and where its first
    descendant row appears in the full grouped row order.
-2. **Row layer** - the existing grid rows endpoint still returns rows by
-   `offset` and `limit`, just as it does for the flat grid.
+2. **Row layer** - the existing grid rows endpoint still returns rows by offset
+   and limit, just as it does for the flat grid.
 
 The bridge between the layers is `row_offset`: the absolute zero-based position
 of a group's first leaf row in the fully expanded grouped row order. Because the
@@ -35,10 +36,10 @@ groups are collapsed or expanded.
 
 The implementation has to keep three offset spaces separate:
 
-- **Sibling-space** - `group-by-data` pages groups under one parent. Its
-  `offset`, `limit`, and `sibling_index` are group indexes among siblings.
+- **Sibling-space** - the group metadata layer pages groups under one parent.
+  Its offsets and the `sibling_index` are group indexes among siblings.
 - **Absolute-row-space** - `row_offset` is an index into the fully expanded
-  grouped row stream. The client uses it as the `offset` for the rows endpoint.
+  grouped row stream. The client uses it as the offset for the rows endpoint.
 - **Visible layout-space** - the user scrolls through the currently visible
   layout, where collapsed subtrees contribute their group header but none of
   their rows.
@@ -83,7 +84,7 @@ buffering the grid normally needs. The client maps the viewport to:
 - missing group pages by parent or by depth;
 - missing absolute row ranges for visible leaf sections.
 
-Visible parent requests can be batched into a single `group-by-data` call, and
+Visible parent requests can be batched into a single group metadata call, and
 missing row ranges can be deduplicated before calling the rows endpoint. In-flight
 responses must be ignored if the grouping, collapse state, ordering, filtering,
 or optimistic row counts changed after the request was sent.
@@ -103,104 +104,37 @@ missing group pages, or an error response that requires rollback.
 
 Requests that include descendants must be bounded. A wide or deep group tree
 must not turn one request into unbounded server work or an unbounded response.
-When a descendant response is cut short by a cap, the API returns
-`truncated: true` so the client can lazy-load the rest.
+When a descendant response is cut short by a cap, the API signals truncation (the
+`truncated` flag) so the client can lazy-load the rest.
 
-## API Contract
+## Group Metadata API
 
-### Endpoints
+A read-only group metadata endpoint, with a matching public-view variant,
+returns group metadata in pages: which groups exist under a parent, how many
+rows and child groups each has, where each group sits among its siblings, and the
+absolute row offset of its first leaf row. It can also bundle the footer totals
+and preload a bounded slice of descendants in the same round trip. The exact
+parameters, response shape, and field names live in the serializer and view code.
 
-Two read-only endpoints expose group metadata:
+The endpoint supports three request shapes, chosen by what the viewport needs:
 
-```http
-GET /api/database/views/grid/{view_id}/group-by-data/
-GET /api/database/views/grid/{slug}/public/group-by-data/
-```
+- a single parent's page of child groups;
+- several parents' pages in one round trip, for when multiple visible parents at
+  the same depth all need their children at once;
+- a whole-depth page across all parents, which serves uniform expand/collapse
+  states without one request per visible parent.
 
-Both endpoints must apply the same filters, search, sorts, and group-by ordering
-as the rows endpoint. That invariant is what makes `row_offset` line up with the
-rows returned by the ordinary grid rows endpoint.
+Two invariants make this work:
 
-### Query Parameters
+- The group metadata query and the rows query must apply identical filters,
+  search, sorts, and group ordering. If they disagree, fetching rows by a group's
+  `row_offset` places them in the wrong group.
+- Descendant preloading must be bounded; when a cap cuts a response short, the
+  API signals truncation so the client can lazy-load the remainder.
 
-| Param                   | Meaning                                                                        |
-| ----------------------- | ------------------------------------------------------------------------------ |
-| `offset`                | Sibling offset within the parent. This is group-space, not row-space.          |
-| `limit`                 | Maximum sibling groups per page, capped by the server.                         |
-| `parents`               | Optional JSON array of `{parent\|path, offset, limit}` requests. Omitted means top-level groups. |
-| `depth`                 | Zero-based depth. When present, switches to depth mode (used for collapse-all). |
-| `include_descendants`   | Walk the returned parents' subtrees depth-first down to the leaves (see Dispatch Modes). |
-| `descendant_limit`      | Per-descendant-page group limit, capped by the server.                         |
-| `descendant_row_budget` | Total leaf-row budget for descendant loading, defaulting to `limit` and capped by the server. |
-| filters / search        | Same ad-hoc filter and search parameters accepted by the rows endpoint.        |
-
-### Response Shape
-
-```jsonc
-{
-  "pages": [
-    {
-      "parent": { "field_42": "active" },
-      "groups": [
-        {
-          "path": { "field_42": "active", "field_7": "EU" },
-          "depth": 1,
-          "row_count": 1280,
-          "children_count": 12,
-          "sibling_index": 3,
-          "row_offset": 51840
-        }
-      ],
-      "offset": 0,
-      "limit": 40,
-      "group_count": 312
-    }
-  ],
-  "truncated": true
-}
-```
-
-`parent` is `{}` for the top level. `truncated` is present only when descendant
-loading hit a cap.
-
-The group fields are part of the frontend contract:
-
-| Field            | Meaning                                                                 |
-| ---------------- | ----------------------------------------------------------------------- |
-| `path`           | Serialized group path from the root to this group.                      |
-| `depth`          | Zero-based depth of this group in the active group-by hierarchy.         |
-| `row_count`      | Number of leaf rows under this group after filters/search are applied.   |
-| `children_count` | Number of immediate child groups. Omitted or zero at leaf depth.         |
-| `sibling_index`  | This group's zero-based index among siblings under the same parent.      |
-| `row_offset`     | Absolute first-row offset in the fully expanded grouped row order.       |
-| `group_count`    | Total sibling group count for the page's parent.                         |
-
-Group values in `path` and `parent` are serialized using each field type's
-group-by serialization rules. The frontend must treat them as API values, not
-raw database values.
-
-### Dispatch Modes
-
-The same endpoint supports two loading modes:
-
-- **Parent-pages mode** - `parents` asks for one or more parent pages in one
-  request. This is useful when several visible parent groups at the same depth
-  need their child pages at the same time.
-- **Depth mode** - `depth=N` asks for one global page across all parents at that
-  depth. It is used for collapse-all, where only the single top-level depth is
-  visible.
-
-When `include_descendants` is used, the server walks each requested parent's
-subtree **depth-first** (pre-order) and returns the visited pages down to the
-leaves, so one request returns the whole visible subtree rather than a single
-level. The walk is bounded by an absolute row window: it anchors at the first
-returned group's row offset `start` and only expands groups whose `row_offset`
-falls within `[start, start + budget)`, where `budget` is the viewport size taken
-from `descendant_row_budget` (or from `limit` when omitted); groups starting past
-the window render a placeholder and lazy-load on scroll. The page and group caps
-still bound pathological trees (`truncated: true` when hit). The server threads
-known parent offsets into descendant calculations so child `row_offset` values
-stay aligned without extra work.
+Group values in group paths are serialized using each field type's group-by
+serialization rules. The frontend must treat them as API values, not raw database
+values.
 
 ## Server-Side Responsibilities
 
@@ -211,20 +145,20 @@ The server owns all facts that the client cannot derive reliably:
 - child group counts for non-leaf groups;
 - sibling indexes;
 - absolute row offsets in the fully expanded grouped order;
-- capped descendant expansion and `truncated` signaling.
+- capped descendant expansion and truncation signaling.
 
 These values must be computed from the same logical row set that the rows
-endpoint uses. If the rows endpoint and `group-by-data` disagree about filters,
-search, sort order, or group order, row fetching by `row_offset` will place rows
-in the wrong group.
+endpoint uses. If the rows endpoint and the group metadata layer disagree about
+filters, search, sort order, or group order, row fetching by `row_offset` will
+place rows in the wrong group.
 
 ## Client-Side Responsibilities
 
 The client realizes the feature by following the API contract above:
 
 - keep loaded group pages sparse and keyed by parent path/depth;
-- render unloaded group ranges as placeholders sized from `group_count` and
-  known geometry;
+- render unloaded group ranges as placeholders sized from known sibling counts
+  and geometry;
 - map visible leaf row sections to absolute row ranges using `row_offset`;
 - fetch missing rows from the ordinary rows endpoint; on the initial expand-all
   load the first rows page (offset 0) is fetched in parallel with the group
@@ -237,13 +171,13 @@ The client realizes the feature by following the API contract above:
 - update visible counts and row positions optimistically, then reconcile with the
   server response.
 
-The public grid must use the public `group-by-data` endpoint and the public rows
+The public grid must use the public group metadata endpoint and the public rows
 endpoint, but the offset and grouping semantics are the same.
 
 ## Scalability Characteristics And Limits
 
 The row layer scales like the flat grid: rows are fetched by true row
-`offset`/`limit`, and rendering stays virtualized to the viewport.
+offset/limit, and rendering stays virtualized to the viewport.
 
 The group layer scales by loading group metadata windows, not the complete group
 tree. Query count per viewport should be proportional to visible groups and
@@ -268,12 +202,27 @@ Known costs to keep in mind:
 
 ## Contract Invariants
 
-- `row_offset`, `sibling_index`, `row_count`, `children_count`, and
-  `group_count` are cross-layer contract fields. Renaming or changing their
-  semantics requires coordinated backend and frontend changes.
-- The rows endpoint and `group-by-data` must apply the same view constraints and
-  ordering.
+- A small set of cross-layer fields — the absolute row offset, sibling index, row
+  count, child count, and total sibling count — form a contract between backend
+  and frontend. Renaming them or changing their semantics requires coordinated
+  backend and frontend changes.
+- The rows endpoint and the group metadata layer must apply the same view
+  constraints and ordering.
 - Geometry used for placeholders, group headers, row sections, and add-row lines
   must match the rendered UI dimensions, otherwise scroll math drifts.
 - Optimistic updates must keep row counts and row placement indexes consistent
   until the next server reconciliation.
+
+## Group Aggregations
+
+When a column has a footer "Summarize" aggregation, each group header shows that
+aggregation computed over the group's rows, at every depth. The values travel
+inside the group metadata response, and the footer total can be bundled into the
+same request, so grouped mode never calls the standalone aggregations endpoint.
+
+Updates are consolidated and backend-authoritative. A single group metadata
+request refreshes both the loaded group window and the footer totals, and every
+edit path and the realtime echo funnel through the same group-aware refresh. Row
+edits refresh silently; a spinner is reserved for changing a column's aggregation
+function. Sorting needs no refresh because these aggregations are
+order-independent.

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -816,6 +816,32 @@ flat/group-by runs, the same way filters and sorts do.
 - New nested group banners and their counters are visible after the refresh.
 - Total row count is unchanged.
 
+### 7.3.1 Group headers show per-column aggregation summaries
+
+Behind the `group_by_aggregations` feature flag.
+
+- When a column has a "Summarize" aggregation configured, each group header shows
+  that column's aggregation computed over that group's rows, column-aligned under
+  the field, at every group-by depth.
+- The summary is visible whether the group is collapsed or expanded.
+- It respects the view's filters and search, the same scope as the group row count.
+- A column set to the `distribution` aggregation shows no value in group headers;
+  its bottom-footer value is unaffected.
+- The bottom footer still shows the overall total for the column.
+
+### 7.3.2 Hovering a group header to pick or change an aggregation
+
+Behind the `group_by_aggregations` feature flag.
+
+- Hovering a group-by header reveals, per column, the aggregation value or a
+  `+ Summarize` affordance on the hovered column (only the hovered column).
+- Clicking it opens the aggregation menu; choosing a function sets it for the
+  column, so the bottom footer and every group's header show that function
+  together (shared column setting).
+- After choosing — and after editing a row — the affected group values show a
+  brief loading spinner and update in place. The group layout (rows, counts,
+  offsets) is not rebuilt; only the aggregation values change.
+
 ## Search
 
 ### 8.1.1 Search in highlight mode

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -838,9 +838,24 @@ Behind the `group_by_aggregations` feature flag.
 - Clicking it opens the aggregation menu; choosing a function sets it for the
   column, so the bottom footer and every group's header show that function
   together (shared column setting).
-- After choosing — and after editing a row — the affected group values show a
-  brief loading spinner and update in place. The group layout (rows, counts,
-  offsets) is not rebuilt; only the aggregation values change.
+- After choosing a function, the affected values show a brief loading spinner and
+  update in place. The group layout (rows, counts, offsets) is not rebuilt; only
+  the aggregation values change.
+
+### 7.3.3 Live group aggregation updates on row changes
+
+Behind the `group_by_aggregations` feature flag.
+
+- Editing a cell updates that row's group value (and its ancestor groups + the
+  footer total) in place, with no spinner — like a spreadsheet SUM.
+- Moving a row between groups (editing a group-by field) updates both the source
+  and destination group values.
+- A second browser session viewing the same grouped view sees the values update
+  via realtime, the same way.
+- Changing the sort does not change aggregation values (they are order-independent),
+  so no aggregation request is made for a sort change.
+- In grouped mode the values come from a single `group-by-data` request (the
+  standalone `/aggregations/` footer endpoint is not called).
 
 ## Search
 

--- a/docs/testing/grid-view-test-plan.md
+++ b/docs/testing/grid-view-test-plan.md
@@ -818,8 +818,6 @@ flat/group-by runs, the same way filters and sorts do.
 
 ### 7.3.1 Group headers show per-column aggregation summaries
 
-Behind the `group_by_aggregations` feature flag.
-
 - When a column has a "Summarize" aggregation configured, each group header shows
   that column's aggregation computed over that group's rows, column-aligned under
   the field, at every group-by depth.
@@ -831,8 +829,6 @@ Behind the `group_by_aggregations` feature flag.
 
 ### 7.3.2 Hovering a group header to pick or change an aggregation
 
-Behind the `group_by_aggregations` feature flag.
-
 - Hovering a group-by header reveals, per column, the aggregation value or a
   `+ Summarize` affordance on the hovered column (only the hovered column).
 - Clicking it opens the aggregation menu; choosing a function sets it for the
@@ -843,8 +839,6 @@ Behind the `group_by_aggregations` feature flag.
   the aggregation values change.
 
 ### 7.3.3 Live group aggregation updates on row changes
-
-Behind the `group_by_aggregations` feature flag.
 
 - Editing a cell updates that row's group value (and its ancestor groups + the
   footer total) in place, with no spinner — like a spreadsheet SUM.

--- a/e2e-tests/fixtures/database/gridSetup.ts
+++ b/e2e-tests/fixtures/database/gridSetup.ts
@@ -9,6 +9,7 @@ import {
   createViewFilter,
   createViewSort,
   createViewGroupBy,
+  setViewFieldAggregation,
 } from "./view";
 import {
   Field,
@@ -66,6 +67,14 @@ export interface GroupBySpec {
   order?: "ASC" | "DESC";
 }
 
+export interface AggregationSpec {
+  fieldName: string;
+  /** Aggregation type, e.g. "sum", "min", "max", "average". */
+  type: string;
+  /** Raw aggregation type; defaults to `type` when the two are the same. */
+  rawType?: string;
+}
+
 // Setup options
 
 export interface GridSetupOptions {
@@ -87,6 +96,8 @@ export interface GridSetupOptions {
   sorts?: SortSpec[];
   /** View-level group-bys applied via the API before the test starts */
   groupBys?: GroupBySpec[];
+  /** Per-column "Summarize" aggregations applied via the API before the test starts */
+  aggregations?: AggregationSpec[];
 }
 
 // Setup result
@@ -286,6 +297,17 @@ export async function setupGrid(
       view,
       fieldByName[g.fieldName],
       g.order ?? "ASC",
+    );
+  }
+
+  // 9. Apply per-column "Summarize" aggregations
+  for (const a of options.aggregations ?? []) {
+    await setViewFieldAggregation(
+      user,
+      view,
+      fieldByName[a.fieldName],
+      a.type,
+      a.rawType ?? a.type,
     );
   }
 

--- a/e2e-tests/fixtures/database/view.ts
+++ b/e2e-tests/fixtures/database/view.ts
@@ -95,6 +95,27 @@ export async function updateFormFieldOptions(
   });
 }
 
+/**
+ * Configure a column's "Summarize" aggregation on a grid view, the same
+ * field-options PATCH the footer/group-header picker sends.
+ */
+export async function setViewFieldAggregation(
+  user: User,
+  view: View,
+  field: Field,
+  aggregationType: string,
+  aggregationRawType: string,
+): Promise<void> {
+  await getClient(user).patch(`database/views/${view.id}/field-options/`, {
+    field_options: {
+      [field.id]: {
+        aggregation_type: aggregationType,
+        aggregation_raw_type: aggregationRawType,
+      },
+    },
+  });
+}
+
 export async function getDefaultGridView(
   user: User,
   table: Table,

--- a/e2e-tests/pages/database/gridPage.ts
+++ b/e2e-tests/pages/database/gridPage.ts
@@ -966,6 +966,35 @@ export class GridPage {
   }
 
   /**
+   * Assert a group-by header aggregation value is shown `count` times. The text is
+   * the short name + value concatenated, e.g. "Sum30"; whitespace is ignored. Polls,
+   * so it also covers the live in-place update after an edit.
+   */
+  async expectGroupAggregation(text: string, count = 1): Promise<void> {
+    const want = text.replace(/\s+/g, "");
+    await expect(async () => {
+      const texts = await this.page
+        .locator(".grid-view__group-by-banner-aggregation")
+        .allTextContents();
+      const matches = texts.filter(
+        (t) => t.replace(/\s+/g, "") === want,
+      ).length;
+      expect(matches).toBe(count);
+    }).toPass({ timeout: 10_000 });
+  }
+
+  /** Assert the bottom footer shows an aggregation value, e.g. "Sum35". */
+  async expectFooterAggregation(text: string): Promise<void> {
+    const want = text.replace(/\s+/g, "");
+    await expect(async () => {
+      const texts = await this.page
+        .locator(".grid-view__foot .grid-view-aggregation")
+        .allTextContents();
+      expect(texts.map((t) => t.replace(/\s+/g, ""))).toContain(want);
+    }).toPass({ timeout: 10_000 });
+  }
+
+  /**
    * Assert that the row at `rowIndex` has the warning class
    * (shown when matchFilters, matchSortings, or matchSearch is false
    * while the row is still selected).

--- a/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
+++ b/e2e-tests/tests/database/grid/grid_row_crud.spec.ts
@@ -261,6 +261,65 @@ test.describe("7 Group-by", () => {
 });
 
 // -----------------------------------------------------------------------------
+// section 7.3  Group aggregations
+// -----------------------------------------------------------------------------
+
+test.describe("7.3 Group aggregations", () => {
+  test.describe.configure({ mode: "serial" });
+  let g: Setup;
+
+  test.beforeAll(async () => {
+    g = await setupGrid({
+      dbName: "GroupAggregationsDb",
+      fields: [
+        { name: "Team", type: "text" },
+        { name: "Score", type: "number" },
+      ],
+      groupBys: [{ fieldName: "Team", order: "ASC" }],
+      aggregations: [{ fieldName: "Score", type: "sum" }],
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await resetRows(g, [
+      { Name: "Alice", Team: "A", Score: 10 },
+      { Name: "Bob", Team: "A", Score: 20 },
+      { Name: "Carol", Team: "B", Score: 5 },
+    ]);
+    const grid = new GridPage(page, g.user);
+    await grid.goTo(g.database, g.table);
+    await grid.expectGroupByBanner("A", 2);
+    await grid.expectGroupByBanner("B", 1);
+  });
+
+  test("7.3.1 group headers show the per-column aggregation and the footer shows the total", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.expectGroupAggregation("Sum30"); // Team A: 10 + 20
+    await grid.expectGroupAggregation("Sum5"); // Team B: 5
+    await grid.expectFooterAggregation("Sum35"); // overall total
+  });
+
+  test("7.3.3 editing a cell updates that group's value and the footer in place", async ({
+    page,
+  }) => {
+    const grid = new GridPage(page, g.user);
+    await grid.expectGroupAggregation("Sum30");
+    await grid.expectFooterAggregation("Sum35");
+
+    // Alice (Team A) Score 10 -> 100.
+    await grid.startEditingField(0, 1);
+    await grid.type("100");
+    await grid.confirmWithEnter();
+
+    await grid.expectGroupAggregation("Sum120"); // Team A: 100 + 20
+    await grid.expectGroupAggregation("Sum5"); // Team B unchanged
+    await grid.expectFooterAggregation("Sum125"); // overall total: 120 + 5
+  });
+});
+
+// -----------------------------------------------------------------------------
 // section 1.5  Create with active group-by
 // -----------------------------------------------------------------------------
 

--- a/web-frontend/modules/core/assets/scss/components/views/grid.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/grid.scss
@@ -553,7 +553,6 @@
   box-sizing: border-box;
   min-width: 0;
   overflow: hidden;
-  container-type: inline-size;
 }
 
 .grid-view__group-by-banner-field--primary {
@@ -567,13 +566,22 @@
   flex: 1 1 auto;
   min-width: 0;
   height: 100%;
+  font-size: 12px;
   color: $palette-neutral-900;
 }
 
-@container (max-width: 130px) {
-  .grid-view__group-by-banner-aggregation .grid-view-aggregation__generic-name {
-    display: none;
-  }
+.grid-view__group-by-banner-aggregation .grid-view-aggregation__generic {
+  justify-content: flex-end;
+}
+
+.grid-view__group-by-banner-aggregation .grid-view-aggregation__generic-name {
+  flex: 0 0 auto;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.grid-view__group-by-banner-aggregation .grid-view-aggregation__generic-value {
+  flex: 0 0 auto;
 }
 
 .grid-view__group-by-banner-aggregation

--- a/web-frontend/modules/core/assets/scss/components/views/grid.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/grid.scss
@@ -546,13 +546,56 @@
   }
 }
 
-.grid-view__group-by-banner-primary {
+.grid-view__group-by-banner-field {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 12px;
   box-sizing: border-box;
+  min-width: 0;
+  overflow: hidden;
+  container-type: inline-size;
+}
+
+.grid-view__group-by-banner-field--primary {
+  gap: 12px;
   padding: 0 12px;
+}
+
+.grid-view-aggregation.grid-view__group-by-banner-aggregation {
+  @extend %ellipsis;
+
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+  color: $palette-neutral-900;
+}
+
+@container (max-width: 130px) {
+  .grid-view__group-by-banner-aggregation .grid-view-aggregation__generic-name {
+    display: none;
+  }
+}
+
+.grid-view__group-by-banner-aggregation
+  .grid-view-aggregation__generic-value--loading {
+  color: transparent;
+}
+
+.grid-view__group-by-banner-aggregation-loading {
+  @include loading(14px);
+
+  margin-left: auto;
+}
+
+.grid-view__group-by-banner-aggregation-empty {
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.grid-view__group-by-banner-field:hover
+  .grid-view__group-by-banner-aggregation-empty,
+.grid-view__group-by-banner-aggregation-empty.grid-view-aggregation__empty--active {
+  opacity: 1;
 }
 
 .grid-view__group-by-banner-stack {

--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -1595,6 +1595,13 @@ export default {
      * outside of GridViewRows.
      */
     cancelMultiSelectIfActive(event) {
+      // A click inside a context menu (e.g. the row "Select row" action) is a
+      // deliberate grid action, not a click outside, so it must not clear the
+      // selection that action just made.
+      if (event.target.closest?.('.context__menu')) {
+        return
+      }
+
       const selectionType =
         this.$store.getters[this.storePrefix + 'view/grid/getSelectionType']
 

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -119,7 +119,10 @@ export default {
       return this.fieldOptions[this.field.id]?.aggregation_raw_type
     },
     value() {
-      if (this.fieldAggregationData[this.field.id] !== undefined) {
+      if (
+        this.viewAggregationType &&
+        this.fieldAggregationData[this.field.id] !== undefined
+      ) {
         const { value } = this.fieldAggregationData[this.field.id]
 
         return this.viewAggregationType.getValue(value, {
@@ -127,9 +130,8 @@ export default {
           field: this.field,
           fieldType: this.fieldType,
         })
-      } else {
-        return undefined
       }
+      return undefined
     },
     loading() {
       return this.fieldAggregationData[this.field.id]?.loading
@@ -138,7 +140,12 @@ export default {
       if (!this.aggregationType) {
         return null
       }
-      return this.$registry.get('viewAggregation', this.aggregationType)
+      try {
+        return this.$registry.get('viewAggregation', this.aggregationType)
+      } catch (_) {
+        // A stale/unknown aggregation type must not crash the grid.
+        return null
+      }
     },
     viewAggregationTypes() {
       return this.$registry

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -101,6 +101,14 @@ export default {
     return { pendingValueUpdate: false }
   },
   computed: {
+    // Group headers reuse this column's config, but only when the flag is on.
+    groupAggregationsEnabled() {
+      return (
+        typeof this.$featureFlagIsEnabled === 'function' &&
+        this.$featureFlagIsEnabled('group_by_aggregations') &&
+        this.$store.getters[this.storePrefix + 'view/grid/isGroupByMode']
+      )
+    },
     userCanMakeAggregations() {
       return this.$hasPermission(
         'database.table.view.update_field_options',
@@ -207,6 +215,15 @@ export default {
         values.aggregation_raw_type = selectedAggregation.getRawType()
       }
 
+      const syncGroups = this.groupAggregationsEnabled
+      if (syncGroups && values.aggregation_type) {
+        // Spin before the optimistic change so the new label never shows the old value.
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+          { fieldId: this.field.id }
+        )
+      }
+
       // Prevent the watcher to trigger while value is not yet saved on server
       this.pendingValueUpdate = true
       try {
@@ -218,8 +235,27 @@ export default {
             readOnly: !this.userCanMakeAggregations,
           }
         )
+      } catch (error) {
+        if (syncGroups) {
+          this.$store.dispatch(
+            this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+            { loading: false }
+          )
+        }
+        throw error
       } finally {
         this.pendingValueUpdate = false
+      }
+
+      if (syncGroups) {
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/refreshGroupByAggregations',
+          {
+            view: this.view,
+            fields: this.$store.getters['field/getAll'],
+            fieldId: this.field.id,
+          }
+        )
       }
     },
   },

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -101,13 +101,9 @@ export default {
     return { pendingValueUpdate: false }
   },
   computed: {
-    // Group headers reuse this column's config, but only when the flag is on.
+    // Group headers reuse this column's aggregation config in grouped mode.
     groupAggregationsEnabled() {
-      return (
-        typeof this.$featureFlagIsEnabled === 'function' &&
-        this.$featureFlagIsEnabled('group_by_aggregations') &&
-        this.$store.getters[this.storePrefix + 'view/grid/isGroupByMode']
-      )
+      return this.$store.getters[this.storePrefix + 'view/grid/isGroupByMode']
     },
     userCanMakeAggregations() {
       return this.$hasPermission(

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -228,8 +228,14 @@ export default {
         values.aggregation_raw_type = selectedAggregation.getRawType()
       }
 
+      // Only the raw type is server-computed; a display-only change re-renders from
+      // the existing value, so skip the spinner and refetch (like the context menu).
+      const rawTypeChanged =
+        values.aggregation_raw_type !==
+        (this.fieldOptions[this.field.id]?.aggregation_raw_type || '')
+
       const syncGroups = this.groupAggregationsEnabled
-      if (syncGroups && values.aggregation_type) {
+      if (syncGroups && rawTypeChanged) {
         // Spin before the optimistic change so the new label never shows the old value.
         this.$store.dispatch(
           this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
@@ -250,7 +256,7 @@ export default {
           }
         )
       } catch (error) {
-        if (syncGroups) {
+        if (syncGroups && rawTypeChanged) {
           this.$store.dispatch(
             this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
             { loading: false }
@@ -261,7 +267,7 @@ export default {
         this.pendingValueUpdate = false
       }
 
-      if (syncGroups) {
+      if (syncGroups && rawTypeChanged) {
         this.$store.dispatch(
           this.storePrefix + 'view/grid/refreshGroupByAggregations',
           {

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldFooter.vue
@@ -173,15 +173,25 @@ export default {
       if (!value) {
         return
       }
-      // If an update is already pending, we don't need this one.
-      if (!this.pendingValueUpdate) {
-        this.$store.dispatch(
-          this.storePrefix + 'view/grid/fetchAllFieldAggregationData',
-          {
-            view: this.view,
-          }
-        )
+      if (this.pendingValueUpdate) {
+        return
       }
+      // Skip while a picker already owns the grouped refresh (its spinner is on);
+      // remote changes leave it off and still refresh here.
+      if (
+        this.groupAggregationsEnabled &&
+        this.$store.getters[
+          this.storePrefix + 'view/grid/getGroupByAggregationsLoading'
+        ](this.field.id)
+      ) {
+        return
+      }
+      this.$store.dispatch(
+        this.storePrefix + 'view/grid/fetchAllFieldAggregationData',
+        {
+          view: this.view,
+        }
+      )
     },
   },
   /*beforeCreate() {
@@ -233,6 +243,7 @@ export default {
             field: this.field,
             values,
             readOnly: !this.userCanMakeAggregations,
+            skipAggregationRefresh: syncGroups,
           }
         )
       } catch (error) {

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -1,0 +1,220 @@
+<template>
+  <div
+    v-if="hasValue || editable"
+    ref="anchor"
+    class="grid-view-aggregation grid-view__group-by-banner-aggregation"
+    :class="{ 'read-only': !editable }"
+    :title="titleText"
+    @click.prevent="
+      editable && $refs.context.toggle($refs.anchor, 'top', 'right', 10)
+    "
+  >
+    <component
+      :is="viewAggregationType.getComponent()"
+      v-if="hasValue"
+      :aggregation-type="viewAggregationType"
+      :value="value"
+      :field="field"
+      :loading="loading"
+    />
+    <div
+      v-else-if="loading && viewAggregationType"
+      class="grid-view__group-by-banner-aggregation-loading"
+    ></div>
+    <div
+      v-else
+      class="grid-view-aggregation__empty grid-view__group-by-banner-aggregation-empty"
+      :class="{
+        'grid-view-aggregation__empty--active':
+          $refs.context && $refs.context.isOpen(),
+      }"
+    >
+      <i class="grid-view-aggregation__empty-icon iconoir-plus"></i>
+      {{ $t('common.summarize') }}
+    </div>
+    <Context ref="context">
+      <ul class="select__items">
+        <li
+          class="select__item select__item--no-options"
+          :class="{ active: !viewAggregationType }"
+        >
+          <a class="select__item-link" @click="selectAggregation('none')">
+            <div class="select__item-name">
+              <span class="select__item-name-text">{{
+                $t('common.none')
+              }}</span>
+            </div>
+          </a>
+          <i
+            v-if="!viewAggregationType"
+            class="select__item-active-icon iconoir-check"
+          ></i>
+        </li>
+        <li
+          v-for="viewAggregation in viewAggregationTypes"
+          :key="viewAggregation.getType()"
+          class="select__item select__item--no-options"
+          :class="{ active: viewAggregation === viewAggregationType }"
+        >
+          <a
+            class="select__item-link"
+            @click="selectAggregation(viewAggregation.getType())"
+          >
+            <div class="select__item-name">
+              <span class="select__item-name-text">{{
+                viewAggregation.getName()
+              }}</span>
+            </div>
+          </a>
+          <i
+            v-if="viewAggregation === viewAggregationType"
+            class="select__item-active-icon iconoir-check"
+          ></i>
+        </li>
+      </ul>
+    </Context>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'GridViewGroupByAggregation',
+  props: {
+    view: {
+      type: Object,
+      required: true,
+    },
+    workspaceId: {
+      type: null,
+      default: null,
+    },
+    field: {
+      type: Object,
+      required: true,
+    },
+    storePrefix: {
+      type: String,
+      required: true,
+    },
+    // The raw, server-computed aggregation value for this group, or undefined when
+    // the field has no per-group value (e.g. an unsupported aggregation type).
+    rawValue: {
+      type: null,
+      default: undefined,
+    },
+    // This group's row count, used as the percentage/total context, mirroring the
+    // grid footer.
+    rowCount: {
+      type: Number,
+      default: 0,
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['change'],
+  computed: {
+    fieldOptions() {
+      return this.$store.getters[
+        this.storePrefix + 'view/grid/getAllFieldOptions'
+      ]
+    },
+    aggregationType() {
+      return this.fieldOptions[this.field.id]?.aggregation_type
+    },
+    viewAggregationType() {
+      if (!this.aggregationType) {
+        return null
+      }
+      try {
+        return this.$registry.get('viewAggregation', this.aggregationType)
+      } catch (_) {
+        return null
+      }
+    },
+    viewAggregationTypes() {
+      return this.$registry
+        .getOrderedList('viewAggregation')
+        .filter(
+          (agg) => agg.fieldIsCompatible(this.field) && agg.isAllowedInView()
+        )
+    },
+    fieldType() {
+      return this.$registry.get('field', this.field.type)
+    },
+    editable() {
+      return this.$hasPermission(
+        'database.table.view.update_field_options',
+        this.view,
+        this.workspaceId
+      )
+    },
+    hasValue() {
+      return this.viewAggregationType !== null && this.rawValue !== undefined
+    },
+    // Full "Label value" tooltip so no information is lost when a narrow column
+    // hides the label (see the container query in grid.scss).
+    titleText() {
+      if (!this.hasValue) {
+        return null
+      }
+      return `${this.viewAggregationType.getShortName()} ${this.value}`
+    },
+    value() {
+      if (!this.viewAggregationType) {
+        return undefined
+      }
+      return this.viewAggregationType.getValue(this.rawValue, {
+        rowCount: this.rowCount,
+        field: this.field,
+        fieldType: this.fieldType,
+      })
+    },
+  },
+  methods: {
+    async selectAggregation(newType) {
+      this.$refs.context.hide()
+
+      const values = {
+        aggregation_type: '',
+        aggregation_raw_type: '',
+      }
+
+      if (newType !== 'none') {
+        const selectedAggregation = this.$registry.get(
+          'viewAggregation',
+          newType
+        )
+        values.aggregation_type = newType
+        values.aggregation_raw_type = selectedAggregation.getRawType()
+      }
+
+      // Spin before the optimistic change so the new label never shows the old value.
+      this.$store.dispatch(
+        this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+        { fieldId: this.field.id }
+      )
+      try {
+        await this.$store.dispatch(
+          this.storePrefix + 'view/grid/updateFieldOptionsOfField',
+          {
+            field: this.field,
+            values,
+            readOnly: !this.editable,
+          }
+        )
+      } catch (error) {
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+          { loading: false }
+        )
+        throw error
+      }
+      // The aggregation values are computed server-side, so the visible group tree
+      // must be refetched to reflect the new function.
+      this.$emit('change')
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -205,11 +205,19 @@ export default {
         values.aggregation_raw_type = selectedAggregation.getRawType()
       }
 
+      // Only the raw type is server-computed; a display-only change re-renders from
+      // the existing value, so skip the spinner and refetch (like the footer).
+      const rawTypeChanged =
+        values.aggregation_raw_type !==
+        (this.fieldOptions[this.field.id]?.aggregation_raw_type || '')
+
       // Spin before the optimistic change so the new label never shows the old value.
-      this.$store.dispatch(
-        this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
-        { fieldId: this.field.id }
-      )
+      if (rawTypeChanged) {
+        this.$store.dispatch(
+          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+          { fieldId: this.field.id }
+        )
+      }
       try {
         await this.$store.dispatch(
           this.storePrefix + 'view/grid/updateFieldOptionsOfField',
@@ -221,15 +229,18 @@ export default {
           }
         )
       } catch (error) {
-        this.$store.dispatch(
-          this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
-          { loading: false }
-        )
+        if (rawTypeChanged) {
+          this.$store.dispatch(
+            this.storePrefix + 'view/grid/setGroupByAggregationsLoading',
+            { loading: false }
+          )
+        }
         throw error
       }
-      // The aggregation values are computed server-side, so the visible group tree
-      // must be refetched to reflect the new function.
-      this.$emit('change')
+      // Only a raw-type change needs the server-computed values refetched.
+      if (rawTypeChanged) {
+        this.$emit('change')
+      }
     },
   },
 }

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -155,8 +155,7 @@ export default {
     hasValue() {
       return this.viewAggregationType !== null && this.rawValue !== undefined
     },
-    // Full "Label value" tooltip so no information is lost when a narrow column
-    // hides the label (see the container query in grid.scss).
+    // Full label + value tooltip; the label is clipped when the column is narrow.
     titleText() {
       if (!this.hasValue) {
         return null
@@ -204,6 +203,7 @@ export default {
             field: this.field,
             values,
             readOnly: !this.editable,
+            skipAggregationRefresh: true,
           }
         )
       } catch (error) {

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -110,6 +110,10 @@ export default {
       type: Number,
       default: 0,
     },
+    aggregationRowCount: {
+      type: Number,
+      default: null,
+    },
     loading: {
       type: Boolean,
       default: false,
@@ -177,7 +181,7 @@ export default {
         return undefined
       }
       return this.viewAggregationType.getValue(this.rawValue, {
-        rowCount: this.rowCount,
+        rowCount: this.aggregationRowCount ?? this.rowCount,
         field: this.field,
         fieldType: this.fieldType,
       })

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -21,8 +21,10 @@
       v-else-if="loading && viewAggregationType"
       class="grid-view__group-by-banner-aggregation-loading"
     ></div>
+    <!-- Only unconfigured columns offer the picker; a configured column with no
+    per-group value (e.g. distribution) shows nothing. -->
     <div
-      v-else
+      v-else-if="!viewAggregationType"
       class="grid-view-aggregation__empty grid-view__group-by-banner-aggregation-empty"
       :class="{
         'grid-view-aggregation__empty--active':

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByAggregation.vue
@@ -130,7 +130,14 @@ export default {
         return null
       }
       try {
-        return this.$registry.get('viewAggregation', this.aggregationType)
+        const aggregation = this.$registry.get(
+          'viewAggregation',
+          this.aggregationType
+        )
+        // A table-level-only aggregation (e.g. distribution) shares this field's
+        // footer config but has no per-group value, so resolve it to null here to
+        // keep the group cell empty instead of rendering against a stale value.
+        return aggregation.isAllowedInGroupBy() ? aggregation : null
       } catch (_) {
         return null
       }
@@ -139,7 +146,10 @@ export default {
       return this.$registry
         .getOrderedList('viewAggregation')
         .filter(
-          (agg) => agg.fieldIsCompatible(this.field) && agg.isAllowedInView()
+          (agg) =>
+            agg.fieldIsCompatible(this.field) &&
+            agg.isAllowedInView() &&
+            agg.isAllowedInGroupBy()
         )
     },
     fieldType() {

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -86,7 +86,7 @@
         :store-prefix="storePrefix"
         :raw-value="aggregationValueFor(field)"
         :row-count="item.rowCount"
-        :loading="aggregationLoadingFor(field.id)"
+        :loading="aggregationLoadingFor(field.id) || groupAggregationsLoading"
         @change="$emit('aggregation-changed', field.id)"
       />
     </div>
@@ -100,7 +100,10 @@
 </template>
 
 <script>
-import { groupBannerIndentPx } from '@baserow/modules/database/utils/gridGroupByRender'
+import {
+  groupBannerIndentPx,
+  pathKey,
+} from '@baserow/modules/database/utils/gridGroupByRender'
 import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
 
 export default {
@@ -160,6 +163,18 @@ export default {
       return this.$store.getters[
         this.storePrefix + 'view/grid/getGroupByAggregationsLoading'
       ]
+    },
+    // Spin while this group's post-insertion aggregation refresh is in flight, to
+    // avoid showing a value derived from the already-bumped row count.
+    groupAggregationsLoading() {
+      if (this.storePrefix === '') {
+        return false
+      }
+      const loadingPaths =
+        this.$store.getters[
+          this.storePrefix + 'view/grid/getGroupByAggregationsLoadingPaths'
+        ]
+      return loadingPaths.includes(pathKey(this.item.path, this.groupByFields))
     },
     groupByField() {
       return this.groupByFields[this.item.depth]

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -151,12 +151,7 @@ export default {
   emits: ['toggle', 'aggregation-changed'],
   computed: {
     aggregationsEnabled() {
-      return (
-        this.storePrefix !== '' &&
-        this.view !== null &&
-        typeof this.$featureFlagIsEnabled === 'function' &&
-        this.$featureFlagIsEnabled('group_by_aggregations')
-      )
+      return this.storePrefix !== '' && this.view !== null
     },
     aggregationLoadingFor() {
       if (this.storePrefix === '') {

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -279,9 +279,10 @@ export default {
       const positions = []
       let x = 0
 
+      // Skip the id/primary boundary: data rows leave the row-details column
+      // borderless, so the banner must not draw a divider there either.
       if (this.includeRowDetails) {
         x += this.rowDetailsWidth
-        positions.push(x)
       }
 
       this.visibleFields.slice(0, -1).forEach((field) => {

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -12,42 +12,45 @@
     }"
     :data-collapsed="item.collapsed ? 'true' : 'false'"
   >
-    <template v-if="includeRowDetails">
-      <div
-        class="grid-view__group-by-banner-chevron-lane"
-        :style="{
-          width: rowDetailsWidth + 'px',
-          paddingLeft: indentPx + 'px',
-        }"
+    <div
+      v-if="includeRowDetails"
+      class="grid-view__group-by-banner-chevron-lane"
+      :style="{
+        width: rowDetailsWidth + 'px',
+        paddingLeft: indentPx + 'px',
+      }"
+    >
+      <button
+        type="button"
+        class="grid-view__group-by-banner-toggle"
+        :aria-expanded="!item.collapsed"
+        :aria-label="
+          item.collapsed
+            ? $t('gridViewGroupByBanner.expandGroup')
+            : $t('gridViewGroupByBanner.collapseGroup')
+        "
+        @click="$emit('toggle', item.path)"
       >
-        <button
-          type="button"
-          class="grid-view__group-by-banner-toggle"
-          :aria-expanded="!item.collapsed"
-          :aria-label="
+        <i
+          :class="
             item.collapsed
-              ? $t('gridViewGroupByBanner.expandGroup')
-              : $t('gridViewGroupByBanner.collapseGroup')
+              ? 'iconoir-nav-arrow-right'
+              : 'iconoir-nav-arrow-down'
           "
-          @click="$emit('toggle', item.path)"
-        >
-          <i
-            :class="
-              item.collapsed
-                ? 'iconoir-nav-arrow-right'
-                : 'iconoir-nav-arrow-down'
-            "
-          />
-        </button>
-      </div>
-      <div
-        v-if="primaryFieldWidth > 0"
-        class="grid-view__group-by-banner-primary"
-        :style="{
-          width: primaryFieldWidth + 'px',
-          paddingLeft: indentPx + 'px',
-        }"
-      >
+        />
+      </button>
+    </div>
+    <div
+      v-for="(field, index) in visibleFields"
+      :key="field.id"
+      class="grid-view__group-by-banner-field"
+      :class="{
+        'grid-view__group-by-banner-field--primary':
+          includeRowDetails && index === 0,
+      }"
+      :style="bannerFieldStyle(field, index)"
+    >
+      <template v-if="includeRowDetails && index === 0">
         <div class="grid-view__group-by-banner-stack">
           <div class="grid-view__group-by-banner-label">
             {{ fieldNameLabel }}
@@ -74,8 +77,19 @@
         <div class="grid-view__group-by-banner-count">
           {{ item.rowCount }}
         </div>
-      </div>
-    </template>
+      </template>
+      <GridViewGroupByAggregation
+        v-else-if="aggregationsEnabled"
+        :view="view"
+        :workspace-id="workspaceId"
+        :field="field"
+        :store-prefix="storePrefix"
+        :raw-value="aggregationValueFor(field)"
+        :row-count="item.rowCount"
+        :loading="aggregationLoadingFor(field.id)"
+        @change="$emit('aggregation-changed', field.id)"
+      />
+    </div>
     <div
       v-for="(position, index) in separatorPositions"
       :key="'separator-' + index"
@@ -87,9 +101,11 @@
 
 <script>
 import { groupBannerIndentPx } from '@baserow/modules/database/utils/gridGroupByRender'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
 
 export default {
   name: 'GridViewGroupByBanner',
+  components: { GridViewGroupByAggregation },
   props: {
     item: {
       type: Object,
@@ -103,10 +119,6 @@ export default {
       type: Boolean,
       default: false,
     },
-    primaryFieldWidth: {
-      type: Number,
-      default: 0,
-    },
     rowDetailsWidth: {
       type: Number,
       default: 72,
@@ -115,17 +127,45 @@ export default {
       type: null,
       default: null,
     },
-    separatorPositions: {
-      type: Array,
-      default: () => [],
-    },
     width: {
       type: Number,
       required: true,
     },
+    visibleFields: {
+      type: Array,
+      default: () => [],
+    },
+    fieldWidths: {
+      type: Object,
+      default: () => ({}),
+    },
+    view: {
+      type: Object,
+      default: null,
+    },
+    storePrefix: {
+      type: String,
+      default: '',
+    },
   },
-  emits: ['toggle'],
+  emits: ['toggle', 'aggregation-changed'],
   computed: {
+    aggregationsEnabled() {
+      return (
+        this.storePrefix !== '' &&
+        this.view !== null &&
+        typeof this.$featureFlagIsEnabled === 'function' &&
+        this.$featureFlagIsEnabled('group_by_aggregations')
+      )
+    },
+    aggregationLoadingFor() {
+      if (this.storePrefix === '') {
+        return () => false
+      }
+      return this.$store.getters[
+        this.storePrefix + 'view/grid/getGroupByAggregationsLoading'
+      ]
+    },
     groupByField() {
       return this.groupByFields[this.item.depth]
     },
@@ -223,6 +263,37 @@ export default {
         return JSON.stringify(value)
       }
       return String(value)
+    },
+    separatorPositions() {
+      const positions = []
+      let x = 0
+
+      if (this.includeRowDetails) {
+        x += this.rowDetailsWidth
+        positions.push(x)
+      }
+
+      this.visibleFields.slice(0, -1).forEach((field) => {
+        x += this.fieldWidths[field.id] || 0
+        positions.push(x)
+      })
+      return positions
+    },
+  },
+  methods: {
+    aggregationValueFor(field) {
+      if (!this.item.aggregations) {
+        return undefined
+      }
+      return this.item.aggregations[`field_${field.id}`]
+    },
+    bannerFieldStyle(field, index) {
+      const style = { width: (this.fieldWidths[field.id] || 0) + 'px' }
+      if (this.includeRowDetails && index === 0) {
+        // Indent the field-name block in lockstep with the chevron.
+        style.paddingLeft = this.indentPx + 'px'
+      }
+      return style
     },
   },
 }

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByBanner.vue
@@ -86,6 +86,7 @@
         :store-prefix="storePrefix"
         :raw-value="aggregationValueFor(field)"
         :row-count="item.rowCount"
+        :aggregation-row-count="item.aggregationRowCount"
         :loading="aggregationLoadingFor(field.id) || groupAggregationsLoading"
         @change="$emit('aggregation-changed', field.id)"
       />

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
@@ -6,12 +6,15 @@
         :item="item"
         :group-by-fields="groupByFields"
         :include-row-details="includeRowDetails"
-        :primary-field-width="primaryFieldWidth"
         :row-details-width="gridViewRowDetailsWidth"
         :workspace-id="workspaceId"
-        :separator-positions="bannerSeparatorPositions"
         :width="sectionWidth"
+        :visible-fields="visibleFields"
+        :field-widths="fieldWidths"
+        :view="view"
+        :store-prefix="storePrefix"
         @toggle="toggleGroup"
+        @aggregation-changed="onAggregationChanged"
       />
       <div
         v-else-if="item.type === 'row' && shouldRenderRows"
@@ -229,30 +232,6 @@ export default {
       })
       return positions
     },
-    /**
-     * Vertical cell separators inside the group banner, at every internal field
-     * boundary. The left section starts with the row-details lane, so offset
-     * field separators and draw that first lane boundary there too.
-     */
-    bannerSeparatorPositions() {
-      const positions = []
-      let x = 0
-
-      if (this.includeRowDetails) {
-        x += this.gridViewRowDetailsWidth
-        positions.push(x)
-      }
-
-      this.visibleFields.slice(0, -1).forEach((field) => {
-        x += this.getFieldWidth(field)
-        positions.push(x)
-      })
-      return positions
-    },
-    primaryFieldWidth() {
-      const primaryField = this.visibleFields[0]
-      return primaryField ? this.getFieldWidth(primaryField) : 0
-    },
     shouldRenderRows() {
       return this.includeRowDetails || this.visibleFields.length > 0
     },
@@ -332,6 +311,20 @@ export default {
             path,
             view: this.view,
             fields: this.allFieldsInTable,
+          }
+        )
+      } catch (error) {
+        notifyIf(error, 'view')
+      }
+    },
+    async onAggregationChanged(fieldId) {
+      try {
+        await this.$store.dispatch(
+          this.storePrefix + 'view/grid/refreshGroupByAggregations',
+          {
+            view: this.view,
+            fields: this.allFieldsInTable,
+            fieldId,
           }
         )
       } catch (error) {

--- a/web-frontend/modules/database/services/view/grid.js
+++ b/web-frontend/modules/database/services/view/grid.js
@@ -157,6 +157,8 @@ export default (client) => {
       descendantLimit = null,
       descendantRowBudget = null,
       groupBy = '',
+      aggregationsOnly = false,
+      includeTotals = false,
     }) {
       const params = new URLSearchParams()
       params.append('offset', offset)
@@ -166,6 +168,12 @@ export default (client) => {
       }
       if (includeDescendants) {
         params.append('include_descendants', 'true')
+      }
+      if (aggregationsOnly) {
+        params.append('aggregations_only', 'true')
+      }
+      if (includeTotals) {
+        params.append('include_totals', 'true')
       }
       if (descendantLimit !== null) {
         params.append('descendant_limit', descendantLimit)

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -152,6 +152,50 @@ function rowHasViewWarning(row) {
   )
 }
 
+function hasConfiguredGroupAggregation(fieldOptions) {
+  return Object.values(fieldOptions || {}).some(
+    (options) => options.aggregation_raw_type
+  )
+}
+
+function groupAggregationPathKeysForPaths(pathsWithFields) {
+  const loadingPaths = []
+  for (const { path, fields } of pathsWithFields) {
+    const depth = getGroupByPathDepth(path, fields)
+    for (let pathDepth = 0; pathDepth < depth; pathDepth += 1) {
+      loadingPaths.push(
+        pathKey(getGroupByPathPrefix(path, fields, pathDepth), fields)
+      )
+    }
+  }
+  return loadingPaths
+}
+
+function markGroupAggregationPathsLoading(
+  { commit, getters },
+  pathsWithFields
+) {
+  if (
+    pathsWithFields.length === 0 ||
+    !hasConfiguredGroupAggregation(getters.getAllFieldOptions)
+  ) {
+    return []
+  }
+
+  const loadingPaths = new Set(getters.getGroupByAggregationsLoadingPaths)
+  const addedPathKeys = []
+  for (const groupPathKey of groupAggregationPathKeysForPaths(
+    pathsWithFields
+  )) {
+    if (!loadingPaths.has(groupPathKey)) {
+      addedPathKeys.push(groupPathKey)
+    }
+    loadingPaths.add(groupPathKey)
+  }
+  commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [...loadingPaths])
+  return addedPathKeys
+}
+
 function getGroupByFieldRefsFromState(state) {
   // Skip group-bys whose field was deleted but still lingers in activeGroupBys until
   // the next refresh; keeping them would make pathKey truncate mid-path and the layout
@@ -683,6 +727,13 @@ function moveGroupByRowToValueGroup(
     return false
   }
 
+  if (oldSection && groupChanged) {
+    markGroupAggregationPathsLoading({ commit, getters }, [
+      { path: oldSection.path, fields: groupByFields },
+      { path: newPath, fields: groupByFields },
+    ])
+  }
+
   if (oldLocation) {
     commit('REMOVE_ROW_AT_LOCATION', {
       sectionKey: oldLocation.sectionKey,
@@ -1068,17 +1119,26 @@ export const mutations = {
   // Updates only the loaded group nodes' `aggregations` from a lean response,
   // matched by path so it survives sibling-order changes. Layout untouched.
   UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES(state, { pages, fields }) {
-    const aggregationsByPath = {}
+    const aggregationDataByPath = {}
     for (const page of pages) {
       for (const group of page.groups || []) {
-        aggregationsByPath[pathKey(group.path, fields)] =
-          group.aggregations || {}
+        aggregationDataByPath[pathKey(group.path, fields)] = {
+          aggregations: group.aggregations || {},
+          rowCount: group.row_count,
+        }
       }
     }
 
     const applyTo = (node) => {
-      const aggregations = aggregationsByPath[pathKey(node.path, fields)]
-      return aggregations !== undefined ? { ...node, aggregations } : node
+      const data = aggregationDataByPath[pathKey(node.path, fields)]
+      return data !== undefined
+        ? {
+            ...node,
+            aggregations: data.aggregations,
+            aggregation_row_count:
+              data.rowCount ?? node.row_count ?? node.rowCount ?? 0,
+          }
+        : node
     }
 
     const newPages = {}
@@ -1699,7 +1759,13 @@ export const actions = {
   // them in place without rebuilding the layout. Used after an aggregation or row change.
   async refreshGroupByAggregations(
     { commit, getters, rootGetters },
-    { view, fields, fieldId = null, silent = false }
+    {
+      view,
+      fields,
+      fieldId = null,
+      silent = false,
+      clearGroupByAggregationLoadingPaths = false,
+    }
   ) {
     const { $client, $config } = this
     if (!getters.isGroupByMode) {
@@ -1765,6 +1831,9 @@ export const actions = {
       if (lastGroupByAggregationRequest.controller === controller) {
         lastGroupByAggregationRequest.controller = null
         commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+        if (clearGroupByAggregationLoadingPaths) {
+          commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [])
+        }
         if (loadingFieldIds !== null) {
           loadingFieldIds.forEach((id) =>
             commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
@@ -3290,7 +3359,7 @@ export const actions = {
    */
   async fetchAllFieldAggregationData(
     { rootGetters, getters, commit, dispatch },
-    { view, fieldId = null }
+    { view, fieldId = null, clearGroupByAggregationLoadingPaths = false }
   ) {
     const { $registry, $client, $i18n, $config } = this
     const isPublic = rootGetters['page/view/public/getIsPublic']
@@ -3309,6 +3378,7 @@ export const actions = {
           fields: rootGetters['field/getAll'],
           fieldId,
           silent: true,
+          clearGroupByAggregationLoadingPaths,
         })
       }
       return
@@ -4179,16 +4249,19 @@ export const actions = {
             0
         }
 
+        optimisticGroupByTreePaths.push({
+          path: rowPath,
+          fields: groupByFields,
+        })
+        markGroupAggregationPathsLoading({ commit, getters }, [
+          { path: rowPath, fields: groupByFields },
+        ])
         commit('UPDATE_GROUP_BY_TREE_PATH_COUNT', {
           path: rowPath,
           fields: groupByFields,
           delta: 1,
           registry: $registry,
           display: groupDisplayFromRow(row, groupByFields),
-        })
-        optimisticGroupByTreePaths.push({
-          path: rowPath,
-          fields: groupByFields,
         })
         commit('INSERT_ROW_AT_LOCATION', {
           sectionKey,
@@ -4249,27 +4322,7 @@ export const actions = {
       // value recomputed from the bumped count before the backend returns.
       const hasGroupAggregation =
         optimisticGroupByTreePaths.length > 0 &&
-        Object.values(getters.getAllFieldOptions).some(
-          (options) => options.aggregation_raw_type
-        )
-      if (hasGroupAggregation) {
-        const loadingPaths = new Set()
-        for (const {
-          path,
-          fields: groupByFields,
-        } of optimisticGroupByTreePaths) {
-          const depth = getGroupByPathDepth(path, groupByFields)
-          for (let pathDepth = 0; pathDepth < depth; pathDepth += 1) {
-            loadingPaths.add(
-              pathKey(
-                getGroupByPathPrefix(path, groupByFields, pathDepth),
-                groupByFields
-              )
-            )
-          }
-        }
-        commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [...loadingPaths])
-      }
+        hasConfiguredGroupAggregation(getters.getAllFieldOptions)
 
       dispatch('visibleByScrollTop')
 
@@ -4698,6 +4751,7 @@ export const actions = {
               fields,
               row,
               values,
+              markGroupAggregationsLoading: optimisticUpdate,
             })
           } else {
             // While the edited row stays selected or open in the row edit modal,
@@ -4817,6 +4871,7 @@ export const actions = {
         dispatch('fetchAllFieldAggregationData', {
           view,
           fieldId: field.id,
+          clearGroupByAggregationLoadingPaths: true,
         })
       } catch (error) {
         if (!canUpdateOptimistically) {
@@ -4831,6 +4886,12 @@ export const actions = {
             fields,
             isRowOpenedInModal,
           })
+        }
+        if (
+          getters.isGroupByMode &&
+          hasConfiguredGroupAggregation(getters.getAllFieldOptions)
+        ) {
+          commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [])
         }
         throw error
       }
@@ -5139,7 +5200,15 @@ export const actions = {
    */
   async updatedExistingRow(
     { commit, getters, dispatch, state },
-    { view, fields, row, values, metadata, updatedFieldIds = [] }
+    {
+      view,
+      fields,
+      row,
+      values,
+      metadata,
+      updatedFieldIds = [],
+      markGroupAggregationsLoading = false,
+    }
   ) {
     const { $registry } = this
     const oldRow = clone(row)
@@ -5278,6 +5347,12 @@ export const actions = {
 
     if (getters.isGroupByMode && groupByPathChanged) {
       if (!keepSelectedGroupByRowInPlace) {
+        if (markGroupAggregationsLoading) {
+          markGroupAggregationPathsLoading({ commit, getters }, [
+            { path: oldGroupByPath, fields: groupByFields },
+            { path: newGroupByPath, fields: groupByFields },
+          ])
+        }
         commit('UPDATE_GROUP_BY_TREE_PATH_COUNT', {
           path: oldGroupByPath,
           fields: groupByFields,

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -3289,13 +3289,9 @@ export const actions = {
     const hasAggregation = Object.values(fieldOptions).some(
       (options) => options.aggregation_raw_type
     )
-    // In grouped mode the per-group values and the footer totals come from one
-    // group-by-data request, so it replaces the standalone footer fetch entirely.
-    // Skip entirely when nothing is configured, matching the flat-mode early return.
-    const groupAggregations =
-      typeof this.app?.$featureFlagIsEnabled === 'function' &&
-      this.app.$featureFlagIsEnabled('group_by_aggregations')
-    if (groupAggregations && getters.isGroupByMode) {
+    // In grouped mode the per-group values and footer totals come from one
+    // group-by-data request, replacing the standalone footer fetch.
+    if (getters.isGroupByMode) {
       if (hasAggregation) {
         return dispatch('refreshGroupByAggregations', {
           view,

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -52,6 +52,7 @@ import {
   getDefinedRowsFromSectionRows,
   forEachGroupByRow,
   getGroupByPathDepth,
+  getGroupByPathPrefix,
   preserveGroupByRowUiState,
   findGroupByRowSection,
   getGroupByAbsoluteRangesForVisibleRange,
@@ -128,6 +129,9 @@ function getEmptyGroupByState() {
     // True while a lean values-only aggregation refresh is in flight, so the group
     // header cells show a loading spinner without rebuilding the layout.
     aggregationsLoading: false,
+    // pathKeys spinning after an optimistic insertion, so the banner shows a spinner
+    // instead of a wrong value recomputed from the bumped row count.
+    aggregationsLoadingPaths: [],
     collapse: { mode: 'expand', paths: [] },
     collapseInitialized: false,
     sectionRows: {},
@@ -1057,6 +1061,9 @@ export const mutations = {
   },
   SET_GROUP_BY_AGGREGATIONS_LOADING(state, value) {
     state.groupBy.aggregationsLoading = value
+  },
+  SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS(state, pathKeys) {
+    state.groupBy.aggregationsLoadingPaths = pathKeys
   },
   // Updates only the loaded group nodes' `aggregations` from a lean response,
   // matched by path so it survives sibling-order changes. Layout untouched.
@@ -4233,6 +4240,32 @@ export const actions = {
         })
       }
 
+      // Spin the inserted group and its ancestors so their banners don't flash a
+      // value recomputed from the bumped count before the backend returns.
+      const hasGroupAggregation =
+        optimisticGroupByTreePaths.length > 0 &&
+        Object.values(getters.getAllFieldOptions).some(
+          (options) => options.aggregation_raw_type
+        )
+      if (hasGroupAggregation) {
+        const loadingPaths = new Set()
+        for (const {
+          path,
+          fields: groupByFields,
+        } of optimisticGroupByTreePaths) {
+          const depth = getGroupByPathDepth(path, groupByFields)
+          for (let pathDepth = 0; pathDepth < depth; pathDepth += 1) {
+            loadingPaths.add(
+              pathKey(
+                getGroupByPathPrefix(path, groupByFields, pathDepth),
+                groupByFields
+              )
+            )
+          }
+        }
+        commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [...loadingPaths])
+      }
+
       dispatch('visibleByScrollTop')
 
       // Check if not all rows are visible.
@@ -4385,6 +4418,12 @@ export const actions = {
         rowsPopulated.forEach((row) => {
           createAndUpdateRowQueue.release(row._.persistentId)
         })
+
+        // Refresh delivered fresh values, or the insertion was rolled back: either
+        // way stop spinning so the up-to-date value shows.
+        if (hasGroupAggregation) {
+          commit('SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS', [])
+        }
       }
     })
     await taskQueue.waitFor(taskId)
@@ -6270,6 +6309,9 @@ export const getters = {
       }
       return false
     }
+  },
+  getGroupByAggregationsLoadingPaths(state) {
+    return state.groupBy.aggregationsLoadingPaths || []
   },
   getGroupBySectionRowsMap: (state) => {
     return makeSectionRowsMap(state.groupBy.sectionRows)

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -1714,12 +1714,14 @@ export const actions = {
     }
     const gridId = getters.getLastGridId
     const controller = supersedeRequest(lastGroupByAggregationRequest)
-    // Row edits refresh silently; the picker passes a fieldId to spin that column.
-    if (!silent) {
-      commit(
-        'SET_GROUP_BY_AGGREGATIONS_LOADING',
-        fieldId !== null ? [fieldId] : true
-      )
+    // A targeted fieldId spins those columns even on an otherwise-silent row-edit
+    // refresh; a loud refresh with no target spins every column.
+    const loadingFieldIds =
+      fieldId === null ? null : Array.isArray(fieldId) ? fieldId : [fieldId]
+    if (loadingFieldIds !== null) {
+      commit('SET_GROUP_BY_AGGREGATIONS_LOADING', loadingFieldIds)
+    } else if (!silent) {
+      commit('SET_GROUP_BY_AGGREGATIONS_LOADING', true)
     }
     try {
       const { data } = await GridService($client).fetchGroupByData({
@@ -1763,11 +1765,13 @@ export const actions = {
       if (lastGroupByAggregationRequest.controller === controller) {
         lastGroupByAggregationRequest.controller = null
         commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
-        if (fieldId !== null) {
-          commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
-            fieldId,
-            value: false,
-          })
+        if (loadingFieldIds !== null) {
+          loadingFieldIds.forEach((id) =>
+            commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
+              fieldId: id,
+              value: false,
+            })
+          )
         }
       }
     }
@@ -3286,7 +3290,7 @@ export const actions = {
    */
   async fetchAllFieldAggregationData(
     { rootGetters, getters, commit, dispatch },
-    { view }
+    { view, fieldId = null }
   ) {
     const { $registry, $client, $i18n, $config } = this
     const isPublic = rootGetters['page/view/public/getIsPublic']
@@ -3303,6 +3307,7 @@ export const actions = {
         return dispatch('refreshGroupByAggregations', {
           view,
           fields: rootGetters['field/getAll'],
+          fieldId,
           silent: true,
         })
       }
@@ -4808,8 +4813,10 @@ export const actions = {
             }
           }
         }
+        // Spin the edited column's group aggregations while the refresh recomputes.
         dispatch('fetchAllFieldAggregationData', {
           view,
+          fieldId: field.id,
         })
       } catch (error) {
         if (!canUpdateOptimistically) {
@@ -5119,7 +5126,11 @@ export const actions = {
       scrollTop: getScrollTop(),
       fields: allFieldsInTable,
     })
-    dispatch('fetchAllFieldAggregationData', { view })
+    // Spin the pasted columns' group aggregations while the refresh recomputes.
+    dispatch('fetchAllFieldAggregationData', {
+      view,
+      fieldId: writeFields.map((f) => f.id),
+    })
   },
   /**
    * Called after an existing row has been updated, which could be by the user or

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -125,6 +125,9 @@ function getEmptyGroupByState() {
     absoluteRows: {},
     revision: 0,
     generation: 0,
+    // True while a lean values-only aggregation refresh is in flight, so the group
+    // header cells show a loading spinner without rebuilding the layout.
+    aggregationsLoading: false,
     collapse: { mode: 'expand', paths: [] },
     collapseInitialized: false,
     sectionRows: {},
@@ -1052,6 +1055,37 @@ export const mutations = {
       ...rowsByOffset,
     }
   },
+  SET_GROUP_BY_AGGREGATIONS_LOADING(state, value) {
+    state.groupBy.aggregationsLoading = value
+  },
+  // Updates only the loaded group nodes' `aggregations` from a lean response,
+  // matched by path so it survives sibling-order changes. Layout untouched.
+  UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES(state, { pages, fields }) {
+    const aggregationsByPath = {}
+    for (const page of pages) {
+      for (const group of page.groups || []) {
+        aggregationsByPath[pathKey(group.path, fields)] =
+          group.aggregations || {}
+      }
+    }
+
+    const applyTo = (node) => {
+      const aggregations = aggregationsByPath[pathKey(node.path, fields)]
+      return aggregations !== undefined ? { ...node, aggregations } : node
+    }
+
+    const newPages = {}
+    for (const [pageKey, page] of Object.entries(state.groupBy.pages || {})) {
+      const newNodes = {}
+      for (const [index, node] of Object.entries(page.nodes || {})) {
+        newNodes[index] = applyTo(node)
+      }
+      newPages[pageKey] = { ...page, nodes: newNodes }
+    }
+    state.groupBy.pages = newPages
+    state.groupBy.treeNodes = (state.groupBy.treeNodes || []).map(applyTo)
+    state.groupBy.revision = (state.groupBy.revision || 0) + 1
+  },
   UPDATE_GROUP_BY_TREE_PATH_COUNT(
     state,
     { path, fields, delta, registry, display = null }
@@ -1635,6 +1669,68 @@ const activeGroupByRowsRequests = new Map()
 const lastAggregationRequest = { request: null, controller: null }
 
 export const actions = {
+  // Toggles per-group aggregation loading. A `fieldId` spins one column; omitting it
+  // spins all (a row edit can change any value).
+  setGroupByAggregationsLoading(
+    { commit },
+    { fieldId = null, loading = true }
+  ) {
+    commit(
+      'SET_GROUP_BY_AGGREGATIONS_LOADING',
+      loading ? (fieldId !== null ? [fieldId] : true) : false
+    )
+  },
+  // Lean values-only refresh: refetches per-group values + bundled totals and updates
+  // them in place without rebuilding the layout. Used after an aggregation or row change.
+  async refreshGroupByAggregations(
+    { commit, getters, rootGetters },
+    { view, fields, fieldId = null }
+  ) {
+    const { $client, $config } = this
+    if (!getters.isGroupByMode) {
+      return
+    }
+    const groupByFields = getGroupByFieldsFromActiveGroupBys(
+      getters.getActiveGroupBys,
+      fields
+    )
+    if (groupByFields.length === 0) {
+      return
+    }
+    const gridId = getters.getLastGridId
+    commit(
+      'SET_GROUP_BY_AGGREGATIONS_LOADING',
+      fieldId !== null ? [fieldId] : true
+    )
+    try {
+      const { data } = await GridService($client).fetchGroupByData({
+        gridId,
+        search: getters.getServerSearchTerm,
+        searchMode: getDefaultSearchModeFromEnv($config),
+        publicUrl: rootGetters['page/view/public/getIsPublic'],
+        publicAuthToken: rootGetters['page/view/public/getAuthToken'],
+        filters: getFilters(view, getters.getAdhocFiltering),
+        offset: 0,
+        limit: getters.getBufferRequestSize,
+        includeDescendants: true,
+        descendantLimit: getters.getBufferRequestSize,
+        aggregationsOnly: true,
+        includeTotals: true,
+      })
+      commit('UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES', {
+        pages: data.pages || [],
+        fields: groupByFields,
+      })
+      for (const [fieldKey, value] of Object.entries(data.aggregations || {})) {
+        const fieldId = parseInt(fieldKey.replace('field_', ''), 10)
+        if (!isNaN(fieldId)) {
+          commit('SET_FIELD_AGGREGATION_DATA', { fieldId, value })
+        }
+      }
+    } finally {
+      commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+    }
+  },
   async fetchGroupByData(
     { commit, getters, rootGetters, state },
     {
@@ -6083,6 +6179,18 @@ export const getters = {
   // per-call fields array would be a new reference every time and defeat the cache.
   getGroupByLayout(state) {
     return getGroupByLayoutFromState(state)
+  },
+  getGroupByAggregationsLoading(state) {
+    const loading = state.groupBy.aggregationsLoading
+    return (fieldId = null) => {
+      if (loading === true) {
+        return true
+      }
+      if (Array.isArray(loading)) {
+        return fieldId !== null && loading.includes(fieldId)
+      }
+      return false
+    }
   },
   getGroupBySectionRowsMap: (state) => {
     return makeSectionRowsMap(state.groupBy.sectionRows)

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -1684,7 +1684,7 @@ export const actions = {
   // them in place without rebuilding the layout. Used after an aggregation or row change.
   async refreshGroupByAggregations(
     { commit, getters, rootGetters },
-    { view, fields, fieldId = null }
+    { view, fields, fieldId = null, silent = false }
   ) {
     const { $client, $config } = this
     if (!getters.isGroupByMode) {
@@ -1698,10 +1698,14 @@ export const actions = {
       return
     }
     const gridId = getters.getLastGridId
-    commit(
-      'SET_GROUP_BY_AGGREGATIONS_LOADING',
-      fieldId !== null ? [fieldId] : true
-    )
+    // Row edits refresh silently (values change in place); the picker passes a
+    // fieldId to show that column's spinner while its function changes.
+    if (!silent) {
+      commit(
+        'SET_GROUP_BY_AGGREGATIONS_LOADING',
+        fieldId !== null ? [fieldId] : true
+      )
+    }
     try {
       const { data } = await GridService($client).fetchGroupByData({
         gridId,
@@ -1728,7 +1732,9 @@ export const actions = {
         }
       }
     } finally {
-      commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+      if (!silent) {
+        commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+      }
     }
   },
   async fetchGroupByData(
@@ -1745,6 +1751,7 @@ export const actions = {
       includeDescendants = false,
       descendantLimit = null,
       descendantRowBudget = null,
+      includeTotals = false,
       signal = null,
     }
   ) {
@@ -1783,6 +1790,7 @@ export const actions = {
       descendantLimit,
       descendantRowBudget,
       groupBy: getGroupBy(rootGetters, gridId, getters.getAdhocGrouping),
+      includeTotals,
       signal,
     })
     if (isGroupByRequestStale(getters, state, groupByGeneration, signal)) {
@@ -1794,6 +1802,12 @@ export const actions = {
         parentPath: page.parent || {},
         fields: groupByFields,
       })
+    }
+    for (const [fieldKey, value] of Object.entries(data.aggregations || {})) {
+      const fieldId = parseInt(fieldKey.replace('field_', ''), 10)
+      if (!isNaN(fieldId)) {
+        commit('SET_FIELD_AGGREGATION_DATA', { fieldId, value })
+      }
     }
     placeLoadedGroupByRowsInViewport({
       commit,
@@ -2689,7 +2703,6 @@ export const actions = {
             return
           }
           dispatch('correctMultiSelect')
-          dispatch('fetchAllFieldAggregationData', { view })
         })
         .catch((error) => {
           if (axios.isCancel(error)) {
@@ -2740,6 +2753,8 @@ export const actions = {
         .then(async () => {
           commit('SET_GROUP_BY_COLLAPSE', groupByCollapse)
           commit('RESET_GROUP_BY_DATA')
+          // Per-group values + footer totals come bundled in this one request, so the
+          // standalone /aggregations/ fetch is not needed in grouped mode.
           await dispatch('fetchGroupByData', {
             gridId,
             view,
@@ -2748,6 +2763,7 @@ export const actions = {
             includeDescendants: groupByCollapse.mode === 'expand',
             descendantLimit: getters.getBufferRequestSize,
             descendantRowBudget: getGroupByDescendantRowBudget(getters),
+            includeTotals: true,
           })
           await dispatch('fetchGroupByRowsByScrollTop', {
             gridId,
@@ -2757,7 +2773,6 @@ export const actions = {
             includeFieldOptions,
           })
           dispatch('correctMultiSelect')
-          dispatch('fetchAllFieldAggregationData', { view })
         })
         .catch((error) => {
           if (axios.isCancel(error)) {
@@ -2967,9 +2982,18 @@ export const actions = {
       descendantLimit: getters.getBufferRequestSize,
       descendantRowBudget: getGroupByDescendantRowBudget(getters),
       groupBy: getGroupBy(rootGetters, gridId, getters.getAdhocGrouping),
+      includeTotals: true,
     })
     if ((state.groupBy.generation || 0) !== groupByGeneration) {
       return true
+    }
+    for (const [fieldKey, value] of Object.entries(
+      groupByData.aggregations || {}
+    )) {
+      const fieldId = parseInt(fieldKey.replace('field_', ''), 10)
+      if (!isNaN(fieldId)) {
+        commit('SET_FIELD_AGGREGATION_DATA', { fieldId, value })
+      }
     }
 
     for (const page of groupByData.pages || []) {
@@ -3214,7 +3238,7 @@ export const actions = {
    * If a request is already in progress, it is aborted in favour of the new one.
    */
   async fetchAllFieldAggregationData(
-    { rootGetters, getters, commit },
+    { rootGetters, getters, commit, dispatch },
     { view }
   ) {
     const { $registry, $client, $i18n, $config } = this
@@ -3222,6 +3246,25 @@ export const actions = {
     const search = getters.getActiveSearchTerm
     const fieldOptions = getters.getAllFieldOptions
     const gridId = getters.getLastGridId
+    const hasAggregation = Object.values(fieldOptions).some(
+      (options) => options.aggregation_raw_type
+    )
+    // In grouped mode the per-group values and the footer totals come from one
+    // group-by-data request, so it replaces the standalone footer fetch entirely.
+    // Skip entirely when nothing is configured, matching the flat-mode early return.
+    const groupAggregations =
+      typeof this.app?.$featureFlagIsEnabled === 'function' &&
+      this.app.$featureFlagIsEnabled('group_by_aggregations')
+    if (groupAggregations && getters.isGroupByMode) {
+      if (hasAggregation) {
+        return dispatch('refreshGroupByAggregations', {
+          view,
+          fields: rootGetters['field/getAll'],
+          silent: true,
+        })
+      }
+      return
+    }
     let atLeastOneAggregation = false
 
     Object.entries(fieldOptions).forEach(([fieldId, options]) => {

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -158,6 +158,14 @@ function hasConfiguredGroupAggregation(fieldOptions) {
   )
 }
 
+// Field ids that have a footer/group aggregation configured, used to spin their
+// cells while an optimistic row change is recalculated.
+function configuredAggregationFieldIds(fieldOptions) {
+  return Object.entries(fieldOptions || {})
+    .filter(([, options]) => options.aggregation_raw_type)
+    .map(([fieldId]) => parseInt(fieldId, 10))
+}
+
 function groupAggregationPathKeysForPaths(pathsWithFields) {
   const loadingPaths = []
   for (const { path, fields } of pathsWithFields) {
@@ -772,7 +780,9 @@ function moveGroupByRowToValueGroup(
       display: groupDisplayFromRow(row, groupByFields),
     })
   }
-  return true
+  // Whether the row crossed into a different group, which is exactly when the
+  // affected groups' aggregations were marked loading and now need a refresh.
+  return groupChanged
 }
 
 /**
@@ -3248,6 +3258,14 @@ export const actions = {
     const previousOptions = getters.getAllFieldOptions[field.id]
     let needAggregationValueUpdate = false
 
+    // Only visible fields' per-group aggregations are computed, so un-hiding an
+    // aggregated field in grouped mode must refetch its now-stale value.
+    const revealsAggregatedField =
+      getters.isGroupByMode &&
+      values.hidden === false &&
+      previousOptions?.hidden === true &&
+      !!previousOptions?.aggregation_raw_type
+
     /**
      * If the aggregation raw type has changed, we delete the corresponding the
      * aggregation value from the store.
@@ -3280,13 +3298,12 @@ export const actions = {
           values: updateValues,
           undoRedoActionGroupId,
         })
-      } catch (error) {
-        commit('UPDATE_FIELD_OPTIONS_OF_FIELD', {
-          fieldId: field.id,
-          values: oldValues,
-        })
-        throw error
-      } finally {
+        if (revealsAggregatedField) {
+          dispatch('fetchAllFieldAggregationData', {
+            view: { id: gridId },
+            fieldId: field.id,
+          })
+        }
         // Grouped pickers refresh aggregations themselves; skip the duplicate fetch.
         if (
           !skipAggregationRefresh &&
@@ -3295,6 +3312,20 @@ export const actions = {
         ) {
           dispatch('fetchAllFieldAggregationData', { view: { id: gridId } })
         }
+      } catch (error) {
+        commit('UPDATE_FIELD_OPTIONS_OF_FIELD', {
+          fieldId: field.id,
+          values: oldValues,
+        })
+        // The optimistic pick spun this field's aggregation; a failed save must
+        // stop that spinner since no refresh will run to clear it.
+        if (needAggregationValueUpdate) {
+          commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
+            fieldId: field.id,
+            value: false,
+          })
+        }
+        throw error
       }
     }
   },
@@ -4324,6 +4355,16 @@ export const actions = {
         optimisticGroupByTreePaths.length > 0 &&
         hasConfiguredGroupAggregation(getters.getAllFieldOptions)
 
+      // Footer values derive from the bumped row count, so spin them until the
+      // refresh lands; otherwise `not empty` (rowCount - value) flashes wrong.
+      const footerAggregationFieldIds =
+        optimisticGroupByTreePaths.length > 0
+          ? configuredAggregationFieldIds(getters.getAllFieldOptions)
+          : []
+      footerAggregationFieldIds.forEach((fieldId) =>
+        commit('SET_FIELD_AGGREGATION_DATA_LOADING', { fieldId, value: true })
+      )
+
       dispatch('visibleByScrollTop')
 
       // Check if not all rows are visible.
@@ -4436,8 +4477,19 @@ export const actions = {
 
         await dispatch('fetchAllFieldAggregationData', {
           view,
+          fieldId:
+            footerAggregationFieldIds.length > 0
+              ? footerAggregationFieldIds
+              : null,
         })
       } catch (error) {
+        // The refresh never ran; stop the spinners here (on success it clears them).
+        footerAggregationFieldIds.forEach((fieldId) =>
+          commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
+            fieldId,
+            value: false,
+          })
+        )
         if (isSingleRowInsertion) {
           const rowStillInBuffer = getters.getRow(rowsPopulated[0].id)
           if (rowStillInBuffer && optimisticGroupByTreePaths.length > 0) {
@@ -5593,6 +5645,14 @@ export const actions = {
     const { $registry, $client, $i18n, $config } = this
     commit('SET_ROW_LOADING', { row, value: true })
 
+    // Spin the footer aggregations while the delete is recalculated, mirroring insert.
+    const footerAggregationFieldIds = getters.isGroupByMode
+      ? configuredAggregationFieldIds(getters.getAllFieldOptions)
+      : []
+    footerAggregationFieldIds.forEach((fieldId) =>
+      commit('SET_FIELD_AGGREGATION_DATA_LOADING', { fieldId, value: true })
+    )
+
     try {
       await RowService($client).delete(table.id, row.id, getters.getLastGridId)
       await dispatch('deletedExistingRow', {
@@ -5600,14 +5660,24 @@ export const actions = {
         fields,
         row,
         getScrollTop,
+        spinGroupAggregations: true,
       })
       await dispatch('fetchByScrollTopDelayed', {
         scrollTop: getScrollTop(),
         fields,
       })
-      dispatch('fetchAllFieldAggregationData', { view })
+      dispatch('fetchAllFieldAggregationData', {
+        view,
+        fieldId: footerAggregationFieldIds.length
+          ? footerAggregationFieldIds
+          : null,
+        clearGroupByAggregationLoadingPaths: true,
+      })
     } catch (error) {
       commit('SET_ROW_LOADING', { row, value: false })
+      footerAggregationFieldIds.forEach((fieldId) =>
+        commit('SET_FIELD_AGGREGATION_DATA_LOADING', { fieldId, value: false })
+      )
       throw error
     }
   },
@@ -5615,7 +5685,7 @@ export const actions = {
    * Attempt to delete all multi-selected rows.
    */
   async deleteSelectedRows(
-    { dispatch, getters },
+    { commit, dispatch, getters },
     { table, view, fields, getScrollTop }
   ) {
     const { $registry, $client, $i18n, $config } = this
@@ -5649,12 +5719,21 @@ export const actions = {
       getters.getLastGridId
     )
 
+    // Spin the footer aggregations while the delete is recalculated, mirroring insert.
+    const footerAggregationFieldIds = getters.isGroupByMode
+      ? configuredAggregationFieldIds(getters.getAllFieldOptions)
+      : []
+    footerAggregationFieldIds.forEach((fieldId) =>
+      commit('SET_FIELD_AGGREGATION_DATA_LOADING', { fieldId, value: true })
+    )
+
     for (const row of rowsToDelete) {
       await dispatch('deletedExistingRow', {
         view,
         fields,
         row,
         getScrollTop,
+        spinGroupAggregations: true,
       })
     }
     dispatch('clearAndDisableMultiSelect', { view })
@@ -5662,7 +5741,13 @@ export const actions = {
       scrollTop: getScrollTop(),
       fields,
     })
-    dispatch('fetchAllFieldAggregationData', { view })
+    dispatch('fetchAllFieldAggregationData', {
+      view,
+      fieldId: footerAggregationFieldIds.length
+        ? footerAggregationFieldIds
+        : null,
+      clearGroupByAggregationLoadingPaths: true,
+    })
   },
   /**
    * Called after an existing row has been deleted, which could be by the user or
@@ -5670,7 +5755,7 @@ export const actions = {
    */
   async deletedExistingRow(
     { commit, getters, dispatch, state },
-    { view, fields, row }
+    { view, fields, row, spinGroupAggregations = false }
   ) {
     const { $registry } = this
     row = clone(row)
@@ -5697,14 +5782,23 @@ export const actions = {
               getters.getActiveGroupBys,
               fields
             )
+            const treePath = getGroupByRowTreePath(
+              state,
+              getters,
+              row,
+              groupByFields,
+              $registry
+            )
+            // Spin the deleted row's group so its banner doesn't recompute from the
+            // decremented count. Only for user deletes: realtime deletes have no
+            // refresh that would clear the paths.
+            if (spinGroupAggregations) {
+              markGroupAggregationPathsLoading({ commit, getters }, [
+                { path: treePath, fields: groupByFields },
+              ])
+            }
             commit('UPDATE_GROUP_BY_TREE_PATH_COUNT', {
-              path: getGroupByRowTreePath(
-                state,
-                getters,
-                row,
-                groupByFields,
-                $registry
-              ),
+              path: treePath,
               fields: groupByFields,
               delta: -1,
               registry: $registry,
@@ -5912,13 +6006,25 @@ export const actions = {
       commit('DELETE_ROW_IN_BUFFER', row)
     } else if (row._.selectedBy.length === 0 && !row._.matchSortings) {
       if (getters.isGroupByMode) {
-        moveGroupByRowToValueGroup(
+        const groupChanged = moveGroupByRowToValueGroup(
           { commit, getters, state },
           { row, view: grid, fields, registry: $registry }
         )
         commit('SET_ROW_MATCH_SORTINGS', { row, value: true })
         dispatch('correctMultiSelect')
         handledLocally = true
+        // The move marked the source and target groups' aggregations loading;
+        // recompute them from the server so those spinners resolve instead of
+        // spinning forever.
+        if (
+          groupChanged &&
+          hasConfiguredGroupAggregation(getters.getAllFieldOptions)
+        ) {
+          dispatch('fetchAllFieldAggregationData', {
+            view: grid,
+            clearGroupByAggregationLoadingPaths: true,
+          })
+        }
       } else {
         await dispatch('updatedExistingRow', {
           view: grid,

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -1668,6 +1668,14 @@ const activeGroupByRowsRequests = new Map()
 // We want to cancel previous aggregation request before creating a new one.
 const lastAggregationRequest = { request: null, controller: null }
 
+const lastGroupByAggregationRequest = { controller: null }
+
+function supersedeRequest(pending) {
+  pending.controller?.abort()
+  pending.controller = new AbortController()
+  return pending.controller
+}
+
 export const actions = {
   // Toggles per-group aggregation loading. A `fieldId` spins one column; omitting it
   // spins all (a row edit can change any value).
@@ -1698,8 +1706,8 @@ export const actions = {
       return
     }
     const gridId = getters.getLastGridId
-    // Row edits refresh silently (values change in place); the picker passes a
-    // fieldId to show that column's spinner while its function changes.
+    const controller = supersedeRequest(lastGroupByAggregationRequest)
+    // Row edits refresh silently; the picker passes a fieldId to spin that column.
     if (!silent) {
       commit(
         'SET_GROUP_BY_AGGREGATIONS_LOADING',
@@ -1720,20 +1728,40 @@ export const actions = {
         descendantLimit: getters.getBufferRequestSize,
         aggregationsOnly: true,
         includeTotals: true,
+        signal: controller.signal,
       })
       commit('UPDATE_GROUP_BY_AGGREGATIONS_FROM_PAGES', {
         pages: data.pages || [],
         fields: groupByFields,
       })
       for (const [fieldKey, value] of Object.entries(data.aggregations || {})) {
-        const fieldId = parseInt(fieldKey.replace('field_', ''), 10)
-        if (!isNaN(fieldId)) {
-          commit('SET_FIELD_AGGREGATION_DATA', { fieldId, value })
+        const aggregationFieldId = parseInt(fieldKey.replace('field_', ''), 10)
+        if (!isNaN(aggregationFieldId)) {
+          commit('SET_FIELD_AGGREGATION_DATA', {
+            fieldId: aggregationFieldId,
+            value,
+          })
+          commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
+            fieldId: aggregationFieldId,
+            value: false,
+          })
         }
       }
+    } catch (error) {
+      if (!axios.isCancel(error)) {
+        throw error
+      }
     } finally {
-      if (!silent) {
+      // Only the latest request clears the spinners, so a superseded one can't.
+      if (lastGroupByAggregationRequest.controller === controller) {
+        lastGroupByAggregationRequest.controller = null
         commit('SET_GROUP_BY_AGGREGATIONS_LOADING', false)
+        if (fieldId !== null) {
+          commit('SET_FIELD_AGGREGATION_DATA_LOADING', {
+            fieldId,
+            value: false,
+          })
+        }
       }
     }
   },
@@ -3127,7 +3155,14 @@ export const actions = {
    */
   async updateFieldOptionsOfField(
     { commit, getters, dispatch, rootGetters },
-    { field, values, oldValues, readOnly = false, undoRedoActionGroupId }
+    {
+      field,
+      values,
+      oldValues,
+      readOnly = false,
+      undoRedoActionGroupId,
+      skipAggregationRefresh = false,
+    }
   ) {
     const { $registry, $client, $i18n, $config } = this
     const previousOptions = getters.getAllFieldOptions[field.id]
@@ -3172,7 +3207,12 @@ export const actions = {
         })
         throw error
       } finally {
-        if (needAggregationValueUpdate && values.aggregation_type) {
+        // Grouped pickers refresh aggregations themselves; skip the duplicate fetch.
+        if (
+          !skipAggregationRefresh &&
+          needAggregationValueUpdate &&
+          values.aggregation_type
+        ) {
           dispatch('fetchAllFieldAggregationData', { view: { id: gridId } })
         }
       }

--- a/web-frontend/modules/database/utils/gridGroupBy.js
+++ b/web-frontend/modules/database/utils/gridGroupBy.js
@@ -293,6 +293,26 @@ export function getGroupByNodeRowCount(node) {
   return node.row_count ?? 0
 }
 
+function hasGroupByNodeAggregations(node) {
+  return (
+    node.aggregations !== undefined ||
+    node.aggregation_row_count !== undefined ||
+    node.aggregationRowCount !== undefined
+  )
+}
+
+function preserveGroupByNodeAggregationRowCount(node) {
+  if (!hasGroupByNodeAggregations(node)) {
+    return {}
+  }
+  return {
+    aggregation_row_count:
+      node.aggregation_row_count ??
+      node.aggregationRowCount ??
+      getGroupByNodeRowCount(node),
+  }
+}
+
 /**
  * Turns a group value into a row-shaped value the sort comparator understands
  * (resolves a single-select id to its option).
@@ -549,6 +569,7 @@ export function updateGroupByTreeNodesForPath(
     updated[existingIndex] = {
       ...current,
       row_count: rowCount,
+      ...preserveGroupByNodeAggregationRowCount(current),
       ...(nodeDisplay && !current.display ? { display: nodeDisplay } : {}),
     }
   }
@@ -618,6 +639,7 @@ export function updateGroupByDataPageForPath({
           updatedNode = {
             ...updatedNode,
             row_count: rowCount,
+            ...preserveGroupByNodeAggregationRowCount(updatedNode),
             ...(nodeDisplay && !node.display ? { display: nodeDisplay } : {}),
           }
         }

--- a/web-frontend/modules/database/utils/gridGroupByRender.js
+++ b/web-frontend/modules/database/utils/gridGroupByRender.js
@@ -161,6 +161,7 @@ export function buildLayout({
       height: HEADER_HEIGHT,
       collapsed,
       gapAbove,
+      aggregations: node.aggregations ?? null,
     })
     y += HEADER_HEIGHT
 
@@ -381,6 +382,7 @@ function buildPagedLayout({
         height: HEADER_HEIGHT,
         collapsed,
         gapAbove,
+        aggregations: node.aggregations ?? null,
       })
       y += HEADER_HEIGHT
 
@@ -614,6 +616,7 @@ export function renderViewport({
         height: item.height,
         collapsed: item.collapsed,
         gapAbove: item.gapAbove,
+        aggregations: item.aggregations ?? null,
       })
       continue
     }

--- a/web-frontend/modules/database/utils/gridGroupByRender.js
+++ b/web-frontend/modules/database/utils/gridGroupByRender.js
@@ -150,6 +150,8 @@ export function buildLayout({
       fields
     )
     const rowCount = node.rowCount ?? node.row_count ?? 0
+    const aggregationRowCount =
+      node.aggregationRowCount ?? node.aggregation_row_count ?? rowCount
 
     items.push({
       type: 'header',
@@ -157,6 +159,7 @@ export function buildLayout({
       path: node.path,
       display: node.display,
       rowCount,
+      aggregationRowCount,
       y,
       height: HEADER_HEIGHT,
       collapsed,
@@ -370,6 +373,8 @@ function buildPagedLayout({
         fields
       )
       const rowCount = node.rowCount ?? node.row_count ?? 0
+      const aggregationRowCount =
+        node.aggregationRowCount ?? node.aggregation_row_count ?? rowCount
       const childrenCount = node.childrenCount ?? node.children_count ?? 0
 
       items.push({
@@ -378,6 +383,7 @@ function buildPagedLayout({
         path: node.path,
         display: node.display,
         rowCount,
+        aggregationRowCount,
         y,
         height: HEADER_HEIGHT,
         collapsed,
@@ -612,6 +618,7 @@ export function renderViewport({
         path: item.path,
         display: item.display,
         rowCount: item.rowCount,
+        aggregationRowCount: item.aggregationRowCount ?? item.rowCount,
         y: item.y,
         height: item.height,
         collapsed: item.collapsed,

--- a/web-frontend/modules/database/viewAggregationTypes.js
+++ b/web-frontend/modules/database/viewAggregationTypes.js
@@ -934,8 +934,9 @@ export class DistributionViewAggregationType extends ViewAggregationType {
     //   [
     //     ["Blue", "(3)", "30%"],
     //     ["Red", "(6)", "60%"],
-    //     ["Others", "(1)", "10%"]
+    //     [undefined, "(1)", "10%"]
     //   ]
+    // The UI renders an undefined label as "Others".
     // A type switch can briefly feed the previous aggregation's scalar value in
     // before the refresh lands; only an array is a real distribution result.
     if (!Array.isArray(value)) {
@@ -951,7 +952,7 @@ export class DistributionViewAggregationType extends ViewAggregationType {
     // we need to add an "Others" entry to account for them. This can happen
     // because the server only sends the top ten distributions by count. If
     // there were more than ten unique values, the rest need to be represented
-    // as a single entry named "Others"
+    // as a single entry with an undefined label, rendered as "Others" in the UI.
     const othersCount =
       rowCount - value.reduce((sum, current) => sum + current[1], 0)
     if (othersCount > 0) {

--- a/web-frontend/modules/database/viewAggregationTypes.js
+++ b/web-frontend/modules/database/viewAggregationTypes.js
@@ -96,6 +96,12 @@ export class ViewAggregationType extends Registerable {
     return true
   }
 
+  // Whether this aggregation produces a single scalar the backend can compute per
+  // group. Non-scalar types (e.g. distribution) are table-level footer only.
+  isAllowedInGroupBy() {
+    return true
+  }
+
   /**
    * @return object
    */
@@ -907,6 +913,10 @@ export class DistributionViewAggregationType extends ViewAggregationType {
     return DistributionAggregation
   }
 
+  isAllowedInGroupBy() {
+    return false
+  }
+
   getValue(value, { rowCount }) {
     // Value is returned from the server as an array of arrays,
     // each inner array representing one value of the distribution
@@ -926,7 +936,9 @@ export class DistributionViewAggregationType extends ViewAggregationType {
     //     ["Red", "(6)", "60%"],
     //     ["Others", "(1)", "10%"]
     //   ]
-    if (!value) {
+    // A type switch can briefly feed the previous aggregation's scalar value in
+    // before the refresh lands; only an array is a real distribution result.
+    if (!Array.isArray(value)) {
       return null
     }
 

--- a/web-frontend/modules/database/viewTypes.js
+++ b/web-frontend/modules/database/viewTypes.js
@@ -802,26 +802,12 @@ export class GridViewType extends ViewType {
     )
   }
 
-  // In grouped mode (flag on), refresh per-group values via a lean request that keeps
-  // the layout; otherwise refresh the footer aggregations as before.
+  // fetchAllFieldAggregationData refreshes the footer in flat mode and the per-group
+  // values + footer totals (one request) in grouped mode, so this works for both.
   refreshAggregationsAfterRowChange(store, fields, storePrefix) {
-    const view = store.getters['view/getSelected']
-    const groupAggregations =
-      typeof this.app.$featureFlagIsEnabled === 'function' &&
-      this.app.$featureFlagIsEnabled('group_by_aggregations')
-    if (
-      groupAggregations &&
-      store.getters[storePrefix + 'view/grid/isGroupByMode']
-    ) {
-      store.dispatch(storePrefix + 'view/grid/refreshGroupByAggregations', {
-        view,
-        fields,
-      })
-    } else {
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view,
-      })
-    }
+    store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
+      view: store.getters['view/getSelected'],
+    })
   }
 
   async rowCreated(

--- a/web-frontend/modules/database/viewTypes.js
+++ b/web-frontend/modules/database/viewTypes.js
@@ -802,6 +802,28 @@ export class GridViewType extends ViewType {
     )
   }
 
+  // In grouped mode (flag on), refresh per-group values via a lean request that keeps
+  // the layout; otherwise refresh the footer aggregations as before.
+  refreshAggregationsAfterRowChange(store, fields, storePrefix) {
+    const view = store.getters['view/getSelected']
+    const groupAggregations =
+      typeof this.app.$featureFlagIsEnabled === 'function' &&
+      this.app.$featureFlagIsEnabled('group_by_aggregations')
+    if (
+      groupAggregations &&
+      store.getters[storePrefix + 'view/grid/isGroupByMode']
+    ) {
+      store.dispatch(storePrefix + 'view/grid/refreshGroupByAggregations', {
+        view,
+        fields,
+      })
+    } else {
+      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
+        view,
+      })
+    }
+  }
+
   async rowCreated(
     { store },
     tableId,
@@ -821,9 +843,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 
@@ -865,9 +885,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 
@@ -882,9 +900,7 @@ export class GridViewType extends ViewType {
         scrollTop: store.getters[storePrefix + 'view/grid/getScrollTop'],
         fields,
       })
-      store.dispatch(storePrefix + 'view/grid/fetchAllFieldAggregationData', {
-        view: store.getters['view/getSelected'],
-      })
+      this.refreshAggregationsAfterRowChange(store, fields, storePrefix)
     }
   }
 

--- a/web-frontend/test/unit/database/components/view/grid/gridView.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridView.spec.js
@@ -1,6 +1,5 @@
 import GridView from '@baserow/modules/database/components/view/grid/GridView'
 import GridViewFreezeHandle from '@baserow/modules/database/components/view/grid/GridViewFreezeHandle'
-import GridViewGroupByRows from '@baserow/modules/database/components/view/grid/GridViewGroupByRows'
 import { GRID_VIEW_MULTI_SELECT_AREA } from '@baserow/modules/database/constants'
 
 describe('GridView component', () => {
@@ -51,37 +50,6 @@ describe('GridView component', () => {
     })
 
     expect(sortedFields.map((field) => field.id)).toEqual([1, 3])
-  })
-
-  test('group-by banner separators include left row-details and field boundaries', () => {
-    const separatorPositions =
-      GridViewGroupByRows.computed.bannerSeparatorPositions.call({
-        includeRowDetails: true,
-        gridViewRowDetailsWidth: 72,
-        visibleFields: [
-          { id: 1, name: 'Name' },
-          { id: 2, name: 'Team' },
-          { id: 3, name: 'Notes' },
-        ],
-        getFieldWidth: (field) => ({ 1: 200, 2: 150, 3: 100 })[field.id],
-      })
-
-    expect(separatorPositions).toEqual([72, 272, 422])
-  })
-
-  test('group-by banner separators in the right section stay on field boundaries', () => {
-    const separatorPositions =
-      GridViewGroupByRows.computed.bannerSeparatorPositions.call({
-        includeRowDetails: false,
-        visibleFields: [
-          { id: 1, name: 'Team' },
-          { id: 2, name: 'Notes' },
-          { id: 3, name: 'Score' },
-        ],
-        getFieldWidth: (field) => ({ 1: 200, 2: 150, 3: 100 })[field.id],
-      })
-
-    expect(separatorPositions).toEqual([200, 350])
   })
 
   // The post-drag click of a multi-select lands on the rows container; that must not

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
@@ -16,6 +16,7 @@ describe('Field footer component', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
     await testApp.afterEach()
   })
 
@@ -168,5 +169,45 @@ describe('Field footer component', () => {
     ).toEqual({ 3: { loading: false, value: 10 } })
 
     expect(wrapper.element).toMatchSnapshot()
+  })
+
+  const mountGroupedFooter = (flagEnabled) => {
+    store.commit('page/view/grid/SET_LAST_GRID_ID', 2)
+    store.commit('page/view/grid/SET_ACTIVE_GROUP_BYS', [{ field: 1 }])
+    return testApp.mount(GridViewFieldFooter, {
+      propsData: {
+        view: { id: 2 },
+        database: { id: 1, workspace: { id: 1 } },
+        field: { id: 3, type: 'text' },
+        storePrefix: 'page/',
+      },
+      global: { mocks: { $featureFlagIsEnabled: () => flagEnabled } },
+    })
+  }
+
+  test('changing the aggregation refreshes the group headers in grouped mode', async () => {
+    const wrapper = await mountGroupedFooter(true)
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await selectValue(wrapper, 2)
+    await flushPromises()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/refreshGroupByAggregations',
+      expect.objectContaining({ fieldId: 3 })
+    )
+  })
+
+  test('changing the aggregation leaves group headers untouched when the flag is off', async () => {
+    const wrapper = await mountGroupedFooter(false)
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await selectValue(wrapper, 2)
+    await flushPromises()
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      'page/view/grid/refreshGroupByAggregations',
+      expect.anything()
+    )
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
@@ -171,6 +171,31 @@ describe('Field footer component', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
+  test('ignores an unknown stored aggregation type instead of crashing', async () => {
+    // A stale/invalid aggregation_type must not crash the grid; the footer treats
+    // it as unconfigured.
+    await store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      2: {
+        aggregation_type: 'not_empty_count1',
+        aggregation_raw_type: 'not_empty_count',
+      },
+    })
+    store.commit('page/view/grid/SET_COUNT', 10)
+    store.commit('page/view/grid/SET_FIELD_AGGREGATION_DATA', {
+      fieldId: 2,
+      value: 5,
+    })
+
+    const wrapper = await mountComponent({
+      view: { id: 1 },
+      database: { id: 1, workspace: { id: 1 } },
+      field: { id: 2, type: 'text' },
+      storePrefix: 'page/',
+    })
+
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
+  })
+
   const mountGroupedFooter = () => {
     store.commit('page/view/grid/SET_LAST_GRID_ID', 2)
     store.commit('page/view/grid/SET_ACTIVE_GROUP_BYS', [{ field: 1 }])

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
@@ -171,7 +171,7 @@ describe('Field footer component', () => {
     expect(wrapper.element).toMatchSnapshot()
   })
 
-  const mountGroupedFooter = (flagEnabled) => {
+  const mountGroupedFooter = () => {
     store.commit('page/view/grid/SET_LAST_GRID_ID', 2)
     store.commit('page/view/grid/SET_ACTIVE_GROUP_BYS', [{ field: 1 }])
     return testApp.mount(GridViewFieldFooter, {
@@ -181,12 +181,11 @@ describe('Field footer component', () => {
         field: { id: 3, type: 'text' },
         storePrefix: 'page/',
       },
-      global: { mocks: { $featureFlagIsEnabled: () => flagEnabled } },
     })
   }
 
   test('changing the aggregation refreshes the group headers in grouped mode', async () => {
-    const wrapper = await mountGroupedFooter(true)
+    const wrapper = await mountGroupedFooter()
     const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
 
     await selectValue(wrapper, 2)
@@ -195,19 +194,6 @@ describe('Field footer component', () => {
     expect(dispatch).toHaveBeenCalledWith(
       'page/view/grid/refreshGroupByAggregations',
       expect.objectContaining({ fieldId: 3 })
-    )
-  })
-
-  test('changing the aggregation leaves group headers untouched when the flag is off', async () => {
-    const wrapper = await mountGroupedFooter(false)
-    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
-
-    await selectValue(wrapper, 2)
-    await flushPromises()
-
-    expect(dispatch).not.toHaveBeenCalledWith(
-      'page/view/grid/refreshGroupByAggregations',
-      expect.anything()
     )
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldFooter.spec.js
@@ -34,6 +34,16 @@ describe('Field footer component', () => {
       .trigger('click')
   }
 
+  const selectAggregationByName = async (wrapper, name) => {
+    await wrapper.find(`.grid-view-aggregation`).trigger('click')
+    const context = wrapper.findComponent(Context)
+
+    const link = context
+      .findAll('.select__item-link')
+      .find((l) => l.find('.select__item-name-text').text() === name)
+    await link.trigger('click')
+  }
+
   test('Default component', async () => {
     await store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
       2: {
@@ -220,5 +230,53 @@ describe('Field footer component', () => {
       'page/view/grid/refreshGroupByAggregations',
       expect.objectContaining({ fieldId: 3 })
     )
+  })
+
+  test('a display-only aggregation change in grouped mode persists without refetching the group tree', async () => {
+    // "Empty" and "Filled" are display variants of the same raw type
+    // (`empty_count`), so switching between them persists the new label but must NOT
+    // spin or issue a group-by-data request — the value re-renders client-side.
+    await store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      3: {
+        aggregation_type: 'empty_count',
+        aggregation_raw_type: 'empty_count',
+      },
+    })
+    mockServer.updateFieldOptions(2, {
+      3: {
+        aggregation_type: 'not_empty_count',
+        aggregation_raw_type: 'empty_count',
+      },
+    })
+    const wrapper = await mountGroupedFooter()
+    // Run the real dispatch chain so the HTTP layer sees exactly what goes out.
+    const realDispatch = store.dispatch.bind(store)
+    const dispatch = vi
+      .spyOn(store, 'dispatch')
+      .mockImplementation((action, payload) => realDispatch(action, payload))
+
+    await selectAggregationByName(wrapper, 'viewAggregationType.notEmptyCount')
+    await flushPromises()
+
+    // The new display type is still persisted (one PATCH to field-options)...
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/updateFieldOptionsOfField',
+      expect.objectContaining({
+        values: expect.objectContaining({
+          aggregation_type: 'not_empty_count',
+        }),
+      })
+    )
+    expect(mockServer.mock.history.patch).toHaveLength(1)
+    // ...but nothing spins and no group-by-data request goes out.
+    expect(dispatch).not.toHaveBeenCalledWith(
+      'page/view/grid/setGroupByAggregationsLoading',
+      expect.anything()
+    )
+    expect(dispatch).not.toHaveBeenCalledWith(
+      'page/view/grid/refreshGroupByAggregations',
+      expect.anything()
+    )
+    expect(mockServer.mock.history.get).toHaveLength(0)
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -102,6 +102,17 @@ describe('GridViewGroupByAggregation', () => {
     expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
   })
 
+  test('never shows the summarize affordance for a configured field without a per-group value', async () => {
+    // A non-scalar aggregation (e.g. distribution) is configured but the backend
+    // returns no per-group value, so the field must not look unconfigured.
+    await configureSum()
+
+    const wrapper = await mountCell({ rawValue: undefined })
+
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('30')
+  })
+
   test('renders nothing for a read-only user when nothing is configured', async () => {
     const wrapper = await mountCell(
       { rawValue: undefined },

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -1,5 +1,6 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
+import DistributionAggregation from '@baserow/modules/database/components/aggregation/DistributionAggregation'
 import Context from '@baserow/modules/core/components/Context'
 import flushPromises from 'flush-promises'
 
@@ -35,6 +36,14 @@ describe('GridViewGroupByAggregation', () => {
   const configureSum = () =>
     store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
       2: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
+    })
+
+  const configureDistribution = () =>
+    store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      2: {
+        aggregation_type: 'distribution',
+        aggregation_raw_type: 'distribution',
+      },
     })
 
   test('renders the per-group aggregation value for a configured field', async () => {
@@ -141,5 +150,30 @@ describe('GridViewGroupByAggregation', () => {
       expect.objectContaining({ field })
     )
     expect(wrapper.emitted('change')).toBeTruthy()
+  })
+
+  test('renders nothing instead of crashing on a table-only aggregation', async () => {
+    // Distribution is footer-only; the field's stale scalar value must not be fed to
+    // its array-shaped getValue (which would throw and break the group render).
+    await configureDistribution()
+
+    const wrapper = await mountCell({ rawValue: 25 })
+
+    expect(wrapper.findComponent(DistributionAggregation).exists()).toBe(false)
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
+  })
+
+  test('omits table-only aggregations from the group context menu', async () => {
+    await configureSum()
+    const wrapper = await mountCell()
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const names = wrapper
+      .findComponent(Context)
+      .findAll('.select__item-name-text')
+      .map((node) => node.text())
+
+    expect(names).toContain('viewAggregationType.sum')
+    expect(names).not.toContain('viewAggregationType.distribution')
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -38,6 +38,14 @@ describe('GridViewGroupByAggregation', () => {
       2: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
     })
 
+  const configureNotEmptyCount = () =>
+    store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      2: {
+        aggregation_type: 'not_empty_count',
+        aggregation_raw_type: 'empty_count',
+      },
+    })
+
   const configureDistribution = () =>
     store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
       2: {
@@ -67,6 +75,20 @@ describe('GridViewGroupByAggregation', () => {
     expect(
       wrapper.find('.grid-view-aggregation__generic-value--loading').exists()
     ).toBe(true)
+  })
+
+  test('formats derived counts with the server-confirmed aggregation row count', async () => {
+    await configureNotEmptyCount()
+
+    const wrapper = await mountCell({
+      rawValue: 1,
+      rowCount: 3,
+      aggregationRowCount: 2,
+    })
+
+    expect(wrapper.find('.grid-view-aggregation__generic-value').text()).toBe(
+      '1'
+    )
   })
 
   test('shows a spinner while loading the first value (none to aggregation)', async () => {

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -14,6 +14,9 @@ describe('GridViewGroupByAggregation', () => {
   })
 
   afterEach(async () => {
+    // Restore spies so a mocked `store.dispatch` from one test can't leak into the
+    // next and turn its setup dispatches into no-ops.
+    vi.restoreAllMocks()
     await testApp.afterEach()
   })
 
@@ -172,6 +175,40 @@ describe('GridViewGroupByAggregation', () => {
       expect.objectContaining({ field })
     )
     expect(wrapper.emitted('change')).toBeTruthy()
+  })
+
+  test('switching to a display type that shares the raw type re-renders without a refetch or spinner', async () => {
+    // not_empty_count and empty_count share the raw type, so switching between them
+    // only re-renders the existing value — no refetch, no spinner (like the footer).
+    await configureNotEmptyCount()
+    const wrapper = await mountCell()
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const context = wrapper.findComponent(Context)
+    const emptyCountItem = context.findAll('.select__item').find((item) => {
+      const name = item.find('.select__item-name-text')
+      return name.exists() && name.text() === 'viewAggregationType.emptyCount'
+    })
+    await emptyCountItem.find('.select__item-link').trigger('click')
+    await flushPromises()
+
+    // The new display type is still persisted.
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/updateFieldOptionsOfField',
+      expect.objectContaining({
+        values: expect.objectContaining({
+          aggregation_type: 'empty_count',
+          aggregation_raw_type: 'empty_count',
+        }),
+      })
+    )
+    // But it neither refetches the group tree nor spins the cell.
+    expect(wrapper.emitted('change')).toBeFalsy()
+    expect(dispatch).not.toHaveBeenCalledWith(
+      'page/view/grid/setGroupByAggregationsLoading',
+      expect.objectContaining({ fieldId: field.id })
+    )
   })
 
   test('renders nothing instead of crashing on a table-only aggregation', async () => {

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -7,10 +7,12 @@ import flushPromises from 'flush-promises'
 describe('GridViewGroupByAggregation', () => {
   let testApp = null
   let store = null
+  let mockServer = null
 
   beforeEach(() => {
     testApp = new TestApp()
     store = testApp.store
+    mockServer = testApp.mockServer
   })
 
   afterEach(async () => {
@@ -179,10 +181,23 @@ describe('GridViewGroupByAggregation', () => {
 
   test('switching to a display type that shares the raw type re-renders without a refetch or spinner', async () => {
     // not_empty_count and empty_count share the raw type, so switching between them
-    // only re-renders the existing value — no refetch, no spinner (like the footer).
+    // only re-renders the existing value — the choice is persisted but no group-by-data
+    // request goes out and the cell never spins (like the footer). The cell emits
+    // `change` to trigger the refetch, so "no change emitted" is the no-request proof.
+    store.commit('page/view/grid/SET_LAST_GRID_ID', 1)
     await configureNotEmptyCount()
+    mockServer.updateFieldOptions(1, {
+      2: {
+        aggregation_type: 'empty_count',
+        aggregation_raw_type: 'empty_count',
+      },
+    })
     const wrapper = await mountCell()
-    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+    // Run the real dispatch chain so the HTTP layer sees exactly what goes out.
+    const realDispatch = store.dispatch.bind(store)
+    const dispatch = vi
+      .spyOn(store, 'dispatch')
+      .mockImplementation((action, payload) => realDispatch(action, payload))
 
     await wrapper.find('.grid-view-aggregation').trigger('click')
     const context = wrapper.findComponent(Context)
@@ -193,7 +208,7 @@ describe('GridViewGroupByAggregation', () => {
     await emptyCountItem.find('.select__item-link').trigger('click')
     await flushPromises()
 
-    // The new display type is still persisted.
+    // The new display type is still persisted (one PATCH to field-options)...
     expect(dispatch).toHaveBeenCalledWith(
       'page/view/grid/updateFieldOptionsOfField',
       expect.objectContaining({
@@ -203,12 +218,14 @@ describe('GridViewGroupByAggregation', () => {
         }),
       })
     )
-    // But it neither refetches the group tree nor spins the cell.
+    expect(mockServer.mock.history.patch).toHaveLength(1)
+    // ...but it neither triggers the refetch, spins the cell, nor issues a GET.
     expect(wrapper.emitted('change')).toBeFalsy()
     expect(dispatch).not.toHaveBeenCalledWith(
       'page/view/grid/setGroupByAggregationsLoading',
       expect.objectContaining({ fieldId: field.id })
     )
+    expect(mockServer.mock.history.get).toHaveLength(0)
   })
 
   test('renders nothing instead of crashing on a table-only aggregation', async () => {

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByAggregation.spec.js
@@ -1,0 +1,134 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
+import Context from '@baserow/modules/core/components/Context'
+import flushPromises from 'flush-promises'
+
+describe('GridViewGroupByAggregation', () => {
+  let testApp = null
+  let store = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    store = testApp.store
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const field = { id: 2, name: 'Amount', type: 'number' }
+
+  const mountCell = (props = {}, mocks = {}) =>
+    testApp.mount(GridViewGroupByAggregation, {
+      propsData: {
+        view: { id: 1 },
+        workspaceId: 1,
+        field,
+        storePrefix: 'page/',
+        rawValue: 30,
+        rowCount: 2,
+        ...props,
+      },
+      global: { mocks },
+    })
+
+  const configureSum = () =>
+    store.dispatch('page/view/grid/forceUpdateAllFieldOptions', {
+      2: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
+    })
+
+  test('renders the per-group aggregation value for a configured field', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell()
+
+    expect(wrapper.find('.grid-view-aggregation').exists()).toBe(true)
+    expect(wrapper.text()).toContain('30')
+  })
+
+  test('keeps the label but hides the value behind the spinner while loading', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell({ loading: true })
+
+    // Label stays; the value gets the modifier that hides it and shows the spinner.
+    expect(wrapper.find('.grid-view-aggregation__generic-name').exists()).toBe(
+      true
+    )
+    expect(
+      wrapper.find('.grid-view-aggregation__generic-value--loading').exists()
+    ).toBe(true)
+  })
+
+  test('shows a spinner while loading the first value (none to aggregation)', async () => {
+    await configureSum()
+
+    const wrapper = await mountCell({ rawValue: undefined, loading: true })
+
+    expect(
+      wrapper.find('.grid-view__group-by-banner-aggregation-loading').exists()
+    ).toBe(true)
+  })
+
+  test('starts the spinner as the aggregation changes, before the refresh', async () => {
+    await configureSum()
+    const wrapper = await mountCell()
+    const realDispatch = store.dispatch.bind(store)
+    vi.spyOn(store, 'dispatch').mockImplementation((action, payload) => {
+      if (action.endsWith('updateFieldOptionsOfField')) {
+        return Promise.resolve(undefined)
+      }
+      return realDispatch(action, payload)
+    })
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const context = wrapper.findComponent(Context)
+    await context
+      .find('.select__items > .select__item:nth-child(2)')
+      .find('.select__item-link')
+      .trigger('click')
+    await flushPromises()
+
+    // Loading is set as part of the change, so the old value never flashes.
+    expect(
+      store.getters['page/view/grid/getGroupByAggregationsLoading'](field.id)
+    ).toBe(true)
+  })
+
+  test('renders a summarize affordance when nothing is configured yet', async () => {
+    const wrapper = await mountCell({ rawValue: undefined })
+
+    // The empty state lets an editable user set an aggregation from the group.
+    expect(wrapper.find('.grid-view-aggregation__empty').exists()).toBe(true)
+  })
+
+  test('renders nothing for a read-only user when nothing is configured', async () => {
+    const wrapper = await mountCell(
+      { rawValue: undefined },
+      { $hasPermission: () => false }
+    )
+
+    expect(wrapper.find('.grid-view-aggregation').exists()).toBe(false)
+  })
+
+  test('selecting an aggregation updates the shared field option and emits change', async () => {
+    await configureSum()
+    const wrapper = await mountCell()
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue(undefined)
+
+    await wrapper.find('.grid-view-aggregation').trigger('click')
+    const context = wrapper.findComponent(Context)
+    // The second item is the first aggregation function after "None".
+    await context
+      .find('.select__items > .select__item:nth-child(2)')
+      .find('.select__item-link')
+      .trigger('click')
+    await flushPromises()
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'page/view/grid/updateFieldOptionsOfField',
+      expect.objectContaining({ field })
+    )
+    expect(wrapper.emitted('change')).toBeTruthy()
+  })
+})

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
@@ -1,6 +1,7 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import GridViewGroupByBanner from '@baserow/modules/database/components/view/grid/GridViewGroupByBanner'
 import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
+import { pathKey } from '@baserow/modules/database/utils/gridGroupByRender'
 
 describe('GridViewGroupByBanner component', () => {
   let testApp = null
@@ -272,7 +273,7 @@ describe('GridViewGroupByBanner aggregations', () => {
     aggregations,
   })
 
-  const mountBanner = (item, featureEnabled = true) =>
+  const mountBanner = (item) =>
     testApp.mount(GridViewGroupByBanner, {
       propsData: {
         item,
@@ -286,12 +287,11 @@ describe('GridViewGroupByBanner aggregations', () => {
         storePrefix: 'page/',
       },
       global: {
-        mocks: { $featureFlagIsEnabled: () => featureEnabled },
         stubs: { GridViewGroupByAggregation: true },
       },
     })
 
-  test('renders an aggregation cell per visible field with the group value when enabled', async () => {
+  test('renders an aggregation cell per visible field with the group value', async () => {
     const wrapper = await mountBanner(header({ field_2: 30 }))
 
     const cell = wrapper.findComponent(GridViewGroupByAggregation)
@@ -299,14 +299,6 @@ describe('GridViewGroupByBanner aggregations', () => {
     expect(cell.props('rawValue')).toBe(30)
     expect(cell.props('rowCount')).toBe(2)
     expect(cell.props('field')).toEqual(amountField)
-  })
-
-  test('renders no aggregation cell when the feature flag is disabled', async () => {
-    const wrapper = await mountBanner(header({ field_2: 30 }), false)
-
-    expect(wrapper.findComponent(GridViewGroupByAggregation).exists()).toBe(
-      false
-    )
   })
 
   test('passes an undefined raw value when the group has no value for the field', async () => {
@@ -331,7 +323,6 @@ describe('GridViewGroupByBanner aggregations', () => {
         storePrefix: 'page/',
       },
       global: {
-        mocks: { $featureFlagIsEnabled: () => true },
         stubs: { GridViewGroupByAggregation: true },
       },
     })
@@ -359,6 +350,30 @@ describe('GridViewGroupByBanner aggregations', () => {
     const cells = wrapper.findAllComponents(GridViewGroupByAggregation)
     expect(cells[0].props('loading')).toBe(true)
     expect(cells[1].props('loading')).toBe(true)
+  })
+
+  test('spins a group while its post-insertion aggregation refresh is in flight', async () => {
+    testApp.store.commit(
+      'page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS',
+      [pathKey({ field_1: 'Green' }, [colorField])]
+    )
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    expect(
+      wrapper.findComponent(GridViewGroupByAggregation).props('loading')
+    ).toBe(true)
+  })
+
+  test('does not spin a group when only a sibling group is refreshing', async () => {
+    testApp.store.commit(
+      'page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING_PATHS',
+      [pathKey({ field_1: 'Blue' }, [colorField])]
+    )
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    expect(
+      wrapper.findComponent(GridViewGroupByAggregation).props('loading')
+    ).toBe(false)
   })
 
   test('forwards the changed field id with the aggregation-changed event', async () => {

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
@@ -1,5 +1,6 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import GridViewGroupByBanner from '@baserow/modules/database/components/view/grid/GridViewGroupByBanner'
+import GridViewGroupByAggregation from '@baserow/modules/database/components/view/grid/GridViewGroupByAggregation'
 
 describe('GridViewGroupByBanner component', () => {
   let testApp = null
@@ -17,6 +18,7 @@ describe('GridViewGroupByBanner component', () => {
       props: {
         groupByFields: [field],
         item: {
+          type: 'header',
           depth: 0,
           path,
           display,
@@ -26,7 +28,8 @@ describe('GridViewGroupByBanner component', () => {
           height: 48,
         },
         includeRowDetails: true,
-        primaryFieldWidth: 200,
+        visibleFields: [field],
+        fieldWidths: { [field.id]: 200 },
         width: 300,
         workspaceId: null,
       },
@@ -52,34 +55,6 @@ describe('GridViewGroupByBanner component', () => {
     })
 
     expect(wrapper.text()).toContain('Row A')
-  })
-
-  test('renders a cell separator at each provided position', async () => {
-    const field = { id: 1, type: 'text', name: 'Name' }
-    const wrapper = await testApp.mount(GridViewGroupByBanner, {
-      props: {
-        groupByFields: [field],
-        item: {
-          depth: 0,
-          path: { field_1: 'A' },
-          display: {},
-          rowCount: 1,
-          collapsed: false,
-          y: 0,
-          height: 48,
-        },
-        includeRowDetails: false,
-        primaryFieldWidth: 0,
-        separatorPositions: [200, 350],
-        width: 500,
-        workspaceId: null,
-      },
-    })
-
-    const separators = wrapper.findAll('.grid-view__group-by-banner-separator')
-    expect(separators).toHaveLength(2)
-    expect(separators.at(0).element.style.left).toBe('199px')
-    expect(separators.at(1).element.style.left).toBe('349px')
   })
 
   test('renders the single select value from the backend display value', async () => {
@@ -147,6 +122,70 @@ describe('GridViewGroupByBanner component', () => {
     ).toBe(true)
   })
 
+  const separatorLefts = (wrapper) =>
+    wrapper
+      .findAll('.grid-view__group-by-banner-separator')
+      .map((separator) => separator.element.style.left)
+
+  test('renders separators after the row details lane and internal left fields', async () => {
+    const fields = [
+      { id: 1, type: 'text', name: 'Name' },
+      { id: 2, type: 'text', name: 'Team' },
+      { id: 3, type: 'text', name: 'Notes' },
+    ]
+    const wrapper = await testApp.mount(GridViewGroupByBanner, {
+      props: {
+        groupByFields: [fields[0]],
+        item: {
+          depth: 0,
+          path: { field_1: 'A' },
+          display: undefined,
+          rowCount: 1,
+          collapsed: false,
+          y: 0,
+          height: 48,
+        },
+        includeRowDetails: true,
+        rowDetailsWidth: 72,
+        visibleFields: fields,
+        fieldWidths: { 1: 200, 2: 150, 3: 100 },
+        width: 522,
+        workspaceId: null,
+      },
+    })
+
+    expect(separatorLefts(wrapper)).toEqual(['71px', '271px', '421px'])
+  })
+
+  test('renders separators on internal right-section field boundaries', async () => {
+    const fields = [
+      { id: 1, type: 'text', name: 'Team' },
+      { id: 2, type: 'text', name: 'Notes' },
+      { id: 3, type: 'text', name: 'Score' },
+    ]
+    const wrapper = await testApp.mount(GridViewGroupByBanner, {
+      props: {
+        groupByFields: [fields[0]],
+        item: {
+          depth: 0,
+          path: { field_1: 'A' },
+          display: undefined,
+          rowCount: 1,
+          collapsed: false,
+          y: 0,
+          height: 48,
+        },
+        includeRowDetails: false,
+        visibleFields: fields,
+        fieldWidths: { 1: 200, 2: 150, 3: 100 },
+        width: 450,
+        workspaceId: null,
+      },
+    })
+
+    expect(separatorLefts(wrapper)).toEqual(['199px', '349px'])
+  })
+
   const mountAtDepth = (fieldCount, depth, rowDetailsWidth = 72) =>
     testApp.mount(GridViewGroupByBanner, {
       props: {
@@ -165,7 +204,8 @@ describe('GridViewGroupByBanner component', () => {
           height: 48,
         },
         includeRowDetails: true,
-        primaryFieldWidth: 200,
+        visibleFields: [{ id: 1, type: 'text', name: 'Field 1' }],
+        fieldWidths: { 1: 200 },
         rowDetailsWidth,
         width: 300,
         workspaceId: null,
@@ -198,10 +238,134 @@ describe('GridViewGroupByBanner component', () => {
   test('indents the field-name block in lockstep with its chevron', async () => {
     const subGroup = await mountAtDepth(2, 1)
     const labelPadding = parseFloat(
-      subGroup.find('.grid-view__group-by-banner-primary').element.style
+      subGroup.find('.grid-view__group-by-banner-field--primary').element.style
         .paddingLeft
     )
     expect(labelPadding).toBe(chevronPadding(subGroup))
     expect(labelPadding).toBeGreaterThan(12)
+  })
+})
+
+describe('GridViewGroupByBanner aggregations', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const colorField = { id: 1, name: 'Color', type: 'text' }
+  const amountField = { id: 2, name: 'Amount', type: 'number' }
+  const sizeField = { id: 3, name: 'Size', type: 'number' }
+
+  const header = (aggregations) => ({
+    type: 'header',
+    depth: 0,
+    path: { field_1: 'Green' },
+    rowCount: 2,
+    y: 0,
+    height: 48,
+    collapsed: false,
+    aggregations,
+  })
+
+  const mountBanner = (item, featureEnabled = true) =>
+    testApp.mount(GridViewGroupByBanner, {
+      propsData: {
+        item,
+        groupByFields: [colorField],
+        includeRowDetails: false,
+        width: 200,
+        workspaceId: 1,
+        visibleFields: [amountField],
+        fieldWidths: { [amountField.id]: 200 },
+        view: { id: 1 },
+        storePrefix: 'page/',
+      },
+      global: {
+        mocks: { $featureFlagIsEnabled: () => featureEnabled },
+        stubs: { GridViewGroupByAggregation: true },
+      },
+    })
+
+  test('renders an aggregation cell per visible field with the group value when enabled', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    const cell = wrapper.findComponent(GridViewGroupByAggregation)
+    expect(cell.exists()).toBe(true)
+    expect(cell.props('rawValue')).toBe(30)
+    expect(cell.props('rowCount')).toBe(2)
+    expect(cell.props('field')).toEqual(amountField)
+  })
+
+  test('renders no aggregation cell when the feature flag is disabled', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }), false)
+
+    expect(wrapper.findComponent(GridViewGroupByAggregation).exists()).toBe(
+      false
+    )
+  })
+
+  test('passes an undefined raw value when the group has no value for the field', async () => {
+    const wrapper = await mountBanner(header({}))
+
+    const cell = wrapper.findComponent(GridViewGroupByAggregation)
+    expect(cell.exists()).toBe(true)
+    expect(cell.props('rawValue')).toBeUndefined()
+  })
+
+  const mountTwoFieldBanner = (aggregations) =>
+    testApp.mount(GridViewGroupByBanner, {
+      propsData: {
+        item: header(aggregations),
+        groupByFields: [colorField],
+        includeRowDetails: false,
+        width: 400,
+        workspaceId: 1,
+        visibleFields: [amountField, sizeField],
+        fieldWidths: { [amountField.id]: 200, [sizeField.id]: 200 },
+        view: { id: 1 },
+        storePrefix: 'page/',
+      },
+      global: {
+        mocks: { $featureFlagIsEnabled: () => true },
+        stubs: { GridViewGroupByAggregation: true },
+      },
+    })
+
+  test('spins only the changed field when a single aggregation is refreshing', async () => {
+    testApp.store.commit('page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING', [
+      amountField.id,
+    ])
+    const wrapper = await mountTwoFieldBanner({ field_2: 30, field_3: 5 })
+
+    const cells = wrapper.findAllComponents(GridViewGroupByAggregation)
+    expect(cells[0].props('field')).toEqual(amountField)
+    expect(cells[0].props('loading')).toBe(true)
+    expect(cells[1].props('field')).toEqual(sizeField)
+    expect(cells[1].props('loading')).toBe(false)
+  })
+
+  test('spins every field when all aggregations are refreshing after a row edit', async () => {
+    testApp.store.commit(
+      'page/view/grid/SET_GROUP_BY_AGGREGATIONS_LOADING',
+      true
+    )
+    const wrapper = await mountTwoFieldBanner({ field_2: 30, field_3: 5 })
+
+    const cells = wrapper.findAllComponents(GridViewGroupByAggregation)
+    expect(cells[0].props('loading')).toBe(true)
+    expect(cells[1].props('loading')).toBe(true)
+  })
+
+  test('forwards the changed field id with the aggregation-changed event', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }))
+
+    wrapper.findComponent(GridViewGroupByAggregation).vm.$emit('change')
+
+    expect(wrapper.emitted('aggregation-changed')[0]).toEqual([amountField.id])
   })
 })

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
@@ -262,11 +262,12 @@ describe('GridViewGroupByBanner aggregations', () => {
   const amountField = { id: 2, name: 'Amount', type: 'number' }
   const sizeField = { id: 3, name: 'Size', type: 'number' }
 
-  const header = (aggregations) => ({
+  const header = (aggregations, aggregationRowCount = undefined) => ({
     type: 'header',
     depth: 0,
     path: { field_1: 'Green' },
     rowCount: 2,
+    aggregationRowCount,
     y: 0,
     height: 48,
     collapsed: false,
@@ -299,6 +300,14 @@ describe('GridViewGroupByBanner aggregations', () => {
     expect(cell.props('rawValue')).toBe(30)
     expect(cell.props('rowCount')).toBe(2)
     expect(cell.props('field')).toEqual(amountField)
+  })
+
+  test('passes the server-confirmed aggregation row count separately', async () => {
+    const wrapper = await mountBanner(header({ field_2: 30 }, 1))
+
+    const cell = wrapper.findComponent(GridViewGroupByAggregation)
+    expect(cell.props('rowCount')).toBe(2)
+    expect(cell.props('aggregationRowCount')).toBe(1)
   })
 
   test('passes an undefined raw value when the group has no value for the field', async () => {

--- a/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewGroupByBanner.spec.js
@@ -128,7 +128,7 @@ describe('GridViewGroupByBanner component', () => {
       .findAll('.grid-view__group-by-banner-separator')
       .map((separator) => separator.element.style.left)
 
-  test('renders separators after the row details lane and internal left fields', async () => {
+  test('renders separators on internal left fields but not the id/primary boundary', async () => {
     const fields = [
       { id: 1, type: 'text', name: 'Name' },
       { id: 2, type: 'text', name: 'Team' },
@@ -155,7 +155,8 @@ describe('GridViewGroupByBanner component', () => {
       },
     })
 
-    expect(separatorLefts(wrapper)).toEqual(['71px', '271px', '421px'])
+    // No separator at 71px: the row-details column is borderless on data rows.
+    expect(separatorLefts(wrapper)).toEqual(['271px', '421px'])
   })
 
   test('renders separators on internal right-section field boundaries', async () => {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -3608,12 +3608,120 @@ describe('Grid view store', () => {
     })
     expect(mockServer.mock.history.get).toHaveLength(2)
     expect(groupByRequestParams.get('include_descendants')).toBe('true')
-    // Expand-all fetches the first rows page in parallel with the skeleton, sized to
-    // the buffer (offset 0) rather than right-sized to the not-yet-known sections.
+    expect(groupByRequestParams.get('include_totals')).toBe('true')
     expect(rowRequestParams.get('offset')).toBe('0')
     expect(rowRequestParams.get('limit')).toBe('40')
     expect(correctMultiSelect).toHaveBeenCalledOnce()
-    expect(fetchAllFieldAggregationData).toHaveBeenCalledOnce()
+    // Grouped mode bundles footer totals into the group-by-data request, so the
+    // standalone aggregation fetch is no longer dispatched.
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
+  })
+
+  test('fetchAllFieldAggregationData refreshes per-group values + footer totals in grouped mode', async () => {
+    const baseState = gridStore.state()
+    const state = Object.assign(baseState, {
+      lastGridId: 1,
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      rowHeight: 33,
+      windowHeight: 330,
+      fieldOptions: {
+        3: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
+      },
+      groupBy: {
+        ...baseState.groupBy,
+        treeNodes: [
+          { path: { field_2: 'A' }, depth: 0, aggregations: { field_3: 10 } },
+        ],
+      },
+    })
+    const aggStore = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: {
+          namespaced: true,
+          getters: {
+            getAll: () => [
+              { id: 2, name: 'Team', type: 'text' },
+              { id: 3, name: 'Amount', type: 'number' },
+            ],
+          },
+        },
+      },
+    })
+    aggStore.replaceState({ ...aggStore.state, grid: state })
+    aggStore.app = { $featureFlagIsEnabled: () => true }
+
+    let params = null
+    mockServer.mock
+      .onGet('/database/views/grid/1/group-by-data/')
+      .reply((config) => {
+        params = config.params
+        return [
+          200,
+          {
+            pages: [
+              {
+                parent: {},
+                groups: [
+                  {
+                    path: { field_2: 'A' },
+                    depth: 0,
+                    aggregations: { field_3: 99 },
+                  },
+                ],
+                offset: 0,
+                limit: 40,
+              },
+            ],
+            aggregations: { field_3: 99 },
+          },
+        ]
+      })
+
+    await aggStore.dispatch('grid/fetchAllFieldAggregationData', {
+      view: { id: 1 },
+    })
+
+    // Consolidated: one group-by-data request carries group values + footer totals;
+    // no standalone /aggregations/ call, and no spinner on a row-driven refresh.
+    expect(params.get('aggregations_only')).toBe('true')
+    expect(params.get('include_totals')).toBe('true')
+    expect(aggStore.state.grid.groupBy.treeNodes[0].aggregations).toEqual({
+      field_3: 99,
+    })
+    expect(aggStore.getters['grid/getAllFieldAggregationData']).toEqual({
+      3: { loading: false, value: 99 },
+    })
+    expect(aggStore.getters['grid/getGroupByAggregationsLoading']()).toBe(false)
+  })
+
+  test('fetchAllFieldAggregationData makes no request in grouped mode when no aggregation is configured', async () => {
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      rowHeight: 33,
+      windowHeight: 330,
+    })
+    const aggStore = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: { namespaced: true, getters: { getAll: () => [] } },
+      },
+    })
+    aggStore.replaceState({ ...aggStore.state, grid: state })
+    aggStore.app = { $featureFlagIsEnabled: () => true }
+
+    let called = false
+    mockServer.mock.onGet(/group-by-data|aggregations/).reply(() => {
+      called = true
+      return [200, { pages: [] }]
+    })
+
+    await aggStore.dispatch('grid/fetchAllFieldAggregationData', {
+      view: { id: 1 },
+    })
+
+    expect(called).toBe(false)
   })
 
   test('refresh keeps the previous group-by state until the next grouping is ready', async () => {
@@ -3841,7 +3949,9 @@ describe('Grid view store', () => {
     ).toEqual([10])
     expect(mockServer.mock.history.get).toHaveLength(2)
     expect(correctMultiSelect).toHaveBeenCalledOnce()
-    expect(fetchAllFieldAggregationData).toHaveBeenCalledOnce()
+    // Grouped mode bundles footer totals into the group-by-data request, so the
+    // standalone aggregation fetch is no longer dispatched.
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
   test('late group-by data responses from an older generation are ignored', async () => {
@@ -4456,7 +4566,9 @@ describe('Grid view store', () => {
     // (otherwise the viewport would sit on an unloaded region and render blank).
     expect(groupByStore.state.grid.scrollTop).toBe(0)
     expect(correctMultiSelect).toHaveBeenCalledOnce()
-    expect(fetchAllFieldAggregationData).toHaveBeenCalledOnce()
+    // Grouped mode bundles footer totals into the group-by-data request, so the
+    // standalone aggregation fetch is no longer dispatched.
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
   test('refresh preserves group-by collapse state when removing a group-by', async () => {
@@ -4579,7 +4691,9 @@ describe('Grid view store', () => {
     })
     expect(mockServer.mock.history.get).toHaveLength(1)
     expect(correctMultiSelect).toHaveBeenCalledOnce()
-    expect(fetchAllFieldAggregationData).toHaveBeenCalledOnce()
+    // Grouped mode bundles footer totals into the group-by-data request, so the
+    // standalone aggregation fetch is no longer dispatched.
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
   test('group-by scroll fetch aborts the previous in-flight scroll request', async () => {
@@ -4737,7 +4851,9 @@ describe('Grid view store', () => {
     expect(groupByStore.state.grid.groupBy.collapse).toEqual(collapse)
     expect(mockServer.mock.history.get).toHaveLength(2)
     expect(correctMultiSelect).toHaveBeenCalledOnce()
-    expect(fetchAllFieldAggregationData).toHaveBeenCalledOnce()
+    // Grouped mode bundles footer totals into the group-by-data request, so the
+    // standalone aggregation fetch is no longer dispatched.
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
   test('fetchInitial uses group-by mode after syncing active group-bys', async () => {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -7,6 +7,7 @@ import {
 import { clone } from '@baserow/modules/core/utils/object'
 import { pathKey } from '@baserow/modules/database/utils/gridGroupByRender'
 import { getDefinedRowsFromSectionRows } from '@baserow/modules/database/utils/gridGroupBy'
+import flushPromises from 'flush-promises'
 
 import { createStore } from 'vuex'
 
@@ -3854,6 +3855,88 @@ describe('Grid view store', () => {
       3: { loading: false, value: 99 },
     })
     expect(aggStore.getters['grid/getGroupByAggregationsLoading']()).toBe(false)
+  })
+
+  test('a targeted fieldId spins that column while a grouped row-edit refresh runs', async () => {
+    const baseState = gridStore.state()
+    const state = Object.assign(baseState, {
+      lastGridId: 1,
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      rowHeight: 33,
+      windowHeight: 330,
+      fieldOptions: {
+        3: { aggregation_type: 'sum', aggregation_raw_type: 'sum' },
+      },
+      groupBy: {
+        ...baseState.groupBy,
+        treeNodes: [
+          { path: { field_2: 'A' }, depth: 0, aggregations: { field_3: 10 } },
+        ],
+      },
+    })
+    const aggStore = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: {
+          namespaced: true,
+          getters: {
+            getAll: () => [
+              { id: 2, name: 'Team', type: 'text' },
+              { id: 3, name: 'Amount', type: 'number' },
+            ],
+          },
+        },
+      },
+    })
+    aggStore.replaceState({ ...aggStore.state, grid: state })
+    aggStore.app = { $featureFlagIsEnabled: () => true }
+
+    let resolveRequest = null
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = () =>
+            resolve([
+              200,
+              {
+                pages: [
+                  {
+                    parent: {},
+                    groups: [
+                      {
+                        path: { field_2: 'A' },
+                        depth: 0,
+                        aggregations: { field_3: 99 },
+                      },
+                    ],
+                    offset: 0,
+                    limit: 40,
+                  },
+                ],
+                aggregations: { field_3: 99 },
+              },
+            ])
+        })
+    )
+
+    const promise = aggStore.dispatch('grid/fetchAllFieldAggregationData', {
+      view: { id: 1 },
+      fieldId: 3,
+    })
+
+    // The edited column spins mid-refresh, even though a row edit refreshes silently.
+    expect(aggStore.getters['grid/getGroupByAggregationsLoading'](3)).toBe(true)
+
+    await flushPromises()
+    resolveRequest()
+    await promise
+
+    expect(aggStore.getters['grid/getGroupByAggregationsLoading'](3)).toBe(
+      false
+    )
+    expect(aggStore.state.grid.groupBy.treeNodes[0].aggregations).toEqual({
+      field_3: 99,
+    })
   })
 
   test('fetchAllFieldAggregationData makes no request in grouped mode when no aggregation is configured', async () => {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -2704,6 +2704,167 @@ describe('Grid view store', () => {
     ])
   })
 
+  test('createNewRowInGroup spins the affected group aggregations until the backend confirms', async () => {
+    const fields = [
+      {
+        id: 1,
+        name: 'Name',
+        type: 'text',
+        primary: true,
+        _: { type: { type: 'text' } },
+      },
+      {
+        id: 2,
+        name: 'Team',
+        type: 'text',
+        _: { type: { type: 'text' } },
+      },
+    ]
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r',
+    }
+    const groupByStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            fetchByScrollTopDelayed: vi.fn(),
+          },
+        },
+        field: {
+          namespaced: true,
+          getters: { getAll: () => fields },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 2,
+      fieldOptions: {
+        1: {
+          hidden: false,
+          order: 0,
+          aggregation_type: 'empty_count',
+          aggregation_raw_type: 'empty_count',
+        },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        ...gridStore.state().groupBy,
+        treeNodes: [
+          {
+            path: { field_2: 'A' },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 0 },
+          },
+          {
+            path: { field_2: 'B' },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 0 },
+          },
+        ],
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    groupByStore.replaceState({ ...groupByStore.state, grid: state })
+    groupByStore.app = { $featureFlagIsEnabled: () => true }
+    groupByStore.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'B'),
+      rows: [
+        {
+          id: 10,
+          order: '1.00',
+          field_1: 'Existing',
+          field_2: 'B',
+          _: { ...rowMetadata, persistentId: 'r10' },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    let finishCreate
+    mockServer.mock.onPost('/database/rows/table/1/batch/').reply(
+      () =>
+        new Promise((resolve) => {
+          finishCreate = () =>
+            resolve([
+              200,
+              {
+                items: [{ id: 11, order: '2.00', field_1: '', field_2: 'B' }],
+                metadata: { updated_field_ids: [] },
+              },
+            ])
+        })
+    )
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(() => [
+      200,
+      {
+        pages: [
+          {
+            parent: {},
+            groups: [
+              {
+                path: { field_2: 'B' },
+                depth: 0,
+                aggregations: { field_1: 1 },
+              },
+            ],
+            offset: 0,
+            limit: 40,
+          },
+        ],
+        aggregations: { field_1: 1 },
+      },
+    ])
+
+    const createPromise = groupByStore.dispatch('grid/createNewRowInGroup', {
+      view: {
+        id: 1,
+        filters: [],
+        filter_groups: [],
+        filter_type: 'AND',
+        sortings: [],
+        group_bys: groupBys,
+      },
+      table: { id: 1 },
+      fields,
+      path: { field_2: 'B' },
+      selectPrimaryCell: true,
+    })
+    await new Promise((resolve) => setTimeout(resolve))
+
+    // While the create request is pending, the inserted group spins instead of
+    // recomputing its aggregations from the optimistically bumped row count.
+    expect(groupByStore.state.grid.groupBy.aggregationsLoadingPaths).toContain(
+      groupPathKey(2, 'B')
+    )
+    // Sibling groups are untouched, so they must not spin.
+    expect(
+      groupByStore.state.grid.groupBy.aggregationsLoadingPaths
+    ).not.toContain(groupPathKey(2, 'A'))
+
+    finishCreate()
+    await createPromise
+
+    // The backend refresh delivered fresh values and cleared the spinner.
+    expect(groupByStore.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
+  })
+
   test('createNewRowInGroup does not duplicate a queued edited row when adding another row', async () => {
     const fields = [
       {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -1296,6 +1296,208 @@ describe('Grid view store', () => {
     expect(store.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
   })
 
+  test('refreshRow recomputes and clears group aggregation spinners after a deselect group move', async () => {
+    const optionA = { id: 101, value: 'A', color: 'blue' }
+    const optionB = { id: 102, value: 'B', color: 'green' }
+    const fields = [
+      { id: 1, name: 'Name', type: 'text', primary: true },
+      {
+        id: 2,
+        name: 'Team',
+        type: 'single_select',
+        select_options: [optionA, optionB],
+      },
+    ]
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r',
+    }
+    store = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            fetchByScrollTopDelayed: vi.fn(),
+          },
+        },
+        field: {
+          namespaced: true,
+          getters: { getAll: () => fields },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 2,
+      fieldOptions: {
+        1: {
+          hidden: false,
+          order: 0,
+          aggregation_type: 'not_empty_count',
+          aggregation_raw_type: 'empty_count',
+        },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        ...gridStore.state().groupBy,
+        treeNodes: [
+          {
+            path: { field_2: optionA.id },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 1 },
+          },
+          {
+            path: { field_2: optionB.id },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 0 },
+          },
+        ],
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    store.replaceState({ ...store.state, grid: state })
+
+    // Row 10 still sits in group A's section, but while selected its value was
+    // edited to B, so it no longer matches the sort and must move to group B once
+    // it is deselected.
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, optionA.id),
+      rows: [
+        {
+          id: 10,
+          order: '1.00',
+          field_1: 'Alice',
+          field_2: optionB,
+          _: {
+            ...rowMetadata,
+            persistentId: 'r10',
+            selectedBy: [2],
+            matchSortings: false,
+          },
+        },
+      ],
+      startPosition: 0,
+    })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, optionB.id),
+      rows: [
+        {
+          id: 11,
+          order: '2.00',
+          field_1: 'Bob',
+          field_2: optionB,
+          _: { ...rowMetadata, persistentId: 'r11' },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    let groupByDataRequests = 0
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(() => {
+      groupByDataRequests += 1
+      return [
+        200,
+        {
+          pages: [
+            {
+              parent: {},
+              groups: [
+                {
+                  path: { field_2: optionA.id },
+                  depth: 0,
+                  row_count: 0,
+                  aggregations: { field_1: 0 },
+                },
+                {
+                  path: { field_2: optionB.id },
+                  depth: 0,
+                  row_count: 2,
+                  aggregations: { field_1: 1 },
+                },
+              ],
+              offset: 0,
+              limit: 40,
+            },
+          ],
+          aggregations: { field_1: 1 },
+        },
+      ]
+    })
+
+    await store.dispatch('grid/removeRowSelectedBy', {
+      grid: {
+        id: 1,
+        filters: [],
+        filter_groups: [],
+        filter_type: 'AND',
+        sortings: [],
+        group_bys: groupBys,
+      },
+      row: store.getters['grid/getRow'](10),
+      field: fields[1],
+      fields,
+      getScrollTop: () => 0,
+    })
+    await flushPromises()
+
+    // The deselect move marks the affected groups' aggregations loading; the
+    // recompute request must land and clear the spinners instead of leaving them
+    // stuck forever.
+    expect(groupByDataRequests).toBe(1)
+    expect(store.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
+  })
+
+  test('updateFieldOptionsOfField clears the aggregation spinner when the save request fails', async () => {
+    const fields = [{ id: 1, name: 'Name', type: 'text', primary: true }]
+    store = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: {
+          namespaced: true,
+          getters: { getAll: () => fields },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      fieldOptions: { 1: { hidden: false, order: 0 } },
+    })
+    store.replaceState({ ...store.state, grid: state })
+
+    mockServer.mock.onPatch('/database/views/1/field-options/').reply(500)
+
+    await expect(
+      store.dispatch('grid/updateFieldOptionsOfField', {
+        field: fields[0],
+        values: {
+          aggregation_type: 'empty_count',
+          aggregation_raw_type: 'empty_count',
+        },
+        oldValues: { aggregation_type: '', aggregation_raw_type: '' },
+        // Mirrors the grouped picker, which owns its own refresh.
+        skipAggregationRefresh: true,
+      })
+    ).rejects.toBeTruthy()
+    await flushPromises()
+
+    // A failed save must stop the spinner too; the picker showed it optimistically.
+    expect(store.state.grid.fieldAggregationData[1].loading).toBe(false)
+  })
+
   test('updateRowValue keeps a modal-open edit in place with a filter warning', async () => {
     const fields = [
       {
@@ -2868,7 +3070,7 @@ describe('Grid view store', () => {
     ])
   })
 
-  test('createNewRowInGroup spins the affected group aggregations until the backend confirms', async () => {
+  test('createNewRowInGroup spins the affected group and footer aggregations until the backend confirms', async () => {
     const fields = [
       {
         id: 1,
@@ -3022,11 +3224,172 @@ describe('Grid view store', () => {
       groupByStore.state.grid.groupBy.aggregationsLoadingPaths
     ).not.toContain(groupPathKey(2, 'A'))
 
+    // The table-level footer aggregation must spin too, otherwise it recomputes
+    // `rowCount - value` from the bumped count and flashes a wrong value.
+    expect(groupByStore.state.grid.fieldAggregationData[1].loading).toBe(true)
+
     finishCreate()
     await createPromise
 
     // The backend refresh delivered fresh values and cleared the spinner.
     expect(groupByStore.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
+    expect(groupByStore.state.grid.fieldAggregationData[1].loading).toBe(false)
+    expect(groupByStore.state.grid.fieldAggregationData[1].value).toBe(1)
+  })
+
+  test('deleteExistingRow spins the affected group and footer aggregations until the backend confirms', async () => {
+    const fields = [
+      {
+        id: 1,
+        name: 'Name',
+        type: 'text',
+        primary: true,
+        _: { type: { type: 'text' } },
+      },
+      {
+        id: 2,
+        name: 'Team',
+        type: 'text',
+        _: { type: { type: 'text' } },
+      },
+    ]
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r',
+    }
+    const groupByStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            fetchByScrollTopDelayed: vi.fn(),
+          },
+        },
+        field: {
+          namespaced: true,
+          getters: { getAll: () => fields },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 2,
+      fieldOptions: {
+        1: {
+          hidden: false,
+          order: 0,
+          aggregation_type: 'empty_count',
+          aggregation_raw_type: 'empty_count',
+        },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        ...gridStore.state().groupBy,
+        treeNodes: [
+          {
+            path: { field_2: 'B' },
+            depth: 0,
+            row_count: 2,
+            aggregations: { field_1: 0 },
+          },
+        ],
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    groupByStore.replaceState({ ...groupByStore.state, grid: state })
+    groupByStore.app = { $featureFlagIsEnabled: () => true }
+    groupByStore.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'B'),
+      rows: [
+        {
+          id: 10,
+          order: '1.00',
+          field_1: 'Existing',
+          field_2: 'B',
+          _: { ...rowMetadata, persistentId: 'r10' },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    mockServer.mock.onDelete('/database/rows/table/1/10/').reply(200, {})
+    let finishRefresh
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(
+      () =>
+        new Promise((resolve) => {
+          finishRefresh = () =>
+            resolve([
+              200,
+              {
+                pages: [
+                  {
+                    parent: {},
+                    groups: [
+                      {
+                        path: { field_2: 'B' },
+                        depth: 0,
+                        aggregations: { field_1: 1 },
+                      },
+                    ],
+                    offset: 0,
+                    limit: 40,
+                  },
+                ],
+                aggregations: { field_1: 1 },
+              },
+            ])
+        })
+    )
+
+    await groupByStore.dispatch('grid/deleteExistingRow', {
+      table: { id: 1 },
+      view: {
+        id: 1,
+        filters: [],
+        filter_groups: [],
+        filter_type: 'AND',
+        sortings: [],
+        group_bys: groupBys,
+      },
+      row: {
+        id: 10,
+        order: '1.00',
+        field_1: 'Existing',
+        field_2: 'B',
+        _: { ...rowMetadata, persistentId: 'r10' },
+      },
+      fields,
+      getScrollTop: () => 0,
+    })
+    // Let the fire-and-forget aggregation refresh issue its request.
+    await new Promise((resolve) => setTimeout(resolve))
+
+    // The delete resolved but the aggregation refresh is still in flight, so the
+    // group banner and the footer aggregation must spin (not recompute from the
+    // decremented count) until it returns.
+    expect(groupByStore.state.grid.groupBy.aggregationsLoadingPaths).toContain(
+      groupPathKey(2, 'B')
+    )
+    expect(groupByStore.state.grid.fieldAggregationData[1].loading).toBe(true)
+
+    finishRefresh()
+    await new Promise((resolve) => setTimeout(resolve))
+
+    expect(groupByStore.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
+    expect(groupByStore.state.grid.fieldAggregationData[1].loading).toBe(false)
+    expect(groupByStore.state.grid.fieldAggregationData[1].value).toBe(1)
   })
 
   test('createNewRowInGroup does not duplicate a queued edited row when adding another row', async () => {
@@ -4022,6 +4385,82 @@ describe('Grid view store', () => {
       3: { loading: false, value: 99 },
     })
     expect(aggStore.getters['grid/getGroupByAggregationsLoading']()).toBe(false)
+  })
+
+  test('un-hiding an aggregated field in grouped mode refetches its stale value', async () => {
+    const baseState = gridStore.state()
+    const state = Object.assign(baseState, {
+      lastGridId: 1,
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      fieldOptions: {
+        3: {
+          hidden: true,
+          aggregation_type: 'sum',
+          aggregation_raw_type: 'sum',
+        },
+      },
+      groupBy: {
+        ...baseState.groupBy,
+        // The field's value was dropped from the tree while it was hidden.
+        treeNodes: [{ path: { field_2: 'A' }, depth: 0, aggregations: {} }],
+      },
+    })
+    const aggStore = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: {
+          namespaced: true,
+          getters: {
+            getAll: () => [
+              { id: 2, name: 'Team', type: 'text' },
+              { id: 3, name: 'Amount', type: 'number' },
+            ],
+          },
+        },
+      },
+    })
+    aggStore.replaceState({ ...aggStore.state, grid: state })
+    aggStore.app = { $featureFlagIsEnabled: () => true }
+
+    mockServer.mock.onPatch('/database/views/1/field-options/').reply(200, {})
+    let refreshed = false
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(() => {
+      refreshed = true
+      return [
+        200,
+        {
+          pages: [
+            {
+              parent: {},
+              groups: [
+                {
+                  path: { field_2: 'A' },
+                  depth: 0,
+                  row_count: 4,
+                  aggregations: { field_3: 99 },
+                },
+              ],
+              offset: 0,
+              limit: 40,
+            },
+          ],
+          aggregations: { field_3: 99 },
+        },
+      ]
+    })
+
+    await aggStore.dispatch('grid/updateFieldOptionsOfField', {
+      field: { id: 3, name: 'Amount', type: 'number' },
+      values: { hidden: false },
+      oldValues: { hidden: true },
+    })
+    await new Promise((resolve) => setTimeout(resolve))
+    await new Promise((resolve) => setTimeout(resolve))
+
+    expect(refreshed).toBe(true)
+    expect(aggStore.state.grid.groupBy.treeNodes[0].aggregations).toEqual({
+      field_3: 99,
+    })
   })
 
   test('a targeted fieldId spins that column while a grouped row-edit refresh runs', async () => {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -1133,6 +1133,169 @@ describe('Grid view store', () => {
     expect(mockServer.mock.history.get).toHaveLength(0)
   })
 
+  test('updateRowValue spins affected group aggregations before an optimistic group move changes counts', async () => {
+    const optionA = { id: 101, value: 'A', color: 'blue' }
+    const optionB = { id: 102, value: 'B', color: 'green' }
+    const fields = [
+      { id: 1, name: 'Name', type: 'text', primary: true },
+      {
+        id: 2,
+        name: 'Team',
+        type: 'single_select',
+        select_options: [optionA, optionB],
+      },
+    ]
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const rowMetadata = {
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+      matchFilters: true,
+      matchSortings: true,
+      matchSearch: true,
+      fieldSearchMatches: [],
+      persistentId: 'r',
+    }
+    store = testApp.createStore({
+      modules: {
+        grid: gridStore,
+        field: {
+          namespaced: true,
+          getters: { getAll: () => fields },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 2,
+      fieldOptions: {
+        1: {
+          hidden: false,
+          order: 0,
+          aggregation_type: 'not_empty_count',
+          aggregation_raw_type: 'empty_count',
+        },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        ...gridStore.state().groupBy,
+        treeNodes: [
+          {
+            path: { field_2: optionA.id },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 1 },
+          },
+          {
+            path: { field_2: optionB.id },
+            depth: 0,
+            row_count: 1,
+            aggregations: { field_1: 0 },
+          },
+        ],
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+
+    store.replaceState({ ...store.state, grid: state })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, optionA.id),
+      rows: [
+        {
+          id: 10,
+          order: '1.00',
+          field_1: '',
+          field_2: optionA,
+          _: {
+            ...rowMetadata,
+            persistentId: 'r10',
+          },
+        },
+      ],
+      startPosition: 0,
+    })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, optionB.id),
+      rows: [
+        {
+          id: 11,
+          order: '2.00',
+          field_1: 'Bob',
+          field_2: optionB,
+          _: { ...rowMetadata, persistentId: 'r11' },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    let finishUpdate
+    mockServer.mock.onPatch('/database/rows/table/1/batch/').reply(
+      () =>
+        new Promise((resolve) => {
+          finishUpdate = () =>
+            resolve([
+              200,
+              {
+                items: [{ id: 10, field_2: optionB }],
+                metadata: { updated_field_ids: [2] },
+              },
+            ])
+        })
+    )
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(200, {
+      pages: [
+        {
+          parent: {},
+          groups: [
+            {
+              path: { field_2: optionB.id },
+              depth: 0,
+              row_count: 2,
+              aggregations: { field_1: 1 },
+            },
+          ],
+          offset: 0,
+          limit: 40,
+        },
+      ],
+      aggregations: { field_1: 1 },
+    })
+
+    const updatePromise = store.dispatch('grid/updateRowValue', {
+      table: { id: 1 },
+      view: {
+        id: 1,
+        filters: [],
+        filter_groups: [],
+        filter_type: 'AND',
+        sortings: [],
+        group_bys: groupBys,
+      },
+      row: store.getters['grid/getRow'](10),
+      field: fields[1],
+      fields,
+      value: optionB,
+      oldValue: optionA,
+    })
+    await new Promise((resolve) => setTimeout(resolve))
+
+    expect(store.state.grid.groupBy.treeNodes[0].row_count).toBe(0)
+    expect(store.state.grid.groupBy.aggregationsLoadingPaths).toEqual([
+      groupPathKey(2, optionA.id),
+      groupPathKey(2, optionB.id),
+    ])
+
+    finishUpdate()
+    await updatePromise
+    await flushPromises()
+
+    expect(store.state.grid.groupBy.aggregationsLoadingPaths).toEqual([])
+  })
+
   test('updateRowValue keeps a modal-open edit in place with a filter warning', async () => {
     const fields = [
       {
@@ -3828,6 +3991,7 @@ describe('Grid view store', () => {
                   {
                     path: { field_2: 'A' },
                     depth: 0,
+                    row_count: 4,
                     aggregations: { field_3: 99 },
                   },
                 ],
@@ -3851,6 +4015,9 @@ describe('Grid view store', () => {
     expect(aggStore.state.grid.groupBy.treeNodes[0].aggregations).toEqual({
       field_3: 99,
     })
+    expect(aggStore.state.grid.groupBy.treeNodes[0].aggregation_row_count).toBe(
+      4
+    )
     expect(aggStore.getters['grid/getAllFieldAggregationData']).toEqual({
       3: { loading: false, value: 99 },
     })
@@ -3906,6 +4073,7 @@ describe('Grid view store', () => {
                       {
                         path: { field_2: 'A' },
                         depth: 0,
+                        row_count: 4,
                         aggregations: { field_3: 99 },
                       },
                     ],
@@ -3937,6 +4105,9 @@ describe('Grid view store', () => {
     expect(aggStore.state.grid.groupBy.treeNodes[0].aggregations).toEqual({
       field_3: 99,
     })
+    expect(aggStore.state.grid.groupBy.treeNodes[0].aggregation_row_count).toBe(
+      4
+    )
   })
 
   test('fetchAllFieldAggregationData makes no request in grouped mode when no aggregation is configured', async () => {

--- a/web-frontend/test/unit/database/utils/gridGroupBy.spec.js
+++ b/web-frontend/test/unit/database/utils/gridGroupBy.spec.js
@@ -493,6 +493,34 @@ describe('gridGroupBy node helpers', () => {
       ])
     })
 
+    test('preserves the confirmed aggregation row count on an optimistic count update', () => {
+      const nodes = [
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 2,
+          aggregations: { field_2: 1 },
+        },
+      ]
+      const result = updateGroupByTreeNodesForPath(
+        nodes,
+        { field_1: 'A' },
+        fields,
+        1,
+        groupBys,
+        registry
+      )
+      expect(result).toEqual([
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 3,
+          aggregations: { field_2: 1 },
+          aggregation_row_count: 2,
+        },
+      ])
+    })
+
     test('inserts a new node in sorted order on a positive delta', () => {
       const nodes = [
         { path: { field_1: 'A' }, depth: 0, row_count: 1 },
@@ -707,6 +735,41 @@ describe('gridGroupBy paged tree maintenance', () => {
       // B's offset shifts because A now has one more row.
       expect(result.nodes[1].row_offset).toBe(3)
       expect(result.totalSiblingCount).toBe(2)
+    })
+
+    test('preserves the confirmed aggregation row count on a paged optimistic count update', () => {
+      const page = {
+        nodes: {
+          0: {
+            path: { field_1: 'A' },
+            depth: 0,
+            row_count: 2,
+            sibling_index: 0,
+            row_offset: 0,
+            aggregations: { field_2: 1 },
+          },
+        },
+        totalSiblingCount: 1,
+        rowOffset: 0,
+      }
+      const result = updateGroupByDataPageForPath({
+        page,
+        path: { field_1: 'A' },
+        fields,
+        depth: 0,
+        delta: 1,
+        groupBys,
+        registry,
+      })
+      expect(result.nodes[0]).toEqual({
+        path: { field_1: 'A' },
+        depth: 0,
+        row_count: 3,
+        sibling_index: 0,
+        row_offset: 0,
+        aggregations: { field_2: 1 },
+        aggregation_row_count: 2,
+      })
     })
 
     test('increments a matching node without densifying sparse loaded windows', () => {

--- a/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
+++ b/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
@@ -212,6 +212,53 @@ describe('gridGroupByRender', () => {
     expect(pagedAddRow.y).toBe(HEADER_HEIGHT + 2 * rowHeight)
   })
 
+  test('buildLayout carries per-group aggregations onto header items', () => {
+    const fields = [textField(1)]
+    const layout = buildLayout({
+      nodes: [
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 2,
+          aggregations: { field_2: 30 },
+        },
+        { path: { field_1: 'B' }, depth: 0, row_count: 1 },
+      ],
+      collapse: { mode: 'expand', paths: [] },
+      fields,
+    })
+
+    const headers = layout.items.filter((item) => item.type === 'header')
+    expect(headers[0].aggregations).toStrictEqual({ field_2: 30 })
+    expect(headers[1].aggregations).toBe(null)
+  })
+
+  test('renderViewport preserves header aggregations', () => {
+    const fields = [textField(1)]
+    const layout = buildLayout({
+      nodes: [
+        {
+          path: { field_1: 'A' },
+          depth: 0,
+          row_count: 1,
+          aggregations: { field_2: 5 },
+        },
+      ],
+      collapse: { mode: 'expand', paths: [] },
+      fields,
+    })
+
+    const items = renderViewport({
+      layout,
+      sectionRows: new Map(),
+      viewport: { scrollTop: 0, clientHeight: 1000 },
+      fields,
+    })
+
+    const header = items.find((item) => item.type === 'header')
+    expect(header.aggregations).toStrictEqual({ field_2: 5 })
+  })
+
   test('buildLayout skips collapsed descendants', () => {
     const fields = [textField(1), textField(2)]
     const layout = buildLayout({

--- a/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
+++ b/web-frontend/test/unit/database/utils/gridGroupByRender.spec.js
@@ -220,6 +220,7 @@ describe('gridGroupByRender', () => {
           path: { field_1: 'A' },
           depth: 0,
           row_count: 2,
+          aggregation_row_count: 1,
           aggregations: { field_2: 30 },
         },
         { path: { field_1: 'B' }, depth: 0, row_count: 1 },
@@ -230,7 +231,10 @@ describe('gridGroupByRender', () => {
 
     const headers = layout.items.filter((item) => item.type === 'header')
     expect(headers[0].aggregations).toStrictEqual({ field_2: 30 })
+    expect(headers[0].rowCount).toBe(2)
+    expect(headers[0].aggregationRowCount).toBe(1)
     expect(headers[1].aggregations).toBe(null)
+    expect(headers[1].aggregationRowCount).toBe(1)
   })
 
   test('renderViewport preserves header aggregations', () => {
@@ -241,6 +245,7 @@ describe('gridGroupByRender', () => {
           path: { field_1: 'A' },
           depth: 0,
           row_count: 1,
+          aggregation_row_count: 2,
           aggregations: { field_2: 5 },
         },
       ],
@@ -257,6 +262,7 @@ describe('gridGroupByRender', () => {
 
     const header = items.find((item) => item.type === 'header')
     expect(header.aggregations).toStrictEqual({ field_2: 5 })
+    expect(header.aggregationRowCount).toBe(2)
   })
 
   test('buildLayout skips collapsed descendants', () => {

--- a/web-frontend/test/unit/database/viewAggregationType.spec.js
+++ b/web-frontend/test/unit/database/viewAggregationType.spec.js
@@ -237,6 +237,18 @@ const testData = {
       },
     },
   ],
+  distribution: {
+    inputValue: [
+      ['Blue', 3],
+      ['Red', 6],
+    ],
+    expectedResult: [
+      ['Blue', '(3)', '30%'],
+      ['Red', '(6)', '60%'],
+      [undefined, '(1)', '10%'],
+    ],
+    context: { rowCount: 10 },
+  },
 }
 
 const testDataError = {
@@ -395,6 +407,13 @@ const testDataError = {
       },
     },
   ],
+  // A previous aggregation's scalar value can briefly reach distribution during a
+  // type switch; it must resolve to null rather than throwing on `.map`.
+  distribution: {
+    inputValue: 25,
+    expectedResult: null,
+    context: { rowCount: 100 },
+  },
 }
 
 describe('View Aggregation Tests', () => {
@@ -444,5 +463,21 @@ describe('View Aggregation Tests', () => {
           })
         }
       })
+  })
+
+  test('only scalar aggregations are allowed in group-by mode', () => {
+    const allowed = {}
+    store.$registry
+      .getOrderedList('viewAggregation')
+      .forEach((aggregationType) => {
+        allowed[aggregationType.getType()] =
+          aggregationType.isAllowedInGroupBy()
+      })
+
+    // Distribution has no scalar per-group value, so it is footer-only.
+    expect(allowed.distribution).toBe(false)
+    // Scalar aggregations remain available per group.
+    expect(allowed.sum).toBe(true)
+    expect(allowed.not_empty_count).toBe(true)
   })
 })


### PR DESCRIPTION
## Group aggregations 

Builds on #5592 (per-group aggregation display).

Closes #2258


https://github.com/user-attachments/assets/5255db6f-162c-43d4-9f56-9b48cedcbf14


When a grouped grid view has a column "Summarize" configured, the per-group header values **and** the footer total now update **live and in place** on any change — cell edits, row create/delete, and realtime from other users — with no spinner. The spinner stays for deliberately changing a column's aggregation function.

In grouped mode these come from a **single `group-by-data` request** (`aggregations_only` + `include_totals`); the standalone `/aggregations/` footer endpoint is no longer called while grouped. Sort changes trigger no aggregation refresh (values are order-independent). 

---
Stacked on `feat/group-by-aggregations` (#5592)