### PR TITLE
fix(backend): prevent double HTTP response on MCP SSE connection close

### DIFF
--- a/backend/src/baserow/core/mcp/__init__.py
+++ b/backend/src/baserow/core/mcp/__init__.py
@@ -13,6 +13,18 @@ if TYPE_CHECKING:
 current_key: contextvars.ContextVar[str] = contextvars.ContextVar("current_key")
 
 
+def _is_sse_disconnect_teardown_error(exc: BaseException) -> bool:
+    """
+    True if `exc` is only the benign "response already completed" RuntimeError
+    raised while the SSE stream tears down on client disconnect. anyio wraps
+    child-task errors in an ExceptionGroup, so unwrap before checking.
+    """
+
+    if isinstance(exc, BaseExceptionGroup):
+        return all(_is_sse_disconnect_teardown_error(e) for e in exc.exceptions)
+    return isinstance(exc, RuntimeError) and "already completed" in str(exc)
+
+
 class BaserowMCPServer:
     """
     This class is inspired by FastMCP
@@ -121,7 +133,18 @@ class BaserowMCPServer:
         messages_path = "/mcp/messages/"
         sse = DjangoChannelsSseServerTransport(messages_path)
 
-        async def handle_sse(request: Request) -> None:
+        class _AlreadyStreamedResponse(Response):
+            """
+            A response that sends nothing, because the SSE transport already sent one.
+
+            Returning a normal Response here makes Starlette send a second
+            http.response.start, which uvicorn rejects (Sentry BASEROW-SAAS-BACKEND-Z4).
+            """
+
+            async def __call__(self, scope, receive, send) -> None:
+                return
+
+        async def handle_sse(request: Request) -> Response:
             key = request.path_params["key"]
             key_ctx = current_key.set(key)
 
@@ -130,6 +153,19 @@ class BaserowMCPServer:
                 # If there is no endpoint, then there is no need to start a
                 # connection. It's valid to immediately respond with a 401 error.
                 return Response("Endpoint not found.", status_code=401)
+
+            # connect_sse sends the response itself via request._send. Track that so
+            # we can return a no-op instead of one Starlette would send on top.
+            response_started = False
+            send = request._send
+
+            async def tracking_send(message):
+                nonlocal response_started
+                if message["type"] == "http.response.start":
+                    response_started = True
+                await send(message)
+
+            request._send = tracking_send  # type: ignore[reportPrivateUsage]
 
             try:
                 async with sse.connect_sse(
@@ -142,18 +178,19 @@ class BaserowMCPServer:
                         streams[1],
                         self._mcp_server.create_initialization_options(),
                     )
-                return Response()
+                return _AlreadyStreamedResponse() if response_started else Response()
             except Exception as exc:
-                # This is a known issue in FastMCP
-                # (https://github.com/jlowin/fastmcp/issues/671) that is not causing any
-                # critical issues in practice, but it does cause some noise in the logs.
-                if isinstance(
-                    exc, RuntimeError
-                ) and "after response already completed" in str(exc):
-                    return Response(status_code=204)
-
-                logger.exception("Error while handling SSE connection")
-                return Response("MCP server error", status_code=500)
+                if not response_started:
+                    logger.exception("Error while handling SSE connection")
+                    return Response("MCP server error", status_code=500)
+                # Headers are already out, so we can never send an error status
+                # without re-triggering Z4. Still surface real failures: only the
+                # known teardown race after a client disconnect is benign noise.
+                if _is_sse_disconnect_teardown_error(exc):
+                    logger.debug("SSE connection closed after the response started.")
+                else:
+                    logger.exception("Error after the SSE response had started")
+                return _AlreadyStreamedResponse()
             finally:
                 # Reset the context variable when done
                 current_key.reset(key_ctx)

--- a/backend/src/baserow/core/mcp/__init__.py
+++ b/backend/src/baserow/core/mcp/__init__.py
@@ -154,8 +154,9 @@ class BaserowMCPServer:
                 # connection. It's valid to immediately respond with a 401 error.
                 return Response("Endpoint not found.", status_code=401)
 
-            # connect_sse sends the response itself via request._send. Track that so
-            # we can return a no-op instead of one Starlette would send on top.
+            # connect_sse sends the response itself via the send callable. Wrap it to
+            # track that, so we can return a no-op instead of one Starlette would send
+            # on top.
             response_started = False
             send = request._send
 
@@ -165,13 +166,11 @@ class BaserowMCPServer:
                     response_started = True
                 await send(message)
 
-            request._send = tracking_send  # type: ignore[reportPrivateUsage]
-
             try:
                 async with sse.connect_sse(
                     request.scope,
                     request.receive,
-                    request._send,  # type: ignore[reportPrivateUsage]
+                    tracking_send,
                 ) as streams:
                     await self._mcp_server.run(
                         streams[0],

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -289,7 +289,10 @@ def test_handle_sse_still_logs_errors_raised_after_the_response_started(data_fix
             raise ValueError("boom")
 
         async def receive():
-            await anyio.sleep(10)
+            # Block until the connect_sse teardown cancels this task. Waiting on a
+            # never-set event (rather than sleeping for the fail_after window) keeps
+            # the test from racing its own timeout boundary.
+            await anyio.Event().wait()
             return {"type": "http.disconnect"}
 
         async def send(message):

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -276,13 +276,17 @@ def test_handle_sse_still_logs_errors_raised_after_the_response_started(data_fix
 
     response_starts = 0
 
-    async def failing_run(*args, **kwargs):
-        # Let the EventSourceResponse send http.response.start first, then fail.
-        await anyio.sleep(0.05)
-        raise ValueError("boom")
-
     async def inner():
         nonlocal response_starts
+        response_started = anyio.Event()
+
+        async def failing_run(*args, **kwargs):
+            # Wait until the EventSourceResponse has actually sent
+            # http.response.start, then fail. Synchronising on the event instead
+            # of a fixed sleep keeps the post-response-start branch deterministic
+            # on slow/loaded CI.
+            await response_started.wait()
+            raise ValueError("boom")
 
         async def receive():
             await anyio.sleep(10)
@@ -292,6 +296,7 @@ def test_handle_sse_still_logs_errors_raised_after_the_response_started(data_fix
             nonlocal response_starts
             if message["type"] == "http.response.start":
                 response_starts += 1
+                response_started.set()
 
         scope = {
             "type": "http",

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -8,8 +8,29 @@ from mcp.shared.memory import (
     create_connected_server_and_client_session as client_session,
 )
 
-from baserow.core.mcp import BaserowMCPServer, current_key
+from baserow.core.mcp import (
+    BaserowMCPServer,
+    _is_sse_disconnect_teardown_error,
+    current_key,
+)
 from baserow.core.mcp.sse import DjangoChannelsSseServerTransport
+
+
+def test_is_sse_disconnect_teardown_error():
+    benign = RuntimeError("Response already completed.")
+    real = ValueError("boom")
+
+    # Bare and ExceptionGroup-wrapped benign errors are recognised. anyio wraps
+    # the child-task error from EventSourceResponse in a group.
+    assert _is_sse_disconnect_teardown_error(benign) is True
+    assert _is_sse_disconnect_teardown_error(ExceptionGroup("tg", [benign])) is True
+
+    # Real errors are not, whether bare, wrapped, or mixed with a benign one.
+    assert _is_sse_disconnect_teardown_error(real) is False
+    assert _is_sse_disconnect_teardown_error(ExceptionGroup("tg", [real])) is False
+    assert (
+        _is_sse_disconnect_teardown_error(ExceptionGroup("tg", [benign, real])) is False
+    )
 
 
 @pytest.mark.django_db
@@ -181,6 +202,119 @@ def test_sse_listener_is_closed_when_connection_is_closed():
         assert listener_group() is None
 
     async_to_sync(inner)()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_handle_sse_sends_a_single_http_response_start(data_fixture):
+    """
+    Regression for BASEROW-SAAS-BACKEND-Z4: once the SSE transport has started
+    streaming, the route must not return a Response that Starlette sends on top,
+    because that emits a second http.response.start and raises a RuntimeError.
+    """
+
+    endpoint = data_fixture.create_mcp_endpoint()
+    app = BaserowMCPServer().sse_app()
+    key_token = current_key.set(endpoint.key)
+
+    response_starts = 0
+
+    async def inner():
+        nonlocal response_starts
+        client_disconnected = anyio.Event()
+
+        async def receive():
+            await client_disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            nonlocal response_starts
+            if message["type"] == "http.response.start":
+                response_starts += 1
+                # Streaming has begun; disconnect so the transport tears down and
+                # the route returns.
+                client_disconnected.set()
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": f"/mcp/{endpoint.key}/sse",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        with anyio.fail_after(10):
+            await app(scope, receive, send)
+
+    try:
+        with transaction.atomic():
+            async_to_sync(inner)()
+    finally:
+        current_key.reset(key_token)
+
+    # Exactly one start: the SSE stream's. On the pre-fix code Starlette sends a
+    # second one for the returned Response().
+    assert response_starts == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_handle_sse_still_logs_errors_raised_after_the_response_started(data_fixture):
+    """
+    A real failure inside the MCP session after streaming has begun must stay
+    visible (logged at error level), not be swallowed as a benign disconnect,
+    while still never sending a second http.response.start.
+    """
+
+    from loguru import logger
+
+    endpoint = data_fixture.create_mcp_endpoint()
+    mcp = BaserowMCPServer()
+    app = mcp.sse_app()
+    key_token = current_key.set(endpoint.key)
+
+    errors = []
+    sink_id = logger.add(errors.append, level="ERROR")
+
+    response_starts = 0
+
+    async def failing_run(*args, **kwargs):
+        # Let the EventSourceResponse send http.response.start first, then fail.
+        await anyio.sleep(0.05)
+        raise ValueError("boom")
+
+    async def inner():
+        nonlocal response_starts
+
+        async def receive():
+            await anyio.sleep(10)
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            nonlocal response_starts
+            if message["type"] == "http.response.start":
+                response_starts += 1
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": f"/mcp/{endpoint.key}/sse",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        mcp._mcp_server.run = failing_run
+        with anyio.fail_after(10):
+            await app(scope, receive, send)
+
+    try:
+        with transaction.atomic():
+            async_to_sync(inner)()
+    finally:
+        logger.remove(sink_id)
+        current_key.reset(key_token)
+
+    # The failure was surfaced as an error, and the response was not double-sent.
+    assert response_starts == 1
+    assert any(record.record["level"].name == "ERROR" for record in errors)
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/fix_spurious_internal_error_logged_when_an_mcp_connection_cl.json
+++ b/changelog/entries/unreleased/bug/fix_spurious_internal_error_logged_when_an_mcp_connection_cl.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix spurious internal error logged when an MCP connection closes",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-28"
+}


### PR DESCRIPTION
### What is in this PR
The MCP server-sent-events (SSE) route no longer raises an internal error when a connection closes, eliminating Sentry [`BASEROW-SAAS-BACKEND-Z4`](https://baserow-eu.sentry.io/issues/127669635) (559 events).

### Root cause
`handle_sse` (`backend/src/baserow/core/mcp/__init__.py`) returned `Response()` after the `async with sse.connect_sse(...)` block. But the SSE transport (`core/mcp/sse.py:155-167`) already sent `http.response.start` and streamed the body via `request._send` through a background `EventSourceResponse` task. Starlette then sent the returned `Response()`, emitting a **second** `http.response.start`, which uvicorn rejects with:

```
RuntimeError: Expected ASGI message 'http.response.body', but got 'http.response.start'.
```

That send happens inside Starlette *after* `handle_sse` returns, so the existing `except` (which only matched `"after response already completed"`) never caught it.

The fix tracks whether the response has started and, once the SSE transport owns the connection, returns a no-op response so Starlette can't resend. This also supersedes the old, ineffective `204` special-case (which would itself have double-sent if the stream had started).

### How to test this PR
#### Automated
```
just b test tests/baserow/core/mcp/test_mcp_server.py -k test_handle_sse_sends_a_single_http_response_start
```
The test drives the real `sse_app()` and asserts exactly one `http.response.start`. It fails on `develop` (two starts) and passes here.

#### Manual
Connect any MCP client over SSE to `/mcp/<key>/sse` and then disconnect. Before: a `RuntimeError` is logged on every close. After: the connection closes cleanly with no error.

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered
