### PR TITLE
feat(core): add WebSocket connection, disconnect metrics and reduce sentry noise

### DIFF
--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -1449,7 +1449,7 @@ if SENTRY_DSN:
 
     from baserow.core.sentry import (
         ConsoleSentryTransport,
-        drop_expected_asyncio_websocket_ping_timeout_events,
+        drop_expected_asyncio_websocket_disconnect_events,
     )
 
     # Exclude integrations whose module-level imports are incompatible:
@@ -1484,7 +1484,7 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration(signals_spans=False, middleware_spans=False)],
         traces_sample_rate=sentry_traces_sample_rate,
         send_default_pii=False,
-        before_send=drop_expected_asyncio_websocket_ping_timeout_events,
+        before_send=drop_expected_asyncio_websocket_disconnect_events,
         event_scrubber=EventScrubber(recursive=True, denylist=SENTRY_DENYLIST),
         environment=os.getenv("SENTRY_ENVIRONMENT", ""),
         transport=sentry_transport,

--- a/backend/src/baserow/core/sentry.py
+++ b/backend/src/baserow/core/sentry.py
@@ -85,6 +85,13 @@ def drop_expected_asyncio_websocket_disconnect_events(
     if log_record.name != "asyncio":
         return event
 
+    # This relies on asyncio's exact log format: getMessage() does %-style arg
+    # interpolation on the raw record, and the prefixes above match what the
+    # current Python/websockets stack emits. The asyncio name guard bounds the
+    # blast radius, but if asyncio ever reuses this log path for a different
+    # exception sharing the prefix, the suppression would silently expand. The
+    # baserow.websocket_disconnects metric is the format-independent source of
+    # truth if that ever happens.
     message = log_record.getMessage()
     if message.startswith(_OK_CLOSE_LOG):
         return None

--- a/backend/src/baserow/core/sentry.py
+++ b/backend/src/baserow/core/sentry.py
@@ -86,9 +86,9 @@ def drop_expected_asyncio_websocket_disconnect_events(
         return event
 
     message = log_record.getMessage()
-    if _OK_CLOSE_LOG in message:
+    if message.startswith(_OK_CLOSE_LOG):
         return None
-    if _ERR_CLOSE_LOG in message and "keepalive ping timeout" in message:
+    if message.startswith(_ERR_CLOSE_LOG) and "keepalive ping timeout" in message:
         return None
 
     return event

--- a/backend/src/baserow/core/sentry.py
+++ b/backend/src/baserow/core/sentry.py
@@ -63,16 +63,20 @@ class ConsoleSentryTransport(Transport):
             )
 
 
-def drop_expected_asyncio_websocket_ping_timeout_events(
+# asyncio logs a benign websocket close as "<ExceptionType> exception in shielded
+# future". A clean ConnectionClosedOK is always noise; a ConnectionClosedError is
+# only noise for a keepalive timeout. Their rate lives in the
+# baserow.websocket_disconnects metric. Anchoring on the exception type keeps real
+# errors reportable, including abnormal 1006 closes (which also flag mass
+# disconnects from worker restarts) and protocol errors.
+_OK_CLOSE_LOG = "ConnectionClosedOK exception in shielded future"
+_ERR_CLOSE_LOG = "ConnectionClosedError exception in shielded future"
+
+
+def drop_expected_asyncio_websocket_disconnect_events(
     event: dict[str, Any], hint: dict[str, Any]
 ) -> dict[str, Any] | None:
-    """
-    Ignore websocket keepalive timeouts logged by asyncio.
-
-    These are emitted by the websockets stack when a client disappears without a
-    clean close handshake. They are noisy, expected in production, and don't
-    point to an application error in Baserow itself.
-    """
+    """Sentry before_send hook that drops expected websocket-close noise."""
 
     log_record = hint.get("log_record")
     if not isinstance(log_record, logging.LogRecord):
@@ -82,10 +86,9 @@ def drop_expected_asyncio_websocket_ping_timeout_events(
         return event
 
     message = log_record.getMessage()
-    if (
-        "ConnectionClosedError exception in shielded future" in message
-        and "keepalive ping timeout" in message
-    ):
+    if _OK_CLOSE_LOG in message:
+        return None
+    if _ERR_CLOSE_LOG in message and "keepalive ping timeout" in message:
         return None
 
     return event

--- a/backend/src/baserow/ws/consumers.py
+++ b/backend/src/baserow/ws/consumers.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 from loguru import logger
+from opentelemetry import metrics
 
 from baserow.config.settings.utils import try_int
 from baserow.ws.realtime_events import (
@@ -25,6 +26,27 @@ if TYPE_CHECKING:
         BroadcastToUsersMessage,
         ForceDisconnectMessage,
     )
+
+
+meter = metrics.get_meter(__name__)
+websocket_connections_counter = meter.create_counter(
+    "baserow.websocket_connections",
+    unit="1",
+    description="Accepted realtime WebSocket connections.",
+)
+websocket_disconnects_counter = meter.create_counter(
+    "baserow.websocket_disconnects",
+    unit="1",
+    description="Closed realtime WebSocket connections, labelled by close code.",
+)
+
+# Known close codes pass through; anything else becomes "other" to keep the
+# metric's label cardinality bounded.
+_KNOWN_WEBSOCKET_CLOSE_CODES = frozenset(range(1000, 1016))
+
+
+def _bucket_close_code(code: Optional[int]) -> str:
+    return str(code) if code in _KNOWN_WEBSOCKET_CLOSE_CODES else "other"
 
 
 @dataclass
@@ -146,6 +168,7 @@ class SubscribedPages:
 class CoreConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         await self.accept()
+        websocket_connections_counter.add(1)
 
         user = self.scope["user"]
         await self.send_json(
@@ -167,9 +190,12 @@ class CoreConsumer(AsyncJsonWebsocketConsumer):
         self.scope["pages"] = SubscribedPages()
         await self.channel_layer.group_add("users", self.channel_name)
 
-    async def disconnect(self, message):
+    async def disconnect(self, code):
         await self._remove_all_page_scopes(send_confirmation=False)
         await self.channel_layer.group_discard("users", self.channel_name)
+        websocket_disconnects_counter.add(
+            1, attributes={"code": _bucket_close_code(code)}
+        )
 
     async def receive_json(self, content, **parameters):
         """

--- a/backend/src/baserow/ws/consumers.py
+++ b/backend/src/baserow/ws/consumers.py
@@ -191,11 +191,17 @@ class CoreConsumer(AsyncJsonWebsocketConsumer):
         await self.channel_layer.group_add("users", self.channel_name)
 
     async def disconnect(self, code):
-        await self._remove_all_page_scopes(send_confirmation=False)
-        await self.channel_layer.group_discard("users", self.channel_name)
-        websocket_disconnects_counter.add(
-            1, attributes={"code": _bucket_close_code(code)}
-        )
+        # Record the disconnect in a finally block so the counter still fires if
+        # cleanup raises (e.g. a Redis hiccup in group_discard). Otherwise the
+        # eager connect counter would drift ahead during infrastructure failures,
+        # exactly when the metric matters most.
+        try:
+            await self._remove_all_page_scopes(send_confirmation=False)
+            await self.channel_layer.group_discard("users", self.channel_name)
+        finally:
+            websocket_disconnects_counter.add(
+                1, attributes={"code": _bucket_close_code(code)}
+            )
 
     async def receive_json(self, content, **parameters):
         """

--- a/backend/tests/baserow/core/test_sentry.py
+++ b/backend/tests/baserow/core/test_sentry.py
@@ -1,56 +1,116 @@
 import logging
 from unittest.mock import patch
 
+import pytest
 from sentry_sdk.envelope import Envelope
 
 from baserow.core.sentry import (
     ConsoleSentryTransport,
-    drop_expected_asyncio_websocket_ping_timeout_events,
+    drop_expected_asyncio_websocket_disconnect_events,
     log_sentry_event_to_console,
 )
 
 
-def test_drop_expected_asyncio_websocket_ping_timeout_events():
-    event = {"logger": "asyncio"}
-    record = logging.makeLogRecord(
-        {
-            "name": "asyncio",
-            "levelno": logging.ERROR,
-            "levelname": "ERROR",
-            "msg": (
-                "ConnectionClosedError exception in shielded future future: "
-                "<Future finished exception=ConnectionClosedError(None, "
-                "Close(code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive "
-                "ping timeout'), None)>"
-            ),
-        }
+def _asyncio_record(msg: str, name: str = "asyncio") -> logging.LogRecord:
+    return logging.makeLogRecord(
+        {"name": name, "levelno": logging.ERROR, "levelname": "ERROR", "msg": msg}
     )
 
+
+# Benign websocket-close log records whose rate is tracked by the
+# baserow.websocket_disconnects metric, so they are dropped.
+DROPPED_MESSAGES = [
+    # 1011 keepalive ping timeout (idle/slow client or starved event loop).
+    (
+        "ConnectionClosedError exception in shielded future future: "
+        "<Future finished exception=ConnectionClosedError(None, "
+        "Close(code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive ping "
+        "timeout'), None)>"
+    ),
+    # 1001 going away with a reason (e.g. a proxy restarting).
+    (
+        "ConnectionClosedOK exception in shielded future future: <Future "
+        "finished exception=ConnectionClosedOK(Close(code=1001, reason="
+        "'proxy restarting'), Close(code=1001, reason='proxy restarting'), True)>"
+    ),
+    # 1005 no status received.
+    (
+        "ConnectionClosedOK exception in shielded future future: <Future "
+        "finished exception=ConnectionClosedOK(Close(code=1005, reason=''), "
+        "Close(code=1005, reason=''), True)>"
+    ),
+]
+
+# Messages that must still be reported because they can signal real problems.
+KEPT_MESSAGES = [
+    # 1006 abnormal closure also flags mass disconnects (OOM/restart), so keep it.
+    (
+        "ConnectionClosedError exception in shielded future future: <Future "
+        "finished exception=ConnectionClosedError(Close(code=1006, reason=''), "
+        "None, None)>"
+    ),
+    # 1002 protocol error is a genuinely unexpected close.
+    (
+        "ConnectionClosedError exception in shielded future future: <Future "
+        "finished exception=ConnectionClosedError(Close(code=1002, reason="
+        "'WebSocket Protocol Error'), None, None)>"
+    ),
+    # A cancelled in-flight request is not a websocket close, so no metric covers it.
+    (
+        "CancelledError exception in shielded future future: "
+        "<Future finished exception=CancelledError()>"
+    ),
+    # A non-close error whose text merely mentions a close type must not be dropped:
+    # the match is anchored to the exception type, not any substring.
+    (
+        "RuntimeError exception in shielded future future: <Future finished "
+        "exception=RuntimeError('cleanup failed while handling ConnectionClosedOK')>"
+    ),
+    # Unrelated asyncio errors.
+    "Task exception was never retrieved",
+]
+
+
+@pytest.mark.parametrize("message", DROPPED_MESSAGES)
+def test_drop_expected_asyncio_websocket_disconnect_events_drops_expected(message):
+    event = {"logger": "asyncio"}
+
     assert (
-        drop_expected_asyncio_websocket_ping_timeout_events(
-            event, {"log_record": record}
+        drop_expected_asyncio_websocket_disconnect_events(
+            event, {"log_record": _asyncio_record(message)}
         )
         is None
     )
 
 
-def test_drop_expected_asyncio_websocket_ping_timeout_events_keeps_other_errors():
+@pytest.mark.parametrize("message", KEPT_MESSAGES)
+def test_drop_expected_asyncio_websocket_disconnect_events_keeps_real_errors(message):
     event = {"logger": "asyncio"}
-    record = logging.makeLogRecord(
-        {
-            "name": "asyncio",
-            "levelno": logging.ERROR,
-            "levelname": "ERROR",
-            "msg": "Task exception was never retrieved",
-        }
-    )
 
     assert (
-        drop_expected_asyncio_websocket_ping_timeout_events(
-            event, {"log_record": record}
+        drop_expected_asyncio_websocket_disconnect_events(
+            event, {"log_record": _asyncio_record(message)}
         )
         == event
     )
+
+
+def test_drop_expected_asyncio_websocket_disconnect_events_keeps_non_asyncio_loggers():
+    event = {"logger": "django"}
+    record = _asyncio_record(
+        "ConnectionClosedOK exception in shielded future", name="django.request"
+    )
+
+    assert (
+        drop_expected_asyncio_websocket_disconnect_events(event, {"log_record": record})
+        == event
+    )
+
+
+def test_drop_expected_asyncio_websocket_disconnect_events_without_log_record():
+    event = {"logger": "asyncio"}
+
+    assert drop_expected_asyncio_websocket_disconnect_events(event, {}) == event
 
 
 @patch("baserow.core.sentry.logger")

--- a/backend/tests/baserow/ws/test_ws_consumers.py
+++ b/backend/tests/baserow/ws/test_ws_consumers.py
@@ -494,7 +494,7 @@ def test_bucket_close_code():
 async def test_core_consumer_records_connection_and_disconnect_metrics(data_fixture):
     from baserow.ws import consumers as ws_consumers
 
-    user_1, token_1 = data_fixture.create_user_and_token()
+    _, token_1 = data_fixture.create_user_and_token()
     communicator = WebsocketCommunicator(
         application,
         f"ws/core/?jwt_token={token_1}&web_socket_id=ws-1",

--- a/backend/tests/baserow/ws/test_ws_consumers.py
+++ b/backend/tests/baserow/ws/test_ws_consumers.py
@@ -512,3 +512,21 @@ async def test_core_consumer_records_connection_and_disconnect_metrics(data_fixt
 
         await communicator.disconnect(code=1011)
         disconnects.add.assert_called_once_with(1, attributes={"code": "1011"})
+
+
+@pytest.mark.asyncio
+async def test_core_consumer_records_disconnect_metric_when_cleanup_fails():
+    from baserow.ws import consumers as ws_consumers
+
+    consumer = CoreConsumer()
+    consumer.channel_name = "test_channel_name"
+    consumer.channel_layer = AsyncMock()
+    # A Redis hiccup during cleanup must not swallow the disconnect metric.
+    consumer.channel_layer.group_discard.side_effect = RuntimeError("redis down")
+    consumer._remove_all_page_scopes = AsyncMock()
+
+    with patch.object(ws_consumers, "websocket_disconnects_counter") as disconnects:
+        with pytest.raises(RuntimeError):
+            await consumer.disconnect(code=1006)
+
+    disconnects.add.assert_called_once_with(1, attributes={"code": "1006"})

--- a/backend/tests/baserow/ws/test_ws_consumers.py
+++ b/backend/tests/baserow/ws/test_ws_consumers.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from channels.testing import WebsocketCommunicator
@@ -476,3 +476,39 @@ async def test_core_consumer_broadcast_to_group(
         mock_send_json.assert_called_once_with(event["payload"])
     else:
         mock_send_json.assert_not_called()
+
+
+def test_bucket_close_code():
+    from baserow.ws.consumers import _bucket_close_code
+
+    assert _bucket_close_code(1011) == "1011"
+    assert _bucket_close_code(1001) == "1001"
+    # Application/unknown codes collapse to "other" to bound label cardinality.
+    assert _bucket_close_code(4999) == "other"
+    assert _bucket_close_code(None) == "other"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.websockets
+async def test_core_consumer_records_connection_and_disconnect_metrics(data_fixture):
+    from baserow.ws import consumers as ws_consumers
+
+    user_1, token_1 = data_fixture.create_user_and_token()
+    communicator = WebsocketCommunicator(
+        application,
+        f"ws/core/?jwt_token={token_1}&web_socket_id=ws-1",
+        headers=[(b"origin", b"http://localhost")],
+    )
+
+    with (
+        patch.object(ws_consumers, "websocket_connections_counter") as connections,
+        patch.object(ws_consumers, "websocket_disconnects_counter") as disconnects,
+    ):
+        connected, _ = await communicator.connect()
+        assert connected is True
+        await communicator.receive_json_from()
+        connections.add.assert_called_once_with(1)
+
+        await communicator.disconnect(code=1011)
+        disconnects.add.assert_called_once_with(1, attributes={"code": "1011"})

--- a/changelog/entries/unreleased/feature/add_websocket_connection_and_disconnect_metrics.json
+++ b/changelog/entries/unreleased/feature/add_websocket_connection_and_disconnect_metrics.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add WebSocket connection and disconnect metrics",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-28"
+}


### PR DESCRIPTION
### What this does
Adds OpenTelemetry counters for realtime WebSocket connections and disconnects, then drops the per-event Sentry noise for the clean closes those counters now track.

We were blind to the real disconnect rate. The keepalive-timeout filter (#5225) silenced the only signal we had (a 140k-event Sentry issue that went quiet once it shipped). This puts the rate in a metric so it stays visible, then removes the noisy per-event reports.

### Changes
- `ws/consumers.py`: two counters, following the existing `baserow.rows_created` pattern.
  - `baserow.websocket_connections`, incremented on accept.
  - `baserow.websocket_disconnects`, incremented on close, labelled by close `code`.
  - `CoreConsumer.disconnect`'s param renamed `message` to `code` (Channels already passes the close code). `_bucket_close_code` keeps label cardinality bounded. The counters are no-ops when OTel is off.
- `core/sentry.py`: the `before_send` filter drops two benign closes, matched by exception type:
  - `ConnectionClosedOK` (clean closes: 1000, 1001 going away / proxy restart, 1005).
  - `ConnectionClosedError` with a keepalive ping timeout (1011).
  - Everything else stays reportable, including `1006` abnormal closes (which also flag mass disconnects from worker OOM/restart) and protocol errors (`1002`).

### How to test
```
just b test tests/baserow/ws/test_ws_consumers.py -k=disconnect_metrics
just b test tests/baserow/ws/test_ws_consumers.py -k=bucket_close_code
just b test tests/baserow/core/test_sentry.py
```
The consumer test drives a real connect and disconnect through `WebsocketCommunicator` and checks both counters fire with the right code label. The Sentry tests cover the dropped closes (1011, 1001, 1005), the kept ones (1006, 1002, CancelledError, unrelated errors), and a non-close error that merely mentions a close type (must not be dropped).

### Notes
- The match is anchored to the exception type, so an unrelated error whose text mentions a close type is not dropped. If the log format ever drifts, events are kept rather than lost, and the metric is the format-independent source of truth.
- The metric only exports where OTel is enabled. Worth having an alert on `baserow.websocket_disconnects` before relying on it in place of Sentry.

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered
