### PR TITLE
bug: keep formula function help tooltip above data explorer

### DIFF
--- a/changelog/entries/unreleased/bug/5593_fix_formula_function_help_tooltip_layering.json
+++ b/changelog/entries/unreleased/bug/5593_fix_formula_function_help_tooltip_layering.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed formula function help tooltips appearing below the data explorer.",
+    "issue_origin": "github",
+    "issue_number": 5593,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}

--- a/web-frontend/modules/core/assets/scss/components/node_help_tooltip.scss
+++ b/web-frontend/modules/core/assets/scss/components/node_help_tooltip.scss
@@ -43,3 +43,7 @@
     @extend %mb-16;
   }
 }
+
+.node-help-tooltip-context {
+  z-index: $z-index-tooltip;
+}

--- a/web-frontend/modules/core/components/nodeExplorer/NodeHelpTooltip.vue
+++ b/web-frontend/modules/core/components/nodeExplorer/NodeHelpTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-  <Context ref="context">
+  <Context ref="context" class="node-help-tooltip-context">
     <div v-if="node" class="node-help-tooltip">
       <div class="node-help-tooltip__header">
         <div class="node-help-tooltip__icon">


### PR DESCRIPTION
### What is in this PR
 Fixes formula function help tooltips appearing underneath the data explorer.

### How to test this PR
- Open the application builder.
- Add a table element and configure its fields.
- Focus a formula input so the data explorer is visible.
- Hover over a formula function in the input.
- Confirm the function help tooltip appears above the data explorer and its examples are readable.

closes #5593 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
