### PR TITLE
fix: ensure row updates work with pre-existing files

### DIFF
--- a/backend/src/baserow/core/formula/service_file.py
+++ b/backend/src/baserow/core/formula/service_file.py
@@ -89,6 +89,19 @@ class ServiceFile:
             size=value.get("size"),
         )
 
+    def _has_readable_file(self) -> bool:
+        """
+        Return whether `self.file` is an actual readable stream.
+
+        The `file` attribute can be populated from untrusted serialized payloads
+        where it may end up being a placeholder (e.g. a string uid that was never
+        resolved to an uploaded stream). In those cases we must ignore it and fall
+        back to the other representations (user file, URL, name) instead of trying
+        to read or upload a value that is not a stream.
+        """
+
+        return self.file is not None and hasattr(self.file, "read")
+
     def read_bytes(self) -> bytes:
         """
         Resolve this file value and return its content.
@@ -99,7 +112,7 @@ class ServiceFile:
         raised when none of these representations can be read.
         """
 
-        if self.file is not None and not getattr(self.file, "closed", False):
+        if self._has_readable_file() and not getattr(self.file, "closed", False):
             if hasattr(self.file, "seek"):
                 self.file.seek(0)
             return self.file.read()
@@ -176,7 +189,7 @@ class ServiceFile:
             return self.user_file
 
         handler = UserFileHandler()
-        if self.file is not None:
+        if self._has_readable_file():
             file_name = (
                 self.visible_name or self.name or getattr(self.file, "name", "file")
             )

--- a/backend/src/baserow/core/formula/service_file.py
+++ b/backend/src/baserow/core/formula/service_file.py
@@ -196,10 +196,6 @@ class ServiceFile:
             self.user_file = self._upload_user_file(user, file_name, self.file)
             return self.user_file
 
-        if self.name and handler.is_user_file_name(self.name):
-            self.user_file = handler.get_user_file_by_name(self.name)
-            return self.user_file
-
         if self.url:
             user_file_name = _user_file_name_from_url(self.url)
             if user_file_name:
@@ -234,6 +230,10 @@ class ServiceFile:
                 return self.user_file
 
             raise ValidationError("The file couldn't be read from storage.")
+
+        if self.name and handler.is_user_file_name(self.name):
+            self.user_file = handler.get_user_file_by_name(self.name)
+            return self.user_file
 
         raise ValidationError("A valid file or url is required.")
 

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_utils.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_utils.py
@@ -435,6 +435,33 @@ def test_prepare_file_for_db_with_existing_file(data_fixture):
 
 
 @pytest.mark.django_db
+def test_prepare_file_for_db_prefers_url_over_user_file_like_visible_name(data_fixture):
+    user = data_fixture.create_user()
+    user_file = data_fixture.create_user_file(
+        original_name="sample_budget.xls",
+    )
+
+    value = {
+        "__file__": True,
+        "name": "sample_budget.xls",
+        "url": UserFileHandler().get_user_file_url(user_file),
+    }
+
+    assert prepare_files_for_db(value, user) == [
+        {
+            "image_height": None,
+            "image_width": None,
+            "is_image": False,
+            "mime_type": "application/vnd.ms-excel",
+            "name": user_file.name,
+            "size": AnyInt(),
+            "uploaded_at": AnyStr(),
+            "visible_name": "sample_budget.xls",
+        },
+    ]
+
+
+@pytest.mark.django_db
 def test_prepare_file_for_db_with_existing_file_and_stale_file_placeholder(
     data_fixture,
 ):

--- a/backend/tests/baserow/contrib/integrations/local_baserow/test_utils.py
+++ b/backend/tests/baserow/contrib/integrations/local_baserow/test_utils.py
@@ -435,6 +435,48 @@ def test_prepare_file_for_db_with_existing_file(data_fixture):
 
 
 @pytest.mark.django_db
+def test_prepare_file_for_db_with_existing_file_and_stale_file_placeholder(
+    data_fixture,
+):
+    """
+    When updating a row through a form, an unchanged pre-existing file is sent as
+    a `url` reference, but the frontend may also include a `file` placeholder (a
+    uid string) that was never resolved into an upload stream. We must ignore the
+    non-readable placeholder and resolve the file via its URL instead of raising
+    "The provided stream is not readable.".
+    """
+
+    user = data_fixture.create_user()
+    user_file = data_fixture.create_user_file(original_name="imagen.png")
+
+    # Mirrors the exact payload the frontend sends for an unchanged file: the
+    # original `data` is `undefined`, so `file` holds a leftover uid placeholder
+    # (the multipart part for it is the literal string "undefined", never an
+    # uploaded stream) and the actual file is only addressable via `url`.
+    value = {
+        "__file__": True,
+        "name": "Screenshot 2026-06-29 at 10.34.28.png",
+        "url": UserFileHandler().get_user_file_url(user_file),
+        "content_type": "image/png",
+        "size": "17746",
+        "file": "46913887-0126-4d0f-80f0-d806ea93a360",
+    }
+
+    assert prepare_files_for_db(value, user) == [
+        {
+            "image_height": None,
+            "image_width": None,
+            "is_image": False,
+            "mime_type": "image/png",
+            "name": user_file.name,
+            "size": AnyInt(),
+            "uploaded_at": AnyStr(),
+            "visible_name": "Screenshot 2026-06-29 at 10.34.28.png",
+        },
+    ]
+
+
+@pytest.mark.django_db
 def test_prepare_file_for_db_with_mix(data_fixture, fake):
     user = data_fixture.create_user()
     user_file = data_fixture.create_user_file(

--- a/changelog/entries/unreleased/bug/fixes_a_file_upload_error_when_updating_a_row_that_keeps_an_.json
+++ b/changelog/entries/unreleased/bug/fixes_a_file_upload_error_when_updating_a_row_that_keeps_an_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes a file upload error when updating a row that keeps an existing file",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/builder/elementTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/builder/elementTypes.js
@@ -169,11 +169,16 @@ export class FileInputElementType extends FormElementType {
   beforeActionDispatchContext(element, value, files) {
     const withoutFiles = (element.multiple ? value : [value]).map((v) => {
       if (v?.__file__) {
-        const data = v.data
-        const uid = uuid()
-        // Add file to context
-        files[uid] = data
-        return { ...v, file: uid, data: undefined }
+        // Only register an uploadable file when there's actual file data. An
+        // unchanged, pre-existing file is referenced by its `url` and has no
+        // `data`, so we must not inject a `file` placeholder for it.
+        if (v.data) {
+          const uid = uuid()
+          // Add file to context
+          files[uid] = v.data
+          return { ...v, file: uid, data: undefined }
+        }
+        return { ...v, data: undefined }
       } else {
         return v
       }


### PR DESCRIPTION
### Problem                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                
Dispatching a `LocalBaserowUpsertRow` workflow action that includes a File Input element failed with: `ERROR_SERVICE_IMPROPERLY_CONFIGURED`. This happened whenever the file input held an unchanged, pre-existing file (a URL reference with no new upload).                                                                                                                                              
                                                                                                                                                                                                                                                                
### Cause

`beforeActionDispatchContext` unconditionally rewrote every `__file__` value to `{ ...v, file: <uuid> }` and registered `files[<uuid>] = v.data`, even when data was `undefined`. For a url-only file this produced:                                                   
                                                                                                                                                                                                                                                                
  - a stray multipart part <uuid> = "undefined" (a text field, not a file), and                                                                                                                                                                                 
  - a file object carrying both a url and a file: <uuid> string.                                                                                                                                                                                                
                                                                                                                                                                                                                                                                
On the backend, `FileInputElementType._handle_file` skips objects that already have a url, so the <uuid> string was left in place. `ServiceFile` then prioritized `self.file` (the string) over self.url and passed it to `upload_user_file`, which rejected it as a non-readable stream.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                
### Fix                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                
- Frontend: only register an uploadable file when there's actual data; url-only files are sent as a clean `{ __file__, name, url }` reference.                                                                                                
- Backend: `ServiceFile` now treats file as usable only when it's an actual readable stream (`_has_readable_file`); otherwise it falls back to resolving via url/name. Defense-in-depth so a bad payload can't crash the service.               
   

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
