### PR TITLE
bug: fix application custom CSS after the nuxt upgrade.

### DIFF
--- a/changelog/entries/unreleased/bug/custom_css_and_js_in_published_applications_no_longer_requir.json
+++ b/changelog/entries/unreleased/bug/custom_css_and_js_in_published_applications_no_longer_requir.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Custom CSS and JS in published applications no longer require !important to override styles",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}

--- a/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/plugins.js
@@ -173,7 +173,7 @@ export class EnterprisePlugin extends BaserowPlugin {
           crossorigin,
           defer: s.load_type === 'defer',
           async: s.load_type === 'async',
-          body: true,
+          tagPosition: 'bodyClose',
         })
       }
 
@@ -182,7 +182,7 @@ export class EnterprisePlugin extends BaserowPlugin {
           rel: 'stylesheet',
           href: s.url,
           crossorigin,
-          body: true,
+          tagPosition: 'bodyClose',
         })
       }
     })
@@ -191,14 +191,14 @@ export class EnterprisePlugin extends BaserowPlugin {
       link.push({
         rel: 'stylesheet',
         href: css,
-        body: true,
+        tagPosition: 'bodyClose',
       })
     }
     if (builder.custom_code.js) {
       script.push({
         src: js,
         defer: true,
-        body: true,
+        tagPosition: 'bodyClose',
       })
     }
 

--- a/enterprise/web-frontend/test/unit/enterprise/plugins.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/plugins.spec.js
@@ -1,5 +1,63 @@
+import { EnterprisePlugin } from '@baserow_enterprise/plugins'
+
 describe('Test enterprise Baserow plugin', () => {
-  test('Dummy test', () => {
-    expect(true).toBe(true)
+  const app = {
+    $config: { public: { publicBackendUrl: 'http://localhost:8000' } },
+  }
+
+  const makeBuilder = (overrides = {}) => ({
+    id: 42,
+    scripts: [],
+    custom_code: { css: '', js: '' },
+    ...overrides,
+  })
+
+  // Regression test for the custom CSS/JS injection ordering. unhead v2 (pulled
+  // in by the Nuxt 4 upgrade) dropped the legacy `body: true` flag, which caused
+  // the custom stylesheet to render in <head> before the bundled theme CSS. With
+  // equal specificity the theme then won on source order, forcing users to add
+  // `!important` to their custom rules. The tags must use `tagPosition:
+  // 'bodyClose'` so the custom CSS/JS renders last and wins the cascade tie.
+  describe('getBuilderApplicationHeaderAddition', () => {
+    test('custom CSS and JS are injected at body close', () => {
+      const plugin = new EnterprisePlugin({ app })
+      const builder = makeBuilder({
+        custom_code: { css: '.ab-text { color: red }', js: 'console.log(1)' },
+      })
+
+      const { link, script } = plugin.getBuilderApplicationHeaderAddition({
+        builder,
+        mode: 'public',
+      })
+
+      const cssLink = link.find((l) => l.rel === 'stylesheet')
+      expect(cssLink.tagPosition).toBe('bodyClose')
+      expect(cssLink.body).toBeUndefined()
+
+      const jsScript = script.find((s) => s.src.endsWith('/js/public/'))
+      expect(jsScript.tagPosition).toBe('bodyClose')
+      expect(jsScript.body).toBeUndefined()
+    })
+
+    test('external scripts and stylesheets are injected at body close', () => {
+      const plugin = new EnterprisePlugin({ app })
+      const builder = makeBuilder({
+        scripts: [
+          { type: 'javascript', url: 'https://example.com/a.js', load_type: 'defer' },
+          { type: 'stylesheet', url: 'https://example.com/a.css' },
+        ],
+      })
+
+      const { script } = plugin.getBuilderApplicationHeaderAddition({
+        builder,
+        mode: 'public',
+      })
+
+      expect(script).toHaveLength(2)
+      script.forEach((tag) => {
+        expect(tag.tagPosition).toBe('bodyClose')
+        expect(tag.body).toBeUndefined()
+      })
+    })
   })
 })

--- a/enterprise/web-frontend/test/unit/enterprise/plugins.spec.js
+++ b/enterprise/web-frontend/test/unit/enterprise/plugins.spec.js
@@ -43,7 +43,11 @@ describe('Test enterprise Baserow plugin', () => {
       const plugin = new EnterprisePlugin({ app })
       const builder = makeBuilder({
         scripts: [
-          { type: 'javascript', url: 'https://example.com/a.js', load_type: 'defer' },
+          {
+            type: 'javascript',
+            url: 'https://example.com/a.js',
+            load_type: 'defer',
+          },
           { type: 'stylesheet', url: 'https://example.com/a.css' },
         ],
       })


### PR DESCRIPTION
### What is in this PR

The Nuxt 4 upgrade pulled in `unhead` v2, which dropped the legacy `body: true` flag, so the custom CSS, instead of loading at the end of `<body>` after the theme styles, stayed in `<head>` and lost the cascade tie, forcing users to add `!important`.

### How to test this PR

Look in Slack for the custom CSS, try that in `develop` / this branch.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
