### PR TITLE
bug: show loading overlay for builder table refinements

### DIFF
--- a/changelog/entries/unreleased/bug/3510_show_table_element_loading_overlay_for_refinements.json
+++ b/changelog/entries/unreleased/bug/3510_show_table_element_loading_overlay_for_refinements.json
@@ -1,0 +1,9 @@
+{
+  "type": "bug",
+  "message": "Show a loading overlay on application builder table elements while ad hoc filters, sorting, or search results are loading.",
+  "issue_origin": "github",
+  "issue_number": 3510,
+  "domain": "builder",
+  "bullet_points": [],
+  "created_at": "2026-06-29"
+}

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABTable.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABTable.vue
@@ -38,7 +38,7 @@
       </template>
     </BaserowTable>
     <div
-      v-if="contentLoadingOverlay && rows.length"
+      v-if="contentLoading && rows.length"
       class="ab-table__loading-overlay loading-overlay"
     ></div>
   </div>
@@ -66,11 +66,6 @@ export default {
       default: ORIENTATIONS.HORIZONTAL,
     },
     contentLoading: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
-    contentLoadingOverlay: {
       type: Boolean,
       required: false,
       default: false,

--- a/web-frontend/modules/builder/components/elements/baseComponents/ABTable.vue
+++ b/web-frontend/modules/builder/components/elements/baseComponents/ABTable.vue
@@ -1,41 +1,47 @@
 <template>
-  <BaserowTable
-    :fields="fields"
-    :rows="rows"
-    class="ab-table"
-    :orientation="orientation"
-  >
-    <template #field-name="{ field }">
-      <th :key="field.__id__" class="ab-table__header-cell">
-        <slot name="field-name" :field="field">{{ field.name }}</slot>
-      </th>
-    </template>
-    <template #cell-content="{ rowIndex, value, field, row }">
-      <slot
-        name="cell-content"
-        :value="value"
-        :field="field"
-        :row-index="rowIndex"
-        :row="row"
-      >
-        <td :key="field.id" class="ab-table__cell">
-          <div class="ab-table__cell-content">
-            {{ row[field.__id__] }}
-          </div>
-        </td>
-      </slot>
-    </template>
-    <template #empty-state>
-      <div class="ab-table__empty-state">
-        <template v-if="contentLoading">
-          <div class="loading-spinner" />
-        </template>
-        <template v-else>
-          {{ $t('abTable.empty') }}
-        </template>
-      </div>
-    </template>
-  </BaserowTable>
+  <div class="ab-table__wrapper">
+    <BaserowTable
+      :fields="fields"
+      :rows="rows"
+      class="ab-table"
+      :orientation="orientation"
+    >
+      <template #field-name="{ field }">
+        <th :key="field.__id__" class="ab-table__header-cell">
+          <slot name="field-name" :field="field">{{ field.name }}</slot>
+        </th>
+      </template>
+      <template #cell-content="{ rowIndex, value, field, row }">
+        <slot
+          name="cell-content"
+          :value="value"
+          :field="field"
+          :row-index="rowIndex"
+          :row="row"
+        >
+          <td :key="field.id" class="ab-table__cell">
+            <div class="ab-table__cell-content">
+              {{ row[field.__id__] }}
+            </div>
+          </td>
+        </slot>
+      </template>
+      <template #empty-state>
+        <div class="ab-table__empty-state">
+          <template v-if="contentLoading">
+            <div class="loading-spinner" />
+          </template>
+          <template v-else>
+            {{ $t('abTable.empty') }}
+          </template>
+        </div>
+      </template>
+    </BaserowTable>
+    <div
+      v-if="contentLoadingOverlay && rows.length"
+      class="ab-table__loading-overlay loading-overlay"
+    ></div>
+  </div>
 </template>
 
 <script>
@@ -60,6 +66,11 @@ export default {
       default: ORIENTATIONS.HORIZONTAL,
     },
     contentLoading: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    contentLoadingOverlay: {
       type: Boolean,
       required: false,
       default: false,

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -11,6 +11,7 @@
       :fields="fields"
       :rows="rows"
       :content-loading="contentLoading"
+      :content-loading-overlay="contentLoading && currentOffset === 0"
       :style="getStyleOverride('table')"
       :orientation="orientation"
     >
@@ -104,6 +105,7 @@ export default {
       adhocSortings,
       adhocSearch,
       contentFetchEnabled,
+      currentOffset,
       elementContent,
       hasMorePage,
       contentLoading,
@@ -120,6 +122,7 @@ export default {
       elementContent,
       contentLoading,
       contentFetchEnabled,
+      currentOffset,
       hasMorePage,
       loadMore,
       resolveFormula,

--- a/web-frontend/modules/builder/components/elements/components/TableElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TableElement.vue
@@ -11,7 +11,6 @@
       :fields="fields"
       :rows="rows"
       :content-loading="contentLoading"
-      :content-loading-overlay="contentLoading && currentOffset === 0"
       :style="getStyleOverride('table')"
       :orientation="orientation"
     >
@@ -105,7 +104,6 @@ export default {
       adhocSortings,
       adhocSearch,
       contentFetchEnabled,
-      currentOffset,
       elementContent,
       hasMorePage,
       contentLoading,
@@ -122,7 +120,6 @@ export default {
       elementContent,
       contentLoading,
       contentFetchEnabled,
-      currentOffset,
       hasMorePage,
       loadMore,
       resolveFormula,

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/ab_components/ab_table.scss
@@ -1,3 +1,7 @@
+.ab-table__wrapper {
+  position: relative;
+}
+
 .ab-table {
   border: var(--table-border-size, 1px) solid var(--table-border-color, $black);
   font-size: var(--body-font-size, 12px);
@@ -117,4 +121,8 @@
   text-align: center;
   padding: 50px 0;
   font-weight: 600;
+}
+
+.ab-table__loading-overlay {
+  border-radius: var(--table-border-radius, 0);
 }


### PR DESCRIPTION
### What is in this PR
- Add a loading overlay and spinner when applying a filter,a sort or a seach on the application builder table element 

### How to test this PR
- Add a table element in a page and feed it with a data source
- Set one field as sortable/filtrable/searchable in the table element user actions settings. 
- Preview the page, apply a sort and/or a filter. 
- Observe the loading overlay and spinner. (add network throttling in dev tools if necessary)

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
