### PR TITLE
bug: Added permission check to unique values endpoint

### DIFF
--- a/backend/src/baserow/contrib/database/api/fields/views.py
+++ b/backend/src/baserow/contrib/database/api/fields/views.py
@@ -117,6 +117,9 @@ from baserow.contrib.database.table.exceptions import (
     TableDoesNotExist,
 )
 from baserow.contrib.database.table.handler import TableHandler
+from baserow.contrib.database.table.operations import (
+    ListRowsDatabaseTableOperationType,
+)
 from baserow.contrib.database.tokens.exceptions import NoPermissionToTable
 from baserow.contrib.database.tokens.handler import TokenHandler
 from baserow.contrib.database.views.exceptions import (
@@ -628,6 +631,14 @@ class UniqueRowValueFieldView(APIView):
     @validate_query_parameters(UniqueRowValueParamsSerializer)
     def get(self, request, field_id, query_params):
         field = FieldHandler().get_field(field_id)
+
+        CoreHandler().check_permissions(
+            request.user,
+            ListRowsDatabaseTableOperationType.type,
+            workspace=field.table.database.workspace,
+            context=field.table,
+        )
+
         limit = query_params.get("limit")
         split_comma_separated = query_params.get("split_comma_separated")
 

--- a/backend/tests/baserow/contrib/database/api/fields/test_field_views.py
+++ b/backend/tests/baserow/contrib/database/api/fields/test_field_views.py
@@ -882,6 +882,32 @@ def test_unique_row_values(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_unique_row_values_user_not_in_workspace(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    other_user, other_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    text_field = data_fixture.create_text_field(table=table, order=0, name="Letter")
+    model = table.get_model()
+    model.objects.create(**{f"field_{text_field.id}": "secret"})
+
+    url = reverse(
+        "api:database:fields:unique_row_values", kwargs={"field_id": text_field.id}
+    )
+
+    # A user that is not a member of the field's workspace must not be able to read
+    # the unique row values of that field.
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {other_token}")
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_USER_NOT_IN_GROUP"
+
+    # The member of the workspace can still read the values.
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {token}")
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["values"] == ["secret"]
+
+
+@pytest.mark.django_db
 def test_unique_row_values_splitted_by_comma(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token(
         email="11@11.com", password="password", first_name="abcd"

--- a/changelog/entries/unreleased/bug/added_permission_check_to_unique_field_values_endpoint.json
+++ b/changelog/entries/unreleased/bug/added_permission_check_to_unique_field_values_endpoint.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Added permission check to unique field values endpoint.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}


### PR DESCRIPTION
### What is in this PR

Adds correct permission check to unique values endpoint.

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
