### PR TITLE
fix(backend): set hard time_limit on tasks that inherit the default 360s limit

### DIFF
--- a/backend/src/baserow/contrib/database/search/tasks.py
+++ b/backend/src/baserow/contrib/database/search/tasks.py
@@ -21,7 +21,12 @@ def _get_singleton_autoreschedule_flag(table_id: int) -> SingletonAutoReschedule
     return SingletonAutoRescheduleFlag(f"database_search_data_lock_{table_id}")
 
 
-@app.task(queue="export")
+@app.task(
+    queue="export",
+    # No explicit hard limit means the global 360s default kills large bulk-creates.
+    soft_time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30,
+    time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT,
+)
 def schedule_update_search_data(
     table_id: int,
     field_ids: Optional[List[int]] = None,

--- a/backend/src/baserow/contrib/database/search/tasks.py
+++ b/backend/src/baserow/contrib/database/search/tasks.py
@@ -23,8 +23,7 @@ def _get_singleton_autoreschedule_flag(table_id: int) -> SingletonAutoReschedule
 
 @app.task(
     queue="export",
-    # No explicit hard limit means the global 360s default kills large bulk-creates.
-    soft_time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30,
+    soft_time_limit=max(1, settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30),
     time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT,
 )
 def schedule_update_search_data(

--- a/backend/src/baserow/core/jobs/tasks.py
+++ b/backend/src/baserow/core/jobs/tasks.py
@@ -13,7 +13,6 @@ from baserow.core.telemetry.utils import setup_user_in_baggage_and_spans
     bind=True,
     queue="export",
     soft_time_limit=settings.BASEROW_JOB_SOFT_TIME_LIMIT,
-    # No explicit hard limit means the global 360s default kills jobs before the soft one.
     time_limit=settings.BASEROW_JOB_SOFT_TIME_LIMIT + 30,
 )
 def run_async_job(self, job_id: int):

--- a/backend/src/baserow/core/jobs/tasks.py
+++ b/backend/src/baserow/core/jobs/tasks.py
@@ -13,6 +13,8 @@ from baserow.core.telemetry.utils import setup_user_in_baggage_and_spans
     bind=True,
     queue="export",
     soft_time_limit=settings.BASEROW_JOB_SOFT_TIME_LIMIT,
+    # No explicit hard limit means the global 360s default kills jobs before the soft one.
+    time_limit=settings.BASEROW_JOB_SOFT_TIME_LIMIT + 30,
 )
 def run_async_job(self, job_id: int):
     """Run the job task asynchronously"""

--- a/changelog/entries/unreleased/bug/fixes_background_tasks_being_stopped_early_by_the_default_ti.json
+++ b/changelog/entries/unreleased/bug/fixes_background_tasks_being_stopped_early_by_the_default_ti.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes background tasks being stopped early by the default time limit",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-29"
+}

--- a/premium/backend/src/baserow_premium/fields/tasks.py
+++ b/premium/backend/src/baserow_premium/fields/tasks.py
@@ -102,7 +102,11 @@ def generate_scheduled_ai_field_generation(field_id: int):
         _schedule_generate_ai_value_generation(field_id)
 
 
-@app.task()
+@app.task(
+    # No explicit hard limit means the global 360s default kills large bulk-creates.
+    soft_time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30,
+    time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT,
+)
 def schedule_ai_field_generation(field_id: int, row_ids: list[int] | None = None):
     """
     Populates scheduled rows table for AI field generation.

--- a/premium/backend/src/baserow_premium/fields/tasks.py
+++ b/premium/backend/src/baserow_premium/fields/tasks.py
@@ -103,8 +103,7 @@ def generate_scheduled_ai_field_generation(field_id: int):
 
 
 @app.task(
-    # No explicit hard limit means the global 360s default kills large bulk-creates.
-    soft_time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30,
+    soft_time_limit=max(1, settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT - 30),
     time_limit=settings.CELERY_SEARCH_UPDATE_HARD_TIME_LIMIT,
 )
 def schedule_ai_field_generation(field_id: int, row_ids: list[int] | None = None):


### PR DESCRIPTION
### What this fixes

Some Celery tasks didn't set their own hard time limit, so they fell back to the global default of 360 seconds (6 minutes). On big tables/workspaces these tasks legitimately need longer, so they were being killed halfway through — showing up in Sentry as "Hard time limit (360s) exceeded".

This is the same problem PR #5591 fixed for `run_periodic_fields_updates`; a few other tasks had it too.

### What changed

Three tasks now declare an explicit hard limit that matches the work they actually do:

- **`schedule_update_search_data`** (search) — had no limits at all.
- **`schedule_ai_field_generation`** (premium AI fields) — had no limits at all.
- **`run_async_job`** (the generic background-job runner) — had a 30-minute *soft* limit but no hard limit, so the 360s default killed long jobs before the soft limit (and its graceful failure handling) could even fire.

In each case the soft limit fires shortly before the hard one, so the task gets a chance to wrap up before being force-killed.

### What this does NOT change

Several other tasks set their soft and hard limits to the same value. Those already have explicit limits well above 360s and aren't affected by this bug, so they're left alone.

### How to test

No behaviour to click through — this only changes task time limits. Existing search and job task tests pass (`just b test tests/baserow/contrib/database/search/test_search_tasks.py tests/baserow/core/jobs/`).

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered

Fixes BASEROW-SAAS-BACKEND-3Z