### PR TITLE
fix(web-frontend): escape user name in rich text mentions to prevent stored XSS

### DIFF
--- a/changelog/entries/unreleased/bug/prevents_a_malicious_display_name_from_running_scripts_in_ri.json
+++ b/changelog/entries/unreleased/bug/prevents_a_malicious_display_name_from_running_scripts_in_ri.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Prevents a malicious display name from running scripts in rich text mentions",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-06-30"
+}

--- a/web-frontend/modules/core/editor/mention.js
+++ b/web-frontend/modules/core/editor/mention.js
@@ -3,6 +3,17 @@ import regexp from 'markdown-it-regexp'
 
 const USER_ID_REGEXP = /@(\d+)/
 
+// Escape user-controlled text before it's interpolated into the raw HTML
+// string below, which is rendered with v-html. Without this, a malicious
+// display name could inject markup and execute a stored XSS.
+const escapeHtml = (value) =>
+  String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+
 export const parseMention = (users, loggedUserId = null) =>
   regexp(USER_ID_REGEXP, (match, utils) => {
     const user = users.find((user) => user.user_id === parseInt(match[1]))
@@ -11,9 +22,10 @@ export const parseMention = (users, loggedUserId = null) =>
       if (user.user_id === loggedUserId) {
         className += ' rich-text-editor__mention--current-user'
       }
+      const name = escapeHtml(user.name)
       // NOTE: Keep this in sync with the @tiptap/extension-mention
       // https://github.com/ueberdosis/tiptap/blob/main/packages/extension-mention/src/mention.ts
-      return `<span class="${className}" data-id="${user.user_id}" data-label="${user.name}" data-type="mention">@${user.name}</span>`
+      return `<span class="${className}" data-id="${user.user_id}" data-label="${name}" data-type="mention">@${name}</span>`
     } else {
       return `@${match[1]}`
     }

--- a/web-frontend/test/unit/core/editor/mention.spec.js
+++ b/web-frontend/test/unit/core/editor/mention.spec.js
@@ -1,0 +1,45 @@
+import { parseMarkdown } from '@baserow/modules/core/editor/markdown'
+
+describe('rich-text mention rendering', () => {
+  const XSS_PAYLOAD = '"><img src=x onerror=alert(document.domain)>'
+
+  test('escapes a malicious workspace user name (stored XSS)', () => {
+    const users = [{ user_id: 1, name: XSS_PAYLOAD }]
+
+    const html = parseMarkdown('Hello @1', { workspaceUsers: users })
+
+    // The payload must not survive as a live element, nor break out of the
+    // data-label attribute into the span's content.
+    expect(html).not.toContain('<img')
+    expect(html).not.toContain('data-label=""')
+    expect(html).toContain('&lt;img')
+
+    // Parsing the output confirms no injected element ever materializes; the
+    // payload stays inert text inside the single mention span.
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+    expect(doc.querySelector('img')).toBeNull()
+    const mention = doc.querySelector('span[data-type="mention"]')
+    expect(mention).not.toBeNull()
+    expect(mention.getAttribute('data-id')).toBe('1')
+    expect(mention.textContent).toBe(`@${XSS_PAYLOAD}`)
+  })
+
+  test('renders a normal workspace user name unchanged', () => {
+    const users = [{ user_id: 1, name: 'Jane Doe' }]
+
+    const html = parseMarkdown('Hello @1', { workspaceUsers: users })
+
+    expect(html).toContain('data-label="Jane Doe"')
+    expect(html).toContain('>@Jane Doe</span>')
+    expect(html).toContain('data-type="mention"')
+  })
+
+  test('preserves ampersands in names without double-escaping the markup', () => {
+    const users = [{ user_id: 2, name: 'Tom & Jerry' }]
+
+    const html = parseMarkdown('Ping @2', { workspaceUsers: users })
+
+    expect(html).toContain('Tom &amp; Jerry')
+    expect(html).not.toContain('Tom & Jerry')
+  })
+})


### PR DESCRIPTION
### What this fixes
A workspace member could set their display name to HTML/JavaScript. When someone viewed a rich text cell that @-mentioned that member, the script ran automatically in their browser (stored XSS).

### The fix
HTML-escape the user's name before it's placed into the mention's HTML in `mention.js`. A normal name renders exactly as before; a malicious one now shows as plain text instead of running.

### How to test
- Automated: `just f test` — see `web-frontend/test/unit/core/editor/mention.spec.js`. The test fails on `develop` and passes with this fix.
- Manual: set your first name to `"><img src=x onerror=alert(1)>`, put `@<your-id>` in a long-text/rich-text cell, and open the table. Before: alert fires. After: the text shows as-is.

### Checklist
- [x] Changelog entry added
- [x] Regression test added (fails on develop, passes here)
- [x] Security impact considered