### PR TITLE
fix: ensure formula property extractor supports trashed elements

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/collection_field_types.py
+++ b/backend/src/baserow/contrib/builder/elements/collection_field_types.py
@@ -303,8 +303,12 @@ class ButtonCollectionFieldType(CollectionFieldType):
         }
 
     def before_delete(self, instance: CollectionField):
-        # We delete the related workflow actions
-        BuilderWorkflowAction.objects.filter(event__startswith=instance.uid).delete()
+        # We delete the related workflow actions. This can run while the owning
+        # element is trashed (permanent deletion), so we use the manager that still
+        # includes actions of trashed elements.
+        BuilderWorkflowAction.objects_including_trashed_elements.filter(
+            event__startswith=instance.uid
+        ).delete()
 
 
 class ImageCollectionFieldType(CollectionFieldType):

--- a/backend/src/baserow/contrib/builder/elements/element_types.py
+++ b/backend/src/baserow/contrib/builder/elements/element_types.py
@@ -2411,8 +2411,14 @@ class MenuElementType(ElementType):
         :return: None
         """
 
-        # Get all workflow actions associated with this menu element.
-        all_workflow_actions = BuilderWorkflowAction.objects.filter(element=instance)
+        # Get all workflow actions associated with this menu element. This runs
+        # during permanent deletion, when the element is already trashed, so we use
+        # the manager that still includes actions of trashed elements.
+        all_workflow_actions = (
+            BuilderWorkflowAction.objects_including_trashed_elements.filter(
+                element=instance
+            )
+        )
 
         # If there are menu items, only keep workflow actions that match
         # existing menu items.

--- a/backend/src/baserow/contrib/builder/formula_property_extractor.py
+++ b/backend/src/baserow/contrib/builder/formula_property_extractor.py
@@ -128,6 +128,7 @@ def get_workflow_action_property_names(
         - "external" property names are those needed in the frontend.
     """
 
+    from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
     from baserow.contrib.builder.elements.handler import ElementHandler
     from baserow.contrib.builder.workflow_actions.workflow_action_types import (
         BuilderWorkflowServiceActionType,
@@ -136,9 +137,17 @@ def get_workflow_action_property_names(
     results = {"internal": {}, "external": {}}
 
     for workflow_action in workflow_actions:
-        formula_context = ElementHandler().get_import_context_addition(
-            workflow_action.element_id, element_map
-        )
+        try:
+            formula_context = ElementHandler().get_import_context_addition(
+                workflow_action.element_id, element_map
+            )
+        except ElementDoesNotExist:
+            # The workflow action's element may have been trashed (soft-deleted)
+            # while the action itself still exists; the `element` foreign key only
+            # cascades on permanent deletion. Such an action isn't rendered, so its
+            # formulas don't contribute any used properties and we skip it rather
+            # than failing the whole extraction.
+            continue
 
         found_properties = workflow_action.get_type().extract_properties(
             workflow_action, **formula_context

--- a/backend/src/baserow/contrib/builder/formula_property_extractor.py
+++ b/backend/src/baserow/contrib/builder/formula_property_extractor.py
@@ -128,7 +128,6 @@ def get_workflow_action_property_names(
         - "external" property names are those needed in the frontend.
     """
 
-    from baserow.contrib.builder.elements.exceptions import ElementDoesNotExist
     from baserow.contrib.builder.elements.handler import ElementHandler
     from baserow.contrib.builder.workflow_actions.workflow_action_types import (
         BuilderWorkflowServiceActionType,
@@ -137,17 +136,9 @@ def get_workflow_action_property_names(
     results = {"internal": {}, "external": {}}
 
     for workflow_action in workflow_actions:
-        try:
-            formula_context = ElementHandler().get_import_context_addition(
-                workflow_action.element_id, element_map
-            )
-        except ElementDoesNotExist:
-            # The workflow action's element may have been trashed (soft-deleted)
-            # while the action itself still exists; the `element` foreign key only
-            # cascades on permanent deletion. Such an action isn't rendered, so its
-            # formulas don't contribute any used properties and we skip it rather
-            # than failing the whole extraction.
-            continue
+        formula_context = ElementHandler().get_import_context_addition(
+            workflow_action.element_id, element_map
+        )
 
         found_properties = workflow_action.get_type().extract_properties(
             workflow_action, **formula_context

--- a/backend/src/baserow/contrib/builder/workflow_actions/models.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/models.py
@@ -16,6 +16,20 @@ class EventTypes(models.TextChoices):
     AFTER_LOGIN = "after_login"
 
 
+class BuilderWorkflowActionManager(models.Manager):
+    """
+    By default, we will only return workflow
+    actions associated with untrashed elements.
+    """
+
+    def get_queryset(self):
+        # `exclude` rather than `filter(element__trashed=False)` so that
+        # page-scoped actions, whose `element` is NULL, are still returned.
+        # An `element__trashed=False` filter is an inner join that would
+        # silently drop those NULL-element rows.
+        return super().get_queryset().exclude(element__trashed=True)
+
+
 class BuilderWorkflowAction(
     WorkflowAction,
     OrderableMixin,
@@ -35,6 +49,13 @@ class BuilderWorkflowAction(
     element = models.ForeignKey(
         Element, on_delete=models.CASCADE, null=True, default=None
     )
+
+    # The default manager hides actions whose element has been trashed. Use
+    # `objects_including_trashed_elements` in the rare places that must operate on
+    # those actions regardless of their element's trash state, such as cleaning them
+    # up when the element is permanently deleted.
+    objects = BuilderWorkflowActionManager()
+    objects_including_trashed_elements = models.Manager()
 
     @classmethod
     def is_dynamic_event(cls, event: str) -> bool:

--- a/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_menu_element_type.py
@@ -395,12 +395,14 @@ def test_all_workflow_actions_removed_when_menu_element_deleted(
     assert NotificationWorkflowAction.objects.count() == 2
 
     # Deleting only soft-trashes the element. Its menu items and workflow actions
-    # must survive so a restore can bring them back.
+    # must survive so a restore can bring them back. The default manager hides
+    # actions of trashed elements, so we count via the manager that includes them.
     ElementService().delete_element(menu_element_fixture["user"], menu_element)
 
     assert MenuElement.objects.count() == 0
     assert MenuItemElement.objects.count() == 2
-    assert NotificationWorkflowAction.objects.count() == 2
+    assert NotificationWorkflowAction.objects.count() == 0
+    assert NotificationWorkflowAction.objects_including_trashed_elements.count() == 2
 
     # Permanently deleting the element cleans up the menu items and their
     # associated workflow actions.
@@ -408,7 +410,7 @@ def test_all_workflow_actions_removed_when_menu_element_deleted(
 
     assert MenuElement.objects_and_trash.count() == 0
     assert MenuItemElement.objects.count() == 0
-    assert NotificationWorkflowAction.objects.count() == 0
+    assert NotificationWorkflowAction.objects_including_trashed_elements.count() == 0
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/elements/test_table_element_type.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_table_element_type.py
@@ -393,12 +393,15 @@ def test_delete_table_element_removes_associated_workflow_actions(data_fixture):
     assert NotificationWorkflowAction.objects.count() == 1
 
     # Deleting only soft-trashes the element; its fields' workflow actions survive.
+    # The default manager hides actions of trashed elements, so we count via the
+    # manager that includes them.
     ElementService().delete_element(user, table_element)
-    assert NotificationWorkflowAction.objects.count() == 1
+    assert NotificationWorkflowAction.objects.count() == 0
+    assert NotificationWorkflowAction.objects_including_trashed_elements.count() == 1
 
     # Permanently deleting the element removes the associated workflow actions.
     TrashHandler.permanently_delete(table_element)
-    assert NotificationWorkflowAction.objects.count() == 0
+    assert NotificationWorkflowAction.objects_including_trashed_elements.count() == 0
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
@@ -477,48 +477,44 @@ def test_get_workflow_action_property_names_returns_property_names(data_fixture)
 
 
 @pytest.mark.django_db
-def test_get_workflow_action_property_names_skips_trashed_element(data_fixture):
+def test_get_builder_workflow_actions_excludes_trashed_element(data_fixture):
     """
-    A workflow action whose element has been trashed (soft-deleted) must not crash
-    the extraction. The `element` foreign key only cascades on permanent deletion,
-    so the action survives the trash; since it is no longer rendered, its formulas
-    contribute no used properties and it is skipped.
+    An action whose element has been trashed (soft-deleted) must be dropped from the
+    queryset returned by the service. The `element` foreign key only cascades on
+    permanent deletion, so an action can outlive the trashing of its element. Actions
+    without an element (page-scoped) must still be returned.
     """
 
     user = data_fixture.create_user()
-    table, fields, _ = data_fixture.build_table(
-        user=user,
-        columns=[("Fruit", "text")],
-        rows=[["Apple"]],
-    )
     builder = data_fixture.create_builder_application(user=user)
     page = data_fixture.create_builder_page(user=user, builder=builder)
-    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
-        user=user, page=page, table=table
-    )
     button_element = data_fixture.create_builder_button_element(page=page)
-    workflow_action = (
-        BuilderWorkflowActionService()
-        .create_workflow_action(
-            user,
-            NotificationWorkflowActionType(),
-            page=page,
-            element=button_element,
-            event=EventTypes.CLICK,
-            title=f"get('data_source.{data_source.id}.0.field_{fields[0].id}')",
-        )
-        .specific
+
+    element_action = BuilderWorkflowActionService().create_workflow_action(
+        user,
+        NotificationWorkflowActionType(),
+        page=page,
+        element=button_element,
+        event=EventTypes.CLICK,
+    )
+    page_action = BuilderWorkflowActionService().create_workflow_action(
+        user,
+        NotificationWorkflowActionType(),
+        page=page,
+        event=EventTypes.CLICK,
     )
 
-    # Trash the button. The workflow action still references it via element_id.
+    # Both actions are returned while the element is live.
+    actions = BuilderWorkflowActionService().get_builder_workflow_actions(user, builder)
+    assert {action.id for action in actions} == {element_action.id, page_action.id}
+
+    # Trash the button. Its action still references it via element_id.
     element = ElementHandler().get_element_for_update(button_element.id)
     ElementService().delete_element(user, element)
 
-    # The element is no longer in the live element map, so resolving its import
-    # context would previously raise ElementDoesNotExist.
-    results = get_workflow_action_property_names([workflow_action], {})
-
-    assert results == {"external": {}, "internal": {}}
+    # The trashed element's action is excluded, but the page-scoped one remains.
+    actions = BuilderWorkflowActionService().get_builder_workflow_actions(user, builder)
+    assert {action.id for action in actions} == {page_action.id}
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
+++ b/backend/tests/baserow/contrib/builder/test_formula_property_extractor.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest_unordered import unordered
 
+from baserow.contrib.builder.elements.handler import ElementHandler
+from baserow.contrib.builder.elements.service import ElementService
 from baserow.contrib.builder.formula_property_extractor import (
     FormulaFieldVisitor,
     get_builder_used_property_names,
@@ -27,6 +29,7 @@ from baserow.core.formula.exceptions import InvalidRuntimeFormula
 from baserow.core.formula.parser.exceptions import BaserowFormulaSyntaxError
 from baserow.core.formula.registries import DataProviderType
 from baserow.core.formula.runtime_formula_context import RuntimeFormulaContext
+from baserow.core.user_sources.user_source_user import UserSourceUser
 
 
 class TestDataProviderType(DataProviderType):
@@ -471,6 +474,90 @@ def test_get_workflow_action_property_names_returns_property_names(data_fixture)
         f"field_{fields[1].id}"
     ]
     assert results["internal"] == {}
+
+
+@pytest.mark.django_db
+def test_get_workflow_action_property_names_skips_trashed_element(data_fixture):
+    """
+    A workflow action whose element has been trashed (soft-deleted) must not crash
+    the extraction. The `element` foreign key only cascades on permanent deletion,
+    so the action survives the trash; since it is no longer rendered, its formulas
+    contribute no used properties and it is skipped.
+    """
+
+    user = data_fixture.create_user()
+    table, fields, _ = data_fixture.build_table(
+        user=user,
+        columns=[("Fruit", "text")],
+        rows=[["Apple"]],
+    )
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user, page=page, table=table
+    )
+    button_element = data_fixture.create_builder_button_element(page=page)
+    workflow_action = (
+        BuilderWorkflowActionService()
+        .create_workflow_action(
+            user,
+            NotificationWorkflowActionType(),
+            page=page,
+            element=button_element,
+            event=EventTypes.CLICK,
+            title=f"get('data_source.{data_source.id}.0.field_{fields[0].id}')",
+        )
+        .specific
+    )
+
+    # Trash the button. The workflow action still references it via element_id.
+    element = ElementHandler().get_element_for_update(button_element.id)
+    ElementService().delete_element(user, element)
+
+    # The element is no longer in the live element map, so resolving its import
+    # context would previously raise ElementDoesNotExist.
+    results = get_workflow_action_property_names([workflow_action], {})
+
+    assert results == {"external": {}, "internal": {}}
+
+
+@pytest.mark.django_db
+def test_get_builder_used_property_names_with_trashed_action_element(data_fixture):
+    """
+    Previewing a page after trashing a button that owns a workflow
+    action must not raise ElementDoesNotExist while recomputing used properties.
+    """
+
+    user = data_fixture.create_user()
+    table, fields, _ = data_fixture.build_table(
+        user=user,
+        columns=[("Fruit", "text")],
+        rows=[["Apple"]],
+    )
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        user=user, page=page, table=table
+    )
+    button_element = data_fixture.create_builder_button_element(page=page)
+    BuilderWorkflowActionService().create_workflow_action(
+        user,
+        NotificationWorkflowActionType(),
+        page=page,
+        element=button_element,
+        event=EventTypes.CLICK,
+        title=f"get('data_source.{data_source.id}.0.field_{fields[0].id}')",
+    )
+
+    element = ElementHandler().get_element_for_update(button_element.id)
+    ElementService().delete_element(user, element)
+
+    user_source_user = UserSourceUser(None, None, 1, "foo", "foo@bar.com")
+
+    # Should not raise; the trashed button's action is skipped.
+    results = get_builder_used_property_names(user_source_user, builder)
+
+    assert results == {"all": {}, "external": {}, "internal": {}}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What is in this PR

A fix for @jrmi's caching issue.

### How to test this PR

- Create a page with a button.
- Add an action to that button.
- Preview the page
- Add a container
- move the button in the container
- Delete the button
- Refresh the preview -> it should fail

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
