### PR TITLE
fix: prevent db errors during dispatch from masking errors 

### DIFF
--- a/backend/src/baserow/core/services/registries.py
+++ b/backend/src/baserow/core/services/registries.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar
 
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
+from django.db import transaction
 
 from loguru import logger
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -376,9 +377,18 @@ class ServiceType(
             return DispatchResult(**sample_data)
 
         try:
-            resolved_values = self.resolve_service_formulas(service, dispatch_context)
-            data = self.dispatch_data(service, resolved_values, dispatch_context)
-            serialized_data = self.dispatch_transform(data)
+            # Wrap the dispatch in a savepoint so that, if any of these
+            # operations raise a database error, only this savepoint is rolled
+            # back. This keeps the surrounding transaction usable, so the
+            # caller (and the sample data error save below) can still issue
+            # queries instead of crashing with a `TransactionManagementError`
+            # on a broken transaction.
+            with transaction.atomic():
+                resolved_values = self.resolve_service_formulas(
+                    service, dispatch_context
+                )
+                data = self.dispatch_data(service, resolved_values, dispatch_context)
+                serialized_data = self.dispatch_transform(data)
         except Exception as e:
             if dispatch_context.use_sample_data and (
                 dispatch_context.update_sample_data_for is None

--- a/backend/tests/baserow/contrib/automation/nodes/test_node_dispatch_async.py
+++ b/backend/tests/baserow/contrib/automation/nodes/test_node_dispatch_async.py
@@ -245,6 +245,67 @@ def test_dispatch_node_unexpected_error(mock_logger, mock_dispatch, data_fixture
 
 
 @pytest.mark.django_db
+@patch(f"{NODE_HANDLER_PATH}.logger")
+def test_dispatch_node_database_error_does_not_break_transaction(
+    mock_logger, data_fixture
+):
+    """
+    Regression test: when a service dispatch raises a *database* error, it
+    leaves the surrounding transaction in a "needs rollback" state. The service
+    dispatch wraps its work in a savepoint so the surrounding transaction stays
+    usable, allowing the error handling path to persist the failure
+    (workflow/node history) instead of crashing with a
+    TransactionManagementError on the broken transaction.
+    """
+
+    data = create_workflow(data_fixture)
+    trigger_node = data["trigger_node"]
+    action_node = data["action_node"]
+    workflow_history = data["workflow_history"]
+
+    # First dispatch the trigger so the action node has its previous results.
+    result = AutomationNodeHandler().dispatch_node(
+        trigger_node.id,
+        history_id=workflow_history.id,
+    )
+    assert_dispatches_next_node(result, (action_node, workflow_history, None))
+
+    def _broken_db_dispatch_data(*args, **kwargs):
+        # Run a failing query inside the dispatch so the connection is marked
+        # as needing a rollback, then let the resulting database error
+        # propagate, mimicking a real service dispatch hitting a DB error.
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT * FROM table_that_does_not_exist_xyz")
+
+    # Now dispatch the action node, whose service dispatch hits a DB error.
+    # This must not raise a TransactionManagementError.
+    with patch(
+        "baserow.contrib.integrations.local_baserow.service_types"
+        ".LocalBaserowUpsertRowServiceType.dispatch_data",
+        side_effect=_broken_db_dispatch_data,
+    ):
+        result = AutomationNodeHandler().dispatch_node(
+            action_node.id,
+            history_id=workflow_history.id,
+        )
+    assert result is None
+
+    workflow_history.refresh_from_db()
+    assert workflow_history.status == HistoryStatusChoices.ERROR
+    assert "Unexpected error while running workflow" in workflow_history.message
+
+    node_history = (
+        AutomationNodeHistory.objects.filter(workflow_history=workflow_history)
+        .order_by("-id")
+        .first()
+    )
+    assert node_history.status == HistoryStatusChoices.ERROR
+    assert "Unexpected error while running workflow" in node_history.message
+
+
+@pytest.mark.django_db
 @patch(f"{TRIGGER_NODE_TYPE_PATH}.dispatch")
 @patch(f"{NODE_HANDLER_PATH}.logger")
 def test_dispatch_node_expected_error(mock_logger, mock_dispatch, data_fixture):

--- a/backend/tests/baserow/core/service/test_service_type.py
+++ b/backend/tests/baserow/core/service/test_service_type.py
@@ -146,6 +146,7 @@ def test_service_type_prepare_values(data_fixture):
     ) == {"integration": integration_c}
 
 
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "field_names,expected_field_names",
     [
@@ -241,6 +242,7 @@ def test_dispatch_returns_sample_data_when_simulated():
     assert result.data == {"foo": "bar"}
 
 
+@pytest.mark.django_db
 def test_dispatch_even_if_simulated_when_updated():
     """
     Ensure that when dispatch_context.is_simulated is True, the cached sample
@@ -272,6 +274,7 @@ def test_dispatch_even_if_simulated_when_updated():
     assert result.data == {"someother": "data"}
 
 
+@pytest.mark.django_db
 def test_dispatch_even_if_simulated_without_sample_data():
     """
     Ensure that when dispatch_context.is_simulated is True, the cached sample

--- a/changelog/entries/unreleased/bug/fixes_automation_runs_not_recording_the_real_error_when_a_no.json
+++ b/changelog/entries/unreleased/bug/fixes_automation_runs_not_recording_the_real_error_when_a_no.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes automation runs not recording the real error when a node hits a database problem",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-06-30"
+}


### PR DESCRIPTION
### What is in this PR

Automation node dispatch runs inside a single `transaction.atomic()` block. When a service's `dispatch_data` hit a database error, the transaction was poisoned (`needs_rollback=True`), so the error handler's attempt to record the failure (`workflow_history.save()`) then raised a `TransactionManagementError`, crashing the run and masking the real cause.

This wraps the dispatch work in a savepoint inside the shared `ServiceType.dispatch` (`core/services/registries.py`). On a DB error only the savepoint rolls back, leaving the transaction usable so the failure is recorded (status ERROR) and the original error surfaces

The savepoint sits in `dispatch` (not the automation handler) so it closes before the handler's except runs, and below the except that persists `sample_data` error state, wrapping higher would roll that write back and break simulations.

### How to test this PR

> just b test tests/baserow/contrib/automation/nodes/test_node_dispatch_async.py tests/baserow/core/service/ -n=auto

Key test: `test_dispatch_node_database_error_does_not_break_transaction`. Stash the `registries.py` change and re-run to see it fail with `TransactionManagementError`, restore and it passes.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
