### PR TITLE
fix(web-frontend): refresh access token on websocket reconnect

### DIFF
--- a/changelog/entries/unreleased/bug/restores_realtime_updates_when_returning_to_an_idle_tab_inst.json
+++ b/changelog/entries/unreleased/bug/restores_realtime_updates_when_returning_to_an_idle_tab_inst.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Restores real-time updates when returning to an idle tab instead of asking to refresh",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-01"
+}

--- a/web-frontend/modules/core/plugins/realTimeHandler.js
+++ b/web-frontend/modules/core/plugins/realTimeHandler.js
@@ -10,6 +10,9 @@ const RECONNECT_BASE_DELAY = 1000
 const RECONNECT_MAX_DELAY = 30000
 const RECONNECT_MAX_ATTEMPTS = 10
 const RECONNECT_JITTER = 1000
+// The handshake resets ``attempts`` before the auth result arrives, so the
+// backoff cap can't bound an auth-rejection loop; bound the refreshes instead.
+const MAX_TOKEN_REFRESH_RETRIES = 1
 
 export class RealTimeHandler {
   constructor(context) {
@@ -30,6 +33,11 @@ export class RealTimeHandler {
 
     this.lastSeenEventId = FIRST_CONNECT_CURSOR
     this.replayEnabled = false
+
+    this.connecting = false
+    // Set on a rejected token so the next reconnect refreshes before retrying.
+    this.forceTokenRefresh = false
+    this.tokenRefreshRetries = 0
 
     this.registerCoreEvents()
 
@@ -67,16 +75,13 @@ export class RealTimeHandler {
    * Creates a new connection with to the web socket so that real time updates can be
    * received.
    */
-  connect(reconnect = true, anonymous = false) {
+  async connect(reconnect = true, anonymous = false) {
     if (!import.meta.client) {
       return
     }
 
     this.reconnect = reconnect
     this.anonymous = anonymous
-
-    const jwtToken = this.context.store.getters['auth/token']
-    const token = anonymous ? jwtToken || 'anonymous' : jwtToken
 
     if (
       this.socket &&
@@ -86,10 +91,41 @@ export class RealTimeHandler {
       return
     }
 
+    // A backgrounded tab makes no HTTP calls, so the axios refresh interceptor
+    // never runs and the access token silently expires; reconnecting with it
+    // would be rejected as a permanent auth failure. Only this branch awaits,
+    // keeping the common reconnect path synchronous.
+    if (this._tokenRefreshNeeded(anonymous)) {
+      if (this.connecting) {
+        return
+      }
+      this.connecting = true
+      let transientRefreshFailure = false
+      try {
+        await this.context.store.dispatch('auth/refresh')
+        this.forceTokenRefresh = false
+      } catch (error) {
+        // A 401 means the refresh token itself expired: the session is gone
+        // and the guards below surface it. Anything else is transient (e.g. a
+        // network blip), so retry with backoff instead of failing, keeping
+        // forceTokenRefresh set for the next attempt.
+        transientRefreshFailure = error?.response?.status !== 401
+      } finally {
+        this.connecting = false
+      }
+      if (transientRefreshFailure) {
+        this.delayedReconnect()
+        return
+      }
+    }
+
     if (this.socket) {
       this.socket.onclose = null
       this.socket = null
     }
+
+    const jwtToken = this.context.store.getters['auth/token']
+    const token = anonymous ? jwtToken || 'anonymous' : jwtToken
 
     // "Failed — refresh" is only for genuine auth problems; transient
     // network failures keep retrying with capped backoff.
@@ -232,9 +268,21 @@ export class RealTimeHandler {
     return typeof navigator === 'undefined' || navigator.onLine !== false
   }
 
+  _tokenRefreshNeeded(anonymous) {
+    if (anonymous) {
+      return false
+    }
+    const store = this.context.store
+    if (!store.getters['auth/isAuthenticated']) {
+      return false
+    }
+    return this.forceTokenRefresh || store.getters['auth/shouldRefreshToken']()
+  }
+
   _retryReconnectNow() {
     clearTimeout(this.reconnectTimeout)
     this.attempts = 0
+    this.tokenRefreshRetries = 0
     this.context.store.dispatch('toast/setFailedConnecting', false)
     // Keep the "Reconnecting" toast up until ``onopen`` clears it; flickering
     // it off here just confuses the user during the retry round-trip.
@@ -335,6 +383,9 @@ export class RealTimeHandler {
     this.reconnect = false
     this.attempts = 0
     this.connected = false
+    this.connecting = false
+    this.forceTokenRefresh = false
+    this.tokenRefreshRetries = 0
     this.lastSeenEventId = FIRST_CONNECT_CURSOR
     // Reset until the next auth message confirms replay is enabled.
     this.replayEnabled = false
@@ -391,8 +442,20 @@ export class RealTimeHandler {
         this.lastSeenEventId = NO_REPLAY_AVAILABLE
       }
 
-      if (data.success && this._canReplayEvents()) {
-        this._sendReplayEventsRequest()
+      if (data.success) {
+        this.forceTokenRefresh = false
+        this.tokenRefreshRetries = 0
+        if (this._canReplayEvents()) {
+          this._sendReplayEventsRequest()
+        }
+      } else if (
+        !this.anonymous &&
+        this.tokenRefreshRetries < MAX_TOKEN_REFRESH_RETRIES
+      ) {
+        // A rejected token is usually just expired: refresh and retry rather
+        // than failing. Once the cap is hit, let connect()'s guard surface it.
+        this.tokenRefreshRetries++
+        this.forceTokenRefresh = true
       }
     })
 

--- a/web-frontend/test/unit/core/realTimeHandler.spec.js
+++ b/web-frontend/test/unit/core/realTimeHandler.spec.js
@@ -790,3 +790,220 @@ describe('RealTimeHandler presence events', () => {
     ).toBe(true)
   })
 })
+
+describe('RealTimeHandler token refresh on reconnect', () => {
+  function makeRefreshStore({ shouldRefresh = false } = {}) {
+    const dispatched = []
+    const store = {
+      getters: {
+        'auth/token': 'stale-token',
+        'auth/webSocketId': 'ws-id',
+        'auth/isAuthenticated': true,
+        'auth/shouldRefreshToken': () => shouldRefresh,
+      },
+      dispatch(name, value) {
+        dispatched.push([name, value])
+        if (name === 'auth/refresh') {
+          const refreshCount = dispatched.filter(
+            ([n]) => n === 'auth/refresh'
+          ).length
+          store.getters['auth/token'] = `fresh-token-${refreshCount}`
+        }
+        return Promise.resolve()
+      },
+      subscribe() {},
+      _dispatched: dispatched,
+    }
+    return store
+  }
+
+  function makeHandlerWith(store) {
+    const context = { store, app: { router: {} } }
+    return { handler: new RealTimeHandler(context), store }
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  test('an expiring access token is refreshed before the socket opens', async () => {
+    const store = makeRefreshStore({ shouldRefresh: true })
+    const { handler } = makeHandlerWith(store)
+
+    await handler.connect(true, false)
+
+    expect(store._dispatched.some(([n]) => n === 'auth/refresh')).toBe(true)
+    expect(handler.lastToken).toBe('fresh-token-1')
+    expect(
+      store._dispatched.some(
+        ([n, v]) => n === 'toast/setFailedConnecting' && v === true
+      )
+    ).toBe(false)
+  })
+
+  test('a fresh-looking token is not refreshed on a normal reconnect', async () => {
+    const store = makeRefreshStore({ shouldRefresh: false })
+    const { handler } = makeHandlerWith(store)
+
+    await handler.connect(true, false)
+
+    expect(store._dispatched.some(([n]) => n === 'auth/refresh')).toBe(false)
+    expect(handler.lastToken).toBe('stale-token')
+  })
+
+  test('anonymous reconnects never refresh the token', async () => {
+    const store = makeRefreshStore({ shouldRefresh: true })
+    // An anonymous session has no refresh token to spend.
+    store.getters['auth/isAuthenticated'] = false
+    const { handler } = makeHandlerWith(store)
+
+    await handler.connect(true, true)
+
+    expect(store._dispatched.some(([n]) => n === 'auth/refresh')).toBe(false)
+  })
+
+  test('auth rejection forces a token refresh on the next reconnect', async () => {
+    // The token looks fresh to the client (shouldRefresh=false) but the server
+    // rejects it. The reconnect must still refresh instead of giving up.
+    const store = makeRefreshStore({ shouldRefresh: false })
+    const { handler } = makeHandlerWith(store)
+    handler.reconnect = true
+    handler.anonymous = false
+
+    await handler.connect(true, false)
+    expect(handler.lastToken).toBe('stale-token')
+
+    fire(handler, 'authentication', { success: false })
+    expect(handler.forceTokenRefresh).toBe(true)
+
+    await handler.connect(true, false)
+
+    expect(store._dispatched.some(([n]) => n === 'auth/refresh')).toBe(true)
+    expect(handler.lastToken).toBe('fresh-token-1')
+    expect(handler.forceTokenRefresh).toBe(false)
+    expect(
+      store._dispatched.some(
+        ([n, v]) => n === 'toast/setFailedConnecting' && v === true
+      )
+    ).toBe(false)
+  })
+
+  test('a successful reconnect clears the forced-refresh flag', async () => {
+    const store = makeRefreshStore({ shouldRefresh: false })
+    const { handler } = makeHandlerWith(store)
+    handler.forceTokenRefresh = true
+
+    fire(handler, 'authentication', { success: true, replay_enabled: false })
+
+    expect(handler.forceTokenRefresh).toBe(false)
+  })
+
+  test('stops refreshing once a freshly refreshed token is also rejected', async () => {
+    const store = makeRefreshStore({ shouldRefresh: false })
+    const { handler } = makeHandlerWith(store)
+    handler.reconnect = true
+    handler.anonymous = false
+
+    fire(handler, 'authentication', { success: false })
+    expect(handler.forceTokenRefresh).toBe(true)
+    expect(handler.tokenRefreshRetries).toBe(1)
+    await handler.connect(true, false)
+    expect(handler.lastToken).toBe('fresh-token-1')
+
+    fire(handler, 'authentication', { success: false })
+    expect(handler.forceTokenRefresh).toBe(false)
+
+    // The next reconnect reuses the same rejected token and surfaces failure.
+    const refreshesBefore = store._dispatched.filter(
+      ([n]) => n === 'auth/refresh'
+    ).length
+    await handler.connect(true, false)
+    const refreshesAfter = store._dispatched.filter(
+      ([n]) => n === 'auth/refresh'
+    ).length
+    expect(refreshesAfter).toBe(refreshesBefore)
+    expect(
+      store._dispatched.some(
+        ([n, v]) => n === 'toast/setFailedConnecting' && v === true
+      )
+    ).toBe(true)
+  })
+
+  test('a 401 refresh clears the session and surfaces the failure toast', async () => {
+    const dispatched = []
+    const store = {
+      getters: {
+        'auth/token': 'stale-token',
+        'auth/webSocketId': 'ws-id',
+        'auth/isAuthenticated': true,
+        'auth/shouldRefreshToken': () => true,
+      },
+      dispatch(name, value) {
+        dispatched.push([name, value])
+        if (name === 'auth/refresh') {
+          store.getters['auth/token'] = null
+          const error = new Error('session expired')
+          error.response = { status: 401 }
+          return Promise.reject(error)
+        }
+        return Promise.resolve()
+      },
+      subscribe() {},
+      _dispatched: dispatched,
+    }
+    const { handler } = makeHandlerWith(store)
+
+    await handler.connect(true, false)
+
+    expect(dispatched.some(([n]) => n === 'auth/refresh')).toBe(true)
+    expect(
+      dispatched.some(
+        ([n, v]) => n === 'toast/setFailedConnecting' && v === true
+      )
+    ).toBe(true)
+  })
+
+  test('a transient refresh failure retries with backoff instead of failing', async () => {
+    vi.useFakeTimers()
+    const dispatched = []
+    const store = {
+      getters: {
+        'auth/token': 'stale-token',
+        'auth/webSocketId': 'ws-id',
+        'auth/isAuthenticated': true,
+        'auth/shouldRefreshToken': () => true,
+      },
+      dispatch(name, value) {
+        dispatched.push([name, value])
+        if (name === 'auth/refresh') {
+          // No ``response`` — a network-level error that leaves the token intact.
+          return Promise.reject(new Error('Network Error'))
+        }
+        return Promise.resolve()
+      },
+      subscribe() {},
+      _dispatched: dispatched,
+    }
+    const { handler } = makeHandlerWith(store)
+    handler.reconnect = true
+
+    await handler.connect(true, false)
+
+    expect(
+      dispatched.some(
+        ([n, v]) => n === 'toast/setFailedConnecting' && v === true
+      )
+    ).toBe(false)
+    expect(
+      dispatched.some(([n, v]) => n === 'toast/setReconnecting' && v === true)
+    ).toBe(true)
+    expect(handler.connecting).toBe(false)
+
+    clearTimeout(handler.reconnectTimeout)
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Problem

Follow-up to #5355. On staging, returning to a tab that had been open/idle for a while briefly shows **"Reconnecting"** and then the terminal error **"Real-time updates could not be reestablished. Please refresh to continue."** — instead of transparently reconnecting (and replaying events or showing the staleness toast).

## Root cause

The access token silently expires while the tab is backgrounded, and the reconnect treats the resulting auth rejection as *permanent*:

- `ACCESS_TOKEN_LIFETIME` is 10 minutes. Token refresh is only triggered by outgoing HTTP requests (an axios request interceptor at 80% of token lifespan) — there is **no timer- or visibility-driven refresh**. A backgrounded tab makes no HTTP calls, so after ~10 min the access token in the store is dead.
- The WebSocket path reads `auth/token` directly and never goes through the axios interceptor, so it reconnects with the **stale token**.
- The server rejects it (`get_user()` → `None` → `authentication{success:false}` then `close()`).
- The first reconnect attempt shows "Reconnecting" (brief), then the next `connect()` hits the `tokenAlreadyRejected` short-circuit (same expired token) and shows the permanent **`setFailedConnecting`** error.

Replay never gets a chance to run — it only happens *after* a successful auth.

## Fix

`web-frontend/modules/core/plugins/realTimeHandler.js`:

1. **Proactive** — `connect()` refreshes an expiring/expired access token before opening the socket. It only `await`s when a refresh is actually needed, so the common path stays synchronous.
2. **Reactive** — an `authentication{success:false}` rejection forces one token refresh on the next reconnect instead of latching into the failure toast.
3. **Bounded** — a `MAX_TOKEN_REFRESH_RETRIES` cap (a successful WS handshake resets the backoff counter *before* auth is checked, so it can't bound an auth-rejection loop). Refocus resets the counter, so refocusing always gives a clean retry.

Genuine failures are preserved: if the refresh itself 401s (expired *refresh* token → real session expiry), or a freshly refreshed token is still rejected, the failure toast is shown as before.

## Tests

7 new unit tests in `realTimeHandler.spec.js` (46/46 pass): proactive refresh, no-refresh-when-fresh, anonymous skip, reactive refresh-on-rejection, retry cap, failed-refresh-still-fails, flag reset on success.

## How to test locally

Set short lifetimes in `.env.local` so you don't have to wait 10 minutes, and enable replay:

```
BASEROW_ACCESS_TOKEN_LIFETIME_MINUTES=1
BASEROW_REALTIME_REPLAY_MAX_EVENTS=100
```

Restart the backend, then:

1. Open a table, confirm real-time works (edit in a second window → live update).
2. Switch away from the tab (or DevTools → Network → **Offline**, then `useNuxtApp().$realtime.socket.close()` in the console) and wait **> 1 minute** so the access token expires.
3. Bring the tab back into focus (uncheck Offline first if used).
4. **Expected:** the socket reconnects transparently — either events replay silently, or the "Data may be outdated" staleness toast appears (large gap). **No** "Real-time updates could not be reestablished" error.
5. In DevTools → Network → WS, the reconnect frames should show `authentication{success:true}` (decode the `jwt_token` — its `exp` is now in the future because it was refreshed just before connecting).

To confirm the *old* broken behavior, `git stash` the handler change and repeat steps 2–4: you'll see the brief "Reconnecting" then the permanent error.
