### PR TITLE
feat(database): add "starts with" view filter type

### DIFF
--- a/backend/src/baserow/contrib/database/apps.py
+++ b/backend/src/baserow/contrib/database/apps.py
@@ -401,6 +401,7 @@ class DatabaseConfig(AppConfig):
             SingleSelectIsAnyOfViewFilterType,
             SingleSelectIsNoneOfViewFilterType,
             SingleSelectNotEqualViewFilterType,
+            StartsWithViewFilterType,
             UserIsNotViewFilterType,
             UserIsViewFilterType,
         )
@@ -414,6 +415,7 @@ class DatabaseConfig(AppConfig):
         view_filter_type_registry.register(ContainsNotViewFilterType())
         view_filter_type_registry.register(ContainsWordViewFilterType())
         view_filter_type_registry.register(DoesntContainWordViewFilterType())
+        view_filter_type_registry.register(StartsWithViewFilterType())
         view_filter_type_registry.register(LengthIsLowerThanViewFilterType())
         view_filter_type_registry.register(HigherThanViewFilterType())
         view_filter_type_registry.register(HigherThanOrEqualViewFilterType())

--- a/backend/src/baserow/contrib/database/fields/field_filters.py
+++ b/backend/src/baserow/contrib/database/fields/field_filters.py
@@ -207,6 +207,18 @@ def contains_filter(
     return Q(**{f"{field_name}__icontains": value})
 
 
+def starts_with_filter(
+    field_name, value, model_field, _, validate=True
+) -> OptionallyAnnotatedQ:
+    value = value.strip()
+    # If an empty value has been provided we do not want to filter at all.
+    if value == "":
+        return Q()
+    if validate:
+        model_field.get_prep_value(value)
+    return Q(**{f"{field_name}__istartswith": value})
+
+
 def contains_word_filter(field_name, value, model_field, _) -> OptionallyAnnotatedQ:
     value = value.strip()
     # If an empty value has been provided we do not want to filter at all.

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -202,6 +202,7 @@ from .field_filters import (
     contains_word_filter,
     filename_contains_filter,
     parse_ids_from_csv_string,
+    starts_with_filter,
 )
 from .field_helpers import prepare_files_for_export
 from .field_sortings import OptionallyAnnotatedOrderBy
@@ -378,6 +379,9 @@ class TextFieldMatchingRegexFieldType(FieldType, ABC):
     def contains_query(self, *args):
         return contains_filter(*args)
 
+    def starts_with_query(self, *args):
+        return starts_with_filter(*args)
+
     def contains_word_query(self, *args):
         return contains_word_filter(*args)
 
@@ -474,6 +478,9 @@ class TextFieldType(CollationSortMixin, FieldType):
     def contains_query(self, *args):
         return contains_filter(*args)
 
+    def starts_with_query(self, *args):
+        return starts_with_filter(*args)
+
     def contains_word_query(self, *args):
         return contains_word_filter(*args)
 
@@ -543,6 +550,9 @@ class LongTextFieldType(CollationSortMixin, FieldType):
 
     def contains_query(self, *args):
         return contains_filter(*args)
+
+    def starts_with_query(self, *args):
+        return starts_with_filter(*args)
 
     def contains_word_query(self, *args):
         return contains_word_filter(*args)
@@ -797,6 +807,9 @@ class NumberFieldType(FieldType):
 
     def contains_query(self, *args):
         return contains_filter(*args)
+
+    def starts_with_query(self, *args):
+        return starts_with_filter(*args)
 
     def get_export_serialized_value(self, row, field_name, cache, files_zip, storage):
         value = self.get_internal_value_from_db(row, field_name)
@@ -4712,6 +4725,13 @@ class SingleSelectFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             return Q()
         return Q(**{f"{field_name}__value__icontains": value})
 
+    def starts_with_query(self, field_name, value, model_field, field):
+        value = value.strip()
+        # If an empty value has been provided we do not want to filter at all.
+        if value == "":
+            return Q()
+        return Q(**{f"{field_name}__value__istartswith": value})
+
     def contains_word_query(self, field_name, value, model_field, field):
         value = value.strip()
         # If an empty value has been provided we do not want to filter at all.
@@ -5634,6 +5654,15 @@ class FormulaFieldType(FormulaFieldTypeArrayFilterSupport, ReadOnlyFieldType):
             field_type,
         ) = self.get_field_instance_and_type_from_formula_field(field)
         return field_type.contains_query(field_name, value, model_field, field_instance)
+
+    def starts_with_query(self, field_name, value, model_field, field: FormulaField):
+        (
+            field_instance,
+            field_type,
+        ) = self.get_field_instance_and_type_from_formula_field(field)
+        return field_type.starts_with_query(
+            field_name, value, model_field, field_instance
+        )
 
     def contains_word_query(self, field_name, value, model_field, field):
         (
@@ -7451,6 +7480,9 @@ class AutonumberFieldType(ReadOnlyFieldType):
 
     def contains_query(self, *args):
         return contains_filter(*args)
+
+    def starts_with_query(self, *args):
+        return starts_with_filter(*args)
 
     def update_rows_with_field_sequence(
         self, field: Field, view: Optional["View"] = None

--- a/backend/src/baserow/contrib/database/fields/registries.py
+++ b/backend/src/baserow/contrib/database/fields/registries.py
@@ -523,8 +523,7 @@ class FieldType(
         :type model_field: models.Field
         :param field: The related field's instance.
         :type field: Field
-        :return: A Q or AnnotatedQ filter.
-            given value.
+        :return: A Q or AnnotatedQ filter for the given value.
         :rtype: OptionallyAnnotatedQ
         """
 

--- a/backend/src/baserow/contrib/database/fields/registries.py
+++ b/backend/src/baserow/contrib/database/fields/registries.py
@@ -510,6 +510,26 @@ class FieldType(
 
         return Q()
 
+    def starts_with_query(self, field_name, value, model_field, field):
+        """
+        Returns a Q or AnnotatedQ filter which performs a starts with filter over the
+        provided field for this specific type of field.
+
+        :param field_name: The name of the field.
+        :type field_name: str
+        :param value: The value to check if this field starts with or not.
+        :type value: str
+        :param model_field: The field's actual django field model instance.
+        :type model_field: models.Field
+        :param field: The related field's instance.
+        :type field: Field
+        :return: A Q or AnnotatedQ filter.
+            given value.
+        :rtype: OptionallyAnnotatedQ
+        """
+
+        return Q()
+
     def contains_word_query(self, field_name, value, model_field, field):
         """
         Returns a Q or AnnotatedQ filter which performs a regex filter over the

--- a/backend/src/baserow/contrib/database/views/view_filters.py
+++ b/backend/src/baserow/contrib/database/views/view_filters.py
@@ -314,6 +314,9 @@ class StartsWithViewFilterType(ViewFilterType):
     """
 
     type = "starts_with"
+    # Field types that resolve to one of these via `get_compatible_filter_field_type`
+    # also become compatible, so they must implement `starts_with_query`. Otherwise
+    # the base implementation returns an empty `Q()` and the filter matches every row.
     compatible_field_types = [
         TextFieldType.type,
         LongTextFieldType.type,

--- a/backend/src/baserow/contrib/database/views/view_filters.py
+++ b/backend/src/baserow/contrib/database/views/view_filters.py
@@ -307,6 +307,39 @@ class ContainsNotViewFilterType(NotViewFilterTypeMixin, ContainsViewFilterType):
     type = "contains_not"
 
 
+class StartsWithViewFilterType(ViewFilterType):
+    """
+    The starts with filter checks if the field value starts with the provided filter
+    value. It is compatible with models.CharField and models.TextField.
+    """
+
+    type = "starts_with"
+    compatible_field_types = [
+        TextFieldType.type,
+        LongTextFieldType.type,
+        URLFieldType.type,
+        EmailFieldType.type,
+        PhoneNumberFieldType.type,
+        NumberFieldType.type,
+        AutonumberFieldType.type,
+        SingleSelectFieldType.type,
+        FormulaFieldType.compatible_with_formula_types(
+            BaserowFormulaTextType.type,
+            BaserowFormulaCharType.type,
+            BaserowFormulaURLType.type,
+            BaserowFormulaNumberType.type,
+            BaserowFormulaSingleSelectType.type,
+        ),
+    ]
+
+    def get_filter(self, field_name, value, model_field, field) -> OptionallyAnnotatedQ:
+        try:
+            field_type = field_type_registry.get_by_model(field)
+            return field_type.starts_with_query(field_name, value, model_field, field)
+        except Exception:
+            return self.default_filter_on_exception()
+
+
 class LengthIsLowerThanViewFilterType(ViewFilterType):
     """
     The length is lower than filter checks if the fields character

--- a/backend/src/baserow/contrib/database/views/view_filters.py
+++ b/backend/src/baserow/contrib/database/views/view_filters.py
@@ -310,9 +310,7 @@ class ContainsNotViewFilterType(NotViewFilterTypeMixin, ContainsViewFilterType):
 class StartsWithViewFilterType(ViewFilterType):
     """
     The starts with filter checks if the field value starts with the provided filter
-    value. The compatible field types are listed in `compatible_field_types` and
-    cover text-based fields as well as number, autonumber, single select and the
-    matching formula types.
+    value.
     """
 
     type = "starts_with"

--- a/backend/src/baserow/contrib/database/views/view_filters.py
+++ b/backend/src/baserow/contrib/database/views/view_filters.py
@@ -310,7 +310,9 @@ class ContainsNotViewFilterType(NotViewFilterTypeMixin, ContainsViewFilterType):
 class StartsWithViewFilterType(ViewFilterType):
     """
     The starts with filter checks if the field value starts with the provided filter
-    value. It is compatible with models.CharField and models.TextField.
+    value. The compatible field types are listed in `compatible_field_types` and
+    cover text-based fields as well as number, autonumber, single select and the
+    matching formula types.
     """
 
     type = "starts_with"

--- a/backend/tests/baserow/contrib/database/view/test_view_filters.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_filters.py
@@ -1028,6 +1028,11 @@ def test_starts_with_filter_type(data_fixture):
         formula=f"field('{text_field.name}')",
         formula_type="text",
     )
+    number_formula_field = data_fixture.create_formula_field(
+        table=table,
+        name="number formula",
+        formula=f"field('{number_field.name}')",
+    )
 
     handler = ViewHandler()
     model = table.get_model()
@@ -1142,6 +1147,14 @@ def test_starts_with_filter_type(data_fixture):
 
     view_filter.field = formula_field
     view_filter.value = "hello"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    # A non-text formula delegates to the underlying field type's query.
+    view_filter.field = number_formula_field
+    view_filter.value = "123"
     view_filter.save()
     ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
     assert len(ids) == 1

--- a/backend/tests/baserow/contrib/database/view/test_view_filters.py
+++ b/backend/tests/baserow/contrib/database/view/test_view_filters.py
@@ -1004,6 +1004,151 @@ def test_contains_word_filter_type(data_fixture):
 
 
 @pytest.mark.django_db
+def test_starts_with_filter_type(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+    text_field = data_fixture.create_text_field(table=table)
+    long_text_field = data_fixture.create_long_text_field(table=table)
+    url_field = data_fixture.create_url_field(table=table)
+    email_field = data_fixture.create_email_field(table=table)
+    phone_number_field = data_fixture.create_phone_number_field(table=table)
+    number_field = data_fixture.create_number_field(table=table)
+    autonumber_field = data_fixture.create_autonumber_field(table=table)
+    single_select_field = data_fixture.create_single_select_field(table=table)
+    option_a = data_fixture.create_select_option(
+        field=single_select_field, value="Active", color="blue"
+    )
+    option_b = data_fixture.create_select_option(
+        field=single_select_field, value="Done", color="red"
+    )
+    formula_field = data_fixture.create_formula_field(
+        table=table,
+        name="formula",
+        formula=f"field('{text_field.name}')",
+        formula_type="text",
+    )
+
+    handler = ViewHandler()
+    model = table.get_model()
+
+    # The autonumber field is read only and is assigned sequentially, so the
+    # first created row gets 1 and the second gets 2.
+    row, row_2 = (
+        RowHandler()
+        .create_rows(
+            user,
+            table,
+            rows_values=[
+                {
+                    f"field_{text_field.id}": "hello world",
+                    f"field_{long_text_field.id}": "hello long world",
+                    f"field_{url_field.id}": "https://www.example.com",
+                    f"field_{email_field.id}": "john.doe@example.com",
+                    f"field_{phone_number_field.id}": "+1-541-754-3010",
+                    f"field_{number_field.id}": 12345,
+                    f"field_{single_select_field.id}": option_a.id,
+                },
+                {
+                    f"field_{text_field.id}": "doesnt match",
+                    f"field_{long_text_field.id}": "another value",
+                    f"field_{url_field.id}": "http://baserow.io",
+                    f"field_{email_field.id}": "jane.doe@baserow.io",
+                    f"field_{phone_number_field.id}": "+44-20-7946-0000",
+                    f"field_{number_field.id}": 90000,
+                    f"field_{single_select_field.id}": option_b.id,
+                },
+            ],
+            model=model,
+        )
+        .created_rows
+    )
+
+    view_filter = data_fixture.create_view_filter(
+        view=grid_view, field=text_field, type="starts_with", value="hello"
+    )
+    # Only the row starting with the value is kept.
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    # The match is case insensitive.
+    view_filter.value = "HELLO"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    # A value that is contained but not at the start does not match.
+    view_filter.value = "world"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 0
+
+    # An empty value does not filter at all.
+    view_filter.value = ""
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 2
+
+    view_filter.field = long_text_field
+    view_filter.value = "hello"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = url_field
+    view_filter.value = "https://"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = email_field
+    view_filter.value = "john"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = phone_number_field
+    view_filter.value = "+1"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = number_field
+    view_filter.value = "123"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = autonumber_field
+    view_filter.value = "1"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = single_select_field
+    view_filter.value = "act"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+    view_filter.field = formula_field
+    view_filter.value = "hello"
+    view_filter.save()
+    ids = [r.id for r in handler.apply_filters(grid_view, model.objects.all()).all()]
+    assert len(ids) == 1
+    assert row.id in ids
+
+
+@pytest.mark.django_db
 def test_doesnt_contain_word_filter_type(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)

--- a/changelog/entries/unreleased/feature/adds_a_starts_with_filter_for_text_fields.json
+++ b/changelog/entries/unreleased/feature/adds_a_starts_with_filter_for_text_fields.json
@@ -2,7 +2,7 @@
     "type": "feature",
     "message": "Adds a \"starts with\" filter for text fields",
     "issue_origin": "github",
-    "issue_number": null,
+    "issue_number": 1943,
     "domain": "database",
     "bullet_points": [],
     "created_at": "2026-07-01"

--- a/changelog/entries/unreleased/feature/adds_a_starts_with_filter_for_text_fields.json
+++ b/changelog/entries/unreleased/feature/adds_a_starts_with_filter_for_text_fields.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Adds a \"starts with\" filter for text fields",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-01"
+}

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -187,6 +187,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         baserow_field_type = self.get_baserow_field_type(field)
         return baserow_field_type.contains_query(field_name, value, model_field, field)
 
+    def starts_with_query(self, field_name, value, model_field, field):
+        baserow_field_type = self.get_baserow_field_type(field)
+        return baserow_field_type.starts_with_query(
+            field_name, value, model_field, field
+        )
+
     def parse_filter_value(self, field, model_field, value):
         baserow_field_type = self.get_baserow_field_type(field)
         return baserow_field_type.parse_filter_value(field, model_field, value)

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_filters.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_filters.py
@@ -262,6 +262,58 @@ def test_ai_field_text_output_supports_contains_word_filter(premium_data_fixture
 
 @pytest.mark.django_db
 @pytest.mark.field_ai
+def test_ai_field_text_output_supports_starts_with_filter(premium_data_fixture):
+    user = premium_data_fixture.create_user()
+    table = premium_data_fixture.create_database_table(user=user)
+    grid_view = premium_data_fixture.create_grid_view(table=table)
+    premium_data_fixture.register_fake_generate_ai_type()
+
+    ai_field = premium_data_fixture.create_ai_field(
+        table=table,
+        order=1,
+        name="AI Text",
+        ai_generative_ai_type="test_generative_ai",
+        ai_generative_ai_model="test_1",
+        ai_output_type="text",
+        ai_prompt="'test'",
+    )
+
+    handler = RowHandler()
+
+    row_1 = handler.create_row(
+        user=user, table=table, values={f"field_{ai_field.id}": "Hello world"}
+    )
+    row_2 = handler.create_row(
+        user=user, table=table, values={f"field_{ai_field.id}": "Goodbye world"}
+    )
+    row_3 = handler.create_row(
+        user=user, table=table, values={f"field_{ai_field.id}": "Hello there"}
+    )
+
+    # Create a starts_with filter
+    view_handler = ViewHandler()
+    view_handler.create_filter(
+        user=user,
+        view=grid_view,
+        field=ai_field,
+        type_name="starts_with",
+        value="Hello",
+    )
+
+    # Apply the filter. Without the AIFieldType.starts_with_query delegation the
+    # base implementation returns Q() and every row would match, so guard against
+    # that regression here.
+    queryset = view_handler.get_queryset(None, grid_view)
+
+    # Should return only rows starting with "Hello"
+    assert queryset.count() == 2
+    assert row_1 in queryset
+    assert row_3 in queryset
+    assert row_2 not in queryset
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
 def test_ai_field_text_output_supports_equal_filter(premium_data_fixture):
     user = premium_data_fixture.create_user()
     table = premium_data_fixture.create_database_table(user=user)
@@ -481,6 +533,7 @@ def test_ai_field_is_compatible_with_text_filters(premium_data_fixture):
         "contains_not",
         "contains_word",
         "doesnt_contain_word",
+        "starts_with",
         "equal",
         "not_equal",
         "length_is_lower_than",

--- a/premium/web-frontend/modules/baserow_premium/fieldTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/fieldTypes.js
@@ -119,6 +119,10 @@ export class AIFieldType extends FieldType {
     return this.getBaserowFieldType(field).getContainsWordFilterFunction(field)
   }
 
+  getStartsWithFilterFunction(field) {
+    return this.getBaserowFieldType(field).getStartsWithFilterFunction(field)
+  }
+
   toHumanReadableString(field, value) {
     return this.getBaserowFieldType(field).toHumanReadableString(field, value)
   }

--- a/premium/web-frontend/test/unit/premium/fieldTypes.spec.js
+++ b/premium/web-frontend/test/unit/premium/fieldTypes.spec.js
@@ -1,0 +1,31 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+
+describe('Premium AIFieldType filter delegation', () => {
+  let testApp = null
+  let registry = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    registry = testApp.getRegistry()
+  })
+
+  afterEach(() => {
+    testApp.afterEach()
+  })
+
+  // Guards the regression where AIFieldType only delegated the contains filter
+  // functions. Without a getStartsWithFilterFunction delegation the base
+  // implementation returns `() => false`, marking edited rows as non-matching
+  // client-side while the backend keeps them visible.
+  test('getStartsWithFilterFunction delegates to the underlying output type', () => {
+    const aiFieldType = registry.get('field', 'ai')
+    const field = { ai_output_type: 'text' }
+
+    const filterFunction = aiFieldType.getStartsWithFilterFunction(field)
+
+    expect(filterFunction('Hello world', 'Hello world', 'hello')).toBe(true)
+    expect(filterFunction('Goodbye world', 'Goodbye world', 'hello')).toBe(
+      false
+    )
+  })
+})

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -257,6 +257,7 @@
     "containsNot": "doesn't contain",
     "containsWord": "contains word",
     "doesntContainWord": "doesn't contain word",
+    "startsWith": "starts with",
     "filenameContains": "filename contains",
     "has": "has",
     "hasNot": "doesn't have",

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -159,6 +159,7 @@ import {
   genericContainsFilter,
   genericContainsWordFilter,
   genericHasValueEqualFilter,
+  genericStartsWithFilter,
 } from '@baserow/modules/database/utils/fieldFilters'
 import GridViewFieldFormula from '@baserow/modules/database/components/view/grid/fields/GridViewFieldFormula'
 import FieldFormulaSubForm from '@baserow/modules/database/components/field/FieldFormulaSubForm'
@@ -764,6 +765,13 @@ export class FieldType extends Registerable {
   }
 
   /**
+   * Should return a starts with filter function unique for this field type.
+   */
+  getStartsWithFilterFunction(field) {
+    return (rowValue, humanReadableRowValue, filterValue) => false
+  }
+
+  /**
    * Converts rowValue to its human readable form first before applying the
    * filter returned from getContainsFilterFunction.
    */
@@ -801,6 +809,21 @@ export class FieldType extends Registerable {
     return (
       filterValue === '' ||
       this.getContainsWordFilterFunction(field)(
+        rowValue,
+        this.toHumanReadableString(field, rowValue),
+        filterValue
+      )
+    )
+  }
+
+  /**
+   * Converts rowValue to its human readable form first before applying the
+   * filter returned from getStartsWithFilterFunction.
+   */
+  startsWithFilter(rowValue, filterValue, field) {
+    return (
+      filterValue === '' ||
+      this.getStartsWithFilterFunction(field)(
         rowValue,
         this.toHumanReadableString(field, rowValue),
         filterValue
@@ -1205,6 +1228,10 @@ export class TextFieldType extends FieldType {
     return genericContainsWordFilter
   }
 
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
+  }
+
   canBeReferencedByFormulaField() {
     return true
   }
@@ -1323,6 +1350,10 @@ export class LongTextFieldType extends FieldType {
 
   getContainsWordFilterFunction(field) {
     return genericContainsWordFilter
+  }
+
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
   }
 
   canBeReferencedByFormulaField() {
@@ -1931,6 +1962,10 @@ export class NumberFieldType extends FieldType {
 
   getContainsFilterFunction() {
     return genericContainsFilter
+  }
+
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
   }
 
   canBeReferencedByFormulaField() {
@@ -3279,6 +3314,10 @@ export class URLFieldType extends FieldType {
     return genericContainsWordFilter
   }
 
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
+  }
+
   canParseQueryParameter() {
     return true
   }
@@ -3383,6 +3422,10 @@ export class EmailFieldType extends FieldType {
 
   getContainsWordFilterFunction(field) {
     return genericContainsWordFilter
+  }
+
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
   }
 
   canBeReferencedByFormulaField() {
@@ -3830,6 +3873,10 @@ export class SingleSelectFieldType extends SelectOptionBaseFieldType {
 
   getContainsWordFilterFunction(field) {
     return genericContainsWordFilter
+  }
+
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
   }
 
   canBeReferencedByFormulaField() {
@@ -4298,6 +4345,10 @@ export class PhoneNumberFieldType extends FieldType {
     return genericContainsFilter
   }
 
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
+  }
+
   canBeReferencedByFormulaField() {
     return true
   }
@@ -4455,6 +4506,14 @@ export class FormulaFieldType extends mix(
       this._mapFormulaTypeToFieldType(field.formula_type)
     )
     return underlyingFieldType.getContainsWordFilterFunction()
+  }
+
+  getStartsWithFilterFunction(field) {
+    const underlyingFieldType = this.app.$registry.get(
+      'field',
+      this._mapFormulaTypeToFieldType(field.formula_type)
+    )
+    return underlyingFieldType.getStartsWithFilterFunction()
   }
 
   toHumanReadableString(field, value) {
@@ -5059,6 +5118,10 @@ export class AutonumberFieldType extends FieldType {
 
   getContainsFilterFunction() {
     return genericContainsFilter
+  }
+
+  getStartsWithFilterFunction() {
+    return genericStartsWithFilter
   }
 
   canBeReferencedByFormulaField() {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -4512,14 +4512,6 @@ export class FormulaFieldType extends mix(
     return underlyingFieldType.getContainsWordFilterFunction()
   }
 
-  getStartsWithFilterFunction(field) {
-    const underlyingFieldType = this.app.$registry.get(
-      'field',
-      this._mapFormulaTypeToFieldType(field.formula_type)
-    )
-    return underlyingFieldType.getStartsWithFilterFunction()
-  }
-
   /**
    * Delegate to the underlying field type so the searchable-string conversion
    * (e.g. a number's raw value vs its formatted display) stays consistent with

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -817,15 +817,19 @@ export class FieldType extends Registerable {
   }
 
   /**
-   * Converts rowValue to its human readable form first before applying the
-   * filter returned from getStartsWithFilterFunction.
+   * Converts rowValue to its searchable form first before applying the filter
+   * returned from getStartsWithFilterFunction. We use `toSearchableString` rather
+   * than `toHumanReadableString` so the real-time match stays consistent with the
+   * backend, which filters on the raw value and knows nothing about display
+   * formatting (e.g. a number's prefix or thousands separator would otherwise
+   * break the start-anchored match).
    */
   startsWithFilter(rowValue, filterValue, field) {
     return (
       filterValue === '' ||
       this.getStartsWithFilterFunction(field)(
         rowValue,
-        this.toHumanReadableString(field, rowValue),
+        this.toSearchableString(field, rowValue),
         filterValue
       )
     )
@@ -4514,6 +4518,19 @@ export class FormulaFieldType extends mix(
       this._mapFormulaTypeToFieldType(field.formula_type)
     )
     return underlyingFieldType.getStartsWithFilterFunction()
+  }
+
+  /**
+   * Delegate to the underlying field type so the searchable-string conversion
+   * (e.g. a number's raw value vs its formatted display) stays consistent with
+   * the backend, matching how starts_with_query is delegated on the backend.
+   */
+  startsWithFilter(rowValue, filterValue, field) {
+    const underlyingFieldType = this.app.$registry.get(
+      'field',
+      this._mapFormulaTypeToFieldType(field.formula_type)
+    )
+    return underlyingFieldType.startsWithFilter(rowValue, filterValue, field)
   }
 
   toHumanReadableString(field, value) {

--- a/web-frontend/modules/database/plugin.js
+++ b/web-frontend/modules/database/plugin.js
@@ -72,6 +72,7 @@ import {
   LinkRowNotContainsFilterType,
   ContainsWordViewFilterType,
   DoesntContainWordViewFilterType,
+  StartsWithViewFilterType,
   UserIsFilterType,
   UserIsNotFilterType,
   DateIsEqualMultiStepViewFilterType,
@@ -543,6 +544,7 @@ export default defineNuxtPlugin({
       'viewFilter',
       new DoesntContainWordViewFilterType(context)
     )
+    $registry.register('viewFilter', new StartsWithViewFilterType(context))
     $registry.register(
       'viewFilter',
       new FilenameContainsViewFilterType(context)

--- a/web-frontend/modules/database/utils/fieldFilters.js
+++ b/web-frontend/modules/database/utils/fieldFilters.js
@@ -40,19 +40,19 @@ export function genericContainsFilter(
 
 export function genericStartsWithFilter(
   rowValue,
-  humanReadableRowValue,
+  searchableRowValue,
   filterValue
 ) {
-  if (humanReadableRowValue == null) {
+  if (searchableRowValue == null) {
     return false
   }
   // The backend runs `__istartswith` on the raw cell value and only strips the
   // filter value, so we must not trim the row value here or leading whitespace
   // would make the real-time match disagree with the backend query.
-  humanReadableRowValue = String(humanReadableRowValue).toLowerCase()
+  searchableRowValue = String(searchableRowValue).toLowerCase()
   filterValue = String(filterValue).toLowerCase().trim()
 
-  return humanReadableRowValue.startsWith(filterValue)
+  return searchableRowValue.startsWith(filterValue)
 }
 
 export function genericContainsWordFilter(

--- a/web-frontend/modules/database/utils/fieldFilters.js
+++ b/web-frontend/modules/database/utils/fieldFilters.js
@@ -46,7 +46,10 @@ export function genericStartsWithFilter(
   if (humanReadableRowValue == null) {
     return false
   }
-  humanReadableRowValue = String(humanReadableRowValue).toLowerCase().trim()
+  // The backend runs `__istartswith` on the raw cell value and only strips the
+  // filter value, so we must not trim the row value here or leading whitespace
+  // would make the real-time match disagree with the backend query.
+  humanReadableRowValue = String(humanReadableRowValue).toLowerCase()
   filterValue = String(filterValue).toLowerCase().trim()
 
   return humanReadableRowValue.startsWith(filterValue)

--- a/web-frontend/modules/database/utils/fieldFilters.js
+++ b/web-frontend/modules/database/utils/fieldFilters.js
@@ -38,6 +38,20 @@ export function genericContainsFilter(
   return humanReadableRowValue.includes(filterValue)
 }
 
+export function genericStartsWithFilter(
+  rowValue,
+  humanReadableRowValue,
+  filterValue
+) {
+  if (humanReadableRowValue == null) {
+    return false
+  }
+  humanReadableRowValue = String(humanReadableRowValue).toLowerCase().trim()
+  filterValue = String(filterValue).toLowerCase().trim()
+
+  return humanReadableRowValue.startsWith(filterValue)
+}
+
 export function genericContainsWordFilter(
   rowValue,
   humanReadableRowValue,

--- a/web-frontend/modules/database/viewFilters.js
+++ b/web-frontend/modules/database/viewFilters.js
@@ -689,6 +689,48 @@ export class ContainsNotViewFilterType extends ViewFilterType {
   }
 }
 
+export class StartsWithViewFilterType extends ViewFilterType {
+  static getType() {
+    return 'starts_with'
+  }
+
+  getName() {
+    const { $i18n: i18n } = this.app
+    return i18n.t('viewFilter.startsWith')
+  }
+
+  getInputComponent(field) {
+    const inputComponent = {
+      [NumberFieldType.getType()]: ViewFilterTypeNumber,
+    }
+    return inputComponent[field?.type] || ViewFilterTypeText
+  }
+
+  getCompatibleFieldTypes() {
+    return [
+      'text',
+      'long_text',
+      'url',
+      'email',
+      'phone_number',
+      'number',
+      'autonumber',
+      'single_select',
+      FormulaFieldType.compatibleWithFormulaTypes(
+        'text',
+        'char',
+        'url',
+        'number',
+        'single_select'
+      ),
+    ]
+  }
+
+  matches(rowValue, filterValue, field, fieldType) {
+    return fieldType.startsWithFilter(rowValue, filterValue, field)
+  }
+}
+
 export class ContainsWordViewFilterType extends ViewFilterType {
   static getType() {
     return 'contains_word'

--- a/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
+++ b/web-frontend/test/unit/database/components/view/__snapshots__/viewFilterForm.spec.js.snap
@@ -461,6 +461,34 @@ exports[`ViewFilterForm match snapshots > Full view filter component 1`] = `
                         <!--v-if-->
                         <span
                           class="select__item-name-text"
+                          title="viewFilter.startsWith"
+                        >
+                          viewFilter.startsWith
+                        </span>
+                        
+                      </div>
+                      <!--v-if-->
+                    </a>
+                    <i
+                      class="select__item-active-icon iconoir-check"
+                    />
+                  </li>
+                  <li
+                    class="select__item select__item--no-options visible"
+                    role="listitem"
+                  >
+                    <a
+                      class="select__item-link"
+                    >
+                      <div
+                        class="select__item-name"
+                      >
+                        <!--v-if-->
+                        
+                        <!--v-if-->
+                        <!--v-if-->
+                        <span
+                          class="select__item-name-text"
                           title="viewFilter.lengthIsLowerThan"
                         >
                           viewFilter.lengthIsLowerThan

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -811,6 +811,24 @@ describe('FieldType tests', () => {
     }
   )
 
+  test('NumberFieldType startsWithFilter matches the raw value despite formatting', () => {
+    // The field is formatted with a prefix, suffix and thousands separator, so its
+    // human readable form ($12,345.00 USD) differs from the raw stored value. The
+    // real-time filter must match the raw value to stay consistent with the backend.
+    const field = {
+      number_decimal_places: 2,
+      number_negative: false,
+      number_prefix: '$',
+      number_suffix: 'USD',
+      number_separator: 'COMMA_PERIOD',
+    }
+    const fieldType = new NumberFieldType()
+
+    expect(fieldType.startsWithFilter('12345', '123', field)).toBe(true)
+    expect(fieldType.startsWithFilter('12345', '$', field)).toBe(false)
+    expect(fieldType.startsWithFilter('12345', '999', field)).toBe(false)
+  })
+
   test.each([null, ''])(
     'Verify that NumberFieldType prepareValueForDuplicate returns null for %s',
     (emptyValue) => {

--- a/web-frontend/test/unit/database/viewFilters.spec.js
+++ b/web-frontend/test/unit/database/viewFilters.spec.js
@@ -3,6 +3,7 @@ import { createFile } from '@baserow/test/fixtures/fields'
 import {
   EqualViewFilterType,
   FilenameContainsViewFilterType,
+  StartsWithViewFilterType,
   UserIsFilterType,
   UserIsNotFilterType,
 } from '@baserow/modules/database/viewFilters'
@@ -49,6 +50,34 @@ describe('View Filter Tests', () => {
       'text',
       'newly_edited_value_not_matching'
     )
+    expect(row._.matchFilters).toBe(false)
+  })
+
+  test('When A Starts With Filter is applied a string field correctly indicates if the row will continue to match after an edit', async () => {
+    await thereIsATableWithRowAndFilter(
+      {
+        name: 'Text Field Field',
+        type: 'text',
+        primary: true,
+      },
+      { id: 1, order: 0, field_1: 'hello world' },
+      {
+        id: 1,
+        view: 1,
+        field: 1,
+        type: StartsWithViewFilterType.getType(),
+        value: 'hello',
+      }
+    )
+
+    const row = store.getters['page/view/grid/getRow'](1)
+
+    // Case insensitive match at the start of the value.
+    await editFieldWithoutSavingNewValue(row, 'text', 'Hello everyone')
+    expect(row._.matchFilters).toBe(true)
+
+    // The value is contained but not at the start, so it no longer matches.
+    await editFieldWithoutSavingNewValue(row, 'text', 'say hello')
     expect(row._.matchFilters).toBe(false)
   })
 


### PR DESCRIPTION
## What & why

Adds a new **"starts with"** view filter type (`starts_with`) that keeps rows whose field value *begins with* the provided filter value (case-insensitive).

Closes #1943.

Example: filtering a text field with `starts_with` = `hello` keeps `hello world` and filters out `doesnt match`.

## Implementation

Mirrors the existing `contains` filter, which delegates matching to per-field-type query methods on both layers.

**Backend** (`__istartswith`)
- `field_filters.py` — `starts_with_filter()` helper
- `registries.py` — default `starts_with_query()` on the base `FieldType`
- `field_types.py` — overrides on the supported field types (text/long_text/url/email/phone via shared bases, number, autonumber, single_select via `__value__istartswith`, and formula delegation)
- `view_filters.py` — `StartsWithViewFilterType`, registered in `apps.py`

**Web-frontend** (real-time `matches()` via JS `.startsWith()`)
- `utils/fieldFilters.js` — `genericStartsWithFilter()`
- `fieldTypes.js` — base `getStartsWithFilterFunction()` + `startsWithFilter()`, plus per-type overrides
- `viewFilters.js` — `StartsWithViewFilterType`, registered in `plugin.js`
- `locales/en.json` — `"startsWith": "starts with"` (English only; other locales via Weblate)

## Supported field types

text, long text, url, email, phone number, number, autonumber, single select, and text/char/url/number/single_select formulas.

Intentionally **not** included (weak "starts with" semantics): multiple_select, date, created_on, last_modified.

## API docs

Both the redoc schema (api.baserow.io) and the generated docs (baserow.io/api-docs) enumerate filter types dynamically from the registry, so the new type appears automatically once registered — no manual doc entry needed (same as `contains`).

## Tests

- **Backend:** `test_starts_with_filter_type` — covers all supported field types, case-insensitivity, leading-vs-substring match, and empty value (no filtering).
- **Frontend:** real-time `matches()` test in `viewFilters.spec.js`.
- Manually verified in a browser against the live dev stack: filter keeps only matching rows, the orange "Row does not match filters" warning appears in real time when a row is edited to no longer match, and clicking away removes it.

## Notes
- Zero schema/migration changes.
- Changelog entry included.
