### PR TITLE
fix(core): only delete workspaces where a deleted user was the last admin

### DIFF
--- a/backend/src/baserow/core/user/handler.py
+++ b/backend/src/baserow/core/user/handler.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import AbstractUser, update_last_login
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.db import router, transaction
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, Exists, OuterRef, Q, QuerySet
 from django.db.utils import IntegrityError
 from django.utils import translation
 from django.utils.translation import gettext as _
@@ -823,17 +823,29 @@ class UserHandler(metaclass=baserow_trace_methods(tracer)):
                 (u.id, u.username, u.email, u.profile.language, workspace_ids)
             )
 
-        # A workspace need to be deleted if there was an admin before and there is no
-        # *active* admin after the users deletion.
-        workspaces_to_be_deleted = Workspace.objects.annotate(
-            admin_count_after=Count(
-                "workspaceuser",
-                filter=(
-                    Q(workspaceuser__permissions="ADMIN")
-                    & ~Q(workspaceuser__user__in=users_to_delete)
+        # A workspace need to be deleted if one of the deleted users was an admin
+        # and there is no *active* admin left after the deletion. Workspaces where
+        # none of the deleted users were admins are left untouched, even if they
+        # already had no admin.
+        had_deleted_admin = WorkspaceUser.objects.filter(
+            workspace=OuterRef("pk"),
+            permissions="ADMIN",
+            user__in=users_to_delete,
+        )
+        workspaces_to_be_deleted = (
+            Workspace.objects.filter(template=None)
+            .annotate(
+                had_deleted_admin=Exists(had_deleted_admin),
+                admin_count_after=Count(
+                    "workspaceuser",
+                    filter=(
+                        Q(workspaceuser__permissions="ADMIN")
+                        & ~Q(workspaceuser__user__in=users_to_delete)
+                    ),
                 ),
-            ),
-        ).filter(template=None, admin_count_after=0)
+            )
+            .filter(had_deleted_admin=True, admin_count_after=0)
+        )
 
         with transaction.atomic():
             for workspace in workspaces_to_be_deleted:

--- a/backend/src/baserow/core/user/handler.py
+++ b/backend/src/baserow/core/user/handler.py
@@ -823,7 +823,7 @@ class UserHandler(metaclass=baserow_trace_methods(tracer)):
                 (u.id, u.username, u.email, u.profile.language, workspace_ids)
             )
 
-        # A workspace need to be deleted if one of the deleted users was an admin
+        # A workspace needs to be deleted if one of the deleted users was an admin
         # and there is no *active* admin left after the deletion. Workspaces where
         # none of the deleted users were admins are left untouched, even if they
         # already had no admin.

--- a/backend/tests/baserow/core/user/test_user_handler.py
+++ b/backend/tests/baserow/core/user/test_user_handler.py
@@ -599,6 +599,13 @@ def test_delete_expired_users_and_related_workspaces_if_last_admin(
         user=user5, workspace=workspaceuser4_2.workspace
     )
 
+    # An existing workspace that already has no admin and where none of the
+    # deleted users are admins must not be affected by the deletion.
+    user7 = data_fixture.create_user(email="test7@localhost")
+    workspaceuser7 = data_fixture.create_user_workspace(
+        user=user7, permissions="MEMBER"
+    )
+
     handler = UserHandler()
 
     # Last login before max expiration date (should be deleted)
@@ -619,22 +626,25 @@ def test_delete_expired_users_and_related_workspaces_if_last_admin(
             )
 
     user_ids = User.objects.values_list("pk", flat=True)
-    assert len(user_ids) == 4
+    assert len(user_ids) == 5
     assert user1.id not in user_ids
     assert user5.id not in user_ids
     assert user2.id in user_ids
     assert user3.id in user_ids
     assert user4.id in user_ids
     assert user6.id in user_ids
+    assert user7.id in user_ids
 
     workspace_ids = Workspace.objects.values_list("pk", flat=True)
-    assert len(workspace_ids) == 3
+    assert len(workspace_ids) == 4
     assert workspaceuser1.workspace.id not in workspace_ids
     assert workspaceuser1_2.workspace.id not in workspace_ids
     assert workspaceuser1_3.workspace.id in workspace_ids
     assert workspaceuser2.workspace.id in workspace_ids
     assert workspaceuser4.workspace.id in workspace_ids
     assert workspaceuser4_2.workspace.id not in workspace_ids
+    # The admin-less workspace unrelated to the deleted users survives.
+    assert workspaceuser7.workspace.id in workspace_ids
 
     end_table_names = sorted(connection.introspection.table_names())
 

--- a/backend/tests/baserow/core/user/test_user_handler.py
+++ b/backend/tests/baserow/core/user/test_user_handler.py
@@ -625,7 +625,7 @@ def test_delete_expired_users_and_related_workspaces_if_last_admin(
                 grace_delay=timedelta(days=3)
             )
 
-    user_ids = User.objects.values_list("pk", flat=True)
+    user_ids = set(User.objects.values_list("pk", flat=True))
     assert len(user_ids) == 5
     assert user1.id not in user_ids
     assert user5.id not in user_ids
@@ -635,7 +635,7 @@ def test_delete_expired_users_and_related_workspaces_if_last_admin(
     assert user6.id in user_ids
     assert user7.id in user_ids
 
-    workspace_ids = Workspace.objects.values_list("pk", flat=True)
+    workspace_ids = set(Workspace.objects.values_list("pk", flat=True))
     assert len(workspace_ids) == 4
     assert workspaceuser1.workspace.id not in workspace_ids
     assert workspaceuser1_2.workspace.id not in workspace_ids

--- a/changelog/entries/unreleased/bug/only_delete_a_workspace_on_account_deletion_when_a_deleted_u.json
+++ b/changelog/entries/unreleased/bug/only_delete_a_workspace_on_account_deletion_when_a_deleted_u.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Only delete a workspace on account deletion when a deleted user was its last admin",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-01"
+}


### PR DESCRIPTION
## Problem

`UserHandler.delete_expired_users_and_related_workspaces_if_last_admin` (the periodic task that permanently deletes accounts scheduled for deletion) scanned **every** workspace and deleted any that had no non-deleted admin.

## Fix

Restrict the deletion candidates to workspaces where one of the deleted users was actually an **admin**.

Now a workspace is only deleted if a deleted user was its admin **and** no active admin remains. Admin-less workspaces unrelated to the deletion are left untouched.

## How to verify

The regression is captured by the change to `test_delete_expired_users_and_related_workspaces_if_last_admin`: it now creates an admin-less workspace (a lone `MEMBER`, unrelated to the deleted users) and asserts it survives.

