### PR TITLE
task: allow to customize history from plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Do not commit secrets or local overrides. Use `.env.local` for development, keep
 
 ## Good practices
 
-- On a specific branch, always merge backend migrations file instead of creating new ones.
+- On a specific branch, always merge backend migrations file instead of creating new ones only if it was created on the very same branch.
 - Django migrations must be executed with zero downtime. This means the new database schema must remain compatible with the previous application version during the deployment.
   - Every new field must define a `db_default`.
   - Do not remove fields unless you are certain they are no longer used by the previous application version. Instead, keep the field and add a `# TODO ZDM: remove this field in the next version` comment so it can be safely removed in a subsequent release.

--- a/backend/src/baserow/contrib/automation/api/workflows/serializers.py
+++ b/backend/src/baserow/contrib/automation/api/workflows/serializers.py
@@ -125,12 +125,19 @@ class AutomationHistorySerializer(serializers.ModelSerializer):
 
 
 class AutomationWorkflowHistorySerializer(AutomationHistorySerializer):
+    plugin_data = serializers.SerializerMethodField()
+
     class Meta:
         model = AutomationWorkflowHistory
         fields = AutomationHistorySerializer.Meta.fields + (
             "is_test_run",
             "simulate_until_node",
+            "plugin_data",
         )
+
+    @extend_schema_field(serializers.DictField())
+    def get_plugin_data(self, obj):
+        return self.context.get("workflow_history_plugin_data", {}).get(obj.id, {})
 
 
 class AutomationWorkflowHistoryPagination(PageNumberPagination):

--- a/backend/src/baserow/contrib/automation/api/workflows/views.py
+++ b/backend/src/baserow/contrib/automation/api/workflows/views.py
@@ -52,6 +52,7 @@ from baserow.core.exceptions import ApplicationDoesNotExist
 from baserow.core.jobs.exceptions import MaxJobCountExceeded
 from baserow.core.jobs.handler import JobHandler
 from baserow.core.jobs.registries import job_type_registry
+from baserow.core.registries import plugin_registry
 
 AUTOMATION_WORKFLOWS_TAG = "Automation workflows"
 
@@ -272,9 +273,17 @@ class AutomationWorkflowHistoryView(APIView):
         )
 
         page = paginator.paginate_queryset(queryset, request, self)
+        plugin_data = {}
+        for plugin in plugin_registry.get_all():
+            for history_id, data in plugin.get_automation_workflow_history_plugin_data(
+                request.user, workflow_id, page
+            ).items():
+                plugin_data.setdefault(history_id, {})[plugin.type] = data
+
         serializer = AutomationWorkflowHistorySerializer(
             page,
             many=True,
+            context={"workflow_history_plugin_data": plugin_data},
         )
 
         return paginator.get_paginated_response(

--- a/backend/src/baserow/contrib/automation/history/handler.py
+++ b/backend/src/baserow/contrib/automation/history/handler.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Dict, List, Optional, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from django.db.models import Prefetch, QuerySet
 
@@ -16,6 +16,9 @@ from baserow.contrib.automation.history.models import (
 )
 from baserow.contrib.automation.nodes.models import AutomationNode
 from baserow.contrib.automation.workflows.models import AutomationWorkflow
+from baserow.core.db import specific_iterator
+from baserow.core.services.handler import ServiceHandler
+from baserow.core.services.models import Service
 
 
 class AutomationHistoryHandler:
@@ -153,14 +156,11 @@ class AutomationHistoryHandler:
         except AutomationNodeHistory.DoesNotExist:
             raise AutomationNodeHistoryDoesNotExist(node_history_id)
 
-    def get_node_histories(
-        self, workflow_history: AutomationWorkflowHistory
+    def _query_node_histories(
+        self, base_queryset: QuerySet[AutomationNodeHistory]
     ) -> QuerySet[AutomationNodeHistory]:
-        """Returns a queryset of AutomationNodeHistory by the workflow history."""
-
         return (
-            AutomationNodeHistory.objects.filter(workflow_history=workflow_history)
-            .select_related("node", "node__workflow")
+            base_queryset.select_related("node", "node__workflow")
             .prefetch_related(
                 Prefetch(
                     "node_results",
@@ -169,8 +169,75 @@ class AutomationHistoryHandler:
                     ),
                 )
             )
-            .order_by("started_on", "id")
+            .order_by("workflow_history_id", "started_on", "id")
         )
+
+    def _with_specific_nodes(
+        self, node_histories: QuerySet[AutomationNodeHistory]
+    ) -> List[AutomationNodeHistory]:
+        """
+        Resolves the related nodes to their specific model instances in batches.
+        """
+
+        node_histories = list(node_histories)
+        nodes = [node_history.node for node_history in node_histories]
+        specific_nodes = {
+            node.id: node
+            for node in specific_iterator(
+                nodes,
+                base_model=AutomationNode,
+                select_related=["workflow"],
+            )
+        }
+        service_ids = [
+            node.service_id
+            for node in specific_nodes.values()
+            if node.service_id is not None
+        ]
+        specific_services_map = {
+            service.id: service
+            for service in ServiceHandler().get_services(
+                base_queryset=Service.objects.filter(id__in=service_ids)
+            )
+        }
+        for node in specific_nodes.values():
+            service_id = node.service_id
+            if service_id is not None and service_id in specific_services_map:
+                node.service = specific_services_map[service_id]
+
+        for node_history in node_histories:
+            node_history.node = specific_nodes[node_history.node_id]
+        return node_histories
+
+    def get_node_histories(
+        self,
+        workflow_history: AutomationWorkflowHistory,
+        specific: bool = False,
+    ) -> QuerySet[AutomationNodeHistory] | List[AutomationNodeHistory]:
+        """Returns a queryset of AutomationNodeHistory by the workflow history."""
+
+        node_histories = self._query_node_histories(
+            AutomationNodeHistory.objects.filter(workflow_history=workflow_history)
+        )
+        if specific:
+            return self._with_specific_nodes(node_histories)
+        return node_histories
+
+    def get_node_histories_for_workflow_histories(
+        self,
+        workflow_history_ids: Iterable[int],
+        specific: bool = False,
+    ) -> QuerySet[AutomationNodeHistory] | List[AutomationNodeHistory]:
+        """Returns node histories for the given workflow history ids."""
+
+        node_histories = self._query_node_histories(
+            AutomationNodeHistory.objects.filter(
+                workflow_history_id__in=workflow_history_ids
+            )
+        )
+        if specific:
+            return self._with_specific_nodes(node_histories)
+        return node_histories
 
     def get_node_history_result(
         self, node_history: AutomationNodeHistory

--- a/backend/src/baserow/core/populate.py
+++ b/backend/src/baserow/core/populate.py
@@ -28,6 +28,7 @@ def load_test_data():
             admin = User.objects.get(email=email)
 
         admin.is_staff = True
+        admin.is_superuser = True
         admin.save()
 
         user_handler.update_user(

--- a/backend/src/baserow/core/registries.py
+++ b/backend/src/baserow/core/registries.py
@@ -237,6 +237,16 @@ class Plugin(APIUrlsInstanceMixin, Instance):
 
         return queryset
 
+    def get_automation_workflow_history_plugin_data(
+        self, user: "AbstractUser", workflow_id: int, workflow_histories: List[Any]
+    ) -> Dict[int, Any]:
+        """
+        Provides plugin-specific data for serialized automation workflow history
+        entries. The returned dict must be keyed by workflow history id.
+        """
+
+        return {}
+
 
 class PluginRegistry(APIUrlsRegistryMixin, Registry[Plugin]):
     """

--- a/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
+++ b/backend/tests/baserow/contrib/automation/api/workflows/test_workflow_views.py
@@ -678,6 +678,7 @@ def test_get_workflow_histories(api_client, data_fixture):
                 "message": "",
                 "status": "success",
                 "simulate_until_node": None,
+                "plugin_data": {},
             },
         ],
     }

--- a/changelog/entries/unreleased/refactor/5616_allow_to_customize_history_entries_from_plugins.json
+++ b/changelog/entries/unreleased/refactor/5616_allow_to_customize_history_entries_from_plugins.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Allow to customize history entries from plugins",
+    "issue_origin": "github",
+    "issue_number": 5616,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-07-02"
+}

--- a/web-frontend/modules/automation/components/workflow/WorkflowAddNodeMenu.vue
+++ b/web-frontend/modules/automation/components/workflow/WorkflowAddNodeMenu.vue
@@ -6,9 +6,13 @@
       class="context__menu-item"
     >
       <a
-        v-tooltip="nodeType.isDeactivatedReason({ workspace })"
+        v-tooltip="
+          nodeType.isDeactivatedReason({ workspace: resolvedWorkspace })
+        "
         class="context__menu-item-link context__menu-item-link--with-desc"
-        :class="{ disabled: nodeType.isDeactivated({ workspace }) }"
+        :class="{
+          disabled: nodeType.isDeactivated({ workspace: resolvedWorkspace }),
+        }"
         @click="onChange(nodeType)"
       >
         <span class="context__menu-item-title" :title="nodeType.name">
@@ -23,7 +27,18 @@
             :src="nodeType.image"
             class="context__menu-item-icon"
           />
-          {{ nodeType.name }}
+          <span class="context__menu-item-title-text">
+            {{ nodeType.name }}
+          </span>
+          <component
+            :is="component"
+            v-for="(component, index) in getNodeContextComponents(nodeType)"
+            :key="index"
+            :workflow="resolvedWorkflow"
+            :automation="resolvedAutomation"
+            :node="getNodeContextNode(nodeType)"
+            :node-type="nodeType"
+          />
         </span>
         <div class="context__menu-item-description">
           {{ nodeType.description }}
@@ -34,7 +49,7 @@
           :ref="`deactivatedClickModal_${nodeType.getType()}`"
           v-bind="getDeactivatedClickModal(nodeType)[1]"
           :name="nodeType.name"
-          :workspace="workspace"
+          :workspace="resolvedWorkspace"
         ></component>
       </a>
     </li>
@@ -42,11 +57,12 @@
 </template>
 
 <script>
+import { unref } from 'vue'
 import context from '@baserow/modules/core/mixins/context'
 export default {
   name: 'WorkflowNodeContext',
   mixins: [context],
-  inject: ['workspace'],
+  inject: ['workspace', 'workflow', 'automation'],
   props: {
     node: {
       type: Object,
@@ -61,6 +77,15 @@ export default {
   },
   emits: ['change'],
   computed: {
+    resolvedAutomation() {
+      return unref(this.automation)
+    },
+    resolvedWorkflow() {
+      return unref(this.workflow)
+    },
+    resolvedWorkspace() {
+      return unref(this.workspace)
+    },
     editingTriggerNode() {
       return this.onlyTrigger
     },
@@ -87,7 +112,7 @@ export default {
   },
   methods: {
     onChange(nodeType) {
-      if (nodeType.isDeactivated({ workspace: this.workspace })) {
+      if (nodeType.isDeactivated({ workspace: this.resolvedWorkspace })) {
         const deactivatedClickModal = this.getDeactivatedClickModal(nodeType)
         if (deactivatedClickModal !== null) {
           this.$refs[`deactivatedClickModal_${nodeType.getType()}`][0].show()
@@ -98,8 +123,29 @@ export default {
     },
     getDeactivatedClickModal(nodeType) {
       return nodeType.getDeactivatedClickModal({
-        workspace: this.workspace,
+        workspace: this.resolvedWorkspace,
       })
+    },
+    getNodeContextNode(nodeType) {
+      return {
+        ...(this.node || {}),
+        type: nodeType.getType(),
+      }
+    },
+    getNodeContextComponents(nodeType) {
+      const node = this.getNodeContextNode(nodeType)
+      return Object.values(this.$registry.getAll('plugin')).reduce(
+        (components, plugin) =>
+          components.concat(
+            plugin.getAutomationWorkflowNodeContextComponents({
+              workflow: this.resolvedWorkflow,
+              automation: this.resolvedAutomation,
+              node,
+              nodeType,
+            })
+          ),
+        []
+      )
     },
   },
 }

--- a/web-frontend/modules/automation/components/workflow/sidePanels/WorkflowHistory.vue
+++ b/web-frontend/modules/automation/components/workflow/sidePanels/WorkflowHistory.vue
@@ -58,6 +58,17 @@
           {{ totalRunTimeMessage }}
         </div>
       </template>
+      <div
+        v-if="workflowHistoryComponents.length"
+        class="workflow-history__components"
+      >
+        <component
+          :is="component"
+          v-for="(component, index) in workflowHistoryComponents"
+          :key="index"
+          :workflow-history="item"
+        />
+      </div>
     </template>
   </Expandable>
 </template>
@@ -142,6 +153,14 @@ const completedDate = computed(() => {
 
 const humanCompletedDate = computed(() => {
   return moment.utc(props.item.completed_on).tz(getUserTimeZone()).fromNow()
+})
+
+const workflowHistoryComponents = computed(() => {
+  return Object.values(app.$registry.getAll('plugin')).reduce(
+    (components, plugin) =>
+      components.concat(plugin.getWorkflowHistoryComponents(props.item)),
+    []
+  )
 })
 
 const historyTitlePrefix = computed(() => {

--- a/web-frontend/modules/core/assets/scss/components/automation/workflow/workflow_history.scss
+++ b/web-frontend/modules/core/assets/scss/components/automation/workflow/workflow_history.scss
@@ -32,6 +32,11 @@
   font-size: 11px;
 }
 
+.workflow-history__components {
+  margin-left: 24px;
+  margin-top: 8px;
+}
+
 .workflow-history__message {
   font-size: 12px;
   line-height: 16px;

--- a/web-frontend/modules/core/assets/scss/components/context.scss
+++ b/web-frontend/modules/core/assets/scss/components/context.scss
@@ -172,6 +172,13 @@
   @include flex-align-items(10px);
 }
 
+.context__menu-item-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .context__form {
   min-width: 260px;
   padding: 16px;

--- a/web-frontend/modules/core/plugins.js
+++ b/web-frontend/modules/core/plugins.js
@@ -174,6 +174,29 @@ export class BaserowPlugin extends Registerable {
   }
 
   /**
+   * Every registered plugin can display multiple additional components in each
+   * workflow history run entry.
+   * @returns {*[]}
+   */
+  getWorkflowHistoryComponents(workflowHistory) {
+    return []
+  }
+
+  /**
+   * Every registered plugin can display multiple additional components next to
+   * node names in the automation workflow node creation/replacement context.
+   * @returns {*[]}
+   */
+  getAutomationWorkflowNodeContextComponents({
+    workflow,
+    automation,
+    node,
+    nodeType,
+  }) {
+    return []
+  }
+
+  /**
    * Provides additional icons before 'standard' icons in the field header in a
    * grid view.
    *


### PR DESCRIPTION
### What is in this PR

This PR allows to customize a few thing in the automtation to make it possible to show the cost of workflow runs.
We can customize:
- Add custom plugin data to history payload
- Add component to history display
- Add component to node add/replace context

### How to test this PR

You should test this PR alongside with the related SaaS PR (not linked here).


Closes #5616 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
