### PR TITLE
fix: accepting a workspace invitation no longer changes an existing member's role

### DIFF
--- a/backend/src/baserow/core/handler.py
+++ b/backend/src/baserow/core/handler.py
@@ -1242,16 +1242,17 @@ class CoreHandler(metaclass=baserow_trace_methods(tracer, exclude="clear_context
     ) -> WorkspaceUser:
         """
         Adds a user to the workspace by creating the appropriate `WorkspaceUser`.
-        If the user is already in the workspace, the permissions field is updated.
+        If the user is already a member of the workspace the existing membership is
+        returned unchanged, so their permissions are never overwritten.
 
         :param workspace: the workspace in which we want to add the user.
         :param user: the user we want to add.
         :param permissions: the permissions of the user in this workspace. 'member' by
             default if not specified.
-        :return: The created `WorkspaceUser` object.
+        :return: The created or existing `WorkspaceUser` object.
         """
 
-        workspace_user, _ = WorkspaceUser.objects.update_or_create(
+        workspace_user, created = WorkspaceUser.objects.get_or_create(
             user=user,
             workspace=workspace,
             defaults={
@@ -1260,12 +1261,13 @@ class CoreHandler(metaclass=baserow_trace_methods(tracer, exclude="clear_context
             },
         )
 
-        workspace_user_added.send(
-            self,
-            workspace_user_id=workspace_user.id,
-            workspace_user=workspace_user,
-            user=user,
-        )
+        if created:
+            workspace_user_added.send(
+                self,
+                workspace_user_id=workspace_user.id,
+                workspace_user=workspace_user,
+                user=user,
+            )
 
         return workspace_user
 
@@ -1277,7 +1279,8 @@ class CoreHandler(metaclass=baserow_trace_methods(tracer, exclude="clear_context
         the right permissions. It can only be accepted if the invitation was
         addressed to the email address of the user. Because the invitation has been
         accepted it can then be deleted. If the user is already a member of the
-        workspace then the permissions are updated.
+        workspace the invitation is consumed without changing their existing
+        permissions, so a stale invitation can never lower an existing member's role.
 
         :param user: The user who has accepted the invitation.
         :param invitation: The invitation that must be accepted.

--- a/backend/tests/baserow/core/test_core_handler.py
+++ b/backend/tests/baserow/core/test_core_handler.py
@@ -782,6 +782,7 @@ def test_accept_workspace_invitation(data_fixture):
     assert WorkspaceInvitation.objects.all().count() == 0
     assert WorkspaceUser.objects.all().count() == 1
 
+    # A second invitation must not change an existing member's permissions.
     workspace_invitation = data_fixture.create_workspace_invitation(
         email="test@test.nl", permissions="ADMIN", workspace=workspace
     )
@@ -789,7 +790,7 @@ def test_accept_workspace_invitation(data_fixture):
         user=user_1, invitation=workspace_invitation
     )
     assert workspace_user.workspace_id == workspace.id
-    assert workspace_user.permissions == "ADMIN"
+    assert workspace_user.permissions == "MEMBER"
     assert WorkspaceInvitation.objects.all().count() == 0
     assert WorkspaceUser.objects.all().count() == 1
 
@@ -803,6 +804,33 @@ def test_accept_workspace_invitation(data_fixture):
     assert workspace_user.permissions == "MEMBER"
     assert WorkspaceInvitation.objects.all().count() == 0
     assert WorkspaceUser.objects.all().count() == 2
+
+
+@pytest.mark.django_db
+def test_accept_workspace_invitation_does_not_downgrade_last_admin(data_fixture):
+    # Accepting a stale MEMBER invitation must not demote an existing admin.
+    workspace = data_fixture.create_workspace()
+    user = data_fixture.create_user(email="admin@test.nl")
+    data_fixture.create_user_workspace(
+        workspace=workspace, user=user, permissions="ADMIN"
+    )
+    workspace_invitation = data_fixture.create_workspace_invitation(
+        email="admin@test.nl", permissions="MEMBER", workspace=workspace
+    )
+
+    handler = CoreHandler()
+
+    workspace_user = handler.accept_workspace_invitation(
+        user=user, invitation=workspace_invitation
+    )
+
+    assert workspace_user.permissions == "ADMIN"
+    assert (
+        WorkspaceUser.objects.filter(workspace=workspace, permissions="ADMIN").count()
+        == 1
+    )
+    assert WorkspaceUser.objects.filter(workspace=workspace).count() == 1
+    assert WorkspaceInvitation.objects.all().count() == 0
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/accepting_a_workspace_invitation_no_longer_changes_the_role_.json
+++ b/changelog/entries/unreleased/bug/accepting_a_workspace_invitation_no_longer_changes_the_role_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Accepting a workspace invitation no longer changes the role of an existing member",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-01"
+}


### PR DESCRIPTION
## Problem

Accepting a workspace invitation could **lower** an existing member's role, potentially leaving a workspace with no admin:

1. As admin of workspace *W*, invite `a@hey.com` as **MEMBER** (allowed — not yet a member).
2. Change your own account email to `a@hey.com`.
3. Accept the invitation → you're demoted to MEMBER; if you were the only admin, the workspace is left without one.

Root cause: `accept_workspace_invitation` → `add_user_to_workspace` did a blind `update_or_create` that overwrote an existing member's `permissions`, bypassing the last-admin guard used by the normal `update_workspace_user` path.

## Fix

Make `add_user_to_workspace` idempotent via `get_or_create`: an existing member's role is never overwritten, and `workspace_user_added` fires only on actual creation. Invitations now only *add* new members; role changes for existing members go through the members UI, which enforces the last-admin invariant.

Covers core and enterprise (RBAC stores the workspace-level role in `WorkspaceUser.permissions`) and all entry points (API accept, signup-with-invite, SSO). No schema/env changes.

## Tests

- Updated `test_accept_workspace_invitation`: a second invitation no longer changes an existing member's permissions.
- Added `test_accept_workspace_invitation_does_not_downgrade_last_admin`.
- `test_ws_signals` and enterprise `test_role_receivers` still pass.

## Notes

Out of scope: `delete_workspace_user` has no last-admin guard, but the "cannot delete yourself" check makes last-admin removal via delete unreachable.
