### PR TITLE
fix: recover realtime connection on window refocus and self-heal after failures

### DIFF
--- a/changelog/entries/unreleased/bug/recover_realtime_updates_on_window_refocus_and_keep_retr.json
+++ b/changelog/entries/unreleased/bug/recover_realtime_updates_on_window_refocus_and_keep_retr.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Real-time updates now recover when the window is refocused and keep retrying after repeated failures, instead of getting stuck asking to refresh",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-01"
+}

--- a/web-frontend/modules/core/plugins/realTimeHandler.js
+++ b/web-frontend/modules/core/plugins/realTimeHandler.js
@@ -10,6 +10,8 @@ const RECONNECT_BASE_DELAY = 1000
 const RECONNECT_MAX_DELAY = 30000
 const RECONNECT_MAX_ATTEMPTS = 10
 const RECONNECT_JITTER = 1000
+// Force-close a socket stuck in CONNECTING so onclose can drive a reconnect.
+const CONNECTION_TIMEOUT = 10000
 // The handshake resets ``attempts`` before the auth result arrives, so the
 // backoff cap can't bound an auth-rejection loop; bound the refreshes instead.
 const MAX_TOKEN_REFRESH_RETRIES = 1
@@ -22,6 +24,7 @@ export class RealTimeHandler {
     this.reconnect = false
     this.anonymous = false
     this.reconnectTimeout = null
+    this.connectionTimeout = null
     this.attempts = 0
     this.events = {}
     this.pages = []
@@ -68,6 +71,7 @@ export class RealTimeHandler {
       window.addEventListener('pageshow', this._onShouldRetryNow)
       document.addEventListener('visibilitychange', this._onVisibilityChange)
       window.addEventListener('online', this._onShouldRetryNow)
+      window.addEventListener('focus', this._onShouldRetryNow)
     }
   }
 
@@ -157,7 +161,9 @@ export class RealTimeHandler {
     this.socket = new WebSocket(
       `${url}?jwt_token=${token}&web_socket_id=${webSocketId}`
     )
+    this._armConnectionTimeout()
     this.socket.onopen = () => {
+      this._clearConnectionTimeout()
       this.connected = true
       this.attempts = 0
       this.authenticationSuccess = true
@@ -196,6 +202,7 @@ export class RealTimeHandler {
     }
 
     this.socket.onclose = () => {
+      this._clearConnectionTimeout()
       this.connected = false
       this.subscribedToPages = this.pages.length === 0
       this.context.store.dispatch('presence/clearAllSpaces')
@@ -232,8 +239,15 @@ export class RealTimeHandler {
     this.attempts++
 
     if (this.attempts > RECONNECT_MAX_ATTEMPTS) {
+      // Surface the failure but keep retrying at the slowest interval: this is
+      // the only way the connection self-heals when no visibility/focus/online
+      // event fires (e.g. the tab stayed visible through a backend outage).
+      this.attempts = RECONNECT_MAX_ATTEMPTS + 1
       this.context.store.dispatch('toast/setReconnecting', false)
       this.context.store.dispatch('toast/setFailedConnecting', true)
+      this.reconnectTimeout = setTimeout(() => {
+        this.connect(true, this.anonymous)
+      }, RECONNECT_MAX_DELAY)
       return
     }
 
@@ -266,6 +280,21 @@ export class RealTimeHandler {
   _isNavigatorOnline() {
     // ``navigator.onLine === false`` is the only reliable signal.
     return typeof navigator === 'undefined' || navigator.onLine !== false
+  }
+
+  _armConnectionTimeout() {
+    clearTimeout(this.connectionTimeout)
+    this.connectionTimeout = setTimeout(() => {
+      // Still mid-handshake: abandon it so onclose starts a fresh attempt.
+      if (this.socket && this.socket.readyState === WebSocket.CONNECTING) {
+        this.socket.close()
+      }
+    }, CONNECTION_TIMEOUT)
+  }
+
+  _clearConnectionTimeout() {
+    clearTimeout(this.connectionTimeout)
+    this.connectionTimeout = null
   }
 
   _tokenRefreshNeeded(anonymous) {
@@ -380,6 +409,7 @@ export class RealTimeHandler {
     this.context.store.dispatch('toast/setReconnecting', false)
     this.context.store.dispatch('toast/setWorkspaceOutdated', false)
     clearTimeout(this.reconnectTimeout)
+    this._clearConnectionTimeout()
     this.reconnect = false
     this.attempts = 0
     this.connected = false

--- a/web-frontend/test/unit/core/realTimeHandler.spec.js
+++ b/web-frontend/test/unit/core/realTimeHandler.spec.js
@@ -299,6 +299,18 @@ describe('RealTimeHandler reconnect logic', () => {
     connectSpy.mockRestore()
   })
 
+  test('wires a window focus listener to the retry handler', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const handler = new RealTimeHandler({
+      store: makeStore(),
+      app: { router: {} },
+    })
+    const focusCall = addSpy.mock.calls.find(([type]) => type === 'focus')
+    expect(focusCall).toBeDefined()
+    expect(focusCall[1]).toBe(handler._onShouldRetryNow)
+    addSpy.mockRestore()
+  })
+
   test('delayedReconnect skipped when reconnect is false', () => {
     const { handler } = env
     handler.reconnect = false
@@ -581,21 +593,30 @@ describe('RealTimeHandler max attempts', () => {
     vi.useRealTimers()
   })
 
-  test('delayedReconnect stops and shows failed toast after exceeding max attempts', () => {
+  test('shows the failed toast but keeps retrying slowly after max attempts', () => {
     const { handler, store } = env
     handler.reconnect = true
-    // After 10 successful calls, attempts will be 10.
-    // The 11th call increments to 11 which exceeds RECONNECT_MAX_ATTEMPTS (10).
     handler.attempts = 10
+    const connectSpy = vi.spyOn(handler, 'connect').mockImplementation(() => {})
 
     handler.delayedReconnect()
 
+    // Capped so slow retries can't grow the count unbounded.
     expect(handler.attempts).toBe(11)
+    handler.delayedReconnect()
+    expect(handler.attempts).toBe(11)
+
     expect(
       store._dispatched.some(
         ([n, v]) => n === 'toast/setFailedConnecting' && v === true
       )
     ).toBe(true)
+
+    // Self-heals when the backend returns, with no user action.
+    expect(connectSpy).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(30000)
+    expect(connectSpy).toHaveBeenCalledWith(true, false)
+    connectSpy.mockRestore()
   })
 
   test('connect does not show failed toast while tab is hidden', () => {
@@ -724,6 +745,68 @@ describe('RealTimeHandler connect early-exit', () => {
         ([n, v]) => n === 'toast/setReconnecting' && v === false
       )
     ).toBe(true)
+  })
+})
+
+describe('RealTimeHandler connection watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('force-closes a socket stuck in CONNECTING so a reconnect can start', () => {
+    const { handler } = makeHandler()
+    let closed = false
+    handler.socket = {
+      readyState: WebSocket.CONNECTING,
+      close() {
+        closed = true
+      },
+      send() {},
+    }
+    handler._armConnectionTimeout()
+
+    vi.advanceTimersByTime(9999)
+    expect(closed).toBe(false)
+    vi.advanceTimersByTime(1)
+    expect(closed).toBe(true)
+  })
+
+  test('does not close a socket that finished connecting', () => {
+    const { handler } = makeHandler()
+    let closed = false
+    handler.socket = {
+      readyState: WebSocket.OPEN,
+      close() {
+        closed = true
+      },
+      send() {},
+    }
+    handler._armConnectionTimeout()
+
+    vi.advanceTimersByTime(10000)
+    expect(closed).toBe(false)
+  })
+
+  test('clearing the watchdog cancels the pending force-close', () => {
+    const { handler } = makeHandler()
+    let closed = false
+    handler.socket = {
+      readyState: WebSocket.CONNECTING,
+      close() {
+        closed = true
+      },
+      send() {},
+    }
+    handler._armConnectionTimeout()
+    handler._clearConnectionTimeout()
+
+    vi.advanceTimersByTime(10000)
+    expect(closed).toBe(false)
+    expect(handler.connectionTimeout).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Problem

After #5623 (refresh access token on websocket reconnect), the realtime connection can still get permanently stuck on **"Real-time updates could not be reestablished. Please refresh to continue."** with no reconnect attempt when the tab is brought back.

Root cause: reconnection recovery is driven only by `visibilitychange→visible`, `pageshow`, and `online`. None of these fire when:

- you return from **another application/window** (the tab stayed `visibilityState === 'visible'`, so `visibilitychange` never fires), or
- the OS **sleeps/wakes** on the active tab.

Combined with two terminal-latch gaps:

1. After `RECONNECT_MAX_ATTEMPTS` (10), `delayedReconnect()` shows the failed toast and returns **without scheduling anything** — there is no timer-based retry, so a backend outage or sleep while the tab stays visible latches permanently.
2. A socket stuck in `CONNECTING` (black-holed handshake) is treated as "already connecting" by the guard in `connect()`, silently swallowing **every** future reconnect.

The previous fix only refreshed the token on an attempt that was actually triggered, so it never applied to these latched states.

## Changes

- **Recover on window focus** — add a `window` `focus` listener wired to the existing retry path, covering app/window switches and OS wake where `visibilitychange` never fires.
- **Self-heal instead of giving up** — after max attempts, keep retrying at the slowest interval (30s) and cap the attempt counter, so the connection recovers on its own once the backend/network returns.
- **Handshake watchdog** — force-close a socket stuck in `CONNECTING` after 10s so its `onclose` drives a fresh reconnect instead of latching.

## Testing

`web-frontend/test/unit/core/realTimeHandler.spec.js` — 51 passing, including new coverage for the focus-listener wiring, the slow self-heal retry + attempt cap, and the connection watchdog (force-close, no-op when open, cancel on clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
