### PR TITLE
bug:  validate missing workflow action params

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
+++ b/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Fixes open page workflow actions with missing page parameters",
+    "message": "Fixes workflow actions with missing page parameters",
     "issue_origin": "github",
     "issue_number": 3110,
     "domain": "builder",

--- a/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
+++ b/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes open page workflow actions with missing page parameters",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-07-03"
+}

--- a/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
+++ b/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
@@ -2,7 +2,7 @@
     "type": "bug",
     "message": "Fixes open page workflow actions with missing page parameters",
     "issue_origin": "github",
-    "issue_number": null,
+    "issue_number": 3110,
     "domain": "builder",
     "bullet_points": [],
     "created_at": "2026-07-03"

--- a/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
+++ b/changelog/entries/unreleased/bug/fixes_open_page_workflow_actions_with_missing_page_parameter.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Fixes workflow actions with missing page parameters",
+    "message": "Improved element internal page navigation by requiring page parameter values.",
     "issue_origin": "github",
     "issue_number": 3110,
     "domain": "builder",

--- a/web-frontend/modules/builder/collectionFieldTypes.js
+++ b/web-frontend/modules/builder/collectionFieldTypes.js
@@ -213,7 +213,10 @@ export class LinkCollectionFieldType extends CollectionFieldType {
       ) {
         return this.app.$i18n.t('elementType.errorPageParameterInError')
       }
-    } else if (field.navigation_type === 'custom' && !field.navigate_to_url) {
+    } else if (
+      field.navigation_type === 'custom' &&
+      !field.navigate_to_url.formula
+    ) {
       return this.app.$i18n.t('elementType.errorNavigationUrlMissing')
     }
 

--- a/web-frontend/modules/builder/locales/en.json
+++ b/web-frontend/modules/builder/locales/en.json
@@ -166,7 +166,7 @@
     "errorIframeUrlMissing": "Missing IFrame URL property",
     "errorIframeContentMissing": "Missing IFrame content",
     "errorNoMenuItem": "No menu item configured",
-    "errorMenuItemInError": "At least one menu is misconfigured",
+    "errorMenuItemInError": "At least one menu item is misconfigured",
     "errorSubMenuItemInError": "At least one sub menu is misconfigured"
   },
   "addElementButton": {

--- a/web-frontend/modules/builder/utils/params.js
+++ b/web-frontend/modules/builder/utils/params.js
@@ -15,19 +15,7 @@ export function defaultValueForParameterType(type) {
 // This needs to match QUERY_PARAM_EXACT_MATCH_REGEX from backend.
 export const QUERY_PARAM_REGEX = /^([A-Za-z][A-Za-z0-9_-]*)$/g
 
-/**
- * Responsible for detecting if a navigable record's path parameters have diverged
- * from the destination page's path parameters. This can happen if a record
- * points to a page, and then the page's parameters are altered.
- *
- * @param {Object} navigationObject - An `element` or `workflowAction` object
- *  which points to navigation data. In the case of an `element` this could be
- *  a button, and in the case of a `workflowAction` this could be an "open page"
- *  workflow action type.
- * @param {Array} pages - An array of "visible" pages in the application.
- * @returns {Boolean} Whether this navigable object has parameters in error.
- */
-export function pathParametersInError(navigationObject, pages) {
+function getNavigationPathParameters(navigationObject, pages) {
   if (
     navigationObject.navigation_type === 'page' &&
     !isNaN(navigationObject.navigate_to_page_id)
@@ -37,20 +25,13 @@ export function pathParametersInError(navigationObject, pages) {
     )
 
     if (destinationPage) {
-      const destinationPageParams = destinationPage.path_params || []
-      const pageParams = navigationObject.page_parameters || []
-
-      const destinationPageParamNames = destinationPageParams.map(
-        ({ name }) => name
-      )
-      const pageParamNames = pageParams.map(({ name }) => name)
-
-      if (!_.isEqual(destinationPageParamNames, pageParamNames)) {
-        return true
+      return {
+        destinationPageParams: destinationPage.path_params || [],
+        pageParams: navigationObject.page_parameters || [],
       }
     }
   }
-  return false
+  return null
 }
 
 function pathParameterHasValue(pageParam) {
@@ -64,36 +45,44 @@ function pathParameterHasValue(pageParam) {
   return Boolean(value)
 }
 
+function pathParameterNamesMismatch(destinationPageParams, pageParams) {
+  const destinationPageParamNames = destinationPageParams.map(
+    ({ name }) => name
+  )
+  const pageParamNames = pageParams.map(({ name }) => name)
+
+  return !_.isEqual(destinationPageParamNames, pageParamNames)
+}
+
+function pathParameterValuesMissing(destinationPageParams, pageParams) {
+  return destinationPageParams.some(({ name }) => {
+    const pageParam = pageParams.find((param) => param.name === name)
+    return !pathParameterHasValue(pageParam)
+  })
+}
+
 /**
- * Responsible for detecting if a navigable record has missing path parameter
- * values. This differs from pathParametersInError, which only detects whether
- * the saved parameters match the destination page's path parameters.
+ * Responsible for detecting if a navigable record's path parameters are
+ * misconfigured. Parameters are in error when their saved names no longer match
+ * the destination page's path parameters, or when a required value is missing.
  *
  * @param {Object} navigationObject - An `element` or `workflowAction` object
  *  which points to navigation data.
  * @param {Array} pages - An array of "visible" pages in the application.
- * @returns {Boolean} Whether this navigable object has missing path parameter
- *  values.
+ * @returns {Boolean} Whether this navigable object has parameters in error.
  */
-export function pathParameterValuesInError(navigationObject, pages) {
-  if (
-    navigationObject.navigation_type === 'page' &&
-    !isNaN(navigationObject.navigate_to_page_id)
-  ) {
-    const destinationPage = pages.find(
-      ({ id }) => id === navigationObject.navigate_to_page_id
+export function pathParametersInError(navigationObject, pages) {
+  const pathParameters = getNavigationPathParameters(navigationObject, pages)
+
+  if (pathParameters) {
+    const { destinationPageParams, pageParams } = pathParameters
+
+    return (
+      pathParameterNamesMismatch(destinationPageParams, pageParams) ||
+      pathParameterValuesMissing(destinationPageParams, pageParams)
     )
-
-    if (destinationPage) {
-      const destinationPageParams = destinationPage.path_params || []
-      const pageParams = navigationObject.page_parameters || []
-
-      return destinationPageParams.some(({ name }) => {
-        const pageParam = pageParams.find((param) => param.name === name)
-        return !pathParameterHasValue(pageParam)
-      })
-    }
   }
+
   return false
 }
 

--- a/web-frontend/modules/builder/utils/params.js
+++ b/web-frontend/modules/builder/utils/params.js
@@ -53,6 +53,50 @@ export function pathParametersInError(navigationObject, pages) {
   return false
 }
 
+function pathParameterHasValue(pageParam) {
+  const value = pageParam?.value
+  if (value === null || typeof value === 'undefined') {
+    return false
+  }
+  if (typeof value === 'object') {
+    return Boolean(value.formula)
+  }
+  return Boolean(value)
+}
+
+/**
+ * Responsible for detecting if a navigable record has missing path parameter
+ * values. This differs from pathParametersInError, which only detects whether
+ * the saved parameters match the destination page's path parameters.
+ *
+ * @param {Object} navigationObject - An `element` or `workflowAction` object
+ *  which points to navigation data.
+ * @param {Array} pages - An array of "visible" pages in the application.
+ * @returns {Boolean} Whether this navigable object has missing path parameter
+ *  values.
+ */
+export function pathParameterValuesInError(navigationObject, pages) {
+  if (
+    navigationObject.navigation_type === 'page' &&
+    !isNaN(navigationObject.navigate_to_page_id)
+  ) {
+    const destinationPage = pages.find(
+      ({ id }) => id === navigationObject.navigate_to_page_id
+    )
+
+    if (destinationPage) {
+      const destinationPageParams = destinationPage.path_params || []
+      const pageParams = navigationObject.page_parameters || []
+
+      return destinationPageParams.some(({ name }) => {
+        const pageParam = pageParams.find((param) => param.name === name)
+        return !pathParameterHasValue(pageParam)
+      })
+    }
+  }
+  return false
+}
+
 /**
  * Given dispatch refinement records, this function is responsible for generating
  * the URLSearchParams that data source and workflow action dispatches will use.

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -21,7 +21,10 @@ import { AIAgentServiceType } from '@baserow/modules/integrations/ai/serviceType
 import { DataProviderType } from '@baserow/modules/core/dataProviderTypes'
 import resolveElementUrl from '@baserow/modules/builder/utils/urlResolution'
 import { ensureString } from '@baserow/modules/core/utils/validator'
-import { pathParametersInError } from '@baserow/modules/builder/utils/params'
+import {
+  pathParameterValuesInError,
+  pathParametersInError,
+} from '@baserow/modules/builder/utils/params'
 import { handleDispatchError } from '@baserow/modules/builder/utils/error'
 import { SlackWriteMessageServiceType } from '@baserow/modules/integrations/slack/serviceTypes'
 
@@ -92,13 +95,12 @@ export class OpenPageWorkflowActionType extends WorkflowActionType {
           'workflowActionTypes.errorNavigateToPageMissing'
         )
       }
+      const visiblePages = this.app.$store.getters['page/getVisiblePages'](
+        applicationContext.builder
+      )
       if (
-        pathParametersInError(
-          workflowAction,
-          this.app.$store.getters['page/getVisiblePages'](
-            applicationContext.builder
-          )
-        )
+        pathParametersInError(workflowAction, visiblePages) ||
+        pathParameterValuesInError(workflowAction, visiblePages)
       ) {
         return this.app.$i18n.t('workflowActionTypes.errorPageParameterInError')
       }

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -100,7 +100,7 @@ export class OpenPageWorkflowActionType extends WorkflowActionType {
       }
     } else if (
       workflowAction.navigation_type === 'custom' &&
-      !workflowAction.navigate_to_url
+      !workflowAction.navigate_to_url.formula
     ) {
       return this.app.$i18n.t('workflowActionTypes.errorNavigationUrlMissing')
     }

--- a/web-frontend/modules/builder/workflowActionTypes.js
+++ b/web-frontend/modules/builder/workflowActionTypes.js
@@ -21,10 +21,7 @@ import { AIAgentServiceType } from '@baserow/modules/integrations/ai/serviceType
 import { DataProviderType } from '@baserow/modules/core/dataProviderTypes'
 import resolveElementUrl from '@baserow/modules/builder/utils/urlResolution'
 import { ensureString } from '@baserow/modules/core/utils/validator'
-import {
-  pathParameterValuesInError,
-  pathParametersInError,
-} from '@baserow/modules/builder/utils/params'
+import { pathParametersInError } from '@baserow/modules/builder/utils/params'
 import { handleDispatchError } from '@baserow/modules/builder/utils/error'
 import { SlackWriteMessageServiceType } from '@baserow/modules/integrations/slack/serviceTypes'
 
@@ -98,10 +95,7 @@ export class OpenPageWorkflowActionType extends WorkflowActionType {
       const visiblePages = this.app.$store.getters['page/getVisiblePages'](
         applicationContext.builder
       )
-      if (
-        pathParametersInError(workflowAction, visiblePages) ||
-        pathParameterValuesInError(workflowAction, visiblePages)
-      ) {
+      if (pathParametersInError(workflowAction, visiblePages)) {
         return this.app.$i18n.t('workflowActionTypes.errorPageParameterInError')
       }
     } else if (

--- a/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
+++ b/web-frontend/test/unit/builder/collectionFieldTypes.spec.js
@@ -1,0 +1,92 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+
+describe('Builder collection field types', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  describe('LinkCollectionFieldType getErrorMessage', () => {
+    test('is in error when custom navigation URL is missing', () => {
+      const fieldType = testApp.getRegistry().get('collectionField', 'link')
+      const builder = { id: 1, pages: [] }
+      const field = {
+        type: 'link',
+        link_name: { formula: "'Foo'" },
+        navigation_type: 'custom',
+        navigate_to_url: { formula: '' },
+      }
+
+      expect(fieldType.isInError({ field, builder })).toBe(true)
+      expect(fieldType.getErrorMessage({ field, builder })).toBe(
+        'elementType.errorNavigationUrlMissing'
+      )
+
+      // Once a custom URL formula is provided, the field is no longer in error.
+      field.navigate_to_url = { formula: "'https://baserow.io'" }
+
+      expect(fieldType.isInError({ field, builder })).toBe(false)
+    })
+
+    test('is in error when page navigation has no destination page', () => {
+      const fieldType = testApp.getRegistry().get('collectionField', 'link')
+      const builder = { id: 1, pages: [] }
+      const field = {
+        type: 'link',
+        link_name: { formula: "'Foo'" },
+        navigation_type: 'page',
+        navigate_to_page_id: '',
+      }
+
+      expect(fieldType.isInError({ field, builder })).toBe(true)
+      expect(fieldType.getErrorMessage({ field, builder })).toBe(
+        'elementType.errorNavigateToPageMissing'
+      )
+    })
+
+    test('is in error when a required page parameter is empty', () => {
+      const fieldType = testApp.getRegistry().get('collectionField', 'link')
+      const builder = {
+        id: 1,
+        pages: [
+          {
+            id: 1,
+            shared: false,
+            order: 1,
+            path: '/',
+            path_params: [],
+          },
+          {
+            id: 2,
+            shared: false,
+            order: 2,
+            path: '/details/:id',
+            path_params: [{ name: 'id', type: 'numeric' }],
+          },
+        ],
+      }
+      const field = {
+        type: 'link',
+        link_name: { formula: "'Foo'" },
+        navigation_type: 'page',
+        navigate_to_page_id: 2,
+        page_parameters: [{ name: 'id', value: { formula: '' } }],
+      }
+
+      expect(fieldType.isInError({ field, builder })).toBe(true)
+      expect(fieldType.getErrorMessage({ field, builder })).toBe(
+        'elementType.errorPageParameterInError'
+      )
+
+      // Once the page parameter has a value, the field is no longer in error.
+      field.page_parameters = [{ name: 'id', value: { formula: "'10'" } }]
+
+      expect(fieldType.isInError({ field, builder })).toBe(false)
+    })
+  })
+})

--- a/web-frontend/test/unit/builder/elementTypes.spec.js
+++ b/web-frontend/test/unit/builder/elementTypes.spec.js
@@ -1098,6 +1098,9 @@ describe('elementTypes tests', () => {
         value: { formula: "'Test'" },
       }
       expect(elementType.isInError(element, { page, element })).toBe(true)
+      expect(elementType.getErrorMessage(element, { page, element })).toBe(
+        'elementType.errorNavigationUrlMissing'
+      )
 
       // Otherwise it is valid
       element.navigate_to_url = { formula: 'http://localhost' }

--- a/web-frontend/test/unit/builder/elementTypes.spec.js
+++ b/web-frontend/test/unit/builder/elementTypes.spec.js
@@ -1155,6 +1155,45 @@ describe('elementTypes tests', () => {
         true
       )
     })
+
+    test('Returns true if Button Element open page action has a missing page parameter value.', () => {
+      const targetPage = {
+        id: 1,
+        shared: false,
+        order: 1,
+        path_params: [{ name: 'id', type: 'numeric' }],
+      }
+      const page = {
+        id: 2,
+        shared: false,
+        order: 2,
+        name: 'Foo Page',
+        workflowActions: [
+          {
+            type: 'open_page',
+            element_id: 50,
+            page_parameters: [{ name: 'id', value: {} }],
+            navigation_type: 'page',
+            navigate_to_page_id: targetPage.id,
+          },
+        ],
+      }
+      const element = {
+        id: 50,
+        value: { formula: "'Click me'" },
+        page_id: page.id,
+      }
+      const builder = {
+        id: 1,
+        pages: [targetPage, page],
+      }
+      const elementType = testApp.$registry.get('element', 'button')
+
+      expect(elementType.isInError(element, { page, element, builder })).toBe(
+        true
+      )
+    })
+
     test('Returns true if Button Element has errors, false otherwise', () => {
       const page = {
         id: 1,

--- a/web-frontend/test/unit/builder/utils/params.spec.js
+++ b/web-frontend/test/unit/builder/utils/params.spec.js
@@ -1,4 +1,7 @@
-import { pathParametersInError } from '@baserow/modules/builder/utils/params'
+import {
+  pathParameterValuesInError,
+  pathParametersInError,
+} from '@baserow/modules/builder/utils/params'
 
 describe('Builder parameter util tests', () => {
   describe('pathParametersInError', () => {
@@ -88,6 +91,95 @@ describe('Builder parameter util tests', () => {
       ]
 
       const result = pathParametersInError(element, pages)
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('pathParameterValuesInError', () => {
+    test('should return false when element is not a page navigation', () => {
+      const element = {
+        navigation_type: 'link',
+        navigate_to_page_id: 1,
+        page_parameters: [],
+      }
+      const pages = [{ id: 1, path_params: [{ name: 'id', type: 'text' }] }]
+
+      const result = pathParameterValuesInError(element, pages)
+      expect(result).toBe(false)
+    })
+
+    test('should return false when destinationPage is not found', () => {
+      const element = {
+        navigation_type: 'page',
+        navigate_to_page_id: 3,
+        page_parameters: [],
+      }
+      const pages = [{ id: 1, path_params: [{ name: 'id', type: 'text' }] }]
+
+      const result = pathParameterValuesInError(element, pages)
+      expect(result).toBe(false)
+    })
+
+    test('should return false when all path parameters have values', () => {
+      const element = {
+        navigation_type: 'page',
+        navigate_to_page_id: 1,
+        page_parameters: [
+          { name: 'param1', value: { formula: "'10'" } },
+          { name: 'param2', value: { formula: "'abc'" } },
+        ],
+      }
+      const pages = [
+        {
+          id: 1,
+          path_params: [
+            { name: 'param1', type: 'numeric' },
+            { name: 'param2', type: 'text' },
+          ],
+        },
+      ]
+
+      const result = pathParameterValuesInError(element, pages)
+      expect(result).toBe(false)
+    })
+
+    test('should return true when a path parameter value is missing', () => {
+      const element = {
+        navigation_type: 'page',
+        navigate_to_page_id: 1,
+        page_parameters: [
+          { name: 'param1', value: { formula: "'10'" } },
+          { name: 'param2', value: {} },
+        ],
+      }
+      const pages = [
+        {
+          id: 1,
+          path_params: [
+            { name: 'param1', type: 'numeric' },
+            { name: 'param2', type: 'text' },
+          ],
+        },
+      ]
+
+      const result = pathParameterValuesInError(element, pages)
+      expect(result).toBe(true)
+    })
+
+    test('should return true when a path parameter formula is empty', () => {
+      const element = {
+        navigation_type: 'page',
+        navigate_to_page_id: 1,
+        page_parameters: [{ name: 'param1', value: { formula: '' } }],
+      }
+      const pages = [
+        {
+          id: 1,
+          path_params: [{ name: 'param1', type: 'numeric' }],
+        },
+      ]
+
+      const result = pathParameterValuesInError(element, pages)
       expect(result).toBe(true)
     })
   })

--- a/web-frontend/test/unit/builder/utils/params.spec.js
+++ b/web-frontend/test/unit/builder/utils/params.spec.js
@@ -1,7 +1,4 @@
-import {
-  pathParameterValuesInError,
-  pathParametersInError,
-} from '@baserow/modules/builder/utils/params'
+import { pathParametersInError } from '@baserow/modules/builder/utils/params'
 
 describe('Builder parameter util tests', () => {
   describe('pathParametersInError', () => {
@@ -30,13 +27,13 @@ describe('Builder parameter util tests', () => {
       expect(result).toBe(false)
     })
 
-    test('should return false when page parameters and destinationPage path parameters match', () => {
+    test('should return false when all path parameters have values', () => {
       const element = {
         navigation_type: 'page',
         navigate_to_page_id: 1,
         page_parameters: [
-          { name: 'param1', value: '10' },
-          { name: 'param2', value: 'abc' },
+          { name: 'param1', value: { formula: "'10'" } },
+          { name: 'param2', value: { formula: "'abc'" } },
         ],
       }
       const pages = [
@@ -93,55 +90,6 @@ describe('Builder parameter util tests', () => {
       const result = pathParametersInError(element, pages)
       expect(result).toBe(true)
     })
-  })
-
-  describe('pathParameterValuesInError', () => {
-    test('should return false when element is not a page navigation', () => {
-      const element = {
-        navigation_type: 'link',
-        navigate_to_page_id: 1,
-        page_parameters: [],
-      }
-      const pages = [{ id: 1, path_params: [{ name: 'id', type: 'text' }] }]
-
-      const result = pathParameterValuesInError(element, pages)
-      expect(result).toBe(false)
-    })
-
-    test('should return false when destinationPage is not found', () => {
-      const element = {
-        navigation_type: 'page',
-        navigate_to_page_id: 3,
-        page_parameters: [],
-      }
-      const pages = [{ id: 1, path_params: [{ name: 'id', type: 'text' }] }]
-
-      const result = pathParameterValuesInError(element, pages)
-      expect(result).toBe(false)
-    })
-
-    test('should return false when all path parameters have values', () => {
-      const element = {
-        navigation_type: 'page',
-        navigate_to_page_id: 1,
-        page_parameters: [
-          { name: 'param1', value: { formula: "'10'" } },
-          { name: 'param2', value: { formula: "'abc'" } },
-        ],
-      }
-      const pages = [
-        {
-          id: 1,
-          path_params: [
-            { name: 'param1', type: 'numeric' },
-            { name: 'param2', type: 'text' },
-          ],
-        },
-      ]
-
-      const result = pathParameterValuesInError(element, pages)
-      expect(result).toBe(false)
-    })
 
     test('should return true when a path parameter value is missing', () => {
       const element = {
@@ -162,7 +110,7 @@ describe('Builder parameter util tests', () => {
         },
       ]
 
-      const result = pathParameterValuesInError(element, pages)
+      const result = pathParametersInError(element, pages)
       expect(result).toBe(true)
     })
 
@@ -179,7 +127,7 @@ describe('Builder parameter util tests', () => {
         },
       ]
 
-      const result = pathParameterValuesInError(element, pages)
+      const result = pathParametersInError(element, pages)
       expect(result).toBe(true)
     })
   })

--- a/web-frontend/test/unit/builder/workflowActionTypes.spec.js
+++ b/web-frontend/test/unit/builder/workflowActionTypes.spec.js
@@ -37,4 +37,86 @@ describe('Builder workflow action types', () => {
       'slack_write_message',
     ])
   })
+
+  test('open page action is in error when saved page parameters are outdated', () => {
+    const workflowActionType = testApp
+      .getRegistry()
+      .get('workflowAction', 'open_page')
+    const builder = {
+      id: 1,
+      pages: [
+        {
+          id: 1,
+          shared: false,
+          order: 1,
+          path: '/',
+          path_params: [],
+        },
+        {
+          id: 2,
+          shared: false,
+          order: 2,
+          path: '/details/:slug',
+          path_params: [{ name: 'slug', type: 'text' }],
+        },
+      ],
+    }
+    const workflowAction = {
+      type: 'open_page',
+      navigation_type: 'page',
+      navigate_to_page_id: 2,
+      page_parameters: [],
+    }
+
+    expect(
+      workflowActionType.isInError(workflowAction, {
+        builder,
+      })
+    ).toBe(true)
+  })
+
+  test('open page action is in error when a required page parameter is empty', () => {
+    const workflowActionType = testApp
+      .getRegistry()
+      .get('workflowAction', 'open_page')
+    const builder = {
+      id: 1,
+      pages: [
+        {
+          id: 1,
+          shared: false,
+          order: 1,
+          path: '/',
+          path_params: [],
+        },
+        {
+          id: 2,
+          shared: false,
+          order: 2,
+          path: '/details/:id',
+          path_params: [{ name: 'id', type: 'numeric' }],
+        },
+      ],
+    }
+    const workflowAction = {
+      type: 'open_page',
+      navigation_type: 'page',
+      navigate_to_page_id: 2,
+      page_parameters: [{ name: 'id', value: {} }],
+    }
+
+    expect(
+      workflowActionType.isInError(workflowAction, {
+        builder,
+      })
+    ).toBe(true)
+
+    workflowAction.page_parameters = [{ name: 'id', value: { formula: '' } }]
+
+    expect(
+      workflowActionType.isInError(workflowAction, {
+        builder,
+      })
+    ).toBe(true)
+  })
 })

--- a/web-frontend/test/unit/builder/workflowActionTypes.spec.js
+++ b/web-frontend/test/unit/builder/workflowActionTypes.spec.js
@@ -119,4 +119,36 @@ describe('Builder workflow action types', () => {
       })
     ).toBe(true)
   })
+
+  test('open page action is in error when custom navigation URL is missing', () => {
+    const workflowActionType = testApp
+      .getRegistry()
+      .get('workflowAction', 'open_page')
+    const builder = { id: 1, pages: [] }
+    const workflowAction = {
+      type: 'open_page',
+      navigation_type: 'custom',
+      navigate_to_url: { formula: '' },
+    }
+
+    expect(
+      workflowActionType.isInError(workflowAction, {
+        builder,
+      })
+    ).toBe(true)
+    expect(
+      workflowActionType.getErrorMessage(workflowAction, {
+        builder,
+      })
+    ).toBe('workflowActionTypes.errorNavigationUrlMissing')
+
+    // Once a custom URL formula is provided, the action is no longer in error.
+    workflowAction.navigate_to_url = { formula: "'https://baserow.io'" }
+
+    expect(
+      workflowActionType.isInError(workflowAction, {
+        builder,
+      })
+    ).toBe(false)
+  })
 })


### PR DESCRIPTION
### What is in this PR

This PR validates `open_page` workflow actions before they are considered usable or executed.

Previously, a button could have an Open Page workflow action targeting a page with required path parameters, for example `/page-1/:id`, while leaving the `id` value empty. The workflow action was not marked as invalid, so the button was not shown in error in the builder preview and could still reach runtime execution.


### How to test this PR

1. Create an Application Builder page with a path parameter, for example `/page-1/:id`.
2. Add a Button element on another page.
3. Add an Open Page workflow action to the button.
4. Select the page with the required path parameter.
5. Leave the path parameter value empty and observe the Open page action is marked as invalid. 
6. Open the preview of the published page and observe the button is not displayed. 

Fixes #3110


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
