### PR TITLE
Fix number format prefix and suffix spacing

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -611,7 +611,19 @@ class NumberFieldType(FieldType):
             "The number_type option has been removed and can no longer be provided. "
             "Instead set number_decimal_places to 0 for an integer or 1-5 for a "
             "decimal."
-        )
+        ),
+        "number_prefix": serializers.CharField(
+            max_length=10,
+            required=False,
+            allow_blank=True,
+            trim_whitespace=False,
+        ),
+        "number_suffix": serializers.CharField(
+            max_length=100,
+            required=False,
+            allow_blank=True,
+            trim_whitespace=False,
+        ),
     }
     _can_group_by = True
     _db_column_fields = ["number_decimal_places"]
@@ -745,7 +757,7 @@ class NumberFieldType(FieldType):
             f"{minus_sign}"
             f"{instance.number_prefix}"
             f"{integer_part_with_sep}{fractional_part}"
-            f"{instance.number_suffix}".strip()
+            f"{instance.number_suffix}"
         )
 
     def get_model_field(self, instance, **kwargs):

--- a/backend/src/baserow/contrib/database/formula/types/formula_types.py
+++ b/backend/src/baserow/contrib/database/formula/types/formula_types.py
@@ -389,6 +389,18 @@ class BaserowFormulaNumberType(
             "number_negative": serializers.BooleanField(
                 required=False, read_only=True, default=True
             ),
+            "number_prefix": serializers.CharField(
+                max_length=10,
+                required=False,
+                allow_blank=True,
+                trim_whitespace=False,
+            ),
+            "number_suffix": serializers.CharField(
+                max_length=10,
+                required=False,
+                allow_blank=True,
+                trim_whitespace=False,
+            ),
         }
 
     def __init__(

--- a/backend/tests/baserow/contrib/database/api/fields/test_field_views.py
+++ b/backend/tests/baserow/contrib/database/api/fields/test_field_views.py
@@ -767,6 +767,54 @@ def test_update_field_number_type_deprecation_error(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_create_and_update_number_field_preserves_prefix_suffix_spaces(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+
+    response = api_client.post(
+        reverse("api:database:fields:list", kwargs={"table_id": table.id}),
+        {
+            "name": "Duration",
+            "type": "number",
+            "number_prefix": "$ ",
+            "number_suffix": " Days",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json["number_prefix"] == "$ "
+    assert response_json["number_suffix"] == " Days"
+
+    number_field = NumberField.objects.get(id=response_json["id"])
+    assert number_field.number_prefix == "$ "
+    assert number_field.number_suffix == " Days"
+
+    response = api_client.patch(
+        reverse("api:database:fields:item", kwargs={"field_id": number_field.id}),
+        {
+            "number_prefix": " about ",
+            "number_suffix": " days ",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+
+    assert response.status_code == HTTP_200_OK
+    response_json = response.json()
+    assert response_json["number_prefix"] == " about "
+    assert response_json["number_suffix"] == " days "
+
+    number_field.refresh_from_db()
+    assert number_field.number_prefix == " about "
+    assert number_field.number_suffix == " days "
+
+
+@pytest.mark.django_db
 def test_change_field_type_with_active_sort_on_field(api_client, data_fixture):
     import uuid
 

--- a/backend/tests/baserow/contrib/database/field/test_field_types.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_types.py
@@ -1283,6 +1283,29 @@ def test_number_field_type_export_with_nan_value_and_formatting(data_fixture):
 
 
 @pytest.mark.django_db
+def test_number_field_type_export_preserves_prefix_suffix_spaces(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field_handler = FieldHandler()
+
+    number_field = field_handler.create_field(
+        user=user,
+        table=table,
+        type_name="number",
+        name="number",
+        number_decimal_places=0,
+        number_prefix=" about ",
+        number_suffix=" days ",
+    )
+
+    field_type = field_type_registry.get_by_model(number_field)
+    field_object = {"field": number_field, "type": field_type, "name": "number"}
+    export_value = field_type.get_export_value(1, field_object)
+
+    assert export_value == " about 1 days "
+
+
+@pytest.mark.django_db
 def test_all_fields_with_db_index_have_index(data_fixture):
     table, user, row, blank_row, context = setup_interesting_test_table(data_fixture)
     field_handler = FieldHandler()

--- a/web-frontend/modules/database/utils/number.js
+++ b/web-frontend/modules/database/utils/number.js
@@ -148,7 +148,7 @@ export const formatNumberValue = (
   }
 
   const sign = isNegative ? '-' : ''
-  return `${sign}${numberPrefix}${formatted}${numberSuffix}`.trim()
+  return `${sign}${numberPrefix}${formatted}${numberSuffix}`
 }
 
 export const parseNumberValue = (field, value, roundDecimals = true) => {

--- a/web-frontend/test/unit/database/mixins/number.spec.js
+++ b/web-frontend/test/unit/database/mixins/number.spec.js
@@ -62,6 +62,15 @@ describe('test number formatting and parsing', () => {
     expect(formatNumberValue(field, -1234.56)).toBe('-$1 234,56 USD')
   })
 
+  test('number formatting preserves prefix and suffix spaces', () => {
+    const field = { ...baseField }
+    field.number_prefix = ' about '
+    field.number_suffix = ' days '
+
+    expect(formatNumberValue(field, 2)).toBe(' about 2.00 days ')
+    expect(formatNumberValue(field, -2)).toBe('- about 2.00 days ')
+  })
+
   test('number formatting with different decimal places', () => {
     const field = { ...baseField }
     field.number_decimal_places = 0


### PR DESCRIPTION
Fixes #5646

## Summary
- Preserve whitespace supplied for number format prefixes and suffixes through the field API.
- Avoid trimming formatted number output so stored spaces render and export unchanged.

## Tests
- `just b test tests/baserow/contrib/database/api/fields/test_field_views.py::test_create_and_update_number_field_preserves_prefix_suffix_spaces tests/baserow/contrib/database/field/test_field_types.py::test_number_field_type_export_preserves_prefix_suffix_spaces`
- `just f yarn test:core --run test/unit/database/mixins/number.spec.js`