### PR TITLE
fix(test): Fix flaky test_replay_events_cant_replay_when_last_seen_expired

### DIFF
--- a/backend/tests/baserow/ws/test_ws_realtime_events.py
+++ b/backend/tests/baserow/ws/test_ws_realtime_events.py
@@ -1676,6 +1676,12 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     user, token = await sync_to_async(data_fixture.create_user_and_token)()
     await sync_to_async(data_fixture.create_workspace)(user=user)
 
+    # The client's last seen event was cleaned up by retention.
+    expired_id = await sync_to_async(_record_user_broadcast)(
+        user.id, {"type": "expired"}
+    )
+    await sync_to_async(RealtimeEvent.objects.filter(id=expired_id).delete)()
+
     await sync_to_async(_record_event)(
         "users",
         {
@@ -1696,12 +1702,12 @@ async def test_replay_events_cant_replay_when_last_seen_expired(data_fixture):
     assert connected is True
     await communicator.receive_json_from()
 
-    # last_seen_id=1 does not exist — retention cleaned it (simulated by
-    # never having created id=1). Replay can't proceed — client must refresh.
+    # The expired id no longer exists, so replay can't anchor against it —
+    # the client must refresh.
     await communicator.send_json_to(
         {
             "type": "replay_events",
-            "last_seen_id": 1,
+            "last_seen_id": expired_id,
         }
     )
 


### PR DESCRIPTION
### What is in this PR

**Problem:** The test hardcoded `last_seen_id=1`, assuming event id `1` never exists. But the test itself records one `RealtimeEvent` — when it runs as the first event-recording test on an xdist worker (fresh id sequence), that event actually gets id `1`. The replay window then anchors successfully against `last_seen_id`, returning `force_refresh=False` and failing the assertion. Whether the sequence is fresh depends on nondeterministic test distribution across workers, hence the flakiness. Reproducible deterministically by running the test alone against a fresh database.

**Fix:** Simulate retention for real instead of assuming a free id: record a baseline event, delete its row, and use its id as `last_seen_id`. This mirrors the existing pattern in `test_replay_events_result_missing_last_seen_uses_one_query` and is independent of sequence state.


### How to test this PR

* On develop when this test is run alone - it always fails `just pytest tests/baserow/ws/test_ws_realtime_events.py::test_replay_events_cant_replay_when_last_seen_expired`

* On this branch it pass

