### PR TITLE
fix: restore right margin on grid search button

### DIFF
--- a/web-frontend/modules/core/assets/scss/components/header.scss
+++ b/web-frontend/modules/core/assets/scss/components/header.scss
@@ -110,6 +110,10 @@
   &.header__filter-item--no-margin-left {
     margin-left: 0;
   }
+
+  &:last-child {
+    margin-right: 10px;
+  }
 }
 
 .header__filter-link {


### PR DESCRIPTION
### What is in this PR
This pr address this comment https://github.com/baserow/baserow/pull/5570#issuecomment-4887297532

### How to test this PR
Note there is right margin  on search bar on grid
