### PR TITLE
fix(tests) fix flaky formula tests caused by randomly generated field names containing apostrophes

### DIFF
--- a/backend/src/baserow/test_utils/fixtures/field.py
+++ b/backend/src/baserow/test_utils/fixtures/field.py
@@ -102,7 +102,11 @@ class FieldFixtures:
             kwargs["table"] = self.create_database_table(user=user)
 
         if "name" not in kwargs:
-            kwargs["name"] = self.fake.name()
+            # Faker names can contain apostrophes (e.g. "Kevin O'Kon"), which
+            # break tests that interpolate the field name into a single-quoted
+            # formula string without escaping it. Strip them so a randomly
+            # generated name is always safe to use in a formula reference.
+            kwargs["name"] = self.fake.name().replace("'", "")
 
         if "order" not in kwargs:
             kwargs["order"] = 0

--- a/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
+++ b/backend/tests/baserow/contrib/database/formula/test_baserow_formula_results.py
@@ -753,7 +753,6 @@ def test_can_use_has_option_on_multiple_select_fields(data_fixture):
         ),
     ],
 )
-@pytest.mark.skip  # See: https://github.com/baserow/baserow/issues/4217
 def test_can_use_formula_on_lookup_of_multiple_select_fields(
     formula, expected_value, data_fixture
 ):

--- a/changelog/entries/unreleased/bug/4217_fixed_flaky_formula_tests_caused_by_randomly_generated_field.json
+++ b/changelog/entries/unreleased/bug/4217_fixed_flaky_formula_tests_caused_by_randomly_generated_field.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed flaky formula tests caused by randomly generated field names containing apostrophes",
+    "issue_origin": "github",
+    "issue_number": 4217,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-06"
+}


### PR DESCRIPTION
Closes #4217 

### Root cause

The flakiness was not caused by test ordering or CI grouping. All field fixtures default their name to `fake.name()` — an **unseeded** Faker person name like `Kevin O'Kon`, `D'Amore`

The test interpolates the generated field name directly into a single-quoted formula string:

```python
formula=f"field('{lookup_field.name}')"
# → field('Kevin O'Kon')
```

The formula lexer terminates the string literal at the second apostrophe, producing:

```
BaserowFormulaSyntaxError: Invalid syntax at line 1, col 26: mismatched input 'Kon' expecting ')'
```

### Fix

Fixed at the source: `set_test_field_kwarg_defaults` in `backend/src/baserow/test_utils/fixtures/field.py` now strips apostrophes from the default Faker-generated field name. All field fixtures route through this method, so this covers every existing and future test.

The `@pytest.mark.skip` on `test_can_use_formula_on_lookup_of_multiple_select_fields` has been removed.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
