### PR TITLE
Hardened workspace invitation emails and user name validation

### DIFF
--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -7,7 +7,7 @@ from rest_framework.serializers import ModelSerializer
 
 from baserow.api.mixins import UnknownFieldRaisesExceptionSerializerMixin
 from baserow.api.two_factor_auth.serializers import TwoFactorAuthSerializer
-from baserow.api.user.validators import password_validation
+from baserow.api.user.validators import name_validation, password_validation
 from baserow.core.models import WorkspaceUser
 
 User = get_user_model()
@@ -106,8 +106,13 @@ class UserAdminCreateSerializer(
     data as the password will be returned also.
     """
 
-    # Max length set to match django user models first_name fields max length
-    name = CharField(source="first_name", max_length=150, required=True)
+    name = CharField(
+        source="first_name",
+        min_length=2,
+        max_length=60,
+        required=True,
+        validators=[name_validation],
+    )
     username = EmailField(required=True)
     password = CharField(validators=[password_validation], required=True)
 
@@ -127,8 +132,13 @@ class UserAdminUpdateSerializer(
     data as the password will be returned also.
     """
 
-    # Max length set to match django user models first_name fields max length
-    name = CharField(source="first_name", max_length=150, required=False)
+    name = CharField(
+        source="first_name",
+        min_length=2,
+        max_length=60,
+        required=False,
+        validators=[name_validation],
+    )
     username = EmailField(required=False)
     password = CharField(validators=[password_validation], required=False)
 

--- a/backend/src/baserow/api/user/serializers.py
+++ b/backend/src/baserow/api/user/serializers.py
@@ -20,7 +20,11 @@ from baserow.api.sessions import set_user_session_data_from_request
 from baserow.api.two_factor_auth.tokens import TwoFactorAccessToken
 from baserow.api.user.jwt import get_user_from_token
 from baserow.api.user.registries import user_data_registry
-from baserow.api.user.validators import language_validation, password_validation
+from baserow.api.user.validators import (
+    language_validation,
+    name_validation,
+    password_validation,
+)
 from baserow.api.workspaces.invitations.serializers import (
     UserWorkspaceInvitationSerializer,
 )
@@ -136,7 +140,9 @@ class PublicUserSerializer(serializers.ModelSerializer):
 
 
 class RegisterSerializer(serializers.Serializer):
-    name = serializers.CharField(min_length=2, max_length=150)
+    name = serializers.CharField(
+        min_length=2, max_length=60, validators=[name_validation]
+    )
     email = serializers.EmailField(
         help_text="The email address is also going to be the username."
     )
@@ -182,7 +188,9 @@ class AccountSerializer(serializers.Serializer):
     This serializer must be kept in sync with `UserSerializer`.
     """
 
-    first_name = serializers.CharField(min_length=2, max_length=150, required=False)
+    first_name = serializers.CharField(
+        min_length=2, max_length=60, required=False, validators=[name_validation]
+    )
     language = serializers.CharField(
         source="profile.language",
         required=False,

--- a/backend/src/baserow/api/user/validators.py
+++ b/backend/src/baserow/api/user/validators.py
@@ -1,24 +1,10 @@
-import re
-
 from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
 from rest_framework import serializers
 
-_HIGH_RISK_TLDS = (
-    "com|net|org|io|co|info|biz|xyz|top|shop|site|online|link|club|app|dev|"
-    "live|me|ly|to|cc|gd|ru|cn|de|uk|nl|tk|ml|ga|cf|gq|click|icu|buzz|pw|vip"
-)
-# Matches URL-like content: an explicit protocol, a `www.` prefix, a domain-like token
-# with a high risk TLD (e.g. `evil.com`), or any domain-like token followed by a path
-# (e.g. `x.gd/spam`). Dotted names like `J.Smith`, `Dr.Smith` do not match.
-URL_LIKE_NAME_REGEX = re.compile(
-    rf"https?://|www\.|[a-z0-9][a-z0-9-]*\.(?:{_HIGH_RISK_TLDS})\b|\S\.[a-zA-Z]{{2,}}/",
-    re.IGNORECASE,
-)
-EMAIL_LIKE_NAME_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
-CONTROL_CHARS_REGEX = re.compile(r"[\x00-\x1f\x7f]")
+from baserow.api.validators import EMAIL_LIKE_NAME_REGEX, no_url_validation
 
 
 def name_validation(value):
@@ -34,13 +20,7 @@ def name_validation(value):
             code="name_is_email",
         )
 
-    if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
-        raise serializers.ValidationError(
-            "Names can't contain URLs, domains or control characters.",
-            code="invalid_name",
-        )
-
-    return value
+    return no_url_validation(value)
 
 
 def password_validation(value):

--- a/backend/src/baserow/api/user/validators.py
+++ b/backend/src/baserow/api/user/validators.py
@@ -6,19 +6,33 @@ from django.core.exceptions import ValidationError
 
 from rest_framework import serializers
 
-# Matches URL-like content: an explicit protocol, a `www.` prefix, or a
-# domain-like token (a non-space character followed by a dot and two or more
-# letters, e.g. `evil.com`). A dot followed by a space or a single letter, as
-# in `Dr. Smith` or `J.R.R. Tolkien`, does not match.
-URL_LIKE_NAME_REGEX = re.compile(r"https?://|www\.|\S\.[a-zA-Z]{2,}", re.IGNORECASE)
+_HIGH_RISK_TLDS = (
+    "com|net|org|io|co|info|biz|xyz|top|shop|site|online|link|club|app|dev|"
+    "live|me|ly|to|cc|gd|ru|cn|de|uk|nl|tk|ml|ga|cf|gq|click|icu|buzz|pw|vip"
+)
+# Matches URL-like content: an explicit protocol, a `www.` prefix, a domain-like token
+# with a high risk TLD (e.g. `evil.com`), or any domain-like token followed by a path
+# (e.g. `x.gd/spam`). Dotted names like `J.Smith`, `Dr.Smith` do not match.
+URL_LIKE_NAME_REGEX = re.compile(
+    rf"https?://|www\.|[a-z0-9][a-z0-9-]*\.(?:{_HIGH_RISK_TLDS})\b|\S\.[a-zA-Z]{{2,}}/",
+    re.IGNORECASE,
+)
+EMAIL_LIKE_NAME_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 CONTROL_CHARS_REGEX = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def name_validation(value):
     """
     Rejects names containing URL-like content or control characters to prevent
-    abuse of transactional emails for phishing.
+    abuse of transactional emails for phishing, and email addresses because
+    they're not a name.
     """
+
+    if EMAIL_LIKE_NAME_REGEX.match(value):
+        raise serializers.ValidationError(
+            "Please enter your name, not your email address.",
+            code="name_is_email",
+        )
 
     if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
         raise serializers.ValidationError(

--- a/backend/src/baserow/api/user/validators.py
+++ b/backend/src/baserow/api/user/validators.py
@@ -1,8 +1,32 @@
+import re
+
 from django.conf import settings
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 
 from rest_framework import serializers
+
+# Matches URL-like content: an explicit protocol, a `www.` prefix, or a
+# domain-like token (a non-space character followed by a dot and two or more
+# letters, e.g. `evil.com`). A dot followed by a space or a single letter, as
+# in `Dr. Smith` or `J.R.R. Tolkien`, does not match.
+URL_LIKE_NAME_REGEX = re.compile(r"https?://|www\.|\S\.[a-zA-Z]{2,}", re.IGNORECASE)
+CONTROL_CHARS_REGEX = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def name_validation(value):
+    """
+    Rejects names containing URL-like content or control characters to prevent
+    abuse of transactional emails for phishing.
+    """
+
+    if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
+        raise serializers.ValidationError(
+            "Names can't contain URLs, domains or control characters.",
+            code="invalid_name",
+        )
+
+    return value
 
 
 def password_validation(value):

--- a/backend/src/baserow/api/validators.py
+++ b/backend/src/baserow/api/validators.py
@@ -26,7 +26,7 @@ def no_url_validation(value):
 
     if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
         raise serializers.ValidationError(
-            "Names can't contain URLs, domains or control characters.",
+            "Names can't contain links, domains or web addresses.",
             code="invalid_name",
         )
 

--- a/backend/src/baserow/api/validators.py
+++ b/backend/src/baserow/api/validators.py
@@ -1,0 +1,33 @@
+import re
+
+from rest_framework import serializers
+
+_HIGH_RISK_TLDS = (
+    "com|net|org|io|co|info|biz|xyz|top|shop|site|online|link|club|app|dev|"
+    "live|me|ly|to|cc|gd|ru|cn|de|uk|nl|tk|ml|ga|cf|gq|click|icu|buzz|pw|vip"
+)
+# Matches URL-like content: an explicit protocol, a `www.` prefix, a domain-like token
+# with a high risk TLD (e.g. `evil.com`), or any domain-like token followed by a path
+# (e.g. `x.gd/spam`). Dotted names like `J.Smith`, `Dr.Smith` do not match.
+URL_LIKE_NAME_REGEX = re.compile(
+    rf"https?://|www\.|[a-z0-9][a-z0-9-]*\.(?:{_HIGH_RISK_TLDS})\b|\S\.[a-zA-Z]{{2,}}/",
+    re.IGNORECASE,
+)
+EMAIL_LIKE_NAME_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+CONTROL_CHARS_REGEX = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def no_url_validation(value):
+    """
+    Rejects values containing URL-like content or control characters to prevent abuse
+    of transactional emails for phishing, because user provided names can end up in
+    emails sent to others.
+    """
+
+    if CONTROL_CHARS_REGEX.search(value) or URL_LIKE_NAME_REGEX.search(value):
+        raise serializers.ValidationError(
+            "Names can't contain URLs, domains or control characters.",
+            code="invalid_name",
+        )
+
+    return value

--- a/backend/src/baserow/api/workspaces/serializers.py
+++ b/backend/src/baserow/api/workspaces/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from baserow.api.validators import no_url_validation
 from baserow.core.generative_ai.registries import generative_ai_model_type_registry
 from baserow.core.models import Workspace
 
@@ -26,6 +27,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             "id": {"read_only": True},
             "generative_ai_models_enabled": {"read_only": True},
+            "name": {"validators": [no_url_validation]},
         }
 
     def get_generative_ai_models_enabled(self, object):

--- a/backend/src/baserow/core/emails.py
+++ b/backend/src/baserow/core/emails.py
@@ -4,6 +4,7 @@ from typing import List
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.db import transaction
+from django.template.defaultfilters import truncatechars
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 from django.utils.translation import gettext as _
@@ -13,6 +14,16 @@ from loguru import logger
 from baserow.core.notifications.models import Notification
 from baserow.core.notifications.registries import notification_type_registry
 from baserow.core.registries import email_context_registry
+
+
+def prevent_autolink(value):
+    """
+    Inserts a zero-width space after every dot so that email clients don't turn
+    domain-like tokens in user-controlled content into clickable links. The value
+    still looks exactly the same to the recipient.
+    """
+
+    return value.replace(".", ".\u200b")
 
 
 class BaseEmailMessage(EmailMultiAlternatives):
@@ -119,7 +130,18 @@ class WorkspaceInvitationEmail(BaseEmailMessage):
     def get_context(self):
         context = super().get_context()
         context.update(
-            invitation=self.invitation, public_accept_url=self.public_accept_url
+            invitation=self.invitation,
+            public_accept_url=self.public_accept_url,
+            # The names and email address are user-controlled content. Truncate
+            # pre-existing long names and prevent email clients from linkifying
+            # domain-like tokens so that invitations can't be abused for phishing.
+            invited_by_name=prevent_autolink(
+                truncatechars(self.invitation.invited_by.first_name, 60)
+            ),
+            invited_by_email=prevent_autolink(self.invitation.invited_by.email),
+            workspace_name=prevent_autolink(
+                truncatechars(self.invitation.workspace.name, 60)
+            ),
         )
         return context
 

--- a/backend/src/baserow/core/emails.py
+++ b/backend/src/baserow/core/emails.py
@@ -111,12 +111,10 @@ class WorkspaceInvitationEmail(BaseEmailMessage):
         super().__init__(*args, **kwargs)
 
     def get_subject(self):
-        return _(
-            "%(by)s invited you to %(workspace_name)s - Baserow",
-        ) % {
-            "by": self.invitation.invited_by.first_name,
-            "workspace_name": self.invitation.workspace.name,
-        }
+        # The subject must never contain user-controlled content like the inviter
+        # name or the workspace name because that can be abused to send phishing
+        # emails to anyone via workspace invitations.
+        return _("You've been invited to collaborate on Baserow")
 
     def get_context(self):
         context = super().get_context()

--- a/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
@@ -230,16 +230,15 @@ msgstr ""
 msgid "Please confirm email"
 msgstr ""
 
-#: src/baserow/core/emails.py:115
-#, python-format
-msgid "%(by)s invited you to %(workspace_name)s - Baserow"
+#: src/baserow/core/emails.py:117
+msgid "You've been invited to collaborate on Baserow"
 msgstr ""
 
-#: src/baserow/core/emails.py:148
+#: src/baserow/core/emails.py:146
 msgid "You have 1 new notification - Baserow"
 msgstr ""
 
-#: src/baserow/core/emails.py:150
+#: src/baserow/core/emails.py:148
 #, python-format
 msgid "You have %(count)d new notifications - Baserow"
 msgstr ""
@@ -359,7 +358,7 @@ msgstr[1] ""
 #: src/baserow/core/templates/baserow/core/user/change_email_confirmation.html:207
 #: src/baserow/core/templates/baserow/core/user/password_changed.html:189
 #: src/baserow/core/templates/baserow/core/user/reset_password.html:207
-#: src/baserow/core/templates/baserow/core/workspace_invitation.html:202
+#: src/baserow/core/templates/baserow/core/workspace_invitation.html:207
 msgid ""
 "Baserow is an open source no-code database tool which allows you to "
 "collaborate on projects, customers and more. It gives you the powers of a "
@@ -490,11 +489,15 @@ msgstr ""
 #: src/baserow/core/templates/baserow/core/workspace_invitation.html:178
 #, python-format
 msgid ""
-"<strong>%(first_name)s</strong> has invited you to collaborate on "
-"<strong>%(workspace_name)s</strong>."
+"<strong>%(first_name)s</strong> (%(invited_by_email)s) has invited you to "
+"collaborate on <strong>%(workspace_name)s</strong>."
 msgstr ""
 
-#: src/baserow/core/templates/baserow/core/workspace_invitation.html:187
+#: src/baserow/core/templates/baserow/core/workspace_invitation.html:183
+msgid "If you don't recognize this sender, you can safely ignore this email."
+msgstr ""
+
+#: src/baserow/core/templates/baserow/core/workspace_invitation.html:192
 msgid "Accept invitation"
 msgstr ""
 

--- a/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
+++ b/backend/src/baserow/core/locale/en/LC_MESSAGES/django.po
@@ -225,20 +225,20 @@ msgid ""
 "user \"%(disabled_user_email)s\" (%(disabled_user_id)s)."
 msgstr ""
 
-#: src/baserow/core/emails.py:97
+#: src/baserow/core/emails.py:108
 #: src/baserow/core/templates/baserow/core/user/email_pending_verification.html:173
 msgid "Please confirm email"
 msgstr ""
 
-#: src/baserow/core/emails.py:117
+#: src/baserow/core/emails.py:128
 msgid "You've been invited to collaborate on Baserow"
 msgstr ""
 
-#: src/baserow/core/emails.py:146
+#: src/baserow/core/emails.py:168
 msgid "You have 1 new notification - Baserow"
 msgstr ""
 
-#: src/baserow/core/emails.py:148
+#: src/baserow/core/emails.py:170
 #, python-format
 msgid "You have %(count)d new notifications - Baserow"
 msgstr ""

--- a/backend/src/baserow/core/templates/baserow/core/workspace_invitation.html
+++ b/backend/src/baserow/core/templates/baserow/core/workspace_invitation.html
@@ -175,7 +175,7 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter,sans-serif;font-size:13px;line-height:170%;text-align:left;color:#070810;">{% blocktrans trimmed with invitation.invited_by.first_name|truncatechars:60 as first_name and invitation.invited_by.email as invited_by_email and invitation.workspace.name|truncatechars:60 as workspace_name %} <strong>{{ first_name }}</strong> ({{ invited_by_email }}) has invited you to collaborate on <strong>{{ workspace_name }}</strong>. {% endblocktrans %}</div>
+                        <div style="font-family:Inter,sans-serif;font-size:13px;line-height:170%;text-align:left;color:#070810;">{% blocktrans trimmed with invited_by_name as first_name %} <strong>{{ first_name }}</strong> ({{ invited_by_email }}) has invited you to collaborate on <strong>{{ workspace_name }}</strong>. {% endblocktrans %}</div>
                       </td>
                     </tr>
                     <tr>

--- a/backend/src/baserow/core/templates/baserow/core/workspace_invitation.html
+++ b/backend/src/baserow/core/templates/baserow/core/workspace_invitation.html
@@ -175,7 +175,12 @@
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Inter,sans-serif;font-size:13px;line-height:170%;text-align:left;color:#070810;">{% blocktrans trimmed with invitation.invited_by.first_name as first_name and invitation.workspace.name as workspace_name %} <strong>{{ first_name }}</strong> has invited you to collaborate on <strong>{{ workspace_name }}</strong>. {% endblocktrans %}</div>
+                        <div style="font-family:Inter,sans-serif;font-size:13px;line-height:170%;text-align:left;color:#070810;">{% blocktrans trimmed with invitation.invited_by.first_name|truncatechars:60 as first_name and invitation.invited_by.email as invited_by_email and invitation.workspace.name|truncatechars:60 as workspace_name %} <strong>{{ first_name }}</strong> ({{ invited_by_email }}) has invited you to collaborate on <strong>{{ workspace_name }}</strong>. {% endblocktrans %}</div>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div style="font-family:Inter,sans-serif;font-size:13px;line-height:170%;text-align:left;color:#070810;">{% blocktrans trimmed %} If you don't recognize this sender, you can safely ignore this email. {% endblocktrans %}</div>
                       </td>
                     </tr>
                     <tr>

--- a/backend/src/baserow/core/templates/baserow/core/workspace_invitation.mjml.eta
+++ b/backend/src/baserow/core/templates/baserow/core/workspace_invitation.mjml.eta
@@ -4,7 +4,7 @@
   <mj-column>
     <mj-text mj-class="title">{% trans "Invitation" %}</mj-text>
     <mj-text mj-class="text">
-      {% blocktrans trimmed with invitation.invited_by.first_name|truncatechars:60 as first_name and invitation.invited_by.email as invited_by_email and invitation.workspace.name|truncatechars:60 as workspace_name %}
+      {% blocktrans trimmed with invited_by_name as first_name %}
         <strong>{{ first_name }}</strong> ({{ invited_by_email }}) has invited you
         to collaborate on <strong>{{ workspace_name }}</strong>.
       {% endblocktrans %}

--- a/backend/src/baserow/core/templates/baserow/core/workspace_invitation.mjml.eta
+++ b/backend/src/baserow/core/templates/baserow/core/workspace_invitation.mjml.eta
@@ -4,9 +4,14 @@
   <mj-column>
     <mj-text mj-class="title">{% trans "Invitation" %}</mj-text>
     <mj-text mj-class="text">
-      {% blocktrans trimmed with invitation.invited_by.first_name as first_name and invitation.workspace.name as workspace_name %}
-        <strong>{{ first_name }}</strong> has invited you to collaborate on
-        <strong>{{ workspace_name }}</strong>.
+      {% blocktrans trimmed with invitation.invited_by.first_name|truncatechars:60 as first_name and invitation.invited_by.email as invited_by_email and invitation.workspace.name|truncatechars:60 as workspace_name %}
+        <strong>{{ first_name }}</strong> ({{ invited_by_email }}) has invited you
+        to collaborate on <strong>{{ workspace_name }}</strong>.
+      {% endblocktrans %}
+    </mj-text>
+    <mj-text mj-class="text">
+      {% blocktrans trimmed %}
+        If you don't recognize this sender, you can safely ignore this email.
       {% endblocktrans %}
     </mj-text>
     <mj-button mj-class="button" href="{{ public_accept_url }}">

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -558,6 +558,74 @@ def test_admin_can_create_user(api_client, data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_admin_user_name_validation(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token(
+        email="test@test.nl",
+        password="password",
+        first_name="Test1",
+        is_staff=True,
+    )
+    list_url = reverse("api:admin:users:list")
+    edit_url = reverse("api:admin:users:edit", kwargs={"user_id": user.id})
+
+    response = api_client.post(
+        list_url,
+        {
+            "username": "test2@test.nl",
+            "password": "Test1234",
+            "name": "Blocked! Verify at poshmark-helps.com",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["name"][0]["code"] == "invalid_name"
+
+    response = api_client.patch(
+        edit_url,
+        {"name": "Blocked! Verify at poshmark-helps.com"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["detail"]["name"][0]["code"] == "invalid_name"
+
+    response = api_client.patch(
+        edit_url,
+        {"name": "test@test.nl"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["detail"]["name"][0]["code"] == "name_is_email"
+
+    response = api_client.patch(
+        edit_url,
+        {"name": "x" * 61},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["detail"]["name"][0]["code"] == "max_length"
+
+    response = api_client.patch(
+        edit_url,
+        {"name": "J.Smith"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.first_name == "J.Smith"
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_admin_can_patch_user(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token(
         email="test@test.nl",

--- a/backend/tests/baserow/api/groups/test_workspace_views.py
+++ b/backend/tests/baserow/api/groups/test_workspace_views.py
@@ -162,6 +162,59 @@ def test_create_workspace(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_workspace_name_validation(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workspace = data_fixture.create_workspace(user=user, name="Old name")
+
+    invalid_names = [
+        "SOMETHING! Your account has been blocked: something-helps.com",
+        "Verify again: x.gd/bot",
+        "www.evil.com",
+        "https://evil.com",
+        "bad\nname",
+    ]
+    for invalid_name in invalid_names:
+        response = api_client.post(
+            reverse("api:workspaces:list"),
+            {"name": invalid_name},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        response_json = response.json()
+        assert response.status_code == HTTP_400_BAD_REQUEST, invalid_name
+        assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+        assert response_json["detail"]["name"][0]["code"] == "invalid_name"
+
+        url = reverse("api:workspaces:item", kwargs={"workspace_id": workspace.id})
+        response = api_client.patch(
+            url,
+            {"name": invalid_name},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        response_json = response.json()
+        assert response.status_code == HTTP_400_BAD_REQUEST, invalid_name
+        assert response_json["detail"]["name"][0]["code"] == "invalid_name"
+
+    workspace.refresh_from_db()
+    assert workspace.name == "Old name"
+
+    # Dotted names without a high risk TLD or path must still be allowed.
+    valid_names = ["Dept. Marketing", "rocket.ia", "team.exenra"]
+    for valid_name in valid_names:
+        url = reverse("api:workspaces:item", kwargs={"workspace_id": workspace.id})
+        response = api_client.patch(
+            url,
+            {"name": valid_name},
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {token}",
+        )
+        assert response.status_code == HTTP_200_OK, valid_name
+        workspace.refresh_from_db()
+        assert workspace.name == valid_name
+
+
+@pytest.mark.django_db
 def test_update_workspace(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     user_2, token_2 = data_fixture.create_user_and_token()

--- a/backend/tests/baserow/api/users/test_user_views.py
+++ b/backend/tests/baserow/api/users/test_user_views.py
@@ -83,7 +83,7 @@ def test_create_user(client, data_fixture):
     assert response_failed.status_code == 400
     assert response_failed.json()["error"] == "ERROR_EMAIL_ALREADY_EXISTS"
 
-    too_long_name = "x" * 151
+    too_long_name = "x" * 61
     response_failed = client.post(
         reverse("api:user:index"),
         {
@@ -99,7 +99,7 @@ def test_create_user(client, data_fixture):
         "name": [
             {
                 "code": "max_length",
-                "error": "Ensure this field has no more than 150 characters.",
+                "error": "Ensure this field has no more than 60 characters.",
             }
         ]
     }
@@ -183,7 +183,7 @@ def test_create_user(client, data_fixture):
     )
 
     # Test username with maximum length
-    long_username = "x" * 150
+    long_username = "x" * 60
     response = client.post(
         reverse("api:user:index"),
         {
@@ -199,7 +199,7 @@ def test_create_user(client, data_fixture):
     assert user.first_name == long_username
 
     # Test username with length exceeding the maximum
-    even_longer_username = "x" * 200
+    even_longer_username = "x" * 61
     response = client.post(
         reverse("api:user:index"),
         {
@@ -209,8 +209,94 @@ def test_create_user(client, data_fixture):
         },
         format="json",
     )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
+    data_fixture.create_password_provider()
+    valid_password = "thisIsAValidPassword"
+
+    invalid_names = [
+        "POSHMARK! Your account has been blocked: poshmark-helps.com",
+        "Your account has been blocked: x.gd/2Bqbt",
+        "www.evil.com",
+        "http://x",
+        "https://evil.com",
+        "bad\nname",
+    ]
+    for invalid_name in invalid_names:
+        response = client.post(
+            reverse("api:user:index"),
+            {
+                "name": invalid_name,
+                "email": "spammer@test.nl",
+                "password": valid_password,
+            },
+            format="json",
+        )
+        response_json = response.json()
+        assert response.status_code == HTTP_400_BAD_REQUEST, invalid_name
+        assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+        assert response_json["detail"]["name"][0]["code"] == "invalid_name"
+
+    valid_names = [
+        "Dr. Smith",
+        "St. John",
+        "J.R.R. Tolkien",
+        "Mary-Jane O'Neil",
+    ]
+    for index, valid_name in enumerate(valid_names):
+        response = client.post(
+            reverse("api:user:index"),
+            {
+                "name": valid_name,
+                "email": f"user{index}@test.nl",
+                "password": valid_password,
+            },
+            format="json",
+        )
+        assert response.status_code == HTTP_200_OK, valid_name
+        user = User.objects.get(email=f"user{index}@test.nl")
+        assert user.first_name == valid_name
+
+
+@pytest.mark.django_db
+def test_user_account_name_validation(data_fixture, api_client):
+    user, token = data_fixture.create_user_and_token(
+        email="test@localhost.nl", first_name="Nikolas"
+    )
+
+    response = api_client.patch(
+        reverse("api:user:account"),
+        {"first_name": "Account blocked, verify at poshmark-helps.com"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
     response_json = response.json()
-    assert response_failed.status_code == 400
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["first_name"][0]["code"] == "invalid_name"
+
+    response = api_client.patch(
+        reverse("api:user:account"),
+        {"first_name": "x" * 61},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["detail"]["first_name"][0]["code"] == "max_length"
+
+    response = api_client.patch(
+        reverse("api:user:account"),
+        {"first_name": "x" * 60},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+    user.refresh_from_db()
+    assert user.first_name == "x" * 60
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/api/users/test_user_views.py
+++ b/backend/tests/baserow/api/users/test_user_views.py
@@ -218,11 +218,14 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
     valid_password = "thisIsAValidPassword"
 
     invalid_names = [
-        "POSHMARK! Your account has been blocked: poshmark-helps.com",
-        "Your account has been blocked: x.gd/2Bqbt",
+        "SOMETHING! Your account has been blocked: something-helps.com",
+        "Your account has been blocked: x.gd/bot",
         "www.evil.com",
         "http://x",
         "https://evil.com",
+        "scam.xyz",
+        "evil.click",
+        "unknown-tld.weirdtld/path",
         "bad\nname",
     ]
     for invalid_name in invalid_names:
@@ -245,6 +248,14 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         "St. John",
         "J.R.R. Tolkien",
         "Mary-Jane O'Neil",
+        "J.Smith",
+        "A.Merkel",
+        "John.Smith",
+        "O.J.Simpson",
+        "tech.something",
+        "something.AI",
+        "b.something",
+        "startup.ai",
     ]
     for index, valid_name in enumerate(valid_names):
         response = client.post(
@@ -259,6 +270,29 @@ def test_create_user_with_url_in_name_is_rejected(client, data_fixture):
         assert response.status_code == HTTP_200_OK, valid_name
         user = User.objects.get(email=f"user{index}@test.nl")
         assert user.first_name == valid_name
+
+
+@pytest.mark.django_db
+def test_create_user_with_email_as_name_is_rejected(client, data_fixture):
+    data_fixture.create_password_provider()
+
+    response = client.post(
+        reverse("api:user:index"),
+        {
+            "name": "john.smith@gmail.com",
+            "email": "john.smith@gmail.com",
+            "password": "thisIsAValidPassword",
+        },
+        format="json",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response_json["detail"]["name"][0]["code"] == "name_is_email"
+    assert (
+        response_json["detail"]["name"][0]["error"]
+        == "Please enter your name, not your email address."
+    )
 
 
 @pytest.mark.django_db
@@ -277,6 +311,16 @@ def test_user_account_name_validation(data_fixture, api_client):
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
     assert response_json["detail"]["first_name"][0]["code"] == "invalid_name"
+
+    response = api_client.patch(
+        reverse("api:user:account"),
+        {"first_name": "test@localhost.nl"},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["detail"]["first_name"][0]["code"] == "name_is_email"
 
     response = api_client.patch(
         reverse("api:user:account"),

--- a/backend/tests/baserow/core/test_core_handler.py
+++ b/backend/tests/baserow/core/test_core_handler.py
@@ -534,7 +534,11 @@ def test_get_workspace_invitation(data_fixture):
 
 @pytest.mark.django_db(transaction=True)
 def test_send_workspace_invitation_email(data_fixture, mailoutbox):
-    workspace_invitation = data_fixture.create_workspace_invitation()
+    user = data_fixture.create_user(first_name="Nikolas", email="inviter@example.com")
+    workspace = data_fixture.create_workspace(user=user, name="Test workspace")
+    workspace_invitation = data_fixture.create_workspace_invitation(
+        invited_by=user, workspace=workspace
+    )
     handler = CoreHandler()
 
     with pytest.raises(BaseURLHostnameNotAllowed):
@@ -556,14 +560,17 @@ def test_send_workspace_invitation_email(data_fixture, mailoutbox):
     assert workspace_invitation.email in email.to
 
     html_body = email.alternatives[0][0]
-    assert workspace_invitation.invited_by.first_name in html_body
-    assert f"({workspace_invitation.invited_by.email})" in html_body
+    assert "Nikolas" in html_body
+    # The displayed email address gets a zero-width space inserted after every
+    # dot to prevent email clients from linkifying it.
+    assert "(inviter@example.\u200bcom)" in html_body
+    assert "Test workspace" in html_body
     assert (
         "If you don't recognize this sender, you can safely ignore this email."
         in html_body
     )
-    assert workspace_invitation.invited_by.first_name in email.body
-    assert f"({workspace_invitation.invited_by.email})" in email.body
+    assert "Nikolas" in email.body
+    assert "(inviter@example.\u200bcom)" in email.body
     search_url = "http://localhost:3000/workspace-invite/"
     start_url_index = html_body.index(search_url)
 
@@ -580,8 +587,11 @@ def test_send_workspace_invitation_email(data_fixture, mailoutbox):
 def test_send_workspace_invitation_email_in_different_language(
     data_fixture, mailoutbox
 ):
-    user = data_fixture.create_user(language="fr")
-    workspace_invitation = data_fixture.create_workspace_invitation(invited_by=user)
+    user = data_fixture.create_user(language="fr", first_name="InviterXyz")
+    workspace = data_fixture.create_workspace(user=user, name="WorkspaceXyz")
+    workspace_invitation = data_fixture.create_workspace_invitation(
+        invited_by=user, workspace=workspace
+    )
 
     handler = CoreHandler()
     handler.send_workspace_invitation_email(
@@ -590,7 +600,12 @@ def test_send_workspace_invitation_email_in_different_language(
     )
 
     assert len(mailoutbox) == 1
-    assert mailoutbox[0].subject == "You've been invited to collaborate on Baserow"
+    # The subject must never contain user-controlled content, regardless of the
+    # language it is rendered in, because that can be abused for phishing.
+    subject = mailoutbox[0].subject
+    assert subject != ""
+    assert "InviterXyz" not in subject
+    assert "WorkspaceXyz" not in subject
 
 
 @pytest.mark.django_db(transaction=True)
@@ -612,6 +627,40 @@ def test_send_workspace_invitation_email_truncates_long_names(data_fixture, mail
     assert "x" * 150 not in html_body
     assert "y" * 59 + "…" in html_body
     assert "y" * 150 not in html_body
+
+
+@pytest.mark.django_db(transaction=True)
+def test_send_workspace_invitation_email_prevents_domain_linkification(
+    data_fixture, mailoutbox
+):
+    # Workspace names may legitimately contain domains, and pre-existing user
+    # names and unverified email addresses can too. A zero-width space must be
+    # inserted after every dot so that email clients don't turn them into
+    # clickable links.
+    user = data_fixture.create_user(
+        first_name="Nikolas", email="scammer@evil-domain.com"
+    )
+    workspace = data_fixture.create_workspace(user=user, name="poshmark-helps.com")
+    workspace_invitation = data_fixture.create_workspace_invitation(
+        invited_by=user, workspace=workspace
+    )
+
+    CoreHandler().send_workspace_invitation_email(
+        invitation=workspace_invitation,
+        base_url="http://localhost:3000/workspace-invite",
+    )
+
+    assert len(mailoutbox) == 1
+    email = mailoutbox[0]
+    html_body = email.alternatives[0][0]
+
+    assert "poshmark-helps.com" not in html_body
+    assert "poshmark-helps.\u200bcom" in html_body
+    assert "scammer@evil-domain.com" not in html_body
+    assert "scammer@evil-domain.\u200bcom" in html_body
+
+    assert "poshmark-helps.com" not in email.body
+    assert "poshmark-helps.\u200bcom" in email.body
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/core/test_core_handler.py
+++ b/backend/tests/baserow/core/test_core_handler.py
@@ -551,14 +551,19 @@ def test_send_workspace_invitation_email(data_fixture, mailoutbox):
     assert len(mailoutbox) == 1
     email = mailoutbox[0]
 
-    assert (
-        email.subject == f"{workspace_invitation.invited_by.first_name} invited you "
-        f"to {workspace_invitation.workspace.name} - Baserow"
-    )
+    assert email.subject == "You've been invited to collaborate on Baserow"
     assert email.from_email == "no-reply@localhost"
     assert workspace_invitation.email in email.to
 
     html_body = email.alternatives[0][0]
+    assert workspace_invitation.invited_by.first_name in html_body
+    assert f"({workspace_invitation.invited_by.email})" in html_body
+    assert (
+        "If you don't recognize this sender, you can safely ignore this email."
+        in html_body
+    )
+    assert workspace_invitation.invited_by.first_name in email.body
+    assert f"({workspace_invitation.invited_by.email})" in email.body
     search_url = "http://localhost:3000/workspace-invite/"
     start_url_index = html_body.index(search_url)
 
@@ -585,11 +590,28 @@ def test_send_workspace_invitation_email_in_different_language(
     )
 
     assert len(mailoutbox) == 1
-    assert (
-        mailoutbox[0].subject
-        == f"{workspace_invitation.invited_by.first_name} vous a invité à "
-        f"{workspace_invitation.workspace.name} - Baserow"
+    assert mailoutbox[0].subject == "You've been invited to collaborate on Baserow"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_send_workspace_invitation_email_truncates_long_names(data_fixture, mailoutbox):
+    user = data_fixture.create_user(first_name="x" * 150)
+    workspace = data_fixture.create_workspace(user=user, name="y" * 150)
+    workspace_invitation = data_fixture.create_workspace_invitation(
+        invited_by=user, workspace=workspace
     )
+
+    CoreHandler().send_workspace_invitation_email(
+        invitation=workspace_invitation,
+        base_url="http://localhost:3000/workspace-invite",
+    )
+
+    assert len(mailoutbox) == 1
+    html_body = mailoutbox[0].alternatives[0][0]
+    assert "x" * 59 + "…" in html_body
+    assert "x" * 150 not in html_body
+    assert "y" * 59 + "…" in html_body
+    assert "y" * 150 not in html_body
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/feature/hardened_workspace_invitation_emails_and_user_name_validatio.json
+++ b/changelog/entries/unreleased/feature/hardened_workspace_invitation_emails_and_user_name_validatio.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Hardened workspace invitation emails and user name validation to prevent phishing abuse",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-06"
+}

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -115,6 +115,7 @@
     "minLength": "A minimum of {min} characters is required here.",
     "maxLength": "A maximum of {max} characters is allowed here.",
     "minMaxLength": "A minimum of {min} and a maximum of {max} characters is allowed here.",
+    "nameContainsUrl": "Names can't contain links, domains or web addresses.",
     "invalidCharacters": "This field contains invalid characters.",
     "requiredField": "This field is required.",
     "integerField": "The field must be an integer.",

--- a/web-frontend/locales/en.json
+++ b/web-frontend/locales/en.json
@@ -116,6 +116,7 @@
     "maxLength": "A maximum of {max} characters is allowed here.",
     "minMaxLength": "A minimum of {min} and a maximum of {max} characters is allowed here.",
     "nameContainsUrl": "Names can't contain links, domains or web addresses.",
+    "nameCantBeEmail": "Please enter your name, not your email address.",
     "invalidCharacters": "This field contains invalid characters.",
     "requiredField": "This field is required.",
     "integerField": "The field must be an integer.",

--- a/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
+++ b/web-frontend/modules/core/components/admin/users/forms/UserForm.vue
@@ -24,7 +24,13 @@
           {{ $t('error.minLength', { min: 2 }) }}
         </span>
         <span v-else-if="v$.values.name.maxLength.$invalid">
-          {{ $t('error.maxLength', { max: 150 }) }}
+          {{ $t('error.maxLength', { max: 60 }) }}
+        </span>
+        <span v-else-if="v$.values.name.nameIsNotEmail.$invalid">
+          {{ $t('error.nameCantBeEmail') }}
+        </span>
+        <span v-else-if="v$.values.name.nameContainsNoUrl.$invalid">
+          {{ $t('error.nameContainsUrl') }}
         </span>
       </template>
     </FormGroup>
@@ -144,6 +150,10 @@ import { reactive } from 'vue'
 import { email, maxLength, minLength, required } from '@vuelidate/validators'
 
 import form from '@baserow/modules/core/mixins/form'
+import {
+  nameContainsNoUrl,
+  nameIsNotEmail,
+} from '@baserow/modules/core/validators'
 
 export default {
   name: 'UserForm',
@@ -174,7 +184,9 @@ export default {
         name: {
           required,
           minLength: minLength(2),
-          maxLength: maxLength(150),
+          maxLength: maxLength(60),
+          nameIsNotEmail,
+          nameContainsNoUrl,
         },
         username: {
           required,

--- a/web-frontend/modules/core/components/auth/PasswordRegister.vue
+++ b/web-frontend/modules/core/components/auth/PasswordRegister.vue
@@ -69,6 +69,14 @@
           <i class="iconoir-warning-triangle"></i>
           <span
             v-if="
+              v$.account.name.nameIsNotEmail &&
+              v$.account.name.nameIsNotEmail.$invalid
+            "
+          >
+            {{ $t('error.nameCantBeEmail') }}
+          </span>
+          <span
+            v-else-if="
               v$.account.name.nameContainsNoUrl &&
               v$.account.name.nameContainsNoUrl.$invalid
             "
@@ -136,6 +144,7 @@ import PasswordInput from '@baserow/modules/core/components/helpers/PasswordInpu
 import CaptchaWidget from '@baserow/modules/core/components/auth/CaptchaWidget'
 import {
   nameContainsNoUrl,
+  nameIsNotEmail,
   passwordValidation,
 } from '@baserow/modules/core/validators'
 
@@ -172,6 +181,7 @@ export default {
           required,
           minLength: minLength(2),
           maxLength: maxLength(60),
+          nameIsNotEmail,
           nameContainsNoUrl,
         },
         password: passwordValidation,

--- a/web-frontend/modules/core/components/auth/PasswordRegister.vue
+++ b/web-frontend/modules/core/components/auth/PasswordRegister.vue
@@ -67,7 +67,17 @@
 
         <template #error>
           <i class="iconoir-warning-triangle"></i>
-          {{ $t('error.minMaxLength', { min: 2, max: 150 }) }}
+          <span
+            v-if="
+              v$.account.name.nameContainsNoUrl &&
+              v$.account.name.nameContainsNoUrl.$invalid
+            "
+          >
+            {{ $t('error.nameContainsUrl') }}
+          </span>
+          <span v-else>
+            {{ $t('error.minMaxLength', { min: 2, max: 60 }) }}
+          </span>
         </template>
       </FormGroup>
 
@@ -124,7 +134,10 @@ import { ResponseErrorMessage } from '@baserow/modules/core/plugins/clientHandle
 import error from '@baserow/modules/core/mixins/error'
 import PasswordInput from '@baserow/modules/core/components/helpers/PasswordInput'
 import CaptchaWidget from '@baserow/modules/core/components/auth/CaptchaWidget'
-import { passwordValidation } from '@baserow/modules/core/validators'
+import {
+  nameContainsNoUrl,
+  passwordValidation,
+} from '@baserow/modules/core/validators'
 
 export default {
   name: 'PasswordRegister',
@@ -158,7 +171,8 @@ export default {
         name: {
           required,
           minLength: minLength(2),
-          maxLength: maxLength(150),
+          maxLength: maxLength(60),
+          nameContainsNoUrl,
         },
         password: passwordValidation,
       },

--- a/web-frontend/modules/core/components/settings/AccountForm.vue
+++ b/web-frontend/modules/core/components/settings/AccountForm.vue
@@ -45,6 +45,7 @@ import { required, maxLength, minLength, helpers } from '@vuelidate/validators'
 import { useI18n } from 'vue-i18n'
 
 import form from '@baserow/modules/core/mixins/form'
+import { nameContainsNoUrl } from '@baserow/modules/core/validators'
 
 export default {
   name: 'AccountForm',
@@ -77,17 +78,21 @@ export default {
           ),
           minLength: helpers.withMessage(
             this.$t('error.minMaxLength', {
-              max: 150,
+              max: 60,
               min: 2,
             }),
             minLength(2)
           ),
           maxLength: helpers.withMessage(
             this.$t('error.minMaxLength', {
-              max: 150,
+              max: 60,
               min: 2,
             }),
-            maxLength(150)
+            maxLength(60)
+          ),
+          nameContainsNoUrl: helpers.withMessage(
+            this.$t('error.nameContainsUrl'),
+            nameContainsNoUrl
           ),
         },
       },

--- a/web-frontend/modules/core/components/settings/AccountForm.vue
+++ b/web-frontend/modules/core/components/settings/AccountForm.vue
@@ -45,7 +45,10 @@ import { required, maxLength, minLength, helpers } from '@vuelidate/validators'
 import { useI18n } from 'vue-i18n'
 
 import form from '@baserow/modules/core/mixins/form'
-import { nameContainsNoUrl } from '@baserow/modules/core/validators'
+import {
+  nameContainsNoUrl,
+  nameIsNotEmail,
+} from '@baserow/modules/core/validators'
 
 export default {
   name: 'AccountForm',
@@ -89,6 +92,10 @@ export default {
               min: 2,
             }),
             maxLength(60)
+          ),
+          nameIsNotEmail: helpers.withMessage(
+            this.$t('error.nameCantBeEmail'),
+            nameIsNotEmail
           ),
           nameContainsNoUrl: helpers.withMessage(
             this.$t('error.nameContainsUrl'),

--- a/web-frontend/modules/core/components/workspace/WorkspaceForm.vue
+++ b/web-frontend/modules/core/components/workspace/WorkspaceForm.vue
@@ -15,7 +15,7 @@
         @blur="v$.values.name.$touch"
       ></FormInput>
 
-      <template #error>{{ $t('error.requiredField') }}</template>
+      <template #error>{{ v$.values.name.$errors[0]?.$message }}</template>
     </FormGroup>
     <slot></slot>
   </form>
@@ -26,6 +26,7 @@ import { useVuelidate } from '@vuelidate/core'
 import { required, helpers } from '@vuelidate/validators'
 
 import form from '@baserow/modules/core/mixins/form'
+import { nameContainsNoUrl } from '@baserow/modules/core/validators'
 
 export default {
   name: 'WorkspaceForm',
@@ -54,6 +55,10 @@ export default {
           required: helpers.withMessage(
             this.$t('error.requiredField'),
             required
+          ),
+          nameContainsNoUrl: helpers.withMessage(
+            this.$t('error.nameContainsUrl'),
+            nameContainsNoUrl
           ),
         },
       },

--- a/web-frontend/modules/core/locales/en.json
+++ b/web-frontend/modules/core/locales/en.json
@@ -221,6 +221,9 @@
   "workspaceForm": {
     "nameLabel": "Name"
   },
+  "editWorkspace": {
+    "invalidNameTitle": "Workspace name not allowed"
+  },
   "leaveWorkspaceModal": {
     "title": "Leave {workspace}",
     "message": "Are you sure you want to leave the workspace {workspace}? You won't be able to access the related applications anymore and if you want to regain access, one of the admins must invite you again. If you leave the workspace, it will not be deleted. All the other members will still have access to it. It is not possible to leave a workspace if you're the last admin because that will leave it unmaintained.",

--- a/web-frontend/modules/core/mixins/editWorkspace.js
+++ b/web-frontend/modules/core/mixins/editWorkspace.js
@@ -1,4 +1,5 @@
 import { notifyIf } from '@baserow/modules/core/utils/error'
+import { nameContainsNoUrl } from '@baserow/modules/core/validators'
 
 /**
  * Some helper methods to modify workspaces used by the dashboard.
@@ -13,6 +14,18 @@ export default {
       this.$refs.rename.edit()
     },
     async renameWorkspace(workspace, event) {
+      // The name is edited inline without a form, so there is no place to show
+      // a validation error. Show a toast notification instead and revert the
+      // name.
+      if (!nameContainsNoUrl(event.value)) {
+        this.$refs.rename.set(event.oldValue)
+        this.$store.dispatch('toast/error', {
+          title: this.$t('editWorkspace.invalidNameTitle'),
+          message: this.$t('error.nameContainsUrl'),
+        })
+        return
+      }
+
       this.setLoading(workspace, true)
 
       try {

--- a/web-frontend/modules/core/validators.js
+++ b/web-frontend/modules/core/validators.js
@@ -15,11 +15,23 @@ export const passwordValidation = {
 
 // Must be kept in sync with the backend equivalent in
 // backend/src/baserow/api/user/validators.py. Rejects URL-like content (protocol,
-// `www.` prefix or domain-like token) and control characters to prevent abuse of
-// transactional emails for phishing.
-const URL_LIKE_NAME_REGEX = /https?:\/\/|www\.|\S\.[a-zA-Z]{2,}/i
+// `www.` prefix, domain-like token with a high risk TLD, or any domain-like token
+// followed by a path), control characters, and email addresses to prevent abuse of
+// transactional emails for phishing. Startup TLDs like `.ai` are deliberately not
+// listed because real users have names like `startup.ai`.
+const HIGH_RISK_TLDS =
+  'com|net|org|io|co|info|biz|xyz|top|shop|site|online|link|club|app|dev|' +
+  'live|me|ly|to|cc|gd|ru|cn|de|uk|nl|tk|ml|ga|cf|gq|click|icu|buzz|pw|vip'
+const URL_LIKE_NAME_REGEX = new RegExp(
+  `https?://|www\\.|[a-z0-9][a-z0-9-]*\\.(?:${HIGH_RISK_TLDS})\\b|\\S\\.[a-zA-Z]{2,}/`,
+  'i'
+)
+const EMAIL_LIKE_NAME_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHARS_REGEX = /[\u0000-\u001f\u007f]/
 
 export const nameContainsNoUrl = (value) =>
   !URL_LIKE_NAME_REGEX.test(value) && !CONTROL_CHARS_REGEX.test(value)
+
+export const nameIsNotEmail = (value) =>
+  !EMAIL_LIKE_NAME_REGEX.test(value.trim())

--- a/web-frontend/modules/core/validators.js
+++ b/web-frontend/modules/core/validators.js
@@ -1,7 +1,7 @@
 /*
   In case the password validation rules change the PasswordInput component
   needs to be updated as well in order to display possible new error messages
-  
+
   modules/core/components/helpers/PasswordInput.vue
 */
 
@@ -12,3 +12,14 @@ export const passwordValidation = {
   maxLength: maxLength(256),
   minLength: minLength(8),
 }
+
+// Must be kept in sync with the backend equivalent in
+// backend/src/baserow/api/user/validators.py. Rejects URL-like content (protocol,
+// `www.` prefix or domain-like token) and control characters to prevent abuse of
+// transactional emails for phishing.
+const URL_LIKE_NAME_REGEX = /https?:\/\/|www\.|\S\.[a-zA-Z]{2,}/i
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_REGEX = /[\u0000-\u001f\u007f]/
+
+export const nameContainsNoUrl = (value) =>
+  !URL_LIKE_NAME_REGEX.test(value) && !CONTROL_CHARS_REGEX.test(value)

--- a/web-frontend/test/unit/core/validators.spec.js
+++ b/web-frontend/test/unit/core/validators.spec.js
@@ -1,0 +1,32 @@
+import { nameContainsNoUrl } from '@baserow/modules/core/validators'
+
+describe('nameContainsNoUrl', () => {
+  const validNames = [
+    'Dr. Smith',
+    'St. John',
+    'J.R.R. Tolkien',
+    'Mary-Jane O’Neil',
+    "Mary-Jane O'Neil",
+    'Anne-Marie',
+    'Bram',
+  ]
+
+  const invalidNames = [
+    'POSHMARK! Your account has been blocked: poshmark-helps.com',
+    'Your account has been blocked. Verify again: x.gd/2Bqbt',
+    'www.evil.com',
+    'http://x',
+    'https://evil.com',
+    'A.Smith',
+    'bad\nname',
+    'bad\tname',
+  ]
+
+  test.each(validNames)('accepts %j', (name) => {
+    expect(nameContainsNoUrl(name)).toBe(true)
+  })
+
+  test.each(invalidNames)('rejects %j', (name) => {
+    expect(nameContainsNoUrl(name)).toBe(false)
+  })
+})

--- a/web-frontend/test/unit/core/validators.spec.js
+++ b/web-frontend/test/unit/core/validators.spec.js
@@ -1,4 +1,7 @@
-import { nameContainsNoUrl } from '@baserow/modules/core/validators'
+import {
+  nameContainsNoUrl,
+  nameIsNotEmail,
+} from '@baserow/modules/core/validators'
 
 describe('nameContainsNoUrl', () => {
   const validNames = [
@@ -9,15 +12,25 @@ describe('nameContainsNoUrl', () => {
     "Mary-Jane O'Neil",
     'Anne-Marie',
     'Bram',
+    'J.Smith',
+    'A.Merkel',
+    'John.Smith',
+    'O.J.Simpson',
+    'tech.something',
+    'something.AI',
+    'b.something',
+    'startup.ai',
   ]
 
   const invalidNames = [
-    'POSHMARK! Your account has been blocked: poshmark-helps.com',
-    'Your account has been blocked. Verify again: x.gd/2Bqbt',
+    'SOMETHING! Your account has been blocked: something-helps.com',
+    'Your account has been blocked. Verify again: x.gd/bot',
     'www.evil.com',
     'http://x',
     'https://evil.com',
-    'A.Smith',
+    'scam.xyz',
+    'evil.click',
+    'unknown-tld.weirdtld/path',
     'bad\nname',
     'bad\tname',
   ]
@@ -29,4 +42,20 @@ describe('nameContainsNoUrl', () => {
   test.each(invalidNames)('rejects %j', (name) => {
     expect(nameContainsNoUrl(name)).toBe(false)
   })
+})
+
+describe('nameIsNotEmail', () => {
+  test.each(['J.Smith', 'Dr. Smith', 'Bram', 'name with @ in it'])(
+    'accepts %j',
+    (name) => {
+      expect(nameIsNotEmail(name)).toBe(true)
+    }
+  )
+
+  test.each(['john.smith@gmail.com', 'user@example.org', ' user@example.org '])(
+    'rejects %j',
+    (name) => {
+      expect(nameIsNotEmail(name)).toBe(false)
+    }
+  )
 })


### PR DESCRIPTION
### What is in this PR

We've been seeing abuse of the user invite system on baserow.io. They're using names like "Evil! Your account has been blocked. Please complete verification again: evil.com Best regards" and then start inviting a lot of users to the workspace, so that the content is included in the email.

This pull request hardens the workspace invigation and user name validation to make sure that it's not of value to such spammers anymore.

- Reduces the name max length to 60.
- Validates if domains, links, etc are not present in the name.
- Removed the name from the invite email subject.
- Truncates long names and workspaces in the email.
- Adds sending email to the invite email body and a warning that if the sending email is not recognized.

### How to test this PR

- Check if the above points are working as expected.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
