### PR TITLE
fix: cascade realtime updates in public and restricted views (#5657)

### DIFF
--- a/backend/src/baserow/contrib/database/ws/rows/tasks.py
+++ b/backend/src/baserow/contrib/database/ws/rows/tasks.py
@@ -14,6 +14,7 @@ from baserow.contrib.database.api.rows.serializers import (
 from baserow.contrib.database.rows.registries import row_metadata_registry
 from baserow.contrib.database.table.models import Table
 from baserow.contrib.database.ws.rows.messages import RealtimeRowMessages
+from baserow.contrib.database.ws.views.rows.handler import ViewRealtimeRowsHandler
 from baserow.ws.registries import page_registry
 from baserow.ws.tasks import ChannelGroupMessage, send_messages_to_channel_group
 
@@ -60,15 +61,16 @@ def broadcast_dependant_rows_updated(
     table_page_type = page_registry.get("table")
     channel_layer = get_channel_layer()
     before_by_id = {row["id"]: row for row in (serialized_rows_before or [])}
+    serialized_rows = get_row_serializer_class(model, RowSerializer, is_response=True)(
+        rows, many=True
+    ).data
     payload = RealtimeRowMessages.rows_updated(
         table_id=table_id,
         # Rows without a snapshot fall back to an id-only skeleton.
         serialized_rows_before_update=[
             before_by_id.get(row.id, {"id": row.id}) for row in rows
         ],
-        serialized_rows=get_row_serializer_class(
-            model, RowSerializer, is_response=True
-        )(rows, many=True).data,
+        serialized_rows=serialized_rows,
         metadata=row_metadata_registry.generate_and_merge_metadata_for_rows(
             None, table, [row.id for row in rows]
         ),
@@ -85,4 +87,11 @@ def broadcast_dependant_rows_updated(
                 "exclude_user_ids": None,
             },
         ),
+    )
+
+    # The table page broadcast above doesn't reach publicly shared or restricted
+    # views: those filter rows against the view's filters and live on their own
+    # page groups.
+    ViewRealtimeRowsHandler().broadcast_dependant_rows_updated_to_views(
+        table, model, rows, serialized_rows, updated_field_ids
     )

--- a/backend/src/baserow/contrib/database/ws/views/rows/handler.py
+++ b/backend/src/baserow/contrib/database/ws/views/rows/handler.py
@@ -1,10 +1,14 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from django.db.models import BooleanField, Case, Q, Value, When
 
 from baserow.contrib.database.table.models import GeneratedTableModel, Table
 from baserow.contrib.database.views.models import View
-from baserow.contrib.database.views.row_checker import FilteredViewRowChecker
+from baserow.contrib.database.views.row_checker import (
+    FilteredViewRowChecker,
+    ViewHandler,
+)
+from baserow.contrib.database.ws.rows.messages import RealtimeRowMessages
 
 from .registries import view_realtime_rows_registry
 
@@ -83,3 +87,60 @@ class ViewRealtimeRowsHandler:
         for t in view_realtime_rows_registry.get_all():
             if getattr(view, self._is_name(t.type), False):
                 t.broadcast(view, payload, user=user)
+
+    def broadcast_dependant_rows_updated_to_views(
+        self,
+        table: Table,
+        model: GeneratedTableModel,
+        rows: List[GeneratedTableModel],
+        serialized_rows: List[Dict[str, Any]],
+        updated_field_ids: List[int],
+    ) -> None:
+        """
+        Broadcasts a dependency cascade update to the publicly shared and
+        restricted views of the table, so a row still matching a view's filters
+        gets a `rows_updated` event carrying only that view's visible fields.
+
+        The before row is an id-only skeleton, so the client resolves the before
+        state from its buffered copy (the mechanism from #5642). A row that a
+        cascade pushes out of, or into, a filtered view is not reconciled here
+        and settles on the next refresh (tracked in #5649): the pre-cascade
+        visibility a delete or create would need can't be reconstructed after the
+        cascade has run, and a public client has no filters to reject a row that
+        no longer matches, so sending its new values (or a bare delete) would
+        leak data or corrupt the client's row count.
+
+        :param table: The table the cascade-affected rows belong to.
+        :param model: The model of the table including all fields.
+        :param rows: The affected rows with their post-cascade values.
+        :param serialized_rows: The serialized post-cascade rows, aligned with
+            `rows`, restricted per view before broadcasting.
+        :param updated_field_ids: The ids of the fields whose values changed.
+        """
+
+        row_checker = self.get_views_row_checker(
+            table, model, only_include_views_which_want_realtime_events=True
+        )
+        views = row_checker.get_filtered_views_where_rows_are_visible(rows)
+        if not views:
+            return
+
+        view_handler = ViewHandler()
+        for view, visible_row_ids in views:
+            visible_rows = view_handler.restrict_rows_for_view(
+                view, serialized_rows, visible_row_ids
+            )
+            if not visible_rows:
+                continue
+            self.broadcast_to_types(
+                view,
+                RealtimeRowMessages.rows_updated(
+                    table_id=table.id,
+                    serialized_rows_before_update=[
+                        {"id": row["id"]} for row in visible_rows
+                    ],
+                    serialized_rows=visible_rows,
+                    metadata={},
+                    updated_field_ids=updated_field_ids,
+                ),
+            )

--- a/backend/tests/baserow/contrib/database/ws/public/test_public_ws_dependant_rows_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/public/test_public_ws_dependant_rows_signals.py
@@ -1,0 +1,270 @@
+from unittest.mock import patch
+
+from django.db import connection, transaction
+from django.test.utils import CaptureQueriesContext
+
+import pytest
+
+from baserow.contrib.database.api.constants import PUBLIC_PLACEHOLDER_ENTITY_ID
+from baserow.contrib.database.api.rows.serializers import (
+    RowSerializer,
+    get_row_serializer_class,
+)
+from baserow.contrib.database.rows.handler import RowHandler
+from baserow.contrib.database.ws.views.rows.handler import ViewRealtimeRowsHandler
+
+
+def _payloads_for_view(mock_broadcast_to_channel_group, slug):
+    """The payloads broadcast to a public view's page group, in call order."""
+
+    group_name = f"view-{slug}"
+    return [
+        call.args[1]
+        for call in mock_broadcast_to_channel_group.delay.mock_calls
+        if call.args and call.args[0] == group_name
+    ]
+
+
+def _setup_linked_tables_with_public_view(data_fixture, user, filter_value):
+    table_a, table_b, link_a_b = data_fixture.create_two_linked_tables(user=user)
+    primary_b = table_b.field_set.get(primary=True).specific
+    lookup_a = data_fixture.create_formula_field(
+        table=table_a, formula="join(lookup('link', 'primary'), '')"
+    )
+
+    public_view = data_fixture.create_grid_view(
+        user, table=table_a, public=True, create_options=False
+    )
+    data_fixture.create_grid_view_field_option(public_view, lookup_a, hidden=False)
+    data_fixture.create_view_filter(
+        view=public_view, field=lookup_a, type="contains", value=filter_value
+    )
+
+    return table_a, table_b, link_a_b, primary_b, lookup_a, public_view
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_dependant_row_still_matching_filter_receives_rows_updated_in_public_view(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    user = data_fixture.create_user()
+    (
+        table_a,
+        table_b,
+        link_a_b,
+        primary_b,
+        lookup_a,
+        public_view,
+    ) = _setup_linked_tables_with_public_view(data_fixture, user, filter_value="keep")
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "keep me"}])
+        .created_rows[0]
+    )
+    row_a1 = (
+        RowHandler()
+        .create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+        .created_rows[0]
+    )
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user, table_b, [{"id": row_b1.id, primary_b.db_column: "keep me too"}]
+        )
+
+    payloads = _payloads_for_view(mock_broadcast_to_channel_group, public_view.slug)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["type"] == "rows_updated"
+    assert payload["table_id"] == PUBLIC_PLACEHOLDER_ENTITY_ID
+    assert [row["id"] for row in payload["rows"]] == [row_a1.id]
+    assert payload["rows"][0][f"field_{lookup_a.id}"] == "keep me too"
+    # No pre-cascade values are sent: they might belong to a row the view never
+    # showed. The client resolves the before state from its own buffered copy.
+    assert payload["rows_before_update"] == [{"id": row_a1.id}]
+    # Fields without a grid view option are hidden, so only the visible field leaks.
+    assert set(payload["rows"][0].keys()) == {"id", "order", f"field_{lookup_a.id}"}
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_dependant_row_leaving_filter_gets_no_realtime_event_in_public_view(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    # A cascade that pushes a row out of a filtered public view can't be
+    # reconciled without its pre-cascade visibility: no delete is sent (a bare
+    # delete would corrupt the filterless public client's row count), so the row
+    # settles on the next refresh. See #5649.
+    user = data_fixture.create_user()
+    (
+        table_a,
+        table_b,
+        link_a_b,
+        primary_b,
+        lookup_a,
+        public_view,
+    ) = _setup_linked_tables_with_public_view(data_fixture, user, filter_value="old")
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "old"}])
+        .created_rows[0]
+    )
+    RowHandler().create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user, table_b, [{"id": row_b1.id, primary_b.db_column: "new"}]
+        )
+
+    assert _payloads_for_view(mock_broadcast_to_channel_group, public_view.slug) == []
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_only_still_matching_dependant_rows_are_broadcast_to_public_view(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    # When a single cascade updates several dependant rows, the public view only
+    # receives the ones still matching its filters; a row pushed out is silently
+    # left for the next refresh and its values never reach the view.
+    user = data_fixture.create_user()
+    (
+        table_a,
+        table_b,
+        link_a_b,
+        primary_b,
+        lookup_a,
+        public_view,
+    ) = _setup_linked_tables_with_public_view(data_fixture, user, filter_value="keep")
+
+    row_b1, row_b2 = (
+        RowHandler()
+        .create_rows(
+            user,
+            table_b,
+            [{primary_b.db_column: "keep"}, {primary_b.db_column: "keep"}],
+        )
+        .created_rows
+    )
+    row_a1 = (
+        RowHandler()
+        .create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+        .created_rows[0]
+    )
+    row_a2 = (
+        RowHandler()
+        .create_rows(user, table_a, [{link_a_b.db_column: [row_b2.id]}])
+        .created_rows[0]
+    )
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user,
+            table_b,
+            [
+                {"id": row_b1.id, primary_b.db_column: "keep still"},
+                {"id": row_b2.id, primary_b.db_column: "dropped"},
+            ],
+        )
+
+    payloads = _payloads_for_view(mock_broadcast_to_channel_group, public_view.slug)
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["type"] == "rows_updated"
+    # Only row_a1 still matches "keep"; row_a2 left the view and must be absent.
+    assert [row["id"] for row in payload["rows"]] == [row_a1.id]
+    assert payload["rows"][0][f"field_{lookup_a.id}"] == "keep still"
+    assert row_a2.id not in [row["id"] for row in payload["rows"]]
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_dependant_rows_updates_are_not_broadcast_when_table_has_no_public_view(
+    mock_broadcast_to_channel_group, data_fixture
+):
+    user = data_fixture.create_user()
+    table_a, table_b, link_a_b = data_fixture.create_two_linked_tables(user=user)
+    primary_b = table_b.field_set.get(primary=True).specific
+    data_fixture.create_formula_field(
+        table=table_a, formula="join(lookup('link', 'primary'), '')"
+    )
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "b1"}])
+        .created_rows[0]
+    )
+    RowHandler().create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user, table_b, [{"id": row_b1.id, primary_b.db_column: "renamed"}]
+        )
+
+    view_calls = [
+        call
+        for call in mock_broadcast_to_channel_group.delay.mock_calls
+        if call.args and str(call.args[0]).startswith("view-")
+    ]
+    assert view_calls == []
+
+
+def _count_broadcast_to_views_queries(data_fixture, user, n_public_views):
+    table_a, table_b, link_a_b = data_fixture.create_two_linked_tables(user=user)
+    primary_b = table_b.field_set.get(primary=True).specific
+    lookup_a = data_fixture.create_formula_field(
+        table=table_a, formula="join(lookup('link', 'primary'), '')"
+    )
+    for _ in range(n_public_views):
+        view = data_fixture.create_grid_view(
+            user, table=table_a, public=True, create_options=False
+        )
+        data_fixture.create_grid_view_field_option(view, lookup_a, hidden=False)
+        data_fixture.create_view_filter(
+            view=view, field=lookup_a, type="contains", value="keep"
+        )
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "keep"}])
+        .created_rows[0]
+    )
+    row_a1 = (
+        RowHandler()
+        .create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+        .created_rows[0]
+    )
+
+    model = table_a.get_model()
+    rows = list(model.objects.filter(id__in=[row_a1.id]).enhance_by_fields())
+    serialized_rows = get_row_serializer_class(model, RowSerializer, is_response=True)(
+        rows, many=True
+    ).data
+
+    with CaptureQueriesContext(connection) as captured:
+        ViewRealtimeRowsHandler().broadcast_dependant_rows_updated_to_views(
+            table_a, model, rows, serialized_rows, [lookup_a.id]
+        )
+    return len(captured.captured_queries)
+
+
+@pytest.mark.django_db
+def test_broadcast_to_views_is_one_query_without_views_and_flat_across_views(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+
+    # No public/restricted view: a single lookup that finds none, then nothing.
+    assert _count_broadcast_to_views_queries(data_fixture, user, 0) == 1
+
+    # The per-row-batch work is fixed, so adding more views must not add queries.
+    one_view = _count_broadcast_to_views_queries(data_fixture, user, 1)
+    three_views = _count_broadcast_to_views_queries(data_fixture, user, 3)
+    assert one_view == three_views

--- a/changelog/entries/unreleased/bug/shared_and_restricted_views_now_update_formula_lookup_and_li.json
+++ b/changelog/entries/unreleased/bug/shared_and_restricted_views_now_update_formula_lookup_and_li.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Shared and restricted views now update formula, lookup and link cells when related rows change",
+    "issue_origin": "github",
+    "issue_number": 5657,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-06"
+}

--- a/enterprise/backend/tests/baserow_enterprise_tests/ws/test_restricted_view_dependant_rows_signals.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/ws/test_restricted_view_dependant_rows_signals.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+from django.db import transaction
+
+import pytest
+
+from baserow.contrib.database.rows.handler import RowHandler
+from baserow_enterprise.view_ownership_types import RestrictedViewOwnershipType
+
+
+def _payloads_for_restricted_view(mock_broadcast_to_channel_group, view_id):
+    """The payloads broadcast to a restricted view's page group, in call order."""
+
+    group_name = f"restricted-view-{view_id}"
+    return [
+        call.args[1]
+        for call in mock_broadcast_to_channel_group.delay.mock_calls
+        if call.args and call.args[0] == group_name
+    ]
+
+
+def _setup_linked_tables_with_restricted_view(
+    enterprise_data_fixture, user, filter_value
+):
+    table_a, table_b, link_a_b = enterprise_data_fixture.create_two_linked_tables(
+        user=user
+    )
+    primary_b = table_b.field_set.get(primary=True).specific
+    lookup_a = enterprise_data_fixture.create_formula_field(
+        table=table_a, formula="join(lookup('link', 'primary'), '')"
+    )
+
+    restricted_view = enterprise_data_fixture.create_grid_view(
+        user,
+        table=table_a,
+        ownership_type=RestrictedViewOwnershipType.type,
+        create_options=False,
+    )
+    enterprise_data_fixture.create_grid_view_field_option(
+        restricted_view, lookup_a, hidden=False
+    )
+    enterprise_data_fixture.create_view_filter(
+        view=restricted_view, field=lookup_a, type="contains", value=filter_value
+    )
+
+    return table_a, table_b, link_a_b, primary_b, lookup_a, restricted_view
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_dependant_row_still_matching_filter_receives_rows_updated_in_restricted_view(
+    mock_broadcast_to_channel_group, enterprise_data_fixture
+):
+    user = enterprise_data_fixture.create_user()
+    (
+        table_a,
+        table_b,
+        link_a_b,
+        primary_b,
+        lookup_a,
+        restricted_view,
+    ) = _setup_linked_tables_with_restricted_view(
+        enterprise_data_fixture, user, filter_value="keep"
+    )
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "keep me"}])
+        .created_rows[0]
+    )
+    row_a1 = (
+        RowHandler()
+        .create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+        .created_rows[0]
+    )
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user, table_b, [{"id": row_b1.id, primary_b.db_column: "keep me too"}]
+        )
+
+    payloads = _payloads_for_restricted_view(
+        mock_broadcast_to_channel_group, restricted_view.id
+    )
+    assert len(payloads) == 1
+    payload = payloads[0]
+    assert payload["type"] == "rows_updated"
+    assert payload["table_id"] == table_a.id
+    assert [row["id"] for row in payload["rows"]] == [row_a1.id]
+    assert payload["rows"][0][f"field_{lookup_a.id}"] == "keep me too"
+    assert payload["rows_before_update"] == [{"id": row_a1.id}]
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_dependant_row_leaving_filter_gets_no_realtime_event_in_restricted_view(
+    mock_broadcast_to_channel_group, enterprise_data_fixture
+):
+    # A cascade that pushes a row out of a filtered restricted view can't be
+    # reconciled without its pre-cascade visibility, so no event is sent and the
+    # row settles on the next refresh. See #5649.
+    user = enterprise_data_fixture.create_user()
+    (
+        table_a,
+        table_b,
+        link_a_b,
+        primary_b,
+        lookup_a,
+        restricted_view,
+    ) = _setup_linked_tables_with_restricted_view(
+        enterprise_data_fixture, user, filter_value="old"
+    )
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "old"}])
+        .created_rows[0]
+    )
+    RowHandler().create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(
+            user, table_b, [{"id": row_b1.id, primary_b.db_column: "new"}]
+        )
+
+    assert (
+        _payloads_for_restricted_view(
+            mock_broadcast_to_channel_group, restricted_view.id
+        )
+        == []
+    )


### PR DESCRIPTION
Closes #5657 (follow-up of #5642).

Dependency-cascade updates — formula, lookup, rollup and link cells in a related table — now broadcast to publicly shared and restricted views too, filtered against each view's filters. Backend-only; reuses the existing view realtime path.

Refresh-to-settle gaps, tracked in #5649: a row a cascade pushes into or out of a filtered view, and cascades over `BASEROW_DEPENDANT_ROWS_REALTIME_UPDATE_LIMIT`.
