### PR TITLE
fix: group-by grid view review follow-ups

### DIFF
--- a/web-frontend/modules/database/components/view/grid/GridView.vue
+++ b/web-frontend/modules/database/components/view/grid/GridView.vue
@@ -61,7 +61,7 @@
       @cell-mouseup-left="multiSelectStop"
       @cell-shift-click="multiSelectShiftClick"
       @add-row="addRow($event)"
-      @add-rows="$refs.rowsAddContext.toggleNextToMouse($event)"
+      @add-rows="openAddRowsContext($event)"
       @add-row-after="addRowAfter($event)"
       @update="updateValue"
       @paste="multiplePasteFromCell"
@@ -137,7 +137,7 @@
       @row-hover="setRowHover($event.row, $event.value)"
       @row-context="showRowContext($event.event, $event.row)"
       @add-row="addRow($event)"
-      @add-rows="$refs.rowsAddContext.toggleNextToMouse($event)"
+      @add-rows="openAddRowsContext($event)"
       @add-row-after="addRowAfter($event)"
       @update="updateValue"
       @paste="multiplePasteFromCell"
@@ -408,6 +408,8 @@ export default {
       refreshingRow: false,
       resizeObserver: null,
       presenceSpaceName: null,
+      // Group path for the "add N rows" menu, or null for the flat button.
+      addRowsGroupPath: null,
     }
   },
   computed: {
@@ -1153,21 +1155,43 @@ export default {
         notifyIf(error, 'row')
       }
     },
+    openAddRowsContext(payload) {
+      // Grouped button sends { event, groupPath }; flat sends the raw event.
+      // Stash the path so addRows seeds the batch into the right group.
+      const isGroupedPayload =
+        payload !== null &&
+        typeof payload === 'object' &&
+        'groupPath' in payload
+      this.addRowsGroupPath = isGroupedPayload ? payload.groupPath : null
+      this.$refs.rowsAddContext.toggleNextToMouse(
+        isGroupedPayload ? payload.event : payload
+      )
+    },
     async addRows(rowsAmount) {
       this.$refs.rowsAddContext.hide()
+      const groupPath = this.addRowsGroupPath
+      this.addRowsGroupPath = null
+      // We need a list of all fields including the primary one here.
+      const params = {
+        view: this.view,
+        table: this.table,
+        fields: this.fields,
+        rows: Array.from(Array(rowsAmount)).map(() => ({})),
+        selectPrimaryCell: true,
+        isRowOpenedInModal: this.isRowOpenedInModal,
+      }
       try {
-        await this.$store.dispatch(
-          this.storePrefix + 'view/grid/createNewRows',
-          {
-            view: this.view,
-            table: this.table,
-            // We need a list of all fields including the primary one here.
-            fields: this.fields,
-            rows: Array.from(Array(rowsAmount)).map(() => ({})),
-            selectPrimaryCell: true,
-            isRowOpenedInModal: this.isRowOpenedInModal,
-          }
-        )
+        if (groupPath !== null) {
+          await this.$store.dispatch(
+            this.storePrefix + 'view/grid/createNewRowsInGroup',
+            { ...params, path: groupPath }
+          )
+        } else {
+          await this.$store.dispatch(
+            this.storePrefix + 'view/grid/createNewRows',
+            params
+          )
+        }
       } catch (error) {
         notifyIf(error, 'row')
       }

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
@@ -92,6 +92,7 @@
           width: sectionWidth + 'px',
         }"
         @click="addRow($event, item.path)"
+        @click.right.prevent="addRows($event, item.path)"
         @mouseover="setAddRowHover(item.path)"
         @mouseleave="setAddRowHover(null)"
       >
@@ -180,6 +181,7 @@ export default {
     'unselect',
     'select-next',
     'add-row',
+    'add-rows',
     'add-row-after',
     'edit-modal',
     'refresh-row',
@@ -263,6 +265,10 @@ export default {
     addRow(event, path) {
       event.preventFieldCellUnselect = true
       this.$emit('add-row', { groupPath: path })
+    },
+    addRows(event, path) {
+      event.preventFieldCellUnselect = true
+      this.$emit('add-rows', { event, groupPath: path })
     },
     setAddRowHover(path) {
       this.$store.dispatch(

--- a/web-frontend/modules/database/components/view/grid/GridViewSection.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewSection.vue
@@ -102,6 +102,7 @@
             @unselect="$emit('unselect', $event)"
             @select-next="$emit('select-next', $event)"
             @add-row="$emit('add-row', $event)"
+            @add-rows="$emit('add-rows', $event)"
             @add-row-after="$emit('add-row-after', $event)"
             @edit-modal="$emit('edit-modal', $event)"
             @refresh-row="$emit('refresh-row', $event)"

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -941,6 +941,9 @@ export const state = () => ({
   // Keep the original row and field index to remember where the selection began
   multiSelectStartRowIndex: -1,
   multiSelectStartFieldIndex: -1,
+  // Row holding the single cell selection (-1 if none). Lets grouped
+  // SET_SELECTED_CELL clear it O(1) via rowLocations, no full scan.
+  selectedRowId: -1,
   // The last used grid id.
   lastGridId: -1,
   // If true, ad hoc filtering is used instead of persistent one
@@ -1376,21 +1379,31 @@ export const mutations = {
     }
   },
   SET_SELECTED_CELL(state, { rowId, fieldId }) {
-    const visitRow = (row) => {
-      if (row._.selected) {
-        row._.selected = false
-        row._.selectedFieldId = -1
-      }
-      if (row.id === rowId) {
-        row._.selected = true
-        row._.selectedFieldId = fieldId
-      }
-    }
-
     if (state.activeGroupBys.length > 0) {
-      forEachGroupByRow(state.groupBy.sectionRows, visitRow)
+      // Only selectedRowId can carry _.selected, so clear it directly via
+      // rowLocations instead of scanning every loaded row.
+      const previousRow = getGroupByRowStateById(state, state.selectedRowId)
+      if (previousRow?._.selected) {
+        previousRow._.selected = false
+        previousRow._.selectedFieldId = -1
+      }
+      const newRow = getGroupByRowStateById(state, rowId)
+      if (newRow) {
+        newRow._.selected = true
+        newRow._.selectedFieldId = fieldId
+      }
+      state.selectedRowId = newRow ? rowId : -1
     } else {
-      state.rows.forEach(visitRow)
+      state.rows.forEach((row) => {
+        if (row._.selected) {
+          row._.selected = false
+          row._.selectedFieldId = -1
+        }
+        if (row.id === rowId) {
+          row._.selected = true
+          row._.selectedFieldId = fieldId
+        }
+      })
     }
   },
   SET_MULTISELECT_START_ROW_INDEX(state, value) {
@@ -1536,6 +1549,12 @@ export const mutations = {
         const selectedIndex = state.checkboxSelectedRows.indexOf(oldRow.id)
         if (selectedIndex !== -1) {
           state.checkboxSelectedRows[selectedIndex] = newRow.id
+        }
+
+        // The cell-selection pointer is keyed by id, so it must follow the
+        // temp -> backend id swap or a later deselect can't find the row.
+        if (state.selectedRowId === oldRowId) {
+          state.selectedRowId = newRow.id
         }
 
         const existingRowState =
@@ -2793,14 +2812,6 @@ export const actions = {
     }
   ) {
     const { $client, $config } = this
-    const previousGroupByMode = getters.isGroupByMode
-    const previousGroupByCollapse = clone(getters.getGroupByCollapse)
-    const previousGroupByCollapseInitialized =
-      state.groupBy.collapseInitialized === true
-    const previousGroupByFields = getGroupByFieldsFromActiveGroupBys(
-      state.activeGroupBys,
-      fields
-    )
     const nextGroupBys = clone(view.group_bys || [])
     const groupBysChanged = !_.isEqual(state.activeGroupBys || [], nextGroupBys)
     commit('SET_ADHOC_FILTERING', adhocFiltering)
@@ -2859,40 +2870,16 @@ export const actions = {
     }
 
     if (getters.isGroupByMode) {
-      const groupByFields = getGroupByFieldsFromActiveGroupBys(
-        nextGroupBys,
-        fields
-      )
-      const groupByCollapse =
-        previousGroupByMode || previousGroupByCollapseInitialized
-          ? projectGroupByCollapseState(
-              previousGroupByCollapse,
-              previousGroupByFields,
-              groupByFields
-            )
-          : getGroupByCollapseAllState(false)
+      // Snapshot-and-swap instead of clearing the grid before the fetch, so
+      // a plain refresh never blanks. preserveScroll keeps scroll/collapse.
       const refresh = Promise.resolve()
         .then(async () => {
-          commit('SET_GROUP_BY_COLLAPSE', groupByCollapse)
-          commit('RESET_GROUP_BY_DATA')
-          // Per-group values + footer totals come bundled in this one request, so the
-          // standalone /aggregations/ fetch is not needed in grouped mode.
-          await dispatch('fetchGroupByData', {
-            gridId,
-            view,
-            fields,
-            adhocFiltering,
-            includeDescendants: groupByCollapse.mode === 'expand',
-            descendantLimit: getters.getBufferRequestSize,
-            descendantRowBudget: getGroupByDescendantRowBudget(getters),
-            includeTotals: true,
-          })
-          await dispatch('fetchGroupByRowsByScrollTop', {
-            gridId,
+          await dispatch('refreshActiveGroupBys', {
             view,
             fields,
             scrollTop: getters.getScrollTop,
             includeFieldOptions,
+            preserveScroll: true,
           })
           dispatch('correctMultiSelect')
         })
@@ -3004,12 +2991,20 @@ export const actions = {
   },
   async refreshActiveGroupBys(
     { commit, getters, rootGetters, state },
-    { view, fields, scrollTop, includeFieldOptions = false }
+    {
+      view,
+      fields,
+      scrollTop,
+      includeFieldOptions = false,
+      preserveScroll = false,
+    }
   ) {
+    // preserveScroll reuses this atomic fetch-then-swap for a plain refresh
+    // (unchanged group-bys): keep current scroll and collapse, no reset.
     const { $client, $config, $registry } = this
     const nextGroupBys = clone(view.group_bys || [])
     const previousGroupBys = state.activeGroupBys || []
-    if (_.isEqual(previousGroupBys, nextGroupBys)) {
+    if (!preserveScroll && _.isEqual(previousGroupBys, nextGroupBys)) {
       return false
     }
     if (nextGroupBys.length === 0) {
@@ -3025,13 +3020,15 @@ export const actions = {
       return false
     }
 
-    // New group-by fields rebuild the layout, so the old scroll offset points at an
-    // unloaded region of the new tree. Restart at the top, which this refresh fetches.
-    scrollTop = 0
-    commit('SET_SCROLL_TOP', 0)
-    fireScrollTop.distance = 0
-    fireScrollTop.last = Date.now()
-    fireScrollTop.processing = false
+    // Changed group-by fields rebuild the layout, so restart at the top; an
+    // unchanged-group-bys refresh keeps the layout and its scroll position.
+    if (!preserveScroll) {
+      scrollTop = 0
+      commit('SET_SCROLL_TOP', 0)
+      fireScrollTop.distance = 0
+      fireScrollTop.last = Date.now()
+      fireScrollTop.processing = false
+    }
 
     const previousGroupByFields = getGroupByFieldsFromActiveGroupBys(
       previousGroupBys,
@@ -3054,7 +3051,11 @@ export const actions = {
     // express a mixed collapse, so an expanded branch's deeper nodes go unfetched and
     // render empty. Force expand-all to fetch the whole visible tree. Single-level views
     // fetch their rows separately, so they're unaffected.
-    if (groupByFields.length > 1 && groupByCollapse.paths.length > 0) {
+    if (
+      !preserveScroll &&
+      groupByFields.length > 1 &&
+      groupByCollapse.paths.length > 0
+    ) {
       groupByCollapse = getGroupByCollapseAllState(false)
     }
 
@@ -3071,7 +3072,9 @@ export const actions = {
     // first page is independent of the new tree and can be fetched in parallel with the
     // skeleton. Mixed/collapsed states tie their offsets to the tree, so they can't.
     const parallelExpandRows =
-      groupByCollapse.mode === 'expand' && groupByCollapse.paths.length === 0
+      scrollTop === 0 &&
+      groupByCollapse.mode === 'expand' &&
+      groupByCollapse.paths.length === 0
         ? GridService($client).fetchRows({
             gridId,
             offset: 0,
@@ -4179,6 +4182,41 @@ export const actions = {
       groupPath: path,
       selectPrimaryCell,
       isRowOpenedInModal,
+    })
+  },
+  async createNewRowsInGroup(
+    { dispatch, getters },
+    {
+      view,
+      table,
+      fields,
+      path,
+      rows,
+      before = null,
+      selectPrimaryCell = false,
+      isRowOpenedInModal = undefined,
+      undoRedoActionGroupId = null,
+      skipFetchByScrollTop = false,
+    }
+  ) {
+    const groupByFields = getGroupByFieldsFromActiveGroupBys(
+      getters.getActiveGroupBys,
+      fields
+    )
+    const groupValues = groupPathDefaults(path, groupByFields, this.$registry)
+    // Seed the group values into every row so the batch keeps them together
+    // in this group instead of scattering them by their own values.
+    await dispatch('createNewRows', {
+      view,
+      table,
+      fields,
+      rows: rows.map((values) => ({ ...values, ...groupValues })),
+      before,
+      groupPath: path,
+      selectPrimaryCell,
+      isRowOpenedInModal,
+      undoRedoActionGroupId,
+      skipFetchByScrollTop,
     })
   },
   async createNewRows(

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -1016,6 +1016,7 @@ export const mutations = {
     state.pendingFieldOps = {}
     state.checkboxSelectedRows = []
     state.selectionType = null
+    state.selectedRowId = -1
     state.groupBy = {
       ...getEmptyGroupByState(),
       generation: getNextGroupByGeneration(state),
@@ -1613,6 +1614,9 @@ export const mutations = {
    * Deletes a row of which we are sure that it is in the buffer right now.
    */
   DELETE_ROW_IN_BUFFER(state, row) {
+    if (state.selectedRowId === row.id) {
+      state.selectedRowId = -1
+    }
     if (state.activeGroupBys.length > 0) {
       const location = state.groupBy.rowLocations[row.id]
       if (location) {
@@ -1638,6 +1642,9 @@ export const mutations = {
    * Deletes a row from the buffer without updating the buffer limit and count.
    */
   DELETE_ROW_IN_BUFFER_WITHOUT_UPDATE(state, row) {
+    if (state.selectedRowId === row.id) {
+      state.selectedRowId = -1
+    }
     if (state.activeGroupBys.length > 0) {
       const location = state.groupBy.rowLocations[row.id]
       if (location) {
@@ -2990,7 +2997,7 @@ export const actions = {
     return lastRefreshRequest
   },
   async refreshActiveGroupBys(
-    { commit, getters, rootGetters, state },
+    { commit, dispatch, getters, rootGetters, state },
     {
       view,
       fields,
@@ -3235,6 +3242,19 @@ export const actions = {
       } else {
         commit('REPLACE_ALL_FIELD_OPTIONS', rowData.field_options)
       }
+    }
+    if (preserveScroll) {
+      // Clamp scrollTop to viewport after swapping in snapshot layout.
+      // Fetch the slice anchored there; no-ops if snapshot covers viewport.
+      const clampedScrollTop = getClampedGroupByScrollTop(getters)
+      commit('SET_SCROLL_TOP', clampedScrollTop)
+      await dispatch('fetchGroupByRowsByScrollTop', {
+        gridId,
+        view,
+        fields,
+        scrollTop: clampedScrollTop,
+        includeFieldOptions: includeFieldOptions && rowData === null,
+      })
     }
     return true
   },

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -2486,6 +2486,104 @@ describe('Grid view store', () => {
     fetchByScrollTopDelayed.mockRestore()
   })
 
+  test('createNewRowsInGroup seeds the group values into every batch-created row', async () => {
+    const fields = [
+      {
+        id: 1,
+        name: 'Name',
+        type: 'text',
+        primary: true,
+        _: { type: { type: 'text' } },
+      },
+      {
+        id: 2,
+        name: 'Team',
+        type: 'text',
+        _: { type: { type: 'text' } },
+      },
+    ]
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 1,
+      bufferStartIndex: 0,
+      bufferLimit: 3,
+      fieldOptions: {
+        1: { hidden: false, order: 0 },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        treeNodes: [{ path: { field_2: 'B' }, depth: 0, row_count: 1 }],
+        truncated: false,
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    store.replaceState({ ...store.state, grid: state })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'B'),
+      rows: [
+        {
+          id: 10,
+          order: '1.00',
+          field_1: 'Existing',
+          field_2: 'B',
+          _: {
+            selected: false,
+            selectedFieldId: -1,
+            selectedBy: [],
+            loading: false,
+            matchFilters: true,
+            matchSortings: true,
+            matchSearch: true,
+            fieldSearchMatches: [],
+            persistentId: 'r10',
+          },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    mockServer.mock.onPost('/database/rows/table/1/batch/').reply(200, {
+      items: [
+        { id: 11, order: '2.00', field_1: '', field_2: 'B' },
+        { id: 12, order: '3.00', field_1: '', field_2: 'B' },
+      ],
+      metadata: { updated_field_ids: [] },
+    })
+
+    await store.dispatch('grid/createNewRowsInGroup', {
+      view: {
+        id: 1,
+        filters: [],
+        filter_groups: [],
+        filter_type: 'AND',
+        sortings: [],
+        group_bys: groupBys,
+      },
+      table: { id: 1 },
+      fields,
+      path: { field_2: 'B' },
+      // The right-click "add N rows" affordance sends N empty rows; the group
+      // values must be seeded from the path, not from the (empty) row values.
+      rows: [{}, {}],
+      skipFetchByScrollTop: true,
+    })
+
+    const requestItems = JSON.parse(mockServer.mock.history.post[0].data).items
+    expect(requestItems).toHaveLength(2)
+    expect(requestItems.every((item) => item.field_2 === 'B')).toBe(true)
+
+    expect(
+      store.state.grid.groupBy.sectionRows[groupPathKey(2, 'B')].map(
+        (row) => row.id
+      )
+    ).toEqual([10, 11, 12])
+    expect(store.state.grid.count).toBe(3)
+  })
+
   test('createNewRowInGroup does not show a moved warning for the optimistic row', async () => {
     const fields = [
       {
@@ -4809,6 +4907,129 @@ describe('Grid view store', () => {
     expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
+  test('grouped refresh with unchanged group-bys keeps existing rows visible until the fetch resolves', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      // Same group-bys as the active ones: this is the plain-refresh path
+      // (filter/search/generic) that used to clear the grid before fetching.
+      group_bys: groupBys,
+    }
+    const groupByStore = testApp.createStore({
+      modules: {
+        view: {
+          namespaced: true,
+          getters: { get: () => () => view },
+        },
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: 1,
+      rowHeight: 33,
+      windowHeight: 330,
+      groupBy: {
+        treeNodes: [{ path: { field_2: 'A' }, depth: 0, row_count: 1 }],
+        pages: {
+          '': {
+            parentPath: {},
+            nodes: {
+              0: {
+                path: { field_2: 'A' },
+                depth: 0,
+                row_count: 1,
+                sibling_index: 0,
+                row_offset: 0,
+              },
+            },
+            totalSiblingCount: 1,
+          },
+        },
+        absoluteRows: {
+          0: { id: 10, order: '1.00', field_1: 'Alice', field_2: 'A' },
+        },
+        revision: 0,
+        generation: 5,
+        truncated: false,
+        collapse: { mode: 'expand', paths: [] },
+        collapseInitialized: true,
+        sectionRows: {
+          [groupPathKey(2, 'A')]: [
+            { id: 10, order: '1.00', field_1: 'Alice', field_2: 'A' },
+          ],
+        },
+        rowLocations: {
+          10: { sectionKey: groupPathKey(2, 'A'), position: 0 },
+        },
+      },
+    })
+    groupByStore.replaceState({ ...groupByStore.state, grid: state })
+
+    let treeNodesWhenFetching = null
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(() => {
+      // The old tree must still be in live state at the moment the refresh
+      // fires its request: fetch-then-swap, not clear-then-fetch.
+      treeNodesWhenFetching = groupByStore.state.grid.groupBy.treeNodes.length
+      return [
+        200,
+        {
+          pages: [
+            {
+              parent: {},
+              groups: [
+                {
+                  path: { field_2: 'A' },
+                  depth: 0,
+                  row_count: 2,
+                  children_count: 0,
+                  sibling_index: 0,
+                  row_offset: 0,
+                },
+              ],
+              offset: 0,
+              limit: 40,
+              group_count: 1,
+            },
+          ],
+        },
+      ]
+    })
+    mockServer.mock.onGet('/database/views/grid/1/').reply(200, {
+      results: [
+        { id: 10, order: '1.00', field_1: 'Alice', field_2: 'A' },
+        { id: 11, order: '2.00', field_1: 'Amy', field_2: 'A' },
+      ],
+    })
+
+    await groupByStore.dispatch('grid/refresh', {
+      view,
+      fields: [
+        { id: 1, name: 'Name', type: 'text', primary: true },
+        { id: 2, name: 'Team', type: 'text' },
+      ],
+      adhocFiltering: false,
+      adhocSorting: false,
+    })
+
+    expect(treeNodesWhenFetching).toBeGreaterThan(0)
+    expect(groupByStore.state.grid.groupBy.treeNodes[0].row_count).toBe(2)
+  })
+
   test('late group-by data responses from an older generation are ignored', async () => {
     const fields = [
       { id: 1, name: 'Name', type: 'text', primary: true },
@@ -5083,35 +5304,49 @@ describe('Grid view store', () => {
   })
 
   test('refresh preserves group-by collapse state when already grouped', async () => {
-    const fetchGroupByData = vi.fn()
-    const fetchGroupByCount = vi.fn()
-    const fetchGroupByRowsByScrollTop = vi.fn()
     const correctMultiSelect = vi.fn()
     const fetchAllFieldAggregationData = vi.fn()
-    const groupByActions = {
-      ...gridStore.actions,
-      fetchGroupByData,
-      fetchGroupByCount,
-      fetchGroupByRowsByScrollTop,
-      correctMultiSelect,
-      fetchAllFieldAggregationData,
-    }
-    const groupByStore = testApp.createStore({
-      modules: {
-        grid: {
-          ...gridStore,
-          actions: groupByActions,
-        },
-      },
-    })
     const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
     const collapse = {
       mode: 'collapse',
       paths: [{ field_2: 'A' }],
     }
+    const view = {
+      id: 1,
+      filters: [
+        {
+          id: 1,
+          view: 1,
+          field: 1,
+          type: ContainsViewFilterType.getType(),
+          value: 'A',
+        },
+      ],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [{ field: 1, order: 'ASC' }],
+      group_bys: groupBys,
+    }
+    const groupByStore = testApp.createStore({
+      modules: {
+        view: {
+          namespaced: true,
+          getters: { get: () => () => view },
+        },
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
     const state = Object.assign(gridStore.state(), {
       lastGridId: 1,
       activeGroupBys: groupBys,
+      count: 3,
       rowHeight: 33,
       windowHeight: 330,
       groupBy: {
@@ -5121,6 +5356,7 @@ describe('Grid view store', () => {
         ],
         truncated: false,
         collapse,
+        collapseInitialized: true,
         sectionRows: {},
         rowLocations: {},
       },
@@ -5128,23 +5364,38 @@ describe('Grid view store', () => {
 
     groupByStore.replaceState({ ...groupByStore.state, grid: state })
 
+    mockServer.mock.onGet('/database/views/grid/1/group-by-data/').reply(200, {
+      pages: [
+        {
+          parent: {},
+          groups: [
+            {
+              path: { field_2: 'A' },
+              depth: 0,
+              row_count: 2,
+              sibling_index: 0,
+              row_offset: 0,
+            },
+            {
+              path: { field_2: 'B' },
+              depth: 0,
+              row_count: 1,
+              sibling_index: 1,
+              row_offset: 2,
+            },
+          ],
+          offset: 0,
+          limit: 40,
+          group_count: 2,
+        },
+      ],
+    })
+    mockServer.mock.onGet('/database/views/grid/1/').reply(200, {
+      results: [{ id: 20, order: '1.00', field_1: 'Bob', field_2: 'B' }],
+    })
+
     await groupByStore.dispatch('grid/refresh', {
-      view: {
-        id: 1,
-        filters: [
-          {
-            id: 1,
-            view: 1,
-            field: 1,
-            type: ContainsViewFilterType.getType(),
-            value: 'A',
-          },
-        ],
-        filter_groups: [],
-        filter_type: 'AND',
-        sortings: [{ field: 1, order: 'ASC' }],
-        group_bys: groupBys,
-      },
+      view,
       fields: [
         { id: 1, name: 'Name', type: 'text', primary: true },
         { id: 2, name: 'Team', type: 'text' },
@@ -5153,10 +5404,10 @@ describe('Grid view store', () => {
       adhocSorting: false,
     })
 
+    // The collapsed group survives the refresh and no separate count request
+    // is made (grouped mode bundles it into group-by-data).
     expect(groupByStore.state.grid.groupBy.collapse).toEqual(collapse)
-    expect(fetchGroupByData).toHaveBeenCalledOnce()
-    expect(fetchGroupByCount).not.toHaveBeenCalled()
-    expect(fetchGroupByRowsByScrollTop).toHaveBeenCalledOnce()
+    expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
   test('sort-only refresh keeps grouped scroll position and refetches visible row offsets', async () => {
@@ -7165,6 +7416,104 @@ describe('Grid view store', () => {
     ).toEqual([1])
   })
 
+  test('group-by SET_SELECTED_CELL tracks selectedRowId and clears the previous selection', () => {
+    const state = Object.assign(gridStore.state(), {
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      groupBy: {
+        treeNodes: [
+          { path: { field_2: 'A' }, depth: 0, row_count: 1 },
+          { path: { field_2: 'B' }, depth: 0, row_count: 1 },
+        ],
+        truncated: false,
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    store.replaceState({ ...store.state, grid: state })
+
+    const emptyUi = () => ({
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+    })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'A'),
+      rows: [{ id: 11, order: '1.00', field_2: 'A', _: emptyUi() }],
+      startPosition: 0,
+    })
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'B'),
+      rows: [{ id: 22, order: '2.00', field_2: 'B', _: emptyUi() }],
+      startPosition: 0,
+    })
+
+    const rowA = () =>
+      store.state.grid.groupBy.sectionRows[groupPathKey(2, 'A')][0]
+    const rowB = () =>
+      store.state.grid.groupBy.sectionRows[groupPathKey(2, 'B')][0]
+
+    store.commit('grid/SET_SELECTED_CELL', { rowId: 11, fieldId: 1 })
+    expect(rowA()._.selected).toBe(true)
+    expect(rowA()._.selectedFieldId).toBe(1)
+    expect(store.state.grid.selectedRowId).toBe(11)
+
+    store.commit('grid/SET_SELECTED_CELL', { rowId: 22, fieldId: 2 })
+    expect(rowA()._.selected).toBe(false)
+    expect(rowA()._.selectedFieldId).toBe(-1)
+    expect(rowB()._.selected).toBe(true)
+    expect(rowB()._.selectedFieldId).toBe(2)
+    expect(store.state.grid.selectedRowId).toBe(22)
+
+    store.commit('grid/SET_SELECTED_CELL', { rowId: -1, fieldId: -1 })
+    expect(rowB()._.selected).toBe(false)
+    expect(rowB()._.selectedFieldId).toBe(-1)
+    expect(store.state.grid.selectedRowId).toBe(-1)
+  })
+
+  test('group-by SET_SELECTED_CELL tolerates a previously selected row missing from the buffer', () => {
+    const state = Object.assign(gridStore.state(), {
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      // A stale selection pointer whose row is no longer loaded in any section.
+      selectedRowId: 999,
+      groupBy: {
+        treeNodes: [{ path: { field_2: 'A' }, depth: 0, row_count: 1 }],
+        truncated: false,
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    store.replaceState({ ...store.state, grid: state })
+
+    store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+      sectionKey: groupPathKey(2, 'A'),
+      rows: [
+        {
+          id: 11,
+          order: '1.00',
+          field_2: 'A',
+          _: {
+            selected: false,
+            selectedFieldId: -1,
+            selectedBy: [],
+            loading: false,
+          },
+        },
+      ],
+      startPosition: 0,
+    })
+
+    expect(() =>
+      store.commit('grid/SET_SELECTED_CELL', { rowId: 11, fieldId: 1 })
+    ).not.toThrow()
+    expect(
+      store.state.grid.groupBy.sectionRows[groupPathKey(2, 'A')][0]._.selected
+    ).toBe(true)
+    expect(store.state.grid.selectedRowId).toBe(11)
+  })
+
   test('group-by visible items render sparse section row ranges loaded by scroll', () => {
     const state = Object.assign(gridStore.state(), {
       scrollTop: 2 * 48 + 8 + 33 * 25,
@@ -7252,6 +7601,49 @@ describe('Grid view store', () => {
       sectionKey: groupPathKey(2, 'A'),
       position: 0,
     })
+  })
+
+  test('group-by finalize retargets selectedRowId so the finalized row can still be deselected', () => {
+    const state = Object.assign(gridStore.state(), {
+      activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+      selectedRowId: 'temporary-id',
+      groupBy: {
+        treeNodes: [{ path: { field_2: 'A' }, depth: 0, row_count: 1 }],
+        truncated: false,
+        collapse: { mode: 'expand', paths: [] },
+        sectionRows: {},
+        rowLocations: {},
+      },
+    })
+    store.replaceState({ ...store.state, grid: state })
+
+    const row = {
+      id: 'temporary-id',
+      order: '3.00',
+      field_1: '',
+      field_2: 'A',
+      _: { selected: true, selectedFieldId: 1, selectedBy: [1], loading: true },
+    }
+    store.commit('grid/INSERT_ROW_AT_LOCATION', {
+      sectionKey: groupPathKey(2, 'A'),
+      position: 0,
+      row,
+    })
+    store.commit('grid/FINALIZE_ROWS_IN_BUFFER', {
+      oldRows: [row],
+      newRows: [{ id: 12, order: '4.00', field_1: '', field_2: 'A' }],
+      fields: ['field_1', 'field_2'],
+    })
+
+    // The temp id was replaced by the backend id, so the selection pointer must
+    // follow it; otherwise a later deselect can't find the row to clear it.
+    expect(store.state.grid.selectedRowId).toBe(12)
+
+    store.commit('grid/SET_SELECTED_CELL', { rowId: -1, fieldId: -1 })
+    expect(
+      store.state.grid.groupBy.sectionRows[groupPathKey(2, 'A')][0]._.selected
+    ).toBe(false)
+    expect(store.state.grid.selectedRowId).toBe(-1)
   })
 
   test('createdNewRow', async () => {

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -5557,6 +5557,155 @@ describe('Grid view store', () => {
     expect(fetchAllFieldAggregationData).not.toHaveBeenCalled()
   })
 
+  test('plain refresh scrolled past the first group page refetches the viewport groups and rows', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const groupBys = [{ field: 2, order: 'ASC', type: 'default' }]
+    const fields = [
+      { id: 1, name: 'Name', type: 'text', primary: true },
+      { id: 2, name: 'Team', type: 'text' },
+    ]
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      group_bys: groupBys,
+    }
+    const groupByStore = testApp.createStore({
+      modules: {
+        view: {
+          namespaced: true,
+          getters: {
+            get: () => () => view,
+          },
+        },
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
+
+    const groupCount = 60
+    const rowsPerGroup = 100
+    const groupName = (index) => `G${String(index).padStart(2, '0')}`
+    const makeGroups = (start, end) =>
+      Array.from({ length: end - start }, (_, i) => {
+        const index = start + i
+        return {
+          path: { field_2: groupName(index) },
+          depth: 0,
+          row_count: rowsPerGroup,
+          sibling_index: index,
+          row_offset: index * rowsPerGroup,
+        }
+      })
+
+    // Group stride is 48px header + 100 rows * 33px + 8px gap = 3356px. The
+    // refresh snapshot only fetches the first 40 groups and estimates the other
+    // 20 as header-only placeholders, so 135000 (inside group 40's rows once
+    // real counts load) sits past every loaded section of the snapshot layout.
+    const scrollTop = 135000
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeGroupBys: groupBys,
+      count: groupCount * rowsPerGroup,
+      rowHeight: 33,
+      windowHeight: 330,
+      scrollTop,
+      fieldOptions: {
+        1: { hidden: false, order: 0 },
+        2: { hidden: false, order: 1 },
+      },
+      groupBy: {
+        ...gridStore.state().groupBy,
+        treeNodes: makeGroups(0, groupCount),
+        collapse: { mode: 'expand', paths: [] },
+        collapseInitialized: true,
+      },
+    })
+    groupByStore.replaceState({ ...groupByStore.state, grid: state })
+
+    const groupByDataRequests = []
+    mockServer.mock
+      .onGet('/database/views/grid/1/group-by-data/')
+      .reply((config) => {
+        groupByDataRequests.push(config.params)
+        const parents = config.params.get('parents')
+        const pageRequests = parents
+          ? JSON.parse(parents)
+          : [
+              {
+                parent: {},
+                offset: Number(config.params.get('offset')),
+                limit: Number(config.params.get('limit')),
+              },
+            ]
+        return [
+          200,
+          {
+            pages: pageRequests.map(({ parent, offset, limit }) => ({
+              parent: parent || {},
+              groups: makeGroups(offset, Math.min(offset + limit, groupCount)),
+              offset,
+              limit,
+              group_count: groupCount,
+            })),
+          },
+        ]
+      })
+    mockServer.mock.onGet('/database/views/grid/1/').reply((config) => {
+      const offset = Number(config.params.get('offset'))
+      const limit = Number(config.params.get('limit'))
+      return [
+        200,
+        {
+          count: groupCount * rowsPerGroup,
+          results: Array.from({ length: limit }, (_, index) => {
+            const absolute = offset + index
+            return {
+              id: 10000 + absolute,
+              order: `${absolute}.00`,
+              field_1: `Fresh ${absolute}`,
+              field_2: groupName(Math.floor(absolute / rowsPerGroup)),
+            }
+          }),
+        },
+      ]
+    })
+
+    await groupByStore.dispatch('grid/refresh', {
+      view,
+      fields,
+      adhocFiltering: false,
+      adhocSorting: false,
+    })
+
+    expect(groupByStore.state.grid.scrollTop).toBe(scrollTop)
+    // First request builds the snapshot from group offset 0; the follow-up
+    // fetches the group page anchored at the preserved viewport.
+    expect(groupByDataRequests.length).toBeGreaterThanOrEqual(2)
+    expect(groupByDataRequests[0].get('parents')).toBeNull()
+    expect(groupByDataRequests[0].get('offset')).toBe('0')
+    expect(JSON.parse(groupByDataRequests[1].get('parents'))[0]).toMatchObject({
+      parent: {},
+      offset: 40,
+    })
+    // The row under the preserved scroll position is loaded, not a skeleton:
+    // group 40 starts at 40 * 3356 = 134240, rows at 134288, so 135000 is
+    // position 21 (absolute row 4021).
+    const section =
+      groupByStore.state.grid.groupBy.sectionRows[groupPathKey(2, 'G40')]
+    expect(section[21].field_1).toBe('Fresh 4021')
+    expect(correctMultiSelect).toHaveBeenCalledOnce()
+  })
+
   test('refresh resets a mixed group-by collapse to expand-all when adding a level', async () => {
     const correctMultiSelect = vi.fn()
     const fetchAllFieldAggregationData = vi.fn()
@@ -7512,6 +7661,55 @@ describe('Grid view store', () => {
       store.state.grid.groupBy.sectionRows[groupPathKey(2, 'A')][0]._.selected
     ).toBe(true)
     expect(store.state.grid.selectedRowId).toBe(11)
+  })
+
+  test('group-by row removal and full clear reset selectedRowId', () => {
+    const emptyUi = () => ({
+      selected: false,
+      selectedFieldId: -1,
+      selectedBy: [],
+      loading: false,
+    })
+    const setup = () => {
+      const state = Object.assign(gridStore.state(), {
+        activeGroupBys: [{ field: 2, order: 'ASC', type: 'default' }],
+        groupBy: {
+          treeNodes: [{ path: { field_2: 'A' }, depth: 0, row_count: 2 }],
+          truncated: false,
+          collapse: { mode: 'expand', paths: [] },
+          sectionRows: {},
+          rowLocations: {},
+        },
+      })
+      store.replaceState({ ...store.state, grid: state })
+      store.commit('grid/SET_GROUP_BY_SECTION_ROWS', {
+        sectionKey: groupPathKey(2, 'A'),
+        rows: [
+          { id: 11, order: '1.00', field_2: 'A', _: emptyUi() },
+          { id: 22, order: '2.00', field_2: 'A', _: emptyUi() },
+        ],
+        startPosition: 0,
+      })
+      store.commit('grid/SET_SELECTED_CELL', { rowId: 11, fieldId: 1 })
+      expect(store.state.grid.selectedRowId).toBe(11)
+    }
+
+    setup()
+    store.commit('grid/DELETE_ROW_IN_BUFFER', { id: 11 })
+    expect(store.state.grid.selectedRowId).toBe(-1)
+
+    setup()
+    // Removing a different row keeps the selection pointer.
+    store.commit('grid/DELETE_ROW_IN_BUFFER', { id: 22 })
+    expect(store.state.grid.selectedRowId).toBe(11)
+
+    setup()
+    store.commit('grid/DELETE_ROW_IN_BUFFER_WITHOUT_UPDATE', { id: 11 })
+    expect(store.state.grid.selectedRowId).toBe(-1)
+
+    setup()
+    store.commit('grid/CLEAR_ROWS')
+    expect(store.state.grid.selectedRowId).toBe(-1)
   })
 
   test('group-by visible items render sparse section row ranges loaded by scroll', () => {


### PR DESCRIPTION
Follow-up review discussions from #5470 and #5602.

- **Refresh flicker:** a grouped grid refresh no longer blanks out before the data arrives. It builds the new state in a snapshot and swaps it in atomically (`refreshActiveGroupBys` gains a `preserveScroll` flag), like the flat grid. Past the first group page, the viewport isn't in the snapshot yet: it fills in one round-trip after the swap instead of staying blank (review follow-up).
- **Right-click "add N rows" in grouped mode:** the group add-row button now supports the flat grid's right-click menu; new `createNewRowsInGroup` seeds each row with the group's values.
- **O(1) grouped cell selection:** `SET_SELECTED_CELL` tracks `selectedRowId` and resolves rows via `rowLocations` instead of scanning every loaded row. Row deletion and `CLEAR_ROWS` reset the pointer; eviction paths may leave it dangling, which consumers tolerate (documented on the state field).

Two other deferred items were already merged into their original PRs (the un-hide aggregation refetch, #5602; the O(N²)→`Map` sibling scan, #5470).

Tests: 6 new/updated grid store unit tests; full database suite green.