### PR TITLE
fix(backend): don't relay malformed MCP messages back into the SSE stream

### DIFF
--- a/backend/src/baserow/core/mcp/sse.py
+++ b/backend/src/baserow/core/mcp/sse.py
@@ -204,16 +204,13 @@ class DjangoChannelsSseServerTransport:
             session_message = SessionMessage(message)
             logger.debug(f"Validated client message: {session_message}")
         except ValidationError as err:
-            logger.error(f"Failed to parse message: {err}")
+            # Client error: answer 400 and log it. Don't relay the error into the
+            # SSE stream — group_listener would re-parse the error text as a message,
+            # fail again, and push a misleading exception to the server's read stream
+            # (Sentry BASEROW-SAAS-BACKEND-12K).
+            logger.warning(f"Failed to parse message: {err}")
             response = Response("Could not parse message", status_code=400)
             await response(scope, receive, send)
-            await channel_layer.group_send(
-                f"mcp_sse_{session_id.hex}",
-                {
-                    "type": "sse.message",
-                    "data": str(err),
-                },
-            )
             return
 
         logger.debug(f"Sending message to group for session: {session_id}")

--- a/backend/tests/baserow/core/mcp/test_mcp_server.py
+++ b/backend/tests/baserow/core/mcp/test_mcp_server.py
@@ -204,6 +204,98 @@ def test_sse_listener_is_closed_when_connection_is_closed():
     async_to_sync(inner)()
 
 
+def test_malformed_post_message_is_not_relayed_to_the_server():
+    """
+    Regression for BASEROW-SAAS-BACKEND-12K: a POST whose body fails JSON-RPC
+    validation must be answered with 400 and must NOT be relayed into the SSE
+    stream. The old code sent the error text back through the channel, where the
+    listener re-parsed it as a message, failed again, and pushed a misleading
+    exception to the server's read stream (logged as a server error).
+    """
+
+    async def inner():
+        sse = DjangoChannelsSseServerTransport("/mcp/messages/")
+        channel_layer = get_channel_layer()
+
+        sse_scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/mcp/key/sse",
+            "headers": [],
+            "query_string": b"",
+        }
+
+        client_disconnected = anyio.Event()
+
+        async def sse_receive():
+            await client_disconnected.wait()
+            return {"type": "http.disconnect"}
+
+        async def sse_send(message):
+            pass
+
+        def listener_group():
+            return next(
+                (g for g in channel_layer.groups if g.startswith("mcp_sse_")), None
+            )
+
+        with anyio.fail_after(10):
+            async with sse.connect_sse(sse_scope, sse_receive, sse_send) as (
+                read_stream,
+                _write_stream,
+            ):
+                # Wait until the listener has joined its group and can receive POSTs.
+                while listener_group() is None:
+                    await anyio.sleep(0.01)
+                session_hex = listener_group()[len("mcp_sse_") :]
+
+                # Valid JSON, but not a valid JSON-RPC message (missing fields).
+                body = b'{"not": "a valid json-rpc message"}'
+                post_scope = {
+                    "type": "http",
+                    "method": "POST",
+                    "path": "/mcp/messages/",
+                    "headers": [(b"content-type", b"application/json")],
+                    "query_string": f"session_id={session_hex}".encode(),
+                }
+
+                async def post_receive():
+                    return {
+                        "type": "http.request",
+                        "body": body,
+                        "more_body": False,
+                    }
+
+                status = {}
+
+                async def post_send(message):
+                    if message["type"] == "http.response.start":
+                        status["code"] = message["status"]
+
+                await sse.handle_post_message(post_scope, post_receive, post_send)
+
+                # The client gets a 400 directly on the POST.
+                assert status["code"] == 400
+
+                # Nothing must reach the server's read stream. On the pre-fix code
+                # a re-parsed ValidationError arrives here and the MCP server logs
+                # it as "Received exception from stream".
+                received = None
+                with anyio.move_on_after(0.5):
+                    received = await read_stream.receive()
+                assert received is None, (
+                    "a malformed POST must not be forwarded to the MCP server, "
+                    f"got {received!r}"
+                )
+
+                # Tear the connection down cleanly.
+                client_disconnected.set()
+                async for _ in read_stream:
+                    pass
+
+    async_to_sync(inner)()
+
+
 @pytest.mark.django_db(transaction=True)
 def test_handle_sse_sends_a_single_http_response_start(data_fixture):
     """

--- a/changelog/entries/unreleased/bug/stops_invalid_mcp_requests_from_being_logged_as_server_error.json
+++ b/changelog/entries/unreleased/bug/stops_invalid_mcp_requests_from_being_logged_as_server_error.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Stops invalid MCP requests from being logged as server errors",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-06"
+}


### PR DESCRIPTION
### What this fixes

When an MCP client sends a badly-formed request, the server correctly replied with a `400` — but then it also fed the error text back into the live SSE stream. That text got treated as if it were a new incoming message, failed to parse a second time, and ended up logged as a **server error** (plus a misleading "Internal Server Error" was pushed back to the client).

The result: a lot of noisy, misleading error reports in Sentry (BASEROW-SAAS-BACKEND-12K — 658 and climbing) for what is really just a client sending bad input. No users were actually affected.

### The change

Stop feeding parse failures back into the stream. The client already gets its `400` and we still log the problem locally — now as a `warning`, because a malformed request is the client's mistake, not a server fault.

### How to test

Automated:
```
DATABASE_URL='postgres://baserow:baserow@127.0.0.1:5432/baserow' just b test tests/baserow/core/mcp/test_mcp_server.py -k=malformed_post
```
The new test fails on `develop` and passes with this fix.

Manual: POST a non-JSON-RPC body (e.g. `{"foo":"bar"}`) to an MCP session's `/mcp/messages/` endpoint.
- Before: `400`, plus a server-level error in the logs and an "Internal Server Error" sent to the client.
- After: `400`, a single `warning` log, and nothing leaks into the stream.

### Checklist
- [x] A changelog entry has been added to `changelog/entries/unreleased`
- [x] Quality Standards are met
- [x] Security impact of change has been considered

Fixes BASEROW-SAAS-BACKEND-12K.