### PR TITLE
fix: column element stacking

### DIFF
--- a/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="column-element"
+    :class="stackingClasses"
     :style="{
       '--space-between-columns': `${element.column_gap}px`,
       '--alignment': flexAlignment,
@@ -111,6 +112,17 @@ export default {
         this.element.column_stacking?.[currentDeviceType] ===
         COLUMN_STACKING.STACKED
       )
+    },
+
+    // Enables the public/preview CSS fallback for stacked responsive layouts.
+    stackingClasses() {
+      return {
+        'column-element--public': this.mode !== 'editing',
+        'column-element--stack-smartphone':
+          this.element.column_stacking?.smartphone === COLUMN_STACKING.STACKED,
+        'column-element--stack-tablet':
+          this.element.column_stacking?.tablet === COLUMN_STACKING.STACKED,
+      }
     },
 
     gridTemplateColumns() {

--- a/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/ColumnElement.vue
@@ -118,6 +118,8 @@ export default {
     stackingClasses() {
       return {
         'column-element--public': this.mode !== 'editing',
+        'column-element--stack-desktop':
+          this.element.column_stacking?.desktop === COLUMN_STACKING.STACKED,
         'column-element--stack-smartphone':
           this.element.column_stacking?.smartphone === COLUMN_STACKING.STACKED,
         'column-element--stack-tablet':

--- a/web-frontend/modules/builder/components/page/PageContent.vue
+++ b/web-frontend/modules/builder/components/page/PageContent.vue
@@ -84,15 +84,9 @@ export default {
       },
     },
   },
-  created() {
-    // to make device detection a little faster
-    if (typeof window === 'undefined') {
-      return
-    }
+  mounted() {
     const device = this.closestDeviceType(window.innerWidth)
     this.$store.dispatch('page/setDeviceTypeSelected', device.getType())
-  },
-  mounted() {
     this.dimensions.targetElement = document.documentElement
   },
   methods: {

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
@@ -5,6 +5,12 @@
   align-items: stretch;
 }
 
+@media (min-width: 768px) {
+  .column-element--public.column-element--stack-desktop {
+    grid-template-columns: 1fr !important;
+  }
+}
+
 @media (min-width: 421px) and (max-width: 768px) {
   .column-element--public.column-element--stack-tablet {
     grid-template-columns: 1fr !important;

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
@@ -5,6 +5,18 @@
   align-items: stretch;
 }
 
+@media (min-width: 421px) and (max-width: 768px) {
+  .column-element--public.column-element--stack-tablet {
+    grid-template-columns: 1fr !important;
+  }
+}
+
+@media (max-width: 420px) {
+  .column-element--public.column-element--stack-smartphone {
+    grid-template-columns: 1fr !important;
+  }
+}
+
 .column-element__column {
   position: relative;
   display: flex;

--- a/web-frontend/test/unit/builder/components/elements/components/ColumnElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/ColumnElement.spec.js
@@ -144,4 +144,60 @@ describe('ColumnElement', () => {
     await store.dispatch('page/setDeviceTypeSelected', 'smartphone')
     expect(wrapper.vm.gridTemplateColumns).toBe('repeat(3, minmax(0, 1fr))')
   })
+
+  test('adds public stacking fallback classes based on the element configuration', async () => {
+    const builder = { id: 1, theme: { primary_color: '#ccc' } }
+    const page = { orderedElements: [] }
+    const workspace = {}
+    const element = {
+      column_amount: 3,
+      column_gap: 30,
+      alignment: 'top',
+      layout_type: 'auto',
+      column_weights: [],
+      column_stacking: {
+        smartphone: 'stacked',
+        tablet: 'stacked',
+        desktop: 'horizontal',
+      },
+    }
+
+    let wrapper = await mountComponent({
+      props: {
+        element,
+      },
+      provide: {
+        builder,
+        mode: 'public',
+        currentPage: page,
+        elementPage: page,
+        applicationContext: { builder, page, mode: 'public' },
+        element,
+        workspace,
+      },
+    })
+
+    expect(wrapper.classes()).toContain('column-element--public')
+    expect(wrapper.classes()).toContain('column-element--stack-smartphone')
+    expect(wrapper.classes()).toContain('column-element--stack-tablet')
+
+    wrapper.unmount()
+
+    wrapper = await mountComponent({
+      props: {
+        element,
+      },
+      provide: {
+        builder,
+        mode: 'editing',
+        currentPage: page,
+        elementPage: page,
+        applicationContext: { builder, page, mode: 'editing' },
+        element,
+        workspace,
+      },
+    })
+
+    expect(wrapper.classes()).not.toContain('column-element--public')
+  })
 })


### PR DESCRIPTION
### What is in this PR
- Fixes published Application Builder column elements not stacking correctly on initial mobile page load.
- Adds a CSS fallback for public/preview column elements so `tablet` and `smartphone` stacked settings are applied immediately through media queries. There's no layout shift.
- Keeps the JS device detection minimal by setting the selected device after mount, avoiding hydration timing issues.

### How to test this PR
- Create or open an Application Builder page with a column element containing multiple columns.
- Configure “Stack columns per device type” to `Stacked` for `Tablet` and `Smartphone`.
- Publish or open the builder preview page.
- Load the page directly at a mobile-sized viewport without resizing after load.
- Confirm the columns are stacked immediately.
- Resize to desktop width and confirm the columns return to the side-by-side layout when configured that way.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
