### PR TITLE
chore: remove automation beta flag

### DIFF
--- a/web-frontend/modules/automation/applicationTypes.js
+++ b/web-frontend/modules/automation/applicationTypes.js
@@ -3,7 +3,6 @@ import ApplicationContext from '@baserow/modules/automation/components/applicati
 import AutomationForm from '@baserow/modules/automation/components/form/AutomationForm'
 import SidebarComponentAutomation from '@baserow/modules/automation/components/sidebar/SidebarComponentAutomation'
 import { populateAutomationWorkflow } from '@baserow/modules/automation/store/automationWorkflow'
-import { DEVELOPMENT_STAGES } from '@baserow/modules/core/constants'
 import { pageFinished } from '@baserow/modules/core/utils/routing'
 import { nextTick } from '#imports'
 import WorkflowTemplate from '@baserow/modules/automation/components/workflow/WorkflowTemplate.vue'
@@ -145,10 +144,6 @@ export class AutomationApplicationType extends ApplicationType {
       application,
       application.workspace.id
     )
-  }
-
-  get developmentStage() {
-    return DEVELOPMENT_STAGES.BETA
   }
 
   getOrder() {


### PR DESCRIPTION
### What is in this PR

It's time to remove automation beta flag...

### How to test this PR

<img width="342" height="514" alt="image" src="https://github.com/user-attachments/assets/9a1bec9c-530e-4f7e-982c-8f6ff1f339cc" />

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
