### PR TITLE
chore: improve escaping of URLs and user input in database views

### DIFF
--- a/changelog/entries/unreleased/bug/improves_escaping_of_urls_and_user_input_in_database_views.json
+++ b/changelog/entries/unreleased/bug/improves_escaping_of_urls_and_user_input_in_database_views.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Improves escaping of URLs and user input in database views",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-07"
+}

--- a/web-frontend/modules/core/components/Button.vue
+++ b/web-frontend/modules/core/components/Button.vue
@@ -28,6 +28,7 @@
 
 <script>
 import { hasRealNodes } from '@baserow/modules/core/utils/dom.js'
+import { getUrlScheme } from '@baserow/modules/core/utils/url'
 
 export default {
   name: 'Button',
@@ -197,7 +198,11 @@ export default {
     customBind() {
       const attr = {}
       if (this.tag === 'a') {
-        attr.href = this.href
+        // Escape the href to prevent potential XSS attacks.
+        const scheme = getUrlScheme(this.href)
+        const isExecutable =
+          scheme && ['javascript:', 'vbscript:'].includes(scheme)
+        attr.href = isExecutable ? null : this.href
         attr.target = this.target
         attr.rel = this.rel
         attr.download = this.download

--- a/web-frontend/modules/core/utils/url.js
+++ b/web-frontend/modules/core/utils/url.js
@@ -26,12 +26,30 @@ export function addQueryParamsToRedirectUrl(url, params) {
   return parsedUrl.toString()
 }
 
+const SAFE_URL_PROTOCOLS = [
+  'http:',
+  'https:',
+  'ftp:',
+  'ftps:',
+  'mailto:',
+  'tel:',
+]
+
+export function getUrlScheme(value) {
+  // Strip chars browsers ignore, so `java\tscript:` still reads as `javascript:`.
+  // eslint-disable-next-line no-control-regex
+  const stripped = String(value ?? '').replace(/[\x00-\x20]/g, '')
+  const match = stripped.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/)
+  return match ? `${match[1].toLowerCase()}:` : null
+}
+
 export function ensureUrlProtocol(value) {
-  const protocolRegex = /^[a-zA-Z]+:\/\//
-  if (!protocolRegex.test(value)) {
-    return `https://${value}`
+  const scheme = getUrlScheme(value)
+  if (scheme && SAFE_URL_PROTOCOLS.includes(scheme)) {
+    return value
   }
-  return value
+  // Force https so an unsafe scheme (javascript:, data:) can't execute as a URI.
+  return `https://${value}`
 }
 
 /**

--- a/web-frontend/modules/core/utils/url.js
+++ b/web-frontend/modules/core/utils/url.js
@@ -33,6 +33,7 @@ const SAFE_URL_PROTOCOLS = [
   'ftps:',
   'mailto:',
   'tel:',
+  'sms:',
 ]
 
 export function getUrlScheme(value) {

--- a/web-frontend/modules/core/utils/url.js
+++ b/web-frontend/modules/core/utils/url.js
@@ -48,6 +48,10 @@ export function ensureUrlProtocol(value) {
   if (scheme && SAFE_URL_PROTOCOLS.includes(scheme)) {
     return value
   }
+  // Protocol-relative URLs only need the scheme, not another `//`.
+  if (String(value).startsWith('//')) {
+    return `https:${value}`
+  }
   // Force https so an unsafe scheme (javascript:, data:) can't execute as a URI.
   return `https://${value}`
 }

--- a/web-frontend/modules/database/components/card/RowCardFieldButton.vue
+++ b/web-frontend/modules/database/components/card/RowCardFieldButton.vue
@@ -2,7 +2,7 @@
   <div>
     <Button
       v-if="isValid(value)"
-      :href="value && value.url"
+      :href="getHref(value)"
       tag="a"
       target="_blank"
       rel="nofollow noopener noreferrer"

--- a/web-frontend/modules/database/components/card/RowCardFieldLinkURL.vue
+++ b/web-frontend/modules/database/components/card/RowCardFieldLinkURL.vue
@@ -2,7 +2,7 @@
   <div class="card-text">
     <a
       v-if="isValid(value)"
-      :href="value && value.url"
+      :href="getHref(value)"
       target="_blank"
       rel="nofollow noopener noreferrer"
       class="forced-pointer-events-auto"

--- a/web-frontend/modules/database/components/card/RowCardFieldURL.vue
+++ b/web-frontend/modules/database/components/card/RowCardFieldURL.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card-text">
     <a
-      :href="value"
+      :href="getHref(value)"
       target="_blank"
       rel="nofollow noopener noreferrer"
       class="forced-pointer-events-auto"
@@ -12,6 +12,8 @@
 </template>
 
 <script>
+import { ensureUrlProtocol } from '@baserow/modules/core/utils/url'
+
 export default {
   name: 'RowCardFieldURL',
   height: 16,
@@ -19,6 +21,11 @@ export default {
     value: {
       type: String,
       default: '',
+    },
+  },
+  methods: {
+    getHref(value) {
+      return value ? ensureUrlProtocol(value) : undefined
     },
   },
 }

--- a/web-frontend/modules/database/components/formula/array/FunctionalFormulaButtonArrayItem.vue
+++ b/web-frontend/modules/database/components/formula/array/FunctionalFormulaButtonArrayItem.vue
@@ -6,7 +6,7 @@
       size="tiny"
       type="secondary"
       class="forced-pointer-events-auto array-field__button-button"
-      :href="value && value.url"
+      :href="getHref(value)"
       target="_blank"
       rel="nofollow noopener noreferrer"
       @mousedown.stop

--- a/web-frontend/modules/database/components/formula/array/FunctionalFormulaLinkArrayItem.vue
+++ b/web-frontend/modules/database/components/formula/array/FunctionalFormulaLinkArrayItem.vue
@@ -3,7 +3,7 @@
     <div class="array-field__ellipsis">
       <a
         v-if="selected && isValid(value)"
-        :href="value && value.url"
+        :href="getHref(value)"
         target="_blank"
         rel="nofollow noopener noreferrer"
         class="forced-pointer-events-auto"

--- a/web-frontend/modules/database/components/row/RowEditFieldButton.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldButton.vue
@@ -5,7 +5,7 @@
       tag="a"
       size="tiny"
       type="secondary"
-      :href="copy && copy.url"
+      :href="getHref(copy)"
       target="_blank"
       rel="nofollow noopener noreferrer"
     >

--- a/web-frontend/modules/database/components/row/RowEditFieldLinkURL.vue
+++ b/web-frontend/modules/database/components/row/RowEditFieldLinkURL.vue
@@ -2,7 +2,7 @@
   <div class="control__elements">
     <a
       v-if="isValidLinkURL"
-      :href="copy && copy.url"
+      :href="getHref(copy)"
       target="_blank"
       rel="nofollow noopener noreferrer"
     >

--- a/web-frontend/modules/database/components/view/grid/fields/FunctionalGridViewFieldButton.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/FunctionalGridViewFieldButton.vue
@@ -6,7 +6,7 @@
         tag="a"
         type="secondary"
         size="tiny"
-        :href="value && value.url"
+        :href="getHref(value)"
         target="_blank"
         rel="nofollow noopener noreferrer"
       >

--- a/web-frontend/modules/database/components/view/grid/fields/FunctionalGridViewFieldLinkURL.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/FunctionalGridViewFieldLinkURL.vue
@@ -3,7 +3,7 @@
     <div class="grid-field-text">
       <a
         v-if="selected && isValid(value)"
-        :href="value && value.url"
+        :href="getHref(value)"
         target="_blank"
         rel="nofollow noopener noreferrer"
       >

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldButton.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldButton.vue
@@ -7,7 +7,7 @@
         size="tiny"
         type="secondary"
         rel="nofollow noopener noreferrer"
-        :href="value && value.url"
+        :href="getHref(value)"
         target="_blank"
       >
         {{ getLabelOrURL(value) }}

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkURL.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkURL.vue
@@ -3,7 +3,7 @@
     <div class="grid-field-text">
       <a
         v-if="selected && isValid(value)"
-        :href="value && value.url"
+        :href="getHref(value)"
         target="_blank"
         rel="nofollow noopener noreferrer"
       >

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -9,6 +9,7 @@ import {
 } from '@baserow/modules/database/utils/duration'
 import {
   collatedStringCompare,
+  escapeHtml,
   getFilenameFromUrl,
   isInteger,
   isSimplePhoneNumber,
@@ -3853,7 +3854,9 @@ export class SingleSelectFieldType extends SelectOptionBaseFieldType {
           // @TODO move this template to a component.
           `<div class="select-options-listing">
               <div class="select-options-listing__id">${option.id}</div>
-              <div class="select-options-listing__value background-color--${option.color}">${option.value}</div>
+              <div class="select-options-listing__value background-color--${escapeHtml(
+                option.color
+              )}">${escapeHtml(option.value)}</div>
            </div>
           `
       )
@@ -4151,7 +4154,9 @@ export class MultipleSelectFieldType extends SelectOptionBaseFieldType {
           // @TODO move this template to a component.
           `<div class="select-options-listing">
               <div class="select-options-listing__id">${option.id}</div>
-              <div class="select-options-listing__value background-color--${option.color}">${option.value}</div>
+              <div class="select-options-listing__value background-color--${escapeHtml(
+                option.color
+              )}">${escapeHtml(option.value)}</div>
            </div>
           `
       )

--- a/web-frontend/modules/database/mixins/linkURLField.js
+++ b/web-frontend/modules/database/mixins/linkURLField.js
@@ -14,7 +14,7 @@ export default {
       }
     },
     getHref(value) {
-      return ensureUrlProtocol(value)
+      return value?.url ? ensureUrlProtocol(value.url) : undefined
     },
   },
 }

--- a/web-frontend/modules/database/mixins/linkURLField.js
+++ b/web-frontend/modules/database/mixins/linkURLField.js
@@ -14,7 +14,8 @@ export default {
       }
     },
     getHref(value) {
-      return value?.url ? ensureUrlProtocol(value.url) : undefined
+      const url = typeof value === 'string' ? value : value?.url
+      return url ? ensureUrlProtocol(url) : undefined
     },
   },
 }

--- a/web-frontend/test/unit/core/utils/url.spec.js
+++ b/web-frontend/test/unit/core/utils/url.spec.js
@@ -149,6 +149,7 @@ describe('test url utils', () => {
       ['ftps://example.com/file.txt', 'ftps://example.com/file.txt'],
       ['mailto:a@b.com', 'mailto:a@b.com'],
       ['tel:+123456', 'tel:+123456'],
+      ['sms:+123456', 'sms:+123456'],
       ['//cdn.example.com/lib.js', 'https://cdn.example.com/lib.js'],
     ])('keeps safe/relative URL %j -> %j', (input, expected) => {
       expect(ensureUrlProtocol(input)).toBe(expected)

--- a/web-frontend/test/unit/core/utils/url.spec.js
+++ b/web-frontend/test/unit/core/utils/url.spec.js
@@ -146,8 +146,10 @@ describe('test url utils', () => {
       ['http://example.com', 'http://example.com'],
       ['https://example.com', 'https://example.com'],
       ['ftp://example.com/file.txt', 'ftp://example.com/file.txt'],
+      ['ftps://example.com/file.txt', 'ftps://example.com/file.txt'],
       ['mailto:a@b.com', 'mailto:a@b.com'],
       ['tel:+123456', 'tel:+123456'],
+      ['//cdn.example.com/lib.js', 'https://cdn.example.com/lib.js'],
     ])('keeps safe/relative URL %j -> %j', (input, expected) => {
       expect(ensureUrlProtocol(input)).toBe(expected)
     })

--- a/web-frontend/test/unit/core/utils/url.spec.js
+++ b/web-frontend/test/unit/core/utils/url.spec.js
@@ -1,4 +1,6 @@
 import {
+  ensureUrlProtocol,
+  getUrlScheme,
   isRelativeUrl,
   parseHostnamesFromUrls,
 } from '@baserow/modules/core/utils/url'
@@ -117,6 +119,55 @@ describe('test url utils', () => {
       expect(isValidAbsoluteURL(url)).toBe(false)
     })
   })
+  describe('getUrlScheme', () => {
+    test.each([
+      ['https://example.com', 'https:'],
+      ['HTTP://example.com', 'http:'],
+      ['mailto:a@b.com', 'mailto:'],
+      ['javascript:alert(1)', 'javascript:'],
+      ['JavaScript:alert(1)', 'javascript:'],
+      [' javascript:alert(1)', 'javascript:'],
+      ['\tjavascript:alert(1)', 'javascript:'],
+      ['java\tscript:alert(1)', 'javascript:'],
+      ['data:text/html,x', 'data:'],
+      ['example.com', null],
+      ['/relative/path', null],
+      ['#anchor', null],
+      ['', null],
+    ])('getUrlScheme(%j)', (input, expected) => {
+      expect(getUrlScheme(input)).toBe(expected)
+    })
+  })
+
+  describe('ensureUrlProtocol', () => {
+    test.each([
+      ['example.com', 'https://example.com'],
+      ['www.example.com/path?q=1', 'https://www.example.com/path?q=1'],
+      ['http://example.com', 'http://example.com'],
+      ['https://example.com', 'https://example.com'],
+      ['ftp://example.com/file.txt', 'ftp://example.com/file.txt'],
+      ['mailto:a@b.com', 'mailto:a@b.com'],
+      ['tel:+123456', 'tel:+123456'],
+    ])('keeps safe/relative URL %j -> %j', (input, expected) => {
+      expect(ensureUrlProtocol(input)).toBe(expected)
+    })
+
+    test.each([
+      'javascript:alert(document.cookie)',
+      'javascript://%0aalert(1)',
+      'JavaScript:alert(1)',
+      ' javascript:alert(1)',
+      '\tjavascript:alert(1)',
+      'java\tscript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+    ])('neutralizes dangerous scheme %j', (input) => {
+      const result = ensureUrlProtocol(input)
+      expect(result.startsWith('https://')).toBe(true)
+      expect(getUrlScheme(result)).toBe('https:')
+    })
+  })
+
   describe('test parseHostnamesFromUrls', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -744,6 +744,34 @@ describe('FieldType tests', () => {
   afterEach(() => {
     testApp.afterEach()
   })
+
+  test.each([
+    { name: 'single select', FieldType: SingleSelectFieldType },
+    { name: 'multiple select', FieldType: MultipleSelectFieldType },
+  ])(
+    'getDocsDescription escapes HTML in $name option value and color',
+    ({ FieldType }) => {
+      const fieldType = new FieldType({ app: testApp._app })
+      const field = {
+        select_options: [
+          {
+            id: 1,
+            value: '<img src=x onerror=alert(1)>',
+            color: '"><img src=x onerror=alert(2)>',
+          },
+        ],
+      }
+
+      const description = fieldType.getDocsDescription(field)
+
+      expect(description).not.toContain('<img')
+      expect(description).toContain('&lt;img src=x onerror=alert(1)&gt;')
+      expect(description).toContain(
+        '&quot;&gt;&lt;img src=x onerror=alert(2)&gt;'
+      )
+    }
+  )
+
   test.each(valuesToCall)(
     'Verify that calling prepareValueForCopy will not throw when value is %s',
     (valueType) => {


### PR DESCRIPTION
## Summary

Tightens how the database frontend handles user-provided values so that untrusted input is consistently escaped and normalised before it is rendered.

- **API documentation**: select field option values and colors are now HTML-escaped when building the generated docs description.
- **URL / link / button cells**: cell `href`s are restricted to a safe scheme allowlist (`http`, `https`, `ftp`, `mailto`, `tel`). Values with any other scheme are normalised to `https` so they stay plain, navigable links. This is centralised in `ensureUrlProtocol`, with a defensive check in the shared `Button` component.

## Tests

- Unit tests for the URL scheme helpers (`getUrlScheme`, `ensureUrlProtocol`) covering normalisation and obfuscated-input edge cases.
- A test asserting select option values/colors are escaped in the API docs output.
