### PR TITLE
fix: resolve two separate issues with N+1 queries when creating rows

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -4133,6 +4133,11 @@ class SelectOptionBaseFieldType(FieldType):
     _can_group_by = True
     _db_column_fields = []
 
+    def enhance_field_queryset(self, queryset, field):
+        # Prefetch the options so the generated model's select fields can build their
+        # serializer help text without a query per field.
+        return queryset.prefetch_related("select_options")
+
     def _get_select_option_display_map(self, field):
         return {
             option.id: {

--- a/backend/src/baserow/contrib/database/views/handler.py
+++ b/backend/src/baserow/contrib/database/views/handler.py
@@ -5531,6 +5531,32 @@ class ViewSubscriptionHandler:
             cls.notify_table_views(view_ids_with_subscribers, model)
 
     @classmethod
+    def notify_tables_views_updates(
+        cls, models_by_table: dict[Table, GeneratedTableModel | None]
+    ):
+        """
+        Verify if the views of the given tables have subscribers and notify them of
+        any changes in the view results. The subscribers of all tables are looked up
+        with a single query, so this scales to the many tables that a single row
+        change can affect through dependency cascades.
+
+        :param models_by_table: The tables to notify subscribers of, each mapped to
+            the table model to use, or None to let it be generated when needed.
+        """
+
+        view_ids_by_table = defaultdict(list)
+        subscribed_views = ViewSubscription.objects.filter(
+            view__in=View.objects.filter(table__in=models_by_table.keys())
+        ).values_list("view__table_id", "view_id")
+        for table_id, view_id in subscribed_views:
+            view_ids_by_table[table_id].append(view_id)
+
+        for table, model in models_by_table.items():
+            view_ids = view_ids_by_table.get(table.id)
+            if view_ids:
+                cls.notify_table_views(view_ids, model)
+
+    @classmethod
     def notify_table_views(
         cls, view_ids: list[int], model: GeneratedTableModel | None = None
     ):

--- a/backend/src/baserow/contrib/database/views/receivers.py
+++ b/backend/src/baserow/contrib/database/views/receivers.py
@@ -52,13 +52,11 @@ def _notify_view_results_updated(view: View):
 
 @receiver([rows_updated, rows_created, rows_deleted])
 def notify_rows_signals(sender, rows, user, table, model, dependant_fields, **kwargs):
-    _notify_table_data_updated(table, model)
-
-    updated_tables = set()
+    models_by_table = {table: model}
     for field in dependant_fields:
-        updated_tables.add(field.table)
-    for updated_table in updated_tables:
-        _notify_table_data_updated(updated_table)
+        models_by_table.setdefault(field.table, None)
+
+    ViewSubscriptionHandler.notify_tables_views_updates(models_by_table)
 
 
 @receiver(view_updated)

--- a/backend/tests/baserow/contrib/database/api/rows/test_row_serializers.py
+++ b/backend/tests/baserow/contrib/database/api/rows/test_row_serializers.py
@@ -579,6 +579,21 @@ def test_get_row_serializer_with_user_field_names(
 
 
 @pytest.mark.django_db
+def test_get_row_validation_serializer_does_not_query_select_options_per_field(
+    data_fixture, django_assert_num_queries
+):
+    # The validation serializer builds a help text from each select field's options.
+    # Those options are prefetched during model generation, so building the serializer
+    # must not issue a query per select field (regression for the select option N+1 on
+    # the batch rows endpoint, Sentry BASEROW-SAAS-BACKEND-12V).
+    table, _, _, _, _ = setup_interesting_test_table(data_fixture)
+    model = table.get_model()
+
+    with django_assert_num_queries(0):
+        get_row_serializer_class(model, RowSerializer, user_field_names=True)
+
+
+@pytest.mark.django_db
 def test_get_row_serializer_with_user_field_names_named_meta(data_fixture):
     table = data_fixture.create_database_table(name="Cars")
     text_field = data_fixture.create_text_field(table=table, order=0, name="Meta")

--- a/backend/tests/baserow/contrib/database/rows/test_dependant_rows_realtime.py
+++ b/backend/tests/baserow/contrib/database/rows/test_dependant_rows_realtime.py
@@ -435,3 +435,36 @@ def test_formula_referencing_self_link_recalculates_rows_linking_to_updated_row(
     assert updates[table.id].row_ids == [row_b.id]
     assert self_link.id in updates[table.id].field_ids
     assert formula.id in updates[table.id].field_ids
+
+
+@pytest.mark.django_db
+def test_cascading_row_update_checks_view_subscriptions_in_a_single_query(
+    data_fixture,
+):
+    user = data_fixture.create_user()
+    table_a, table_b, link_a_b = data_fixture.create_two_linked_tables(user=user)
+    primary_b = table_b.field_set.get(primary=True).specific
+    data_fixture.create_formula_field(
+        table=table_a, formula="join(lookup('link', 'primary'), '')"
+    )
+
+    row_b1 = (
+        RowHandler()
+        .create_rows(user, table_b, [{primary_b.db_column: "b1"}])
+        .created_rows[0]
+    )
+    RowHandler().create_rows(user, table_a, [{link_a_b.db_column: [row_b1.id]}])
+
+    # Updating table_b cascades to a dependant field in table_a, so both table_b
+    # and table_a get notified within the same signal.
+    with CaptureQueriesContext(connection) as captured:
+        RowHandler().force_update_rows(
+            user=user,
+            table=table_b,
+            rows_values=[{"id": row_b1.id, primary_b.db_column: "renamed"}],
+        )
+
+    subscription_queries = [
+        q for q in captured.captured_queries if "database_viewsubscription" in q["sql"]
+    ]
+    assert len(subscription_queries) == 1

--- a/backend/tests/baserow/contrib/database/table/test_table_models.py
+++ b/backend/tests/baserow/contrib/database/table/test_table_models.py
@@ -1133,7 +1133,9 @@ def test_model_coming_out_of_cache_queries_correctly(
         )
 
         local_cache.clear()
-        with django_assert_num_queries(3):
+        # One query prefetches the select options of the two single select fields
+        # (a single query, since they share a content type).
+        with django_assert_num_queries(4):
             original_model = table.get_model()
 
         RowHandler().create_row(user=user, table=table, values={})

--- a/changelog/entries/unreleased/bug/speeds_up_creating_and_updating_rows_by_avoiding_redundant_d.json
+++ b/changelog/entries/unreleased/bug/speeds_up_creating_and_updating_rows_by_avoiding_redundant_d.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Speeds up creating and updating rows by avoiding redundant database queries",
+    "message": "Resolve the issue with two separate N+1 queries when creating rows.",
     "issue_origin": "github",
     "issue_number": null,
     "domain": "database",

--- a/changelog/entries/unreleased/bug/speeds_up_creating_and_updating_rows_by_avoiding_redundant_d.json
+++ b/changelog/entries/unreleased/bug/speeds_up_creating_and_updating_rows_by_avoiding_redundant_d.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Speeds up creating and updating rows by avoiding redundant database queries",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-07"
+}


### PR DESCRIPTION
## Summary
- Prefetch select options during generated model field loading to avoid serializer help-text N+1 queries.
- Batch view subscription lookups for row change notifications across dependency-cascade tables.

## Operations that should benefit:
  - Row create, update, and delete paths that trigger realtime view-result checks.
  - Especially operations with dependency cascades across linked tables, like formulas/lookups/rollups depending on changed rows in another table.
  - Batch row create/update/delete endpoints should benefit most, because the same per-table subscription lookup overhead was repeated around large row operations.
  - Row create/update validation on tables with many single-select or multiple-select fields, because generated model loading now prefetches select options instead of letting serializer help-text construction query per select field.

## Tests
- Import the attached database 
- create a new row in the Projects table
- notice the number of queries is lower, and N+1 on views subscribers and select options are gone

Test database

[export_cd4eddaa-0683-4a91-bbdd-3a065b1a6cb0.zip](https://github.com/user-attachments/files/29841278/export_cd4eddaa-0683-4a91-bbdd-3a065b1a6cb0.zip)


Fixes:

https://baserow-eu.sentry.io/issues/132506420
<img width="932" height="226" alt="image" src="https://github.com/user-attachments/assets/8fcb343e-a565-4b20-b57f-49a0eb4314c4" />


https://baserow-eu.sentry.io/issues/132776665

<img width="930" height="141" alt="image" src="https://github.com/user-attachments/assets/c1a88d9e-dcd6-4a1e-9708-3e74fbc3d3b8" />
