### PR TITLE
chore: add an element visibility e2e test

### DIFF
--- a/e2e-tests/fixtures/builder/builderElement.ts
+++ b/e2e-tests/fixtures/builder/builderElement.ts
@@ -6,14 +6,14 @@ export class BuilderElement {
     public page: BuilderPage,
     public id: number,
     public type: string,
-    public properties: Object
+    public properties: Object,
   ) {}
 }
 
 export async function createBuilderElement(
   page: BuilderPage,
   elementType: string,
-  properties: Object = {}
+  properties: Object = {},
 ): Promise<BuilderElement> {
   const response: any = await getClient(page.builder.workspace.user).post(
     `builder/page/${page.id}/elements/`,
@@ -21,8 +21,19 @@ export async function createBuilderElement(
       page_id: page.id,
       type: elementType,
       ...properties,
-    }
+    },
   );
   const { id, type, ...rest } = response.data;
   return new BuilderElement(page, response.data.id, elementType, rest);
+}
+
+export async function updateBuilderElement(
+  element: BuilderElement,
+  values: Object,
+): Promise<BuilderElement> {
+  const response: any = await getClient(
+    element.page.builder.workspace.user,
+  ).patch(`builder/element/${element.id}/`, values);
+  const { id, type, ...rest } = response.data;
+  return new BuilderElement(element.page, response.data.id, element.type, rest);
 }

--- a/e2e-tests/fixtures/builder/domain.ts
+++ b/e2e-tests/fixtures/builder/domain.ts
@@ -1,0 +1,65 @@
+import { getClient } from "../../client";
+import { Builder } from "./builder";
+
+export class PublishedBuilder {
+  constructor(
+    public id: number,
+    // Path of the first non-shared page, e.g. "/page".
+    public pagePath: string,
+    // The published copy of the user source (its id differs from the editor's).
+    public userSourceId: number,
+  ) {}
+
+  // URL path of the preview route that renders the published, visibility
+  // filtered page without needing a real domain to resolve.
+  previewPath(): string {
+    return `/builder/${this.id}/preview${this.pagePath}`;
+  }
+}
+
+/**
+ * Creates a custom domain for the builder, publishes it (waiting for the async
+ * job to finish), and returns the resulting published builder details.
+ */
+export async function publishBuilder(
+  builder: Builder,
+  domainName: string,
+): Promise<PublishedBuilder> {
+  const client = getClient(builder.workspace.user);
+
+  const domain: any = await client.post(`builder/${builder.id}/domains/`, {
+    type: "custom",
+    domain_name: domainName,
+  });
+
+  const job: any = await client.post(
+    `builder/domains/${domain.data.id}/publish/async/`,
+    {},
+  );
+
+  // Poll the publish job until it finishes.
+  let state = job.data.state;
+  for (let i = 0; i < 60 && state !== "finished"; i++) {
+    const poll: any = await client.get(`jobs/${job.data.id}/`);
+    state = poll.data.state;
+    if (state === "failed") {
+      throw new Error(
+        `Publish job failed: ${poll.data.human_readable_error || ""}`,
+      );
+    }
+    if (state !== "finished") {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+  if (state !== "finished") {
+    throw new Error("Publish job did not finish in time");
+  }
+
+  const published: any = await client.get(
+    `builder/domains/published/by_name/${domainName}/`,
+  );
+  const page = published.data.pages.find((p: any) => p.path !== "__shared__");
+  const userSource = published.data.user_sources[0];
+
+  return new PublishedBuilder(published.data.id, page.path, userSource.id);
+}

--- a/e2e-tests/fixtures/builder/integration.ts
+++ b/e2e-tests/fixtures/builder/integration.ts
@@ -1,0 +1,21 @@
+import { getClient } from "../../client";
+import { Builder } from "./builder";
+
+export class Integration {
+  constructor(
+    public id: number,
+    public type: string,
+    public builder: Builder,
+  ) {}
+}
+
+export async function createLocalBaserowIntegration(
+  builder: Builder,
+  name = "Local Baserow",
+): Promise<Integration> {
+  const response: any = await getClient(builder.workspace.user).post(
+    `application/${builder.id}/integrations/`,
+    { type: "local_baserow", name },
+  );
+  return new Integration(response.data.id, response.data.type, builder);
+}

--- a/e2e-tests/fixtures/builder/userSource.ts
+++ b/e2e-tests/fixtures/builder/userSource.ts
@@ -1,0 +1,71 @@
+import { getClient } from "../../client";
+import { Builder } from "./builder";
+import { Integration } from "./integration";
+import { Table } from "../database/table";
+import { Field } from "../database/field";
+
+export class UserSource {
+  constructor(
+    public id: number,
+    public type: string,
+    public builder: Builder,
+  ) {}
+}
+
+/**
+ * Creates a Local Baserow user source backed by the given users table, wired to
+ * a password auth provider so users can authenticate with email + password. The
+ * `roleField` provides each user's role, used by element visibility rules.
+ */
+export async function createLocalBaserowUserSource(
+  builder: Builder,
+  integration: Integration,
+  table: Table,
+  fields: { email: Field; name: Field; role: Field; password: Field },
+  name = "Users",
+): Promise<UserSource> {
+  const response: any = await getClient(builder.workspace.user).post(
+    `application/${builder.id}/user-sources/`,
+    {
+      type: "local_baserow",
+      name,
+      integration_id: integration.id,
+      table_id: table.id,
+      email_field_id: fields.email.id,
+      name_field_id: fields.name.id,
+      role_field_id: fields.role.id,
+      auth_providers: [
+        {
+          type: "local_baserow_password",
+          enabled: true,
+          password_field_id: fields.password.id,
+        },
+      ],
+    },
+  );
+  return new UserSource(response.data.id, response.data.type, builder);
+}
+
+/**
+ * Authenticates a user source user with email + password against the given user
+ * source id and returns the JWT pair. Use the returned refresh token as the
+ * `user_source_token` cookie to browse the published site as that user.
+ */
+export async function userSourceTokenAuth(
+  userSourceId: number,
+  email: string,
+  password: string,
+): Promise<{ accessToken: string; refreshToken: string }> {
+  // Authenticate as a public site visitor would: no Baserow user token. A
+  // published user source belongs to no workspace, so a request carrying the
+  // builder owner's token is rejected (no permission); an unauthenticated
+  // request is the supported path.
+  const response: any = await getClient().post(
+    `user-source/${userSourceId}/token-auth`,
+    { email, password },
+  );
+  return {
+    accessToken: response.data.access_token,
+    refreshToken: response.data.refresh_token,
+  };
+}

--- a/e2e-tests/tests/builder/elements/elementVisibility.spec.ts
+++ b/e2e-tests/tests/builder/elements/elementVisibility.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from "../../baserowTest";
+import {
+  createLicense,
+  deleteLicense,
+  ENTERPRISE_LICENSE,
+  License,
+} from "../../../fixtures/licence";
+import { createBuilder } from "../../../fixtures/builder/builder";
+import { createBuilderPage } from "../../../fixtures/builder/builderPage";
+import {
+  createBuilderElement,
+  updateBuilderElement,
+} from "../../../fixtures/builder/builderElement";
+import { createLocalBaserowIntegration } from "../../../fixtures/builder/integration";
+import {
+  createLocalBaserowUserSource,
+  userSourceTokenAuth,
+} from "../../../fixtures/builder/userSource";
+import { publishBuilder } from "../../../fixtures/builder/domain";
+import { createDatabase } from "../../../fixtures/database/database";
+import { createTable } from "../../../fixtures/database/table";
+import {
+  createField,
+  getFieldsForTable,
+} from "../../../fixtures/database/field";
+import { listRows, updateRows } from "../../../fixtures/database/rows";
+import { baserowConfig } from "../../../playwright.config";
+
+const ROLE = "editor";
+const PASSWORD = "supersecret123";
+
+// The five element visibility permutations. Each is a heading whose resolved
+// text equals its label, so we can assert which ones render in the DOM.
+const ELEMENTS = [
+  { label: "E1_ALL", visibility: "all", role_type: "allow_all", roles: [] },
+  {
+    label: "E2_LOGGED",
+    visibility: "logged-in",
+    role_type: "allow_all",
+    roles: [],
+  },
+  {
+    label: "E3_ALLOW_EDITOR",
+    visibility: "logged-in",
+    role_type: "disallow_all_except",
+    roles: [ROLE],
+  },
+  {
+    label: "E4_DISALLOW_EDITOR",
+    visibility: "logged-in",
+    role_type: "allow_all_except",
+    roles: [ROLE],
+  },
+  {
+    label: "E5_LOGGEDOUT",
+    visibility: "not-logged",
+    role_type: "allow_all",
+    roles: [],
+  },
+];
+const ALL_LABELS = ELEMENTS.map((e) => e.label);
+
+// Which labels each visitor type is expected to see. Notably the authenticated
+// visitor with no role must NOT see the same set as the anonymous visitor -
+// that collision was the bug this test guards against.
+const EXPECTED = {
+  anonymous: ["E1_ALL", "E5_LOGGEDOUT"],
+  loggedInNoRole: ["E1_ALL", "E2_LOGGED", "E4_DISALLOW_EDITOR"],
+  loggedInEditor: ["E1_ALL", "E2_LOGGED", "E3_ALLOW_EDITOR"],
+};
+
+test.describe("Builder element visibility on published pages", () => {
+  let license: License;
+
+  test.beforeEach(async () => {
+    // Local Baserow user sources require an Enterprise license.
+    license = await createLicense(ENTERPRISE_LICENSE);
+  });
+
+  test.afterEach(async () => {
+    await deleteLicense(license);
+  });
+
+  test("visitors only see elements matching their visibility permissions @enterprise", async ({
+    page,
+    workspacePage,
+  }) => {
+    const { user, workspace } = workspacePage;
+
+    // --- Build the application: a page with the five visibility permutations.
+    const builder = await createBuilder("Visibility builder", workspace);
+    const builderPage = await createBuilderPage(
+      "Visibility",
+      "/visibility",
+      builder,
+    );
+    for (const cfg of ELEMENTS) {
+      const element = await createBuilderElement(builderPage, "heading", {
+        value: `'${cfg.label}'`,
+      });
+      // role_type/roles are only accepted on update, so configure visibility
+      // after creation.
+      await updateBuilderElement(element, {
+        visibility: cfg.visibility,
+        role_type: cfg.role_type,
+        roles: cfg.roles,
+      });
+    }
+
+    // --- Build the user source: a users table with a blank-role and an editor
+    // user, wired to a Local Baserow user source with password auth.
+    const database = await createDatabase(user, "Users db", workspace);
+    const table = await createTable(user, "Users", database, [
+      ["Email", "Name", "Role"],
+      ["blank@example.com", "Blank", ""],
+      ["editor@example.com", "Editor", ROLE],
+    ]);
+    await createField(user, "Password", "password", {}, table);
+    const fields = await getFieldsForTable(user, table);
+    const fieldByName = Object.fromEntries(fields.map((f) => [f.name, f]));
+
+    // Passwords are write-only, so set them on the existing rows.
+    const rows = await listRows(user, table);
+    await updateRows(
+      user,
+      table,
+      rows.map((r) => ({ id: r.id, Password: PASSWORD })),
+    );
+
+    const integration = await createLocalBaserowIntegration(builder);
+    const userSource = await createLocalBaserowUserSource(
+      builder,
+      integration,
+      table,
+      {
+        email: fieldByName.Email,
+        name: fieldByName.Name,
+        role: fieldByName.Role,
+        password: fieldByName.Password,
+      },
+    );
+
+    // --- Publish. The published copy filters elements by visibility.
+    const published = await publishBuilder(
+      builder,
+      `e2e-visibility-${userSource.id}-${Date.now()}.example.com`,
+    );
+
+    // --- Authenticate each user source user against the published user source.
+    const blankAuth = await userSourceTokenAuth(
+      published.userSourceId,
+      "blank@example.com",
+      PASSWORD,
+    );
+    const editorAuth = await userSourceTokenAuth(
+      published.userSourceId,
+      "editor@example.com",
+      PASSWORD,
+    );
+
+    const previewUrl = `${baserowConfig.PUBLIC_WEB_FRONTEND_URL}${published.previewPath()}`;
+    const frontendHost = new URL(baserowConfig.PUBLIC_WEB_FRONTEND_URL)
+      .hostname;
+    const cookieName = `${baserowConfig.BASEROW_FRONTEND_COOKIE_PREFIX}user_source_token`;
+
+    // Visit the published page as a given visitor and assert exactly which of
+    // the five headings render. `refreshToken` null means an anonymous visit.
+    const assertVisibleFor = async (
+      refreshToken: string | null,
+      expectedLabels: string[],
+    ) => {
+      // Reset to a clean visitor: no Baserow session, no user source token.
+      await page.context().clearCookies();
+      if (refreshToken) {
+        await page.context().addCookies([
+          {
+            name: cookieName,
+            value: refreshToken,
+            domain: frontendHost,
+            path: "/",
+          },
+        ]);
+      }
+
+      await page.goto(previewUrl, { waitUntil: "networkidle" });
+
+      // E1_ALL is visible to everyone, so wait for it to confirm the page rendered.
+      await expect(
+        page.locator(".ab-heading", { hasText: "E1_ALL" }),
+      ).toBeVisible();
+
+      for (const label of ALL_LABELS) {
+        const heading = page.locator(".ab-heading", { hasText: label });
+        if (expectedLabels.includes(label)) {
+          await expect(heading, `${label} should be visible`).toBeVisible();
+        } else {
+          await expect(heading, `${label} should be hidden`).toHaveCount(0);
+        }
+      }
+    };
+
+    // Order matters: the anonymous visit runs first on purpose. The original bug
+    // was that an anonymous request and a logged-in visitor with no role shared a
+    // server-side cache entry, so the first visitor's element set was served to
+    // both. Visiting anonymously first is what poisons that shared entry, so if
+    // the fix regresses the logged-in-no-role assertion below will fail.
+    await assertVisibleFor(null, EXPECTED.anonymous);
+    await assertVisibleFor(blankAuth.refreshToken, EXPECTED.loggedInNoRole);
+    await assertVisibleFor(editorAuth.refreshToken, EXPECTED.loggedInEditor);
+  });
+});


### PR DESCRIPTION
### What is in this PR

An e2e test to ensure that our five element visibility permutations works correctly, from end to end.

### How to test this PR

I tested it by undoing a change in #5667:

```diff
diff --git a/backend/src/baserow/contrib/builder/pages/handler.py b/backend/src/baserow/contrib/builder/pages/handler.py
index 6e3aaea17..9672a97ad 100644
--- a/backend/src/baserow/contrib/builder/pages/handler.py
+++ b/backend/src/baserow/contrib/builder/pages/handler.py
@@ -268,15 +268,8 @@ class PageHandler:
         :return: the cache key.
         """

-        # Anonymous is the only actor that gets an empty auth segment, so an
-        # authenticated visitor can never share a key with an anonymous one -
-        # even with a blank or missing role. `getattr` guards actors (e.g. a
-        # Django User) that have no `role` attribute at all rather than raising.
-        if user.is_anonymous:
-            auth = ""
-        else:
-            auth = f"_auth_{getattr(user, 'role', '')}"
-        return f"ab_public_page_{page_id}{auth}_{record_name}_records"
+        role = f"_{user.role}" if not user.is_anonymous and user.role else ""
+        return f"ab_public_page_{page_id}{role}_{record_name}_records"

     def is_published_page(self, public_page_id: int) -> bool:
         """
```

Then..

- `just build backend  ci`
- `just e2e up`
- `just e2e test tests/builder/elements/elementVisibility.spec.ts --project=chrome`

And it'll fail:

```
  ✘  1 [chrome] › builder/elements/elementVisibility.spec.ts:84:7 › Builder element visibility on published pages › visitors only see elements matching their visibility permissions @enterprise (16.5s)


  1) [chrome] › builder/elements/elementVisibility.spec.ts:84:7 › Builder element visibility on published pages › visitors only see elements matching their visibility permissions @enterprise

    Error: E2_LOGGED should be visible

    Timed out 10000ms waiting for expect(locator).toBeVisible()

    Locator: locator('.ab-heading').filter({ hasText: 'E2_LOGGED' })
    Expected: visible
    Received: <element(s) not found>
    Call log:
      - E2_LOGGED should be visible with timeout 10000ms
      - waiting for locator('.ab-heading').filter({ hasText: 'E2_LOGGED' })


      193 |         const heading = page.locator(".ab-heading", { hasText: label });
      194 |         if (expectedLabels.includes(label)) {
    > 195 |           await expect(heading, `${label} should be visible`).toBeVisible();
          |                                                               ^
      196 |         } else {
      197 |           await expect(heading, `${label} should be hidden`).toHaveCount(0);
      198 |         }

        at assertVisibleFor (/Users/picklepete/Baserow/baserow/e2e-tests/tests/builder/elements/elementVisibility.spec.ts:195:63)
        at /Users/picklepete/Baserow/baserow/e2e-tests/tests/builder/elements/elementVisibility.spec.ts:208:5
```

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
