### PR TITLE
fix: multi-select filter option selection state

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_multiple_select_filter_options_not_showing_as_selected.json
+++ b/changelog/entries/unreleased/bug/fixes_multiple_select_filter_options_not_showing_as_selected.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes multiple select filter options not showing as selected",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-07"
+}

--- a/web-frontend/modules/database/components/field/FieldSelectOptionsDropdownItem.vue
+++ b/web-frontend/modules/database/components/field/FieldSelectOptionsDropdownItem.vue
@@ -14,7 +14,11 @@
       @mousemove="hover(value, disabled)"
     >
       <div v-if="multiple.value">
-        <Checkbox :disabled="disabled" :checked="isActive(value)"></Checkbox>
+        <Checkbox
+          :disabled="disabled"
+          :checked="isActive(value)"
+          @click.prevent
+        ></Checkbox>
       </div>
       <div
         class="select-options__dropdown-option"


### PR DESCRIPTION
## Summary
- Prevent checkbox clicks inside multi-select filter option items from toggling independently of the option item click handler.
- Keep selected filter options visibly checked after they are applied and after reopening the filters panel.

## Reproduce on dev
1. Create a table with a single select field
2. Add a `is any of` or `is none of` filter for that field.
3. Open the filter value dropdown and click on the checkbox.
4. On develop, notice the checkbox doesn't change the state most of the times, while clicking on the option name works.
5. On this branch, each click works as expected, both on the checkbox and the option name