### PR TITLE
fix: Send email action using instance SMTP should use FROM_EMAIL

### DIFF
--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -842,6 +842,11 @@ if BASEROW_EXTRA_PUBLIC_URLS:
             EXTRA_PUBLIC_WEB_FRONTEND_HOSTNAMES.append(hostname)
 
 FROM_EMAIL = os.getenv("FROM_EMAIL", "no-reply@localhost")
+# Align Django's built-in senders with the Baserow configured sender so that any
+# code relying on Django defaults (e.g. the `Send email` action using instance
+# SMTP) uses the configured FROM_EMAIL instead of `webmaster@localhost`.
+DEFAULT_FROM_EMAIL = FROM_EMAIL
+SERVER_EMAIL = FROM_EMAIL
 RESET_PASSWORD_TOKEN_MAX_AGE = 60 * 60 * 2  # 2 hours
 CHANGE_EMAIL_TOKEN_MAX_AGE = 60 * 60 * 12  # 12 hours
 

--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -870,7 +870,7 @@ class CoreSMTPEmailServiceType(CoreServiceType):
         using_instance_smtp = self._should_use_instance_smtp(service)
 
         if using_instance_smtp:
-            from_email = settings.DEFAULT_FROM_EMAIL
+            from_email = settings.FROM_EMAIL
             connection = get_connection(
                 backend=settings.CELERY_EMAIL_BACKEND,
                 timeout=SMTP_EMAIL_TIMEOUT,

--- a/backend/tests/baserow/contrib/integrations/core/test_smtp_email_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_smtp_email_service_type.py
@@ -165,7 +165,7 @@ def test_send_smtp_email_with_integration_ignores_global_celery_email_backend(
     CELERY_EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
     EMAIL_HOST="instance.smtp.example.com",
     EMAIL_PORT=2525,
-    DEFAULT_FROM_EMAIL="instance@example.com",
+    FROM_EMAIL="My Database <no-reply@example.com>",
 )
 def test_send_smtp_email_uses_instance_smtp_settings(data_fixture):
     service = data_fixture.create_core_smtp_email_service(
@@ -191,13 +191,53 @@ def test_send_smtp_email_uses_instance_smtp_settings(data_fixture):
         mock_email.assert_called_once_with(
             "Test Subject",
             "Hello, this is a test email!",
-            "instance@example.com",
+            "My Database <no-reply@example.com>",
             ["recipient@example.com"],
             bcc=[],
             cc=[],
             connection=mock_connection.return_value,
         )
         assert result.data == {"success": True}
+
+
+@pytest.mark.django_db
+@override_settings(
+    INTEGRATION_ALLOW_SMTP_SERVICE_TO_USE_INSTANCE_SETTINGS=True,
+    CELERY_EMAIL_BACKEND="django.core.mail.backends.smtp.EmailBackend",
+    EMAIL_HOST="instance.smtp.example.com",
+    EMAIL_PORT=2525,
+    FROM_EMAIL="My Database <no-reply@example.com>",
+    DEFAULT_FROM_EMAIL="webmaster@localhost",
+)
+def test_send_smtp_email_instance_smtp_uses_from_email_not_default(data_fixture):
+    # Regression test: the instance SMTP path must use the configured
+    # FROM_EMAIL and not fall back to Django's DEFAULT_FROM_EMAIL, which
+    # defaults to `webmaster@localhost`.
+    service = data_fixture.create_core_smtp_email_service(
+        integration=None,
+        use_instance_smtp_settings=True,
+        from_email="''",
+        from_name="''",
+        to_emails="'recipient@example.com'",
+        subject="'Test Subject'",
+        body="'Hello, this is a test email!'",
+        body_type="plain",
+    )
+
+    service_type = service.get_type()
+    dispatch_context = FakeDispatchContext()
+
+    with mock_django_email() as (mock_email, mock_connection):
+        service_type.dispatch(service, dispatch_context)
+        mock_email.assert_called_once_with(
+            "Test Subject",
+            "Hello, this is a test email!",
+            "My Database <no-reply@example.com>",
+            ["recipient@example.com"],
+            bcc=[],
+            cc=[],
+            connection=mock_connection.return_value,
+        )
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/5640_fix_the_send_email_action_using_instance_smtp_sending_from_w.json
+++ b/changelog/entries/unreleased/bug/5640_fix_the_send_email_action_using_instance_smtp_sending_from_w.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix the Send email action using instance SMTP sending from webmaster@localhost instead of the configured FROM_EMAIL.",
+    "issue_origin": "github",
+    "issue_number": 5640,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-07-08"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug [reported here](https://github.com/baserow/baserow/issues/5640).

The bug is that the `CoreSMTPEmailServiceType` service type, when using the instance SMTP, uses the `settings.DEFAULT_FROM_EMAIL`. We don't explicitly set this anywhere, so it uses Django's default `webmaster@localhost` email address.

This PR ensures that the service type reads `FROM_EMAIL` instead. It also updates `DEFAULT_FROM_EMAIL` to always points to whatever `FROM_EMAIL` is set to.

Closes https://github.com/baserow/baserow/issues/5640
Closes https://github.com/baserow/baserow/issues/5653

### How to test this PR
In `develop`, override the `FROM_EMAIL` in `base.py`:
```
FROM_EMAIL = "My Database <no-reply@example.com>"
```

Then create an Automation workflow with a Send email node configured to use the instance SMTP:
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/aace63cc-5e43-4777-a1c0-aefd1bc1f2b5" />

Then look at the local mailhog UI at http://localhost:8025/#:
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/393792d1-3b5c-4df2-af0b-bf7c028f8222" />

Notice that the From address is the default Django email address, despite overriding the `FROM_EMAIL`.

Check out this branch and repeat the test. This time you'll see that the `FROM_EMAIL` is respected:
> <img width="500" alt="image" src="https://github.com/user-attachments/assets/7010dea3-aa43-44b3-8b6f-a9b64ad5bb9b" />

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
