### PR TITLE
fix: update smartphone breakpoint

### DIFF
--- a/web-frontend/modules/builder/deviceTypes.js
+++ b/web-frontend/modules/builder/deviceTypes.js
@@ -76,10 +76,10 @@ export class SmartphoneDeviceType extends DeviceType {
   }
 
   get minWidth() {
-    return 420
+    return 500
   }
 
   get maxWidth() {
-    return 420
+    return 500
   }
 }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/column_element.scss
@@ -12,13 +12,13 @@
   }
 }
 
-@media (min-width: 421px) and (max-width: 768px) {
+@media (min-width: 501px) and (max-width: 768px) {
   .column-element--public.column-element--stack-tablet {
     grid-template-columns: 1fr;
   }
 }
 
-@media (max-width: 420px) {
+@media (max-width: 500px) {
   .column-element--public.column-element--stack-smartphone {
     grid-template-columns: 1fr;
   }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/menu_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/menu_element.scss
@@ -140,11 +140,11 @@ $bg-color-contrast: var(--page-background-color-contrast, $palette-neutral-100);
   padding: 1em;
   z-index: $z-index-layout-resize;
   overflow-y: auto;
-  max-width: 420px;
+  max-width: 500px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 0 6px 6px 0;
 
-  @media (min-width: 420px) {
+  @media (min-width: 500px) {
     animation: menu-element-slide-in-left 180ms ease-out;
   }
 

--- a/web-frontend/modules/core/assets/scss/components/builder/page_builder.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/page_builder.scss
@@ -24,7 +24,7 @@
   }
 
   &.page-builder__preview--smartphone {
-    max-width: 420px;
+    max-width: 500px;
   }
 }
 


### PR DESCRIPTION
### What is in this PR
- Update the smartphone breakpoint in application builder elements to `500px` instead of `420px`

### How to test this PR
- Create a column element stacked on mobile, side by side on tablet and desktop
- Open the page preview, and with the responsive mode in the devtools observe the layout is changing at 500/501px. (if your page has a vertical scrollbar on mobile, the layout break will happen around 516px) 

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
