### PR TITLE
fix(database): fix user presence on group-by grid being displayed incorrectly

### DIFF
--- a/changelog/entries/unreleased/bug/5684_fixed_single_select_dropdown_and_presence_badge_overlap_issu.json
+++ b/changelog/entries/unreleased/bug/5684_fixed_single_select_dropdown_and_presence_badge_overlap_issu.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed single select dropdown and presence badge overlap issues on group-by grid view",
+    "issue_origin": "github",
+    "issue_number": 5684,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-08"
+}

--- a/web-frontend/modules/core/assets/scss/components/views/grid.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/grid.scss
@@ -826,18 +826,6 @@
   }
 }
 
-.grid-view__group-by-rows-row--warning {
-  z-index: 1;
-}
-
-.grid-view__group-by-rows-row--selected {
-  z-index: 2;
-}
-
-.grid-view__group-by-rows-row--presence {
-  z-index: 3;
-}
-
 .grid-view__group-by-rows-add {
   display: block;
   box-sizing: border-box;

--- a/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewGroupByRows.vue
@@ -22,7 +22,7 @@
         :class="rowClass(item.row)"
         :style="{
           top: item.y + 'px',
-          transform: `translateX(${leftOffset || 0}px)`,
+          left: (leftOffset || 0) + 'px',
         }"
       >
         <GridViewRow
@@ -251,16 +251,7 @@ export default {
       return {
         'grid-view__group-by-rows-row--warning': this.isWarningRow(row),
         'grid-view__group-by-rows-row--selected': row._.selected,
-        'grid-view__group-by-rows-row--presence': this.rowHasPresence(row),
       }
-    },
-    rowHasPresence(row) {
-      if (this.focusEntriesByRow.has(row.id)) return true
-      const prefix = `${row.id}:`
-      for (const key of this.focusEntriesByCell.keys()) {
-        if (key.startsWith(prefix)) return true
-      }
-      return false
     },
     addRow(event, path) {
       event.preventFieldCellUnselect = true


### PR DESCRIPTION
Closes: #5684

This PR fixes two issues:

1. Single select dropdown now opens on top of user presence 
2. When user A selects the cell directly below user B's badge - the badge is now hidden (A's selection should take precedence)

https://github.com/user-attachments/assets/ca0e751a-e384-4390-babf-b909c045ff9c


### How to test this PR

Follow steps to reproduce and observe issue is gone.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
