### PR TITLE
feat: remember last-opened row sidebar tab (comments/history)

### DIFF
--- a/changelog/entries/unreleased/feature/2532_remembers_whether_you_last_opened_the_comments_or_history_ta.json
+++ b/changelog/entries/unreleased/feature/2532_remembers_whether_you_last_opened_the_comments_or_history_ta.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Remembers whether you last opened the comments or history tab when editing a row",
+    "issue_origin": "github",
+    "issue_number": 2532,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-08"
+}

--- a/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
@@ -105,8 +105,8 @@ export default {
     },
   },
   created() {
-    const types = this.sidebarTypes
-    this.selectedType = types[this.selectedTabIndex]?.getType() ?? null
+    this.selectedType =
+      this.sidebarTypes[this.selectedTabIndex]?.getType() ?? null
   },
   methods: {
     // Persist the user's tab choice; skips the mount echo (same type as shown).

--- a/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
@@ -69,8 +69,9 @@ export default {
   },
   data() {
     return {
-      // Tab type selected on open; used to avoid re-persisting on mount.
-      initialSelectedType: null,
+      // Tab type currently shown. Starts at the initial (auto-opened) tab so
+      // the mount echo is not persisted; updated on each real user selection.
+      selectedType: null,
     }
   },
   computed: {
@@ -105,13 +106,14 @@ export default {
   },
   created() {
     const types = this.sidebarTypes
-    this.initialSelectedType = types[this.selectedTabIndex]?.getType() ?? null
+    this.selectedType = types[this.selectedTabIndex]?.getType() ?? null
   },
   methods: {
-    // Persist the user's tab choice, but not the initial mount selection.
+    // Persist the user's tab choice; skips the mount echo (same type as shown).
     onTabSelected(index) {
       const type = this.sidebarTypes[index]?.getType()
-      if (type && type !== this.initialSelectedType) {
+      if (type && type !== this.selectedType) {
+        this.selectedType = type
         setRowEditModalSidebarTab(type)
       }
     },

--- a/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
@@ -6,6 +6,7 @@
     header-no-padding
     content-no-x-padding
     class="row-edit-modal-sidebar"
+    @update:selected-index="onTabSelected"
   >
     <Tab
       v-for="sidebarType in sidebarTypes"
@@ -27,6 +28,10 @@
 <script>
 import Tabs from '@baserow/modules/core/components/Tabs.vue'
 import Tab from '@baserow/modules/core/components/Tab.vue'
+import {
+  getRowEditModalSidebarTab,
+  setRowEditModalSidebarTab,
+} from '@baserow/modules/database/utils/rowEditModalSidebar'
 
 export default {
   name: 'RowEditModalSidebar',
@@ -62,9 +67,24 @@ export default {
       default: false,
     },
   },
+  data() {
+    return {
+      // Tab type selected on open; used to avoid re-persisting on mount.
+      initialSelectedType: null,
+    }
+  },
   computed: {
     selectedTabIndex() {
       const types = this.sidebarTypes
+      const remembered = getRowEditModalSidebarTab()
+      if (remembered) {
+        const rememberedIndex = types.findIndex(
+          (type) => type.getType() === remembered
+        )
+        if (rememberedIndex !== -1) {
+          return rememberedIndex
+        }
+      }
       const index = types.findIndex((type) =>
         type.isSelectedByDefault(this.database, this.table)
       )
@@ -81,6 +101,19 @@ export default {
             this.view
           ) === false && type.getComponent()
       )
+    },
+  },
+  created() {
+    const types = this.sidebarTypes
+    this.initialSelectedType = types[this.selectedTabIndex]?.getType() ?? null
+  },
+  methods: {
+    // Persist the user's tab choice, but not the initial mount selection.
+    onTabSelected(index) {
+      const type = this.sidebarTypes[index]?.getType()
+      if (type && type !== this.initialSelectedType) {
+        setRowEditModalSidebarTab(type)
+      }
     },
   },
 }

--- a/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
@@ -69,18 +69,16 @@ export default {
   },
   data() {
     return {
-      // Tab type currently shown. Starts at the initial (auto-opened) tab so
-      // the mount echo is not persisted; updated on each real user selection.
-      selectedType: null,
+      // Remembered tab type, kept reactive so `selectedTabIndex` stays in sync.
+      rememberedType: getRowEditModalSidebarTab(),
     }
   },
   computed: {
     selectedTabIndex() {
       const types = this.sidebarTypes
-      const remembered = getRowEditModalSidebarTab()
-      if (remembered) {
+      if (this.rememberedType) {
         const rememberedIndex = types.findIndex(
-          (type) => type.getType() === remembered
+          (type) => type.getType() === this.rememberedType
         )
         if (rememberedIndex !== -1) {
           return rememberedIndex
@@ -104,26 +102,17 @@ export default {
       )
     },
   },
-  watch: {
-    // Keep the tracker in sync when the tab is re-selected programmatically
-    // (e.g. the remembered tab becomes unavailable), so that emit is not
-    // mistaken for a user action and does not overwrite the stored preference.
-    selectedTabIndex(index) {
-      this.selectedType = this.sidebarTypes[index]?.getType() ?? null
-    },
-  },
-  created() {
-    this.selectedType =
-      this.sidebarTypes[this.selectedTabIndex]?.getType() ?? null
-  },
   methods: {
-    // Persist the user's tab choice; skips the mount echo (same type as shown).
+    // Persist the user's tab choice. Programmatic emits (mount echo, or a
+    // fallback when the remembered tab is unavailable) carry the already
+    // selected index and are skipped, so they never overwrite the preference.
     onTabSelected(index) {
       const type = this.sidebarTypes[index]?.getType()
-      if (type && type !== this.selectedType) {
-        this.selectedType = type
-        setRowEditModalSidebarTab(type)
+      if (!type || index === this.selectedTabIndex) {
+        return
       }
+      this.rememberedType = type
+      setRowEditModalSidebarTab(type)
     },
   },
 }

--- a/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
+++ b/web-frontend/modules/database/components/row/RowEditModalSidebar.vue
@@ -104,6 +104,14 @@ export default {
       )
     },
   },
+  watch: {
+    // Keep the tracker in sync when the tab is re-selected programmatically
+    // (e.g. the remembered tab becomes unavailable), so that emit is not
+    // mistaken for a user action and does not overwrite the stored preference.
+    selectedTabIndex(index) {
+      this.selectedType = this.sidebarTypes[index]?.getType() ?? null
+    },
+  },
   created() {
     this.selectedType =
       this.sidebarTypes[this.selectedTabIndex]?.getType() ?? null

--- a/web-frontend/modules/database/utils/rowEditModalSidebar.js
+++ b/web-frontend/modules/database/utils/rowEditModalSidebar.js
@@ -1,0 +1,20 @@
+// Persists the last-opened row edit modal sidebar tab, globally per browser.
+// Access localStorage only through here so the backing store can be swapped
+// later (e.g. to a cookie if the row modal ever becomes server-rendered).
+export const ROW_EDIT_MODAL_SIDEBAR_TAB_KEY = 'baserow.rowEditModalSidebarTab'
+
+// Returns the stored tab type string, or null when unset/unavailable.
+export function getRowEditModalSidebarTab() {
+  try {
+    return localStorage.getItem(ROW_EDIT_MODAL_SIDEBAR_TAB_KEY) || null
+  } catch (e) {
+    return null
+  }
+}
+
+// Stores the tab type string. No-op when localStorage is unavailable.
+export function setRowEditModalSidebarTab(type) {
+  try {
+    localStorage.setItem(ROW_EDIT_MODAL_SIDEBAR_TAB_KEY, type)
+  } catch (e) {}
+}

--- a/web-frontend/modules/database/utils/rowEditModalSidebar.js
+++ b/web-frontend/modules/database/utils/rowEditModalSidebar.js
@@ -7,7 +7,8 @@ export const ROW_EDIT_MODAL_SIDEBAR_TAB_KEY = 'baserow.rowEditModalSidebarTab'
 export function getRowEditModalSidebarTab() {
   try {
     return localStorage.getItem(ROW_EDIT_MODAL_SIDEBAR_TAB_KEY) || null
-  } catch (e) {
+  } catch {
+    // Ignore storage errors (e.g. unavailable in private mode).
     return null
   }
 }
@@ -16,5 +17,7 @@ export function getRowEditModalSidebarTab() {
 export function setRowEditModalSidebarTab(type) {
   try {
     localStorage.setItem(ROW_EDIT_MODAL_SIDEBAR_TAB_KEY, type)
-  } catch (e) {}
+  } catch {
+    // Ignore storage errors (e.g. unavailable in private mode or over quota).
+  }
 }

--- a/web-frontend/test/helpers/localStorage.js
+++ b/web-frontend/test/helpers/localStorage.js
@@ -1,0 +1,26 @@
+/**
+ * The Nuxt/happy-dom vitest environment does not provide localStorage. Install
+ * a minimal in-memory implementation on the global scope for tests that need it.
+ */
+export function installLocalStorageMock() {
+  if (global.localStorage) {
+    return
+  }
+  const store = {}
+  global.localStorage = {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = String(value)
+    },
+    removeItem: (key) => {
+      delete store[key]
+    },
+    clear: () => {
+      Object.keys(store).forEach((key) => delete store[key])
+    },
+    key: (index) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length
+    },
+  }
+}

--- a/web-frontend/test/helpers/localStorage.js
+++ b/web-frontend/test/helpers/localStorage.js
@@ -3,11 +3,13 @@
  * a minimal in-memory implementation on the global scope for tests that need it.
  */
 export function installLocalStorageMock() {
-  if (global.localStorage) {
+  if (globalThis.localStorage) {
     return
   }
-  const store = {}
-  global.localStorage = {
+  // Null-prototype store so keys like `toString` or `__proto__` behave like
+  // real localStorage entries instead of hitting inherited properties.
+  const store = Object.create(null)
+  globalThis.localStorage = {
     getItem: (key) => (key in store ? store[key] : null),
     setItem: (key, value) => {
       store[key] = String(value)

--- a/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
@@ -12,7 +12,12 @@ import { installLocalStorageMock } from '@baserow/test/helpers/localStorage'
 // plugin already registers a real `history` type, which register() overwrites.
 const makeType = (
   type,
-  { selectedByDefault = false, deactivated = false, order = 50 } = {}
+  {
+    selectedByDefault = false,
+    deactivated = false,
+    deactivateWhenReadOnly = false,
+    order = 50,
+  } = {}
 ) =>
   class extends RowModalSidebarType {
     static getType() {
@@ -27,7 +32,10 @@ const makeType = (
       return { name: `${type}-component`, render: () => null }
     }
 
-    isDeactivated() {
+    isDeactivated(database, table, readOnly) {
+      if (deactivateWhenReadOnly && readOnly === true) {
+        return true
+      }
       return deactivated
     }
 
@@ -146,5 +154,40 @@ describe('RowEditModalSidebar', () => {
     expect(getRowEditModalSidebarTab()).toBe('history')
     wrapper.vm.onTabSelected(commentsIndex)
     expect(getRowEditModalSidebarTab()).toBe('comments')
+  })
+
+  test('keeps the preference when props deactivate the remembered tab on a reused instance', async () => {
+    // comments stays available; history is remembered but gets deactivated when
+    // the instance is reused with readOnly=true, shifting the selected index.
+    registerTypes([
+      makeType('comments', { selectedByDefault: true, order: 0 }),
+      makeType('history', { deactivateWhenReadOnly: true, order: 10 }),
+    ])
+    setRowEditModalSidebarTab('history')
+
+    const wrapper = await testApp.mount(RowEditModalSidebar, {
+      props: {
+        database,
+        table,
+        fields: [],
+        row: { id: 1, _: {} },
+        view: null,
+        readOnly: false,
+      },
+    })
+    // history is remembered and available -> selected at index 1.
+    expect(wrapper.vm.selectedTabIndex).toBe(1)
+
+    // Reuse the same instance in a context where history is deactivated; the
+    // index drops to 0 (comments) and Tabs re-selects programmatically.
+    await wrapper.setProps({ readOnly: true })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.vm.sidebarTypes.map((t) => t.getType())).toEqual([
+      'comments',
+    ])
+    expect(wrapper.vm.selectedTabIndex).toBe(0)
+    // The stored preference must survive so it returns when history is available.
+    expect(getRowEditModalSidebarTab()).toBe('history')
   })
 })

--- a/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
@@ -1,0 +1,143 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import RowEditModalSidebar from '@baserow/modules/database/components/row/RowEditModalSidebar'
+import { RowModalSidebarType } from '@baserow/modules/database/rowModalSidebarTypes'
+import {
+  getRowEditModalSidebarTab,
+  setRowEditModalSidebarTab,
+} from '@baserow/modules/database/utils/rowEditModalSidebar'
+
+// Minimal fake sidebar types so the test does not depend on premium comments.
+// Explicit order mirrors the real types (comments 0, history 10); the database
+// plugin already registers a real `history` type, which register() overwrites.
+const makeType = (
+  type,
+  { selectedByDefault = false, deactivated = false, order = 50 } = {}
+) =>
+  class extends RowModalSidebarType {
+    static getType() {
+      return type
+    }
+
+    getName() {
+      return type
+    }
+
+    getComponent() {
+      return { name: `${type}-component`, render: () => null }
+    }
+
+    isDeactivated() {
+      return deactivated
+    }
+
+    isSelectedByDefault() {
+      return selectedByDefault
+    }
+
+    getOrder() {
+      return order
+    }
+  }
+
+describe('RowEditModalSidebar', () => {
+  let testApp = null
+
+  // This Nuxt/happy-dom vitest env does not provide localStorage; polyfill it
+  // so the helper's real read/write (and thus persistence assertions) work.
+  beforeAll(() => {
+    if (!global.localStorage) {
+      const store = {}
+      global.localStorage = {
+        getItem: (key) => store[key] ?? null,
+        setItem: (key, value) => {
+          store[key] = value
+        },
+        removeItem: (key) => {
+          delete store[key]
+        },
+        clear: () => {
+          Object.keys(store).forEach((key) => delete store[key])
+        },
+      }
+    }
+  })
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    localStorage.clear()
+  })
+
+  afterEach(async () => {
+    localStorage.clear()
+    await testApp.afterEach()
+  })
+
+  const database = { id: 1, workspace: { id: 1 } }
+  const table = { id: 1 }
+
+  const registerTypes = (types) => {
+    const registry = testApp.getRegistry()
+    types.forEach((TypeClass) =>
+      registry.register('rowModalSidebar', new TypeClass({ app: testApp._app }))
+    )
+  }
+
+  const mount = async () =>
+    testApp.mount(RowEditModalSidebar, {
+      props: { database, table, fields: [], row: { id: 1, _: {} }, view: null },
+    })
+
+  test('selects the default tab when no preference is stored', async () => {
+    registerTypes([
+      makeType('comments', { selectedByDefault: true, order: 0 }),
+      makeType('history', { order: 10 }),
+    ])
+    const wrapper = await mount()
+    expect(wrapper.vm.selectedTabIndex).toBe(0)
+  })
+
+  test('selects the remembered tab when it is available', async () => {
+    setRowEditModalSidebarTab('history')
+    registerTypes([
+      makeType('comments', { selectedByDefault: true, order: 0 }),
+      makeType('history', { order: 10 }),
+    ])
+    const wrapper = await mount()
+    const index = wrapper.vm.sidebarTypes.findIndex(
+      (t) => t.getType() === 'history'
+    )
+    expect(wrapper.vm.selectedTabIndex).toBe(index)
+  })
+
+  test('falls back to default and keeps preference when remembered tab is unavailable', async () => {
+    setRowEditModalSidebarTab('comments')
+    registerTypes([
+      makeType('comments', {
+        selectedByDefault: true,
+        deactivated: true,
+        order: 0,
+      }),
+      makeType('history', { order: 10 }),
+    ])
+    const wrapper = await mount()
+    const historyIndex = wrapper.vm.sidebarTypes.findIndex(
+      (t) => t.getType() === 'history'
+    )
+    expect(wrapper.vm.selectedTabIndex).toBe(historyIndex)
+    // Preference is preserved for when comments is available again.
+    expect(getRowEditModalSidebarTab()).toBe('comments')
+  })
+
+  test('persists the tab type when the user selects a different tab', async () => {
+    registerTypes([
+      makeType('comments', { selectedByDefault: true, order: 0 }),
+      makeType('history', { order: 10 }),
+    ])
+    const wrapper = await mount()
+    const historyIndex = wrapper.vm.sidebarTypes.findIndex(
+      (t) => t.getType() === 'history'
+    )
+    wrapper.vm.onTabSelected(historyIndex)
+    expect(getRowEditModalSidebarTab()).toBe('history')
+  })
+})

--- a/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
@@ -140,4 +140,22 @@ describe('RowEditModalSidebar', () => {
     wrapper.vm.onTabSelected(historyIndex)
     expect(getRowEditModalSidebarTab()).toBe('history')
   })
+
+  test('persists the latest tab when the user switches back and forth', async () => {
+    registerTypes([
+      makeType('comments', { selectedByDefault: true, order: 0 }),
+      makeType('history', { order: 10 }),
+    ])
+    const wrapper = await mount()
+    const commentsIndex = wrapper.vm.sidebarTypes.findIndex(
+      (t) => t.getType() === 'comments'
+    )
+    const historyIndex = wrapper.vm.sidebarTypes.findIndex(
+      (t) => t.getType() === 'history'
+    )
+    wrapper.vm.onTabSelected(historyIndex)
+    expect(getRowEditModalSidebarTab()).toBe('history')
+    wrapper.vm.onTabSelected(commentsIndex)
+    expect(getRowEditModalSidebarTab()).toBe('comments')
+  })
 })

--- a/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
@@ -5,6 +5,7 @@ import {
   getRowEditModalSidebarTab,
   setRowEditModalSidebarTab,
 } from '@baserow/modules/database/utils/rowEditModalSidebar'
+import { installLocalStorageMock } from '@baserow/test/helpers/localStorage'
 
 // Minimal fake sidebar types so the test does not depend on premium comments.
 // Explicit order mirrors the real types (comments 0, history 10); the database
@@ -45,21 +46,7 @@ describe('RowEditModalSidebar', () => {
   // This Nuxt/happy-dom vitest env does not provide localStorage; polyfill it
   // so the helper's real read/write (and thus persistence assertions) work.
   beforeAll(() => {
-    if (!global.localStorage) {
-      const store = {}
-      global.localStorage = {
-        getItem: (key) => store[key] ?? null,
-        setItem: (key, value) => {
-          store[key] = value
-        },
-        removeItem: (key) => {
-          delete store[key]
-        },
-        clear: () => {
-          Object.keys(store).forEach((key) => delete store[key])
-        },
-      }
-    }
+    installLocalStorageMock()
   })
 
   beforeEach(() => {

--- a/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/components/row/rowEditModalSidebar.spec.js
@@ -94,6 +94,8 @@ describe('RowEditModalSidebar', () => {
     ])
     const wrapper = await mount()
     expect(wrapper.vm.selectedTabIndex).toBe(0)
+    // Mounting the default tab must not persist a preference.
+    expect(getRowEditModalSidebarTab()).toBe(null)
   })
 
   test('selects the remembered tab when it is available', async () => {

--- a/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
@@ -1,0 +1,58 @@
+import { beforeAll } from 'vitest'
+import {
+  ROW_EDIT_MODAL_SIDEBAR_TAB_KEY,
+  getRowEditModalSidebarTab,
+  setRowEditModalSidebarTab,
+} from '@baserow/modules/database/utils/rowEditModalSidebar'
+
+describe('rowEditModalSidebar utils', () => {
+  beforeAll(() => {
+    // Provide localStorage if not available in test environment
+    if (!global.localStorage) {
+      const store = {}
+      global.localStorage = {
+        getItem: (key) => store[key] ?? null,
+        setItem: (key, value) => {
+          store[key] = value
+        },
+        removeItem: (key) => {
+          delete store[key]
+        },
+        clear: () => {
+          Object.keys(store).forEach((key) => delete store[key])
+        },
+        key: (index) => Object.keys(store)[index] ?? null,
+        length: Object.keys(store).length,
+      }
+    }
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  test('returns null when nothing is stored', () => {
+    expect(getRowEditModalSidebarTab()).toBe(null)
+  })
+
+  test('round-trips a stored tab type', () => {
+    setRowEditModalSidebarTab('history')
+    expect(localStorage.getItem(ROW_EDIT_MODAL_SIDEBAR_TAB_KEY)).toBe('history')
+    expect(getRowEditModalSidebarTab()).toBe('history')
+  })
+
+  test('get returns null when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('unavailable')
+    })
+    expect(getRowEditModalSidebarTab()).toBe(null)
+  })
+
+  test('set does not throw when localStorage throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('unavailable')
+    })
+    expect(() => setRowEditModalSidebarTab('comments')).not.toThrow()
+  })
+})

--- a/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
@@ -1,30 +1,13 @@
-import { beforeAll } from 'vitest'
 import {
   ROW_EDIT_MODAL_SIDEBAR_TAB_KEY,
   getRowEditModalSidebarTab,
   setRowEditModalSidebarTab,
 } from '@baserow/modules/database/utils/rowEditModalSidebar'
+import { installLocalStorageMock } from '@baserow/test/helpers/localStorage'
 
 describe('rowEditModalSidebar utils', () => {
   beforeAll(() => {
-    // Provide localStorage if not available in test environment
-    if (!global.localStorage) {
-      const store = {}
-      global.localStorage = {
-        getItem: (key) => store[key] ?? null,
-        setItem: (key, value) => {
-          store[key] = value
-        },
-        removeItem: (key) => {
-          delete store[key]
-        },
-        clear: () => {
-          Object.keys(store).forEach((key) => delete store[key])
-        },
-        key: (index) => Object.keys(store)[index] ?? null,
-        length: Object.keys(store).length,
-      }
-    }
+    installLocalStorageMock()
   })
 
   afterEach(() => {

--- a/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
+++ b/web-frontend/test/unit/database/utils/rowEditModalSidebar.spec.js
@@ -43,14 +43,14 @@ describe('rowEditModalSidebar utils', () => {
   })
 
   test('get returns null when localStorage throws', () => {
-    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+    vi.spyOn(localStorage, 'getItem').mockImplementation(() => {
       throw new Error('unavailable')
     })
     expect(getRowEditModalSidebarTab()).toBe(null)
   })
 
   test('set does not throw when localStorage throws', () => {
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
       throw new Error('unavailable')
     })
     expect(() => setRowEditModalSidebarTab('comments')).not.toThrow()


### PR DESCRIPTION
Closes #2532

The row edit modal has two sidebar tabs, Comments and History. Until now it always opened on the default tab, so anyone who mostly uses one tab had to switch to it every time they opened a row.

Now the modal remembers which tab you last opened and reopens on it, for any row, table, or database. The choice is stored per browser.

### How it works
- The last-opened tab is saved in `localStorage` (a single value). It is never sent to the server, which is what the issue discussion preferred over a cookie.
- All storage access goes through a small helper, so the backing store can be swapped later (for example to a cookie) without touching the component.
- If the remembered tab isn't available in the current context (for example Comments in a workspace without it), the modal falls back to the normal default and keeps the saved preference for when that tab is available again.

### Testing
- Unit tests for the helper (round-trip and graceful degradation when storage is unavailable) and for the sidebar component (default selection, remembering, non-destructive fallback, and persisting the latest choice).
- Verified in the browser against the dev stack: switched a row to History, opened a different row, and it reopened on History.

### Screenshot
<img width="1504" height="818" alt="Screenshot 2026-07-08 at 16 29 31" src="https://github.com/user-attachments/assets/35870923-d189-49ac-9f38-c3b5e528a602" />

