### PR TITLE
fix(frontend): preserve blank lines in rich text fields

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -569,6 +569,32 @@ class LongTextFieldType(CollationSortMixin, FieldType):
         value = getattr(row, field.db_column)
         return collate_expression(Value(value))
 
+    def force_same_type_alter_column(self, from_field, to_field):
+        from_rich = getattr(from_field, "long_text_enable_rich_text", False)
+        to_rich = getattr(to_field, "long_text_enable_rich_text", False)
+        return from_rich != to_rich
+
+    def get_alter_column_prepare_new_value(self, connection, from_field, to_field):
+        from_rich = getattr(from_field, "long_text_enable_rich_text", False)
+        to_rich = getattr(to_field, "long_text_enable_rich_text", False)
+
+        if connection.vendor == "postgresql" and not from_rich and to_rich:
+            # Pad runs of 2+ newlines so blank lines survive markdown parsing.
+            return r"""
+                p_in = regexp_replace(p_in, E'\r\n', E'\n', 'g');
+                p_in = regexp_replace(p_in, E'(\n{2,})', E'\\1\n', 'g');
+            """
+
+        if connection.vendor == "postgresql" and from_rich and not to_rich:
+            # Reverse the padding: collapse runs of 3+ newlines by removing one.
+            return r"""
+                p_in = regexp_replace(p_in, E'\n(\n{2,})', E'\\1', 'g');
+            """
+
+        return super().get_alter_column_prepare_new_value(
+            connection, from_field, to_field
+        )
+
 
 class URLFieldType(CollationSortMixin, TextFieldMatchingRegexFieldType):
     type = "url"

--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -569,31 +569,68 @@ class LongTextFieldType(CollationSortMixin, FieldType):
         value = getattr(row, field.db_column)
         return collate_expression(Value(value))
 
-    def force_same_type_alter_column(self, from_field, to_field):
+    def after_update(
+        self,
+        from_field,
+        to_field,
+        from_model,
+        to_model,
+        user,
+        connection,
+        altered_column,
+        before,
+        to_field_kwargs,
+    ):
         from_rich = getattr(from_field, "long_text_enable_rich_text", False)
         to_rich = getattr(to_field, "long_text_enable_rich_text", False)
-        return from_rich != to_rich
 
-    def get_alter_column_prepare_new_value(self, connection, from_field, to_field):
-        from_rich = getattr(from_field, "long_text_enable_rich_text", False)
-        to_rich = getattr(to_field, "long_text_enable_rich_text", False)
+        if from_rich == to_rich or connection.vendor != "postgresql":
+            return
 
-        if connection.vendor == "postgresql" and not from_rich and to_rich:
+        col = to_field.db_column
+
+        if not from_rich and to_rich:
             # Pad runs of 2+ newlines so blank lines survive markdown parsing.
-            return r"""
-                p_in = regexp_replace(p_in, E'\r\n', E'\n', 'g');
-                p_in = regexp_replace(p_in, E'(\n{2,})', E'\\1\n', 'g');
-            """
-
-        if connection.vendor == "postgresql" and from_rich and not to_rich:
-            # Reverse the padding: collapse runs of 3+ newlines by removing one.
-            return r"""
-                p_in = regexp_replace(p_in, E'\n(\n{2,})', E'\\1', 'g');
-            """
-
-        return super().get_alter_column_prepare_new_value(
-            connection, from_field, to_field
-        )
+            # Filter includes \r\n\r\n rows since CRLF is normalized first.
+            qs = to_model.objects.filter(
+                Q(**{f"{col}__contains": "\n\n"})
+                | Q(**{f"{col}__contains": "\r\n\r\n"})
+            )
+            normalized = Func(
+                F(col),
+                Value("\r\n"),
+                Value("\n"),
+                Value("g"),
+                function="regexp_replace",
+                output_field=models.TextField(),
+            )
+            qs.update(
+                **{
+                    col: Func(
+                        normalized,
+                        Value("(\n{2,})"),
+                        Value("\\1\n"),
+                        Value("g"),
+                        function="regexp_replace",
+                        output_field=models.TextField(),
+                    )
+                }
+            )
+        else:
+            # Collapse runs of 3+ newlines by removing one.
+            qs = to_model.objects.filter(**{f"{col}__contains": "\n\n\n"})
+            qs.update(
+                **{
+                    col: Func(
+                        F(col),
+                        Value("\n(\n{2,})"),
+                        Value("\\1"),
+                        Value("g"),
+                        function="regexp_replace",
+                        output_field=models.TextField(),
+                    )
+                }
+            )
 
 
 class URLFieldType(CollationSortMixin, TextFieldMatchingRegexFieldType):

--- a/backend/tests/baserow/contrib/database/field/test_field_types.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_types.py
@@ -452,6 +452,95 @@ def test_long_text_field_type(data_fixture):
 
 
 @pytest.mark.django_db
+def test_long_text_enable_rich_text_pads_blank_lines(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_long_text_field(
+        table=table, name="notes", long_text_enable_rich_text=False
+    )
+
+    model = table.get_model(attribute_names=True)
+    row_standard = model.objects.create(notes="Hello\n\nWorld")
+    row_extra = model.objects.create(notes="Hello\n\n\nWorld")
+    row_crlf = model.objects.create(notes="Hello\r\n\r\nWorld")
+    row_none = model.objects.create(notes=None)
+    row_no_newlines = model.objects.create(notes="Hello World")
+
+    handler = FieldHandler()
+    handler.update_field(
+        user=user, field=field, long_text_enable_rich_text=True
+    )
+
+    model = table.get_model(attribute_names=True)
+    row_standard.refresh_from_db()
+    row_extra.refresh_from_db()
+    row_crlf.refresh_from_db()
+    row_none.refresh_from_db()
+    row_no_newlines.refresh_from_db()
+
+    assert row_standard.notes == "Hello\n\n\nWorld"
+    assert row_extra.notes == "Hello\n\n\n\nWorld"
+    assert row_crlf.notes == "Hello\n\n\nWorld"
+    assert row_none.notes is None
+    assert row_no_newlines.notes == "Hello World"
+
+
+@pytest.mark.django_db
+def test_long_text_disable_rich_text_collapses_padding(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_long_text_field(
+        table=table, name="notes", long_text_enable_rich_text=True
+    )
+
+    model = table.get_model(attribute_names=True)
+    row_padded = model.objects.create(notes="Hello\n\n\nWorld")
+    row_extra = model.objects.create(notes="Hello\n\n\n\nWorld")
+    row_standard = model.objects.create(notes="Hello\n\nWorld")
+    row_single = model.objects.create(notes="Hello\nWorld")
+
+    handler = FieldHandler()
+    handler.update_field(
+        user=user, field=field, long_text_enable_rich_text=False
+    )
+
+    row_padded.refresh_from_db()
+    row_extra.refresh_from_db()
+    row_standard.refresh_from_db()
+    row_single.refresh_from_db()
+
+    assert row_padded.notes == "Hello\n\nWorld"
+    assert row_extra.notes == "Hello\n\n\nWorld"
+    assert row_standard.notes == "Hello\n\nWorld"
+    assert row_single.notes == "Hello\nWorld"
+
+
+@pytest.mark.django_db
+def test_long_text_rich_text_toggle_does_not_inflate_newlines(data_fixture):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_long_text_field(
+        table=table, name="notes", long_text_enable_rich_text=False
+    )
+
+    model = table.get_model(attribute_names=True)
+    row = model.objects.create(notes="Line1\n\nLine2\n\n\nLine3")
+
+    handler = FieldHandler()
+
+    for _ in range(3):
+        handler.update_field(
+            user=user, field=field, long_text_enable_rich_text=True
+        )
+        handler.update_field(
+            user=user, field=field, long_text_enable_rich_text=False
+        )
+
+    row.refresh_from_db()
+    assert row.notes == "Line1\n\nLine2\n\n\nLine3"
+
+
+@pytest.mark.django_db
 def test_valid_url(data_fixture):
     user = data_fixture.create_user()
     table = data_fixture.create_database_table(user=user)

--- a/backend/tests/baserow/contrib/database/field/test_field_types.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_types.py
@@ -467,9 +467,7 @@ def test_long_text_enable_rich_text_pads_blank_lines(data_fixture):
     row_no_newlines = model.objects.create(notes="Hello World")
 
     handler = FieldHandler()
-    handler.update_field(
-        user=user, field=field, long_text_enable_rich_text=True
-    )
+    handler.update_field(user=user, field=field, long_text_enable_rich_text=True)
 
     model = table.get_model(attribute_names=True)
     row_standard.refresh_from_db()
@@ -500,9 +498,7 @@ def test_long_text_disable_rich_text_collapses_padding(data_fixture):
     row_single = model.objects.create(notes="Hello\nWorld")
 
     handler = FieldHandler()
-    handler.update_field(
-        user=user, field=field, long_text_enable_rich_text=False
-    )
+    handler.update_field(user=user, field=field, long_text_enable_rich_text=False)
 
     row_padded.refresh_from_db()
     row_extra.refresh_from_db()
@@ -529,15 +525,49 @@ def test_long_text_rich_text_toggle_does_not_inflate_newlines(data_fixture):
     handler = FieldHandler()
 
     for _ in range(3):
-        handler.update_field(
-            user=user, field=field, long_text_enable_rich_text=True
-        )
-        handler.update_field(
-            user=user, field=field, long_text_enable_rich_text=False
-        )
+        handler.update_field(user=user, field=field, long_text_enable_rich_text=True)
+        handler.update_field(user=user, field=field, long_text_enable_rich_text=False)
 
     row.refresh_from_db()
     assert row.notes == "Line1\n\nLine2\n\n\nLine3"
+
+
+@pytest.mark.django_db
+def test_long_text_rich_text_toggle_k2_oscillation(data_fixture):
+    """Rich k=2 (paragraph break, no blank line) inflates to k=3 on rich→plain→rich.
+
+    This is an inherent cardinality mismatch: rich text distinguishes paragraph
+    break (k=2) from blank line (k=3), but plain text only has k=2 for both.
+    Any integer-shift threshold moves the bug but cannot eliminate it. The
+    current behavior (k=2 inflates to k=3) is the least-bad option — the
+    visual difference is a slightly taller gap, not data corruption.
+    """
+
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    field = data_fixture.create_long_text_field(
+        table=table, name="notes", long_text_enable_rich_text=True
+    )
+
+    model = table.get_model(attribute_names=True)
+    row = model.objects.create(notes="A\n\nB")
+
+    handler = FieldHandler()
+
+    # rich→plain: collapse skips k=2 (threshold k≥3), stays \n\n
+    handler.update_field(user=user, field=field, long_text_enable_rich_text=False)
+    row.refresh_from_db()
+    assert row.notes == "A\n\nB"
+
+    # plain→rich: pad matches k≥2, inflates to \n\n\n
+    handler.update_field(user=user, field=field, long_text_enable_rich_text=True)
+    row.refresh_from_db()
+    assert row.notes == "A\n\n\nB"
+
+    # Second cycle: rich→plain collapses k=3 back to k=2
+    handler.update_field(user=user, field=field, long_text_enable_rich_text=False)
+    row.refresh_from_db()
+    assert row.notes == "A\n\nB"
 
 
 @pytest.mark.django_db

--- a/changelog/entries/unreleased/bug/2495_fix_multi_line_support_for_long_text_with_rich_text_enabled.json
+++ b/changelog/entries/unreleased/bug/2495_fix_multi_line_support_for_long_text_with_rich_text_enabled.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix multi-line support for long text with rich text enabled",
+    "issue_origin": "github",
+    "issue_number": 2495,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-08"
+}

--- a/web-frontend/modules/core/components/editor/RichTextEditor.vue
+++ b/web-frontend/modules/core/components/editor/RichTextEditor.vue
@@ -72,6 +72,10 @@ import { Markdown } from 'tiptap-markdown'
 import RichTextEditorBubbleMenu from '@baserow/modules/core/components/editor/RichTextEditorBubbleMenu'
 import RichTextEditorFloatingMenu from '@baserow/modules/core/components/editor/RichTextEditorFloatingMenu'
 import { EnterStopEditExtension } from '@baserow/modules/core/editor/enterStopEditExtension'
+import {
+  ParagraphWithEmptyPreservation,
+  padBlankLinesForMarkdown,
+} from '@baserow/modules/core/editor/emptyParagraphPreservation'
 import { ScalableImage } from '@baserow/modules/core/editor/image'
 import { isElement } from '@baserow/modules/core/utils/dom'
 import { isOsSpecificModifierPressed } from '@baserow/modules/core/utils/events'
@@ -276,8 +280,12 @@ export default {
       }
     },
     getConfiguredExtensions() {
-      // Base extensions that are always enabled.
-      const extensions = [Document, Paragraph, Text, HardBreak]
+      // When rich text is on, use ParagraphWithEmptyPreservation so
+      // empty paragraphs survive the markdown round-trip.
+      const paragraphExt = this.enableRichTextFormatting
+        ? ParagraphWithEmptyPreservation
+        : Paragraph
+      const extensions = [Document, paragraphExt, Text, HardBreak]
 
       if (this.enableRichTextFormatting) {
         extensions.push(
@@ -334,6 +342,9 @@ export default {
               return true
             }
           },
+          transformPastedText: this.enableRichTextFormatting
+            ? (text) => padBlankLinesForMarkdown(text)
+            : undefined,
           handlePaste: (view, event) => {
             const plainText = event.clipboardData.getData('text/plain')
             if (plainText.startsWith('"') && plainText.endsWith('"')) {

--- a/web-frontend/modules/core/components/editor/RichTextEditor.vue
+++ b/web-frontend/modules/core/components/editor/RichTextEditor.vue
@@ -280,8 +280,6 @@ export default {
       }
     },
     getConfiguredExtensions() {
-      // When rich text is on, use ParagraphWithEmptyPreservation so
-      // empty paragraphs survive the markdown round-trip.
       const paragraphExt = this.enableRichTextFormatting
         ? ParagraphWithEmptyPreservation
         : Paragraph

--- a/web-frontend/modules/core/editor/emptyParagraphPreservation.js
+++ b/web-frontend/modules/core/editor/emptyParagraphPreservation.js
@@ -22,6 +22,8 @@ export function blankLinePreservation(md) {
   if (md._blankLinePreservationInstalled) return
   md._blankLinePreservationInstalled = true
 
+  // markdown-it discards blank lines between blocks. This rule detects gaps
+  // in the source-line map and re-inserts empty <p> tokens to preserve them.
   md.core.ruler.push('preserve_blank_lines', (state) => {
     const tokens = state.tokens
     const newTokens = []
@@ -30,12 +32,15 @@ export function blankLinePreservation(md) {
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i]
 
+      // Only top-level opening/self-closing tokens carry a source map we
+      // can compare against the previous block's end line.
       if (
         token.nesting >= 0 &&
         token.map &&
         token.level === 0 &&
         lastBlockEnd !== null
       ) {
+        // Gap between previous block's end and this block's start = blank lines
         const blankLines = Math.max(0, token.map[0] - lastBlockEnd - 1)
         for (let j = 0; j < blankLines; j++) {
           newTokens.push(new state.Token('paragraph_open', 'p', 1))
@@ -45,6 +50,9 @@ export function blankLinePreservation(md) {
 
       newTokens.push(token)
 
+      // Track where this block ends. Container tokens (nesting=1, e.g.
+      // list/blockquote) overcount — their map spans past trailing blanks,
+      // so we walk children via getContentEnd to find the real boundary.
       if (token.map && token.level === 0 && token.nesting >= 0) {
         lastBlockEnd =
           token.nesting === 1 ? getContentEnd(tokens, i) : token.map[1]

--- a/web-frontend/modules/core/editor/emptyParagraphPreservation.js
+++ b/web-frontend/modules/core/editor/emptyParagraphPreservation.js
@@ -1,0 +1,78 @@
+import Paragraph from '@tiptap/extension-paragraph'
+
+/**
+ * Pads runs of 2+ newlines with one extra newline so that
+ * blankLinePreservation can detect the gap on parse.
+ */
+export function padBlankLinesForMarkdown(text) {
+  return text.replace(/\n{2,}/g, (m) => m + '\n')
+}
+
+/**
+ * Markdown-it plugin that preserves blank lines as empty paragraphs.
+ * Detects gaps in token source-line maps and injects empty paragraph
+ * tokens for each blank line beyond the standard paragraph separator.
+ */
+export function blankLinePreservation(md) {
+  // parse.setup is called on every parse() — guard against duplicate registration
+  if (md._blankLinePreservationInstalled) return
+  md._blankLinePreservationInstalled = true
+
+  md.core.ruler.push('preserve_blank_lines', (state) => {
+    const tokens = state.tokens
+    const newTokens = []
+    let lastBlockEnd = null
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]
+
+      if (
+        token.nesting === 1 &&
+        token.map &&
+        token.level === 0 &&
+        lastBlockEnd !== null
+      ) {
+        const blankLines = token.map[0] - lastBlockEnd - 1
+        for (let j = 0; j < blankLines; j++) {
+          newTokens.push(new state.Token('paragraph_open', 'p', 1))
+          newTokens.push(new state.Token('paragraph_close', 'p', -1))
+        }
+      }
+
+      newTokens.push(token)
+
+      if (token.nesting === 1 && token.map && token.level === 0) {
+        lastBlockEnd = token.map[1]
+      }
+    }
+
+    state.tokens = newTokens
+  })
+}
+
+/**
+ * TipTap Paragraph extension that preserves empty paragraphs through
+ * the markdown round-trip. Empty paragraphs serialize as extra newlines
+ * in markdown, and blankLinePreservation restores them on parse.
+ */
+export const ParagraphWithEmptyPreservation = Paragraph.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state, node) {
+          if (node.childCount === 0) {
+            state.write('')
+          } else {
+            state.renderInline(node)
+          }
+          state.closeBlock(node)
+        },
+        parse: {
+          setup(markdownit) {
+            blankLinePreservation(markdownit)
+          },
+        },
+      },
+    }
+  },
+})

--- a/web-frontend/modules/core/editor/emptyParagraphPreservation.js
+++ b/web-frontend/modules/core/editor/emptyParagraphPreservation.js
@@ -1,20 +1,24 @@
 import Paragraph from '@tiptap/extension-paragraph'
 
-/**
- * Pads runs of 2+ newlines with one extra newline so that
- * blankLinePreservation can detect the gap on parse.
- */
 export function padBlankLinesForMarkdown(text) {
-  return text.replace(/\n{2,}/g, (m) => m + '\n')
+  return text.replace(/\r\n/g, '\n').replace(/\n{2,}/g, (m) => m + '\n')
 }
 
-/**
- * Markdown-it plugin that preserves blank lines as empty paragraphs.
- * Detects gaps in token source-line maps and injects empty paragraph
- * tokens for each blank line beyond the standard paragraph separator.
- */
+// For container blocks (lists, blockquotes), the token map overshoots past
+// trailing blank lines. Walk children to find the real content boundary.
+function getContentEnd(tokens, idx) {
+  const container = tokens[idx]
+  let end = container.map[0]
+  for (let j = idx + 1; j < tokens.length; j++) {
+    if (tokens[j].level <= container.level) break
+    if (tokens[j].type === 'inline' && tokens[j].map) {
+      end = tokens[j].map[1]
+    }
+  }
+  return end
+}
+
 export function blankLinePreservation(md) {
-  // parse.setup is called on every parse() — guard against duplicate registration
   if (md._blankLinePreservationInstalled) return
   md._blankLinePreservationInstalled = true
 
@@ -27,12 +31,12 @@ export function blankLinePreservation(md) {
       const token = tokens[i]
 
       if (
-        token.nesting === 1 &&
+        token.nesting >= 0 &&
         token.map &&
         token.level === 0 &&
         lastBlockEnd !== null
       ) {
-        const blankLines = token.map[0] - lastBlockEnd - 1
+        const blankLines = Math.max(0, token.map[0] - lastBlockEnd - 1)
         for (let j = 0; j < blankLines; j++) {
           newTokens.push(new state.Token('paragraph_open', 'p', 1))
           newTokens.push(new state.Token('paragraph_close', 'p', -1))
@@ -41,8 +45,9 @@ export function blankLinePreservation(md) {
 
       newTokens.push(token)
 
-      if (token.nesting === 1 && token.map && token.level === 0) {
-        lastBlockEnd = token.map[1]
+      if (token.map && token.level === 0 && token.nesting >= 0) {
+        lastBlockEnd =
+          token.nesting === 1 ? getContentEnd(tokens, i) : token.map[1]
       }
     }
 
@@ -50,11 +55,6 @@ export function blankLinePreservation(md) {
   })
 }
 
-/**
- * TipTap Paragraph extension that preserves empty paragraphs through
- * the markdown round-trip. Empty paragraphs serialize as extra newlines
- * in markdown, and blankLinePreservation restores them on parse.
- */
 export const ParagraphWithEmptyPreservation = Paragraph.extend({
   addStorage() {
     return {

--- a/web-frontend/modules/core/editor/markdown.js
+++ b/web-frontend/modules/core/editor/markdown.js
@@ -1,6 +1,7 @@
 import Markdown from 'markdown-it'
 import taskLists from 'markdown-it-task-lists'
 import { parseMention } from '@baserow/modules/core/editor/mention'
+import { blankLinePreservation } from '@baserow/modules/core/editor/emptyParagraphPreservation'
 
 export const parseMarkdown = (
   value,
@@ -66,5 +67,12 @@ export const parseMarkdown = (
   // mentions
   md.use(parseMention(workspaceUsers || [], loggedUserId))
 
-  return md.render(value || '')
+  // blank line preservation
+  md.use(blankLinePreservation)
+
+  let html = md.render(value || '')
+  // Empty paragraphs from blankLinePreservation render as zero-height
+  // <p></p>. Replace with <br> for consistent visual spacing.
+  html = html.replace(/<p><\/p>/g, '<br>')
+  return html
 }

--- a/web-frontend/modules/core/editor/markdown.js
+++ b/web-frontend/modules/core/editor/markdown.js
@@ -70,7 +70,8 @@ export const parseMarkdown = (
   md.use(blankLinePreservation)
 
   let html = md.render(value || '')
-  // Empty <p> from preservation have zero height
+  // Empty <p> renders at full line height (32px) in preview; <br> gives a
+  // smaller gap that better matches the editor's empty-paragraph spacing.
   html = html.replace(/<p><\/p>/g, '<br>')
   return html
 }

--- a/web-frontend/modules/core/editor/markdown.js
+++ b/web-frontend/modules/core/editor/markdown.js
@@ -67,12 +67,10 @@ export const parseMarkdown = (
   // mentions
   md.use(parseMention(workspaceUsers || [], loggedUserId))
 
-  // blank line preservation
   md.use(blankLinePreservation)
 
   let html = md.render(value || '')
-  // Empty paragraphs from blankLinePreservation render as zero-height
-  // <p></p>. Replace with <br> for consistent visual spacing.
+  // Empty <p> from preservation have zero height
   html = html.replace(/<p><\/p>/g, '<br>')
   return html
 }

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
@@ -116,10 +116,8 @@ export default {
       this.save()
     },
     onPaste() {
-      // When the TipTap editor is active, it handles paste via handlePaste
-      // in editorProps. Return true to prevent the grid's paste handler
-      // from also processing the event and overwriting the editor content.
-      return this.editing && !this.isModalOpen()
+      // Prevent grid paste handler when TipTap editor is active
+      return this.editing
     },
     canSaveByPressingEnter() {
       return false

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
@@ -115,6 +115,12 @@ export default {
       this.preventNextUnselect = true
       this.save()
     },
+    onPaste() {
+      // When the TipTap editor is active, it handles paste via handlePaste
+      // in editorProps. Return true to prevent the grid's paste handler
+      // from also processing the event and overwriting the editor content.
+      return this.editing && !this.isModalOpen()
+    },
     canSaveByPressingEnter() {
       return false
     },

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1381,7 +1381,25 @@ export class LongTextFieldType extends FieldType {
     return !field.long_text_enable_rich_text
   }
 
+  prepareRichValueForCopy(field, value) {
+    return {
+      value: this.prepareValueForCopy(field, value),
+      isRichText: !!field.long_text_enable_rich_text,
+    }
+  }
+
   prepareValueForPaste(field, clipboardData, richClipboardData) {
+    if (richClipboardData != null && typeof richClipboardData === 'object') {
+      const { value, isRichText } = richClipboardData
+      if (
+        field.long_text_enable_rich_text &&
+        !isRichText &&
+        value?.includes('\n\n')
+      ) {
+        return padBlankLinesForMarkdown(value)
+      }
+      return value
+    }
     if (typeof richClipboardData === 'string') return richClipboardData
     if (field.long_text_enable_rich_text && clipboardData?.includes('\n\n')) {
       return padBlankLinesForMarkdown(clipboardData)

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -25,6 +25,7 @@ import {
 
 import moment from '@baserow/modules/core/moment'
 import guessFormat from 'moment-guess'
+import { padBlankLinesForMarkdown } from '@baserow/modules/core/editor/emptyParagraphPreservation'
 import { Registerable } from '@baserow/modules/core/registry'
 import { mix } from '@baserow/modules/core/mixins'
 import FieldNumberSubForm from '@baserow/modules/database/components/field/FieldNumberSubForm'
@@ -1378,6 +1379,14 @@ export class LongTextFieldType extends FieldType {
 
   getCanGroupByInView(field) {
     return !field.long_text_enable_rich_text
+  }
+
+  prepareValueForPaste(field, clipboardData, richClipboardData) {
+    if (richClipboardData != null) return richClipboardData
+    if (field.long_text_enable_rich_text && clipboardData?.includes('\n\n')) {
+      return padBlankLinesForMarkdown(clipboardData)
+    }
+    return clipboardData
   }
 
   canHaveDbIndex(fieldValues) {

--- a/web-frontend/modules/database/fieldTypes.js
+++ b/web-frontend/modules/database/fieldTypes.js
@@ -1382,7 +1382,7 @@ export class LongTextFieldType extends FieldType {
   }
 
   prepareValueForPaste(field, clipboardData, richClipboardData) {
-    if (richClipboardData != null) return richClipboardData
+    if (typeof richClipboardData === 'string') return richClipboardData
     if (field.long_text_enable_rich_text && clipboardData?.includes('\n\n')) {
       return padBlankLinesForMarkdown(clipboardData)
     }

--- a/web-frontend/test/unit/core/emptyParagraphPreservation.spec.js
+++ b/web-frontend/test/unit/core/emptyParagraphPreservation.spec.js
@@ -63,6 +63,43 @@ describe('blankLinePreservation', () => {
     expect(countEmptyParagraphs(html)).toBe(3)
   })
 
+  it('does not add phantom empty paragraphs around code fences', () => {
+    const html = render('A\n\n```\ncode\n```\n\nB')
+    expect(countEmptyParagraphs(html)).toBe(0)
+    expect(html).toContain('<p>A</p>')
+    expect(html).toContain('<p>B</p>')
+  })
+
+  it('preserves blank lines around code fences', () => {
+    const html = render('A\n\n\n```\ncode\n```\n\n\nB')
+    expect(countEmptyParagraphs(html)).toBe(2)
+  })
+
+  it('does not add phantom empty paragraphs around horizontal rules', () => {
+    const html = render('A\n\n---\n\nB')
+    expect(countEmptyParagraphs(html)).toBe(0)
+  })
+
+  it('preserves blank lines around horizontal rules', () => {
+    const html = render('A\n\n\n---\n\n\nB')
+    expect(countEmptyParagraphs(html)).toBe(2)
+  })
+
+  it('preserves blank line after a list', () => {
+    const html = render('- a\n- b\n\n\nC')
+    expect(countEmptyParagraphs(html)).toBe(1)
+  })
+
+  it('preserves blank line before a list', () => {
+    const html = render('A\n\n\n- a\n- b')
+    expect(countEmptyParagraphs(html)).toBe(1)
+  })
+
+  it('preserves blank lines on both sides of a list', () => {
+    const html = render('A\n\n\n- x\n- y\n\n\nB')
+    expect(countEmptyParagraphs(html)).toBe(2)
+  })
+
   it('is idempotent when registered multiple times', () => {
     const md = new Markdown()
     md.use(blankLinePreservation)
@@ -85,6 +122,14 @@ describe('padBlankLinesForMarkdown', () => {
 
   it('does not modify text without newlines', () => {
     expect(padBlankLinesForMarkdown('hello')).toBe('hello')
+  })
+
+  it('normalizes \\r\\n before padding', () => {
+    expect(padBlankLinesForMarkdown('a\r\n\r\nb')).toBe('a\n\n\nb')
+  })
+
+  it('handles mixed \\r\\n and \\n', () => {
+    expect(padBlankLinesForMarkdown('a\r\n\r\nb\n\nc')).toBe('a\n\n\nb\n\n\nc')
   })
 })
 

--- a/web-frontend/test/unit/core/emptyParagraphPreservation.spec.js
+++ b/web-frontend/test/unit/core/emptyParagraphPreservation.spec.js
@@ -1,0 +1,130 @@
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Text } from '@tiptap/extension-text'
+import { Markdown as TiptapMarkdown } from 'tiptap-markdown'
+import Markdown from 'markdown-it'
+import {
+  blankLinePreservation,
+  padBlankLinesForMarkdown,
+  ParagraphWithEmptyPreservation,
+} from '@baserow/modules/core/editor/emptyParagraphPreservation'
+
+function render(text) {
+  const md = new Markdown()
+  md.use(blankLinePreservation)
+  return md.render(text)
+}
+
+function countEmptyParagraphs(html) {
+  return (html.match(/<p><\/p>/g) || []).length
+}
+
+describe('blankLinePreservation', () => {
+  it('does not add empty paragraphs for standard paragraph breaks', () => {
+    const html = render('hello\n\nworld')
+    expect(countEmptyParagraphs(html)).toBe(0)
+    expect(html).toContain('<p>hello</p>')
+    expect(html).toContain('<p>world</p>')
+  })
+
+  it('preserves one blank line as one empty paragraph', () => {
+    const html = render('hello\n\n\nworld')
+    expect(countEmptyParagraphs(html)).toBe(1)
+  })
+
+  it('preserves two blank lines as two empty paragraphs', () => {
+    const html = render('hello\n\n\n\nworld')
+    expect(countEmptyParagraphs(html)).toBe(2)
+  })
+
+  it('preserves three blank lines as three empty paragraphs', () => {
+    const html = render('hello\n\n\n\n\nworld')
+    expect(countEmptyParagraphs(html)).toBe(3)
+  })
+
+  it('handles blank lines between heading and paragraph', () => {
+    const html = render('# Title\n\n\nContent')
+    expect(countEmptyParagraphs(html)).toBe(1)
+  })
+
+  it('does not add empty paragraphs for single newlines', () => {
+    const html = render('hello\nworld')
+    expect(countEmptyParagraphs(html)).toBe(0)
+  })
+
+  it('handles empty input', () => {
+    const html = render('')
+    expect(countEmptyParagraphs(html)).toBe(0)
+  })
+
+  it('handles multiple sections with different spacing', () => {
+    const html = render('A\n\nB\n\n\nC\n\n\n\nD')
+    // A→B: standard break (0), B→C: 1 blank line (1), C→D: 2 blank lines (2)
+    expect(countEmptyParagraphs(html)).toBe(3)
+  })
+
+  it('is idempotent when registered multiple times', () => {
+    const md = new Markdown()
+    md.use(blankLinePreservation)
+    md.use(blankLinePreservation)
+    md.use(blankLinePreservation)
+    const html = md.render('hello\n\n\nworld')
+    expect(countEmptyParagraphs(html)).toBe(1)
+  })
+})
+
+describe('padBlankLinesForMarkdown', () => {
+  it('adds one newline to runs of 2+ newlines', () => {
+    expect(padBlankLinesForMarkdown('a\n\nb')).toBe('a\n\n\nb')
+    expect(padBlankLinesForMarkdown('a\n\n\nb')).toBe('a\n\n\n\nb')
+  })
+
+  it('does not modify single newlines', () => {
+    expect(padBlankLinesForMarkdown('a\nb')).toBe('a\nb')
+  })
+
+  it('does not modify text without newlines', () => {
+    expect(padBlankLinesForMarkdown('hello')).toBe('hello')
+  })
+})
+
+describe('ParagraphWithEmptyPreservation round-trip', () => {
+  let editor
+
+  function createEditor(markdown) {
+    return new Editor({
+      extensions: [
+        Document,
+        ParagraphWithEmptyPreservation,
+        Text,
+        TiptapMarkdown.configure({ html: false, breaks: true }),
+      ],
+      content: markdown,
+    })
+  }
+
+  function roundTrip(markdown) {
+    editor = createEditor(markdown)
+    return editor.storage.markdown.getMarkdown().trim()
+  }
+
+  afterEach(() => {
+    editor?.destroy()
+  })
+
+  it('preserves standard paragraph break', () => {
+    expect(roundTrip('hello\n\nworld')).toBe('hello\n\nworld')
+  })
+
+  it('preserves one extra blank line', () => {
+    expect(roundTrip('hello\n\n\nworld')).toBe('hello\n\n\nworld')
+  })
+
+  it('preserves multiple extra blank lines', () => {
+    expect(roundTrip('hello\n\n\n\nworld')).toBe('hello\n\n\n\nworld')
+  })
+
+  it('preserves mixed spacing across sections', () => {
+    expect(roundTrip('A\n\nB\n\n\nC\n\n\n\nD')).toBe('A\n\nB\n\n\nC\n\n\n\nD')
+  })
+})

--- a/web-frontend/test/unit/database/fieldTypes.spec.js
+++ b/web-frontend/test/unit/database/fieldTypes.spec.js
@@ -930,4 +930,94 @@ describe('FieldType tests', () => {
       }
     }
   )
+
+  describe('LongTextFieldType.prepareRichValueForCopy', () => {
+    test('includes isRichText flag from source field', () => {
+      const richField = { long_text_enable_rich_text: true }
+      const plainField = { long_text_enable_rich_text: false }
+
+      const richResult = new LongTextFieldType().prepareRichValueForCopy(
+        richField,
+        'A\n\nB'
+      )
+      expect(richResult).toEqual({ value: 'A\n\nB', isRichText: true })
+
+      const plainResult = new LongTextFieldType().prepareRichValueForCopy(
+        plainField,
+        'A\n\nB'
+      )
+      expect(plainResult).toEqual({ value: 'A\n\nB', isRichText: false })
+    })
+  })
+
+  describe('LongTextFieldType.prepareValueForPaste', () => {
+    test('rich-to-rich same-app paste returns value without padding', () => {
+      const field = { long_text_enable_rich_text: true }
+      const richClipboardData = { value: 'A\n\n\nB', isRichText: true }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\n\nB',
+        richClipboardData
+      )
+      expect(result).toBe('A\n\n\nB')
+    })
+
+    test('plain-to-rich same-app paste pads blank lines', () => {
+      const field = { long_text_enable_rich_text: true }
+      const richClipboardData = { value: 'A\n\nB', isRichText: false }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\nB',
+        richClipboardData
+      )
+      expect(result).toBe('A\n\n\nB')
+    })
+
+    test('rich-to-plain same-app paste returns value without collapsing', () => {
+      const field = { long_text_enable_rich_text: false }
+      const richClipboardData = { value: 'A\n\n\nB', isRichText: true }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\n\nB',
+        richClipboardData
+      )
+      expect(result).toBe('A\n\n\nB')
+    })
+
+    test('external paste into rich text field pads blank lines', () => {
+      const field = { long_text_enable_rich_text: true }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\nB',
+        undefined
+      )
+      expect(result).toBe('A\n\n\nB')
+    })
+
+    test('external paste into plain field returns clipboard data unchanged', () => {
+      const field = { long_text_enable_rich_text: false }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\nB',
+        undefined
+      )
+      expect(result).toBe('A\n\nB')
+    })
+
+    test('legacy string richClipboardData still works', () => {
+      const field = { long_text_enable_rich_text: true }
+
+      const result = new LongTextFieldType().prepareValueForPaste(
+        field,
+        'A\n\nB',
+        'A\n\nB'
+      )
+      expect(result).toBe('A\n\nB')
+    })
+  })
 })


### PR DESCRIPTION
### What is in this PR
Closes #2495

https://github.com/user-attachments/assets/37231847-2145-4bc3-9aba-d689f041f2fa


## Summary
- Blank lines (empty paragraphs) in rich text long text fields were lost during the
  markdown round-trip: editing → save as markdown → reopen → parse back. This happened
  because markdown collapses consecutive blank lines into a single paragraph break.
- Adds a new `emptyParagraphPreservation` module that preserves blank lines through
  three coordinated mechanisms:
  - **Serialization**: A custom TipTap Paragraph extension that serializes empty
    paragraphs as extra newlines in markdown
  - **Parsing**: A markdown-it plugin that detects gaps in token source-line maps and
    injects empty paragraph tokens for each blank line beyond the standard separator
  - **Paste**: A padding utility that adds one extra newline to runs of 2+ newlines
    in pasted plain text, so the parser can detect the intended blank lines

## How it works

The fix operates at two levels:

**Editor (TipTap):** `ParagraphWithEmptyPreservation` replaces the default Paragraph
extension when rich text formatting is enabled. It customizes both serialize (empty
paragraphs → extra `\n`) and parse (blank line detection via markdown-it plugin).

**Read-only rendering:** The same `blankLinePreservation` markdown-it plugin is
registered in `parseMarkdown()` so grid cell previews, cards, and other non-editor
views also render blank lines correctly.

**Paste handling:**
- `transformPastedText` in the TipTap editor pads blank lines for external plain text
  paste (HTML clipboard from internal copy-paste bypasses this — no inflation)
- `prepareValueForPaste` on `LongTextFieldType` handles grid-level paste (cell not in
  edit mode, multi-cell paste)
- `onPaste` guard in `GridViewFieldRichText` prevents double paste processing when
  the TipTap editor is active


## Testing

- type text with blank lines in rich text field → click away → reopen →   blank lines preserved
- paste multi-paragraph text from external text editor → blank lines   preserved
- copy-paste within same rich text field → no blank line inflation
- paste into grid cell (not in edit mode) → blank lines preserved
- verify non-rich-text long text fields are unaffected


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
