### PR TITLE
fix: remove restricted-view row for editor when edit leaves filter (#5660)

### DIFF
--- a/changelog/entries/unreleased/bug/5660_restricted_view_row_removed_for_editor_when_edit_leaves_filter.json
+++ b/changelog/entries/unreleased/bug/5660_restricted_view_row_removed_for_editor_when_edit_leaves_filter.json
@@ -1,0 +1,8 @@
+{
+    "type": "bug",
+    "message": "In a restricted view, a row edited so it no longer matches the filters is now removed immediately for the editing user instead of lingering until a refresh.",
+    "domain": "database",
+    "issue_number": 5660,
+    "bullet_points": [],
+    "created_at": "2026-07-08"
+}

--- a/enterprise/backend/src/baserow_enterprise/ws/restricted_view/rows/view_realtime_rows.py
+++ b/enterprise/backend/src/baserow_enterprise/ws/restricted_view/rows/view_realtime_rows.py
@@ -13,8 +13,16 @@ class RestrictedViewRealtimeRowsType(ViewRealtimeRowsType):
 
     def broadcast(self, view, payload, user=None):
         view_page_type = page_registry.get("restricted_view")
+        # Restricted clients have no filters; the editor needs its own create/delete.
+        editor_needs_own_event = payload.get("type") in (
+            "rows_created",
+            "rows_deleted",
+        )
+        ignore_web_socket_id = (
+            None if editor_needs_own_event else getattr(user, "web_socket_id", None)
+        )
         view_page_type.broadcast(
             payload,
-            ignore_web_socket_id=getattr(user, "web_socket_id", None),
+            ignore_web_socket_id=ignore_web_socket_id,
             restricted_view_id=view.id,
         )

--- a/enterprise/backend/tests/baserow_enterprise_tests/ws/test_restricted_view_rows_signals.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/ws/test_restricted_view_rows_signals.py
@@ -1,0 +1,96 @@
+from unittest.mock import patch
+
+from django.db import transaction
+
+import pytest
+
+from baserow.contrib.database.rows.handler import RowHandler
+from baserow_enterprise.view_ownership_types import RestrictedViewOwnershipType
+
+EDITOR_WEB_SOCKET_ID = "editor-web-socket-id"
+
+
+def _restricted_view_calls(mock_broadcast_to_channel_group, view_id):
+    """The (payload, ignore_web_socket_id) broadcast to a restricted view, in order."""
+
+    group_name = f"restricted-view-{view_id}"
+    return [
+        (call.args[1], call.args[2])
+        for call in mock_broadcast_to_channel_group.delay.mock_calls
+        if call.args and call.args[0] == group_name
+    ]
+
+
+def _setup(enterprise_data_fixture):
+    user = enterprise_data_fixture.create_user(web_socket_id=EDITOR_WEB_SOCKET_ID)
+    table = enterprise_data_fixture.create_database_table(user=user)
+    field = enterprise_data_fixture.create_text_field(table=table)
+    restricted_view = enterprise_data_fixture.create_grid_view(
+        user,
+        table=table,
+        ownership_type=RestrictedViewOwnershipType.type,
+        public=False,
+    )
+    enterprise_data_fixture.create_view_filter(
+        view=restricted_view, field=field, type="equal", value="keep"
+    )
+    return user, table, field, restricted_view
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_row_edited_out_of_restricted_view_deletes_it_for_the_editor(
+    mock_broadcast_to_channel_group, enterprise_data_fixture
+):
+    user, table, field, restricted_view = _setup(enterprise_data_fixture)
+    row = RowHandler().create_row(user, table, values={field.db_column: "keep"})
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(user, table, [{"id": row.id, field.db_column: "drop"}])
+
+    calls = _restricted_view_calls(mock_broadcast_to_channel_group, restricted_view.id)
+    assert len(calls) == 1
+    payload, ignore_web_socket_id = calls[0]
+    assert payload["type"] == "rows_deleted"
+    assert payload["row_ids"] == [row.id]
+    assert ignore_web_socket_id is None
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_row_edited_into_restricted_view_creates_it_for_the_editor(
+    mock_broadcast_to_channel_group, enterprise_data_fixture
+):
+    user, table, field, restricted_view = _setup(enterprise_data_fixture)
+    row = RowHandler().create_row(user, table, values={field.db_column: "drop"})
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(user, table, [{"id": row.id, field.db_column: "keep"}])
+
+    calls = _restricted_view_calls(mock_broadcast_to_channel_group, restricted_view.id)
+    assert len(calls) == 1
+    payload, ignore_web_socket_id = calls[0]
+    assert payload["type"] == "rows_created"
+    assert [r["id"] for r in payload["rows"]] == [row.id]
+    assert ignore_web_socket_id is None
+
+
+@pytest.mark.django_db(transaction=True)
+@patch("baserow.ws.registries.broadcast_to_channel_group")
+def test_row_updated_within_restricted_view_still_excludes_the_editor(
+    mock_broadcast_to_channel_group, enterprise_data_fixture
+):
+    user, table, field, restricted_view = _setup(enterprise_data_fixture)
+    row = RowHandler().create_row(user, table, values={field.db_column: "keep"})
+
+    mock_broadcast_to_channel_group.reset_mock()
+    with transaction.atomic():
+        RowHandler().update_rows(user, table, [{"id": row.id, field.db_column: "keep"}])
+
+    calls = _restricted_view_calls(mock_broadcast_to_channel_group, restricted_view.id)
+    assert len(calls) == 1
+    payload, ignore_web_socket_id = calls[0]
+    assert payload["type"] == "rows_updated"
+    assert ignore_web_socket_id == EDITOR_WEB_SOCKET_ID


### PR DESCRIPTION
## What

Fixes #5660. In an enterprise **restricted** view, when a user with editor permissions edited a visible row so it no longer matched the view's filters, the row stayed visible **for the editor** until a manual refresh (other subscribers already saw it removed correctly).

Restricted clients have their filters stripped client-side, so they can't self-evaluate whether a row still matches. On top of that, `RestrictedViewRealtimeRowsType.broadcast` passed `ignore_web_socket_id` for every event type — excluding the editor's own tab from the "row left view" delete.

## Fix

The broadcast now includes the editing user's socket for `rows_created` / `rows_deleted` (visibility changes the client can't derive on its own), while still excluding it for `rows_updated` (a value change the editor already applied via the API response, so it doesn't need the echo). This also fixes the symmetric "edit a row *into* the view" case.

## How to test manually

1. Create a **restricted** view and give a user **editor** permissions on it.
2. Add a **filter** to the view.
3. Open the view as the restricted user.
4. Change a row so it **no longer matches the filter** → it disappears immediately (previously it lingered until a refresh).

Note: once removed, the row can't be restored from this view — the user no longer has permission to see it, since it now falls outside the filter.

## Tests

Adds enterprise WebSocket signal tests covering the three cases:
- row edited **out** of the view → `rows_deleted` reaches the editor;
- row edited **into** the view → `rows_created` reaches the editor;
- row updated **within** the view → editor still excluded from `rows_updated`.
