### PR TITLE
fix: periodic data syncs silently skipping scheduled runs

### DIFF
--- a/changelog/entries/unreleased/bug/fixes_hourly_and_daily_periodic_data_syncs_silently_skipping.json
+++ b/changelog/entries/unreleased/bug/fixes_hourly_and_daily_periodic_data_syncs_silently_skipping.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes hourly and daily periodic data syncs silently skipping scheduled runs",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-10"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/handler.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/handler.py
@@ -97,27 +97,30 @@ class EnterpriseDataSyncHandler:
         )
 
         is_null = Q(last_periodic_sync__isnull=True)
+        daily_due = Q(
+            # If the interval is daily, the last periodic sync timestamp must be
+            # yesterday or None meaning it hasn't been executed yet.
+            is_null | Q(last_periodic_sync__lt=beginning_of_day),
+            interval=DATA_SYNC_INTERVAL_DAILY,
+            # The data sync must be triggered at the time desired by the user.
+            when__lte=now_time,
+        )
+        hourly_due = Q(
+            # If the interval is hourly, the last periodic data sync timestamp
+            # must be at least an hour ago or None meaning it hasn't been
+            # executed yet.
+            is_null | Q(last_periodic_sync__lt=beginning_of_hour),
+            # Only the minute and second of `when` matter because it runs every hour.
+            Q(when__minute__lt=now.minute)
+            | Q(when__minute=now.minute, when__second__lte=now.second),
+            interval=DATA_SYNC_INTERVAL_HOURLY,
+        )
         all_to_trigger = (
             PeriodicDataSyncInterval.objects.filter(
-                Q(
-                    # If the interval is daily, the last periodic sync timestamp must be
-                    # yesterday or None meaning it hasn't been executed yet.
-                    is_null | Q(last_periodic_sync__lt=beginning_of_day),
-                    interval=DATA_SYNC_INTERVAL_DAILY,
-                )
-                | Q(
-                    # If the interval is hourly, the last periodic data sync timestamp
-                    # must be at least an hour ago or None meaning it hasn't been
-                    # executed yet.
-                    is_null | Q(last_periodic_sync__lt=beginning_of_hour),
-                    interval=DATA_SYNC_INTERVAL_HOURLY,
-                ),
+                daily_due | hourly_due,
                 # Skip deactivated periodic data sync because they're not working
                 # anymore.
                 automatically_deactivated=False,
-                # The now time must be higher than the now time because the data sync
-                # must be triggered at the desired the of the user.
-                when__lte=now_time,
             )
             .select_related("data_sync__table__database__workspace")
             # Take a lock on the periodic data sync because the `last_periodic_sync`
@@ -163,7 +166,9 @@ class EnterpriseDataSyncHandler:
                     )
                 else:
                     transaction.on_commit(
-                        lambda: sync_periodic_data_sync.delay(periodic_data_sync.id)
+                        lambda pds=periodic_data_sync: sync_periodic_data_sync.delay(
+                            pds.id
+                        )
                     )
             else:
                 periodic_data_sync.interval = DATA_SYNC_INTERVAL_MANUAL

--- a/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_enterprise_data_sync_handler.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_enterprise_data_sync_handler.py
@@ -387,6 +387,76 @@ def test_call_periodic_data_sync_syncs_starts_task(
     assert args[0][0] == not_yet_executed_1.id
 
 
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.data_sync
+@override_settings(DEBUG=True)
+@patch("baserow_enterprise.data_sync.handler.sync_periodic_data_sync")
+def test_call_periodic_data_sync_syncs_starts_task_for_each_due_sync(
+    mock_sync_periodic_data_sync,
+    enterprise_data_fixture,
+    synced_roles,
+):
+    enterprise_data_fixture.enable_enterprise()
+    user = enterprise_data_fixture.create_user()
+
+    due = [
+        EnterpriseDataSyncHandler.update_periodic_data_sync_interval(
+            user=user,
+            data_sync=enterprise_data_fixture.create_ical_data_sync(user=user),
+            interval="HOURLY",
+            when=time(hour=12, minute=10, second=1, microsecond=1),
+        )
+        for _ in range(3)
+    ]
+
+    with freeze_time("2024-10-10T12:15:00.00Z"):
+        with transaction.atomic():
+            EnterpriseDataSyncHandler.call_periodic_data_sync_syncs_that_are_due()
+
+    called_ids = {
+        call.args[0] for call in mock_sync_periodic_data_sync.delay.call_args_list
+    }
+    assert called_ids == {periodic_data_sync.id for periodic_data_sync in due}
+
+
+@pytest.mark.django_db
+@pytest.mark.data_sync
+@override_settings(DEBUG=True)
+def test_call_hourly_periodic_data_sync_ignores_hour_of_when(enterprise_data_fixture):
+    enterprise_data_fixture.enable_enterprise()
+    user = enterprise_data_fixture.create_user()
+
+    minute_already_passed = (
+        EnterpriseDataSyncHandler.update_periodic_data_sync_interval(
+            user=user,
+            data_sync=enterprise_data_fixture.create_ical_data_sync(user=user),
+            interval="HOURLY",
+            when=time(hour=15, minute=10, second=1, microsecond=1),
+        )
+    )
+
+    minute_not_yet_passed = (
+        EnterpriseDataSyncHandler.update_periodic_data_sync_interval(
+            user=user,
+            data_sync=enterprise_data_fixture.create_ical_data_sync(user=user),
+            interval="HOURLY",
+            when=time(hour=8, minute=45, second=0),
+        )
+    )
+
+    with freeze_time("2024-10-10T10:30:00.00Z"):
+        EnterpriseDataSyncHandler.call_periodic_data_sync_syncs_that_are_due()
+        frozen_datetime = django_timezone.now()
+
+    minute_already_passed.refresh_from_db()
+    # executed because minute 10 has passed, despite the later hour in `when`.
+    assert minute_already_passed.last_periodic_sync == frozen_datetime
+
+    minute_not_yet_passed.refresh_from_db()
+    # not executed because minute 45 hasn't passed, despite the earlier hour in `when`.
+    assert minute_not_yet_passed.last_periodic_sync is None
+
+
 @pytest.mark.django_db
 @pytest.mark.data_sync
 @override_settings(DEBUG=True)


### PR DESCRIPTION
Fixes two silent-skip bugs in the enterprise periodic data sync dispatcher (`EnterpriseDataSyncHandler.call_periodic_data_sync_syncs_that_are_due`). Both produce no error, no `last_error`, and no `consecutive_failed_count` increment, while `last_periodic_sync` keeps advancing — so the affected syncs look healthy but never run. Reported by a SaaS customer whose hourly PostgreSQL sync required several manual syncs per day.

## Bug 1: only one due sync dispatched per check cycle

The `transaction.on_commit` callback captured the loop variable:

```python
transaction.on_commit(
    lambda: sync_periodic_data_sync.delay(periodic_data_sync.id)
)
```

`on_commit` callbacks run after the loop finishes, so when N periodic syncs were due in the same cycle, all N callbacks enqueued the **same last-iterated id**. Since every active hourly sync becomes due at the top of the hour, they were all fetched in one batch, all marked as executed (`last_periodic_sync = now`), and only one of them (arbitrary, no `order_by`) actually synced. The deactivation loop below already used the correct default-argument binding — the dispatch loop now does the same.

## Bug 2: hourly syncs dead for part of every day

The due-filter applied `when__lte=now_time` (full time-of-day) to hourly syncs too. The frontend hides the hour input for hourly intervals but still stores the creation-time hour in `when`, so an hourly sync configured at e.g. 15:30 never ran between 00:00 and ~13:30 UTC each day. The filter is now split: daily keeps the full time-of-day comparison, hourly only compares the minute and second of `when`. Existing rows with a polluted hour component start working immediately, so no data migration is needed.

## Tests

Both regression tests were written first and failed for the expected reason before the fix:

- `test_call_periodic_data_sync_syncs_starts_task_for_each_due_sync` — 3 due syncs must each get their own task (previously all callbacks enqueued the last id).
- `test_call_hourly_periodic_data_sync_ignores_hour_of_when` — an hourly sync with a later hour in `when` triggers once its minute has passed, and one with an earlier hour does not trigger before its minute.

## Out of scope (known, deliberate)

- The table sync lock is created with `timeout=2` seconds while syncs take much longer, making the already-running guard nearly a no-op.
- A hard task timeout rolls back the whole `sync_periodic_data_sync` transaction, losing `last_error` and the failure counter.
- The frontend still stores the hidden hour in `when` for hourly intervals (harmless now).
