### PR TITLE
feat: add group by field to grid field context menu

### DIFF
--- a/changelog/entries/unreleased/feature/group_rows_by_a_field_directly_from_its_column_menu.json
+++ b/changelog/entries/unreleased/feature/group_rows_by_a_field_directly_from_its_column_menu.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Group rows by a field directly from its column menu",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-10"
+}

--- a/web-frontend/modules/core/assets/scss/components/context.scss
+++ b/web-frontend/modules/core/assets/scss/components/context.scss
@@ -119,10 +119,6 @@
     }
   }
 
-  &.context__menu-item-link--active {
-    padding-right: 32px;
-  }
-
   &.context__menu-item-link--delete {
     &:hover:not(.disabled) {
       background: $palette-red-50;

--- a/web-frontend/modules/core/assets/scss/components/context.scss
+++ b/web-frontend/modules/core/assets/scss/components/context.scss
@@ -119,6 +119,10 @@
     }
   }
 
+  &.context__menu-item-link--active {
+    padding-right: 32px;
+  }
+
   &.context__menu-item-link--delete {
     &:hover:not(.disabled) {
       background: $palette-red-50;

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
@@ -267,6 +267,34 @@
         </li>
         <li
           v-if="
+            canGroupBy &&
+            $hasPermission(
+              'database.table.view.create_group_by',
+              view,
+              database.workspace.id
+            )
+          "
+          class="context__menu-item"
+        >
+          <a
+            class="context__menu-item-link"
+            :class="{ 'context__menu-item-link--active': groupByForField }"
+            @click="toggleGroupBy($event, view, field)"
+          >
+            <i class="context__menu-item-icon iconoir-book-stack"></i>
+            {{
+              groupByForField
+                ? $t('gridViewFieldType.ungroupByField')
+                : $t('gridViewFieldType.groupByField')
+            }}
+            <i
+              v-if="groupByForField"
+              class="context__menu-active-icon iconoir-check"
+            ></i>
+          </a>
+        </li>
+        <li
+          v-if="
             !field.primary &&
             $hasPermission(
               'database.table.view.update_field_options',
@@ -302,7 +330,10 @@ import InsertFieldContext from '@baserow/modules/database/components/field/Inser
 import DuplicateFieldModal from '@baserow/modules/database/components/field/DuplicateFieldModal'
 import HorizontalResize from '@baserow/modules/core/components/HorizontalResize'
 import gridViewHelpers from '@baserow/modules/database/mixins/gridViewHelpers'
-import { DEFAULT_SORT_TYPE_KEY } from '@baserow/modules/database/constants'
+import {
+  DEFAULT_SORT_TYPE_KEY,
+  MAX_GROUP_BYS,
+} from '@baserow/modules/database/constants'
 import fieldOptions from '~/modules/database/store/view/fieldOptions'
 
 export default {
@@ -363,6 +394,18 @@ export default {
         }
       }
       return false
+    },
+    groupByForField() {
+      return this.view.group_bys.find(
+        (groupBy) => groupBy.field === this.field.id
+      )
+    },
+    canGroupBy() {
+      return (
+        this.getCanGroupByInView(this.field) &&
+        (this.groupByForField !== undefined ||
+          this.view.group_bys.length < MAX_GROUP_BYS)
+      )
     },
     showFieldContext() {
       return (
@@ -514,6 +557,33 @@ export default {
         notifyIf(error, 'view')
       }
     },
+    async toggleGroupBy(event, view, field) {
+      // stops the body click-outside handler from also acting on this click
+      event.stopPropagation()
+      event.preventDefault()
+      this.$refs.context.hide()
+
+      const groupBy = view.group_bys.find((g) => g.field === field.id)
+
+      try {
+        if (groupBy === undefined) {
+          await this.$store.dispatch('view/createGroupBy', {
+            view,
+            values: {
+              field: field.id,
+              order: 'ASC',
+              type: DEFAULT_SORT_TYPE_KEY,
+            },
+          })
+        } else {
+          await this.$store.dispatch('view/deleteGroupBy', { view, groupBy })
+        }
+
+        this.$emit('refresh')
+      } catch (error) {
+        notifyIf(error, 'view')
+      }
+    },
     async hide(event, view, field) {
       try {
         await this.$store.dispatch(
@@ -543,6 +613,9 @@ export default {
     },
     getCanSortInView(field) {
       return this.$registry.get('field', field.type).getCanSortInView(field)
+    },
+    getCanGroupByInView(field) {
+      return this.$registry.get('field', field.type).getCanGroupByInView(field)
     },
 
     getIconsBefore() {

--- a/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
+++ b/web-frontend/modules/database/components/view/grid/GridViewFieldType.vue
@@ -278,7 +278,6 @@
         >
           <a
             class="context__menu-item-link"
-            :class="{ 'context__menu-item-link--active': groupByForField }"
             @click="toggleGroupBy($event, view, field)"
           >
             <i class="context__menu-item-icon iconoir-book-stack"></i>
@@ -287,10 +286,6 @@
                 ? $t('gridViewFieldType.ungroupByField')
                 : $t('gridViewFieldType.groupByField')
             }}
-            <i
-              v-if="groupByForField"
-              class="context__menu-active-icon iconoir-check"
-            ></i>
           </a>
         </li>
         <li

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -701,6 +701,8 @@
     "createFilter": "Create filter",
     "duplicate": "Duplicate field",
     "sortField": "Sort",
+    "groupByField": "Group by",
+    "ungroupByField": "Don't group by",
     "hideField": "Hide field",
     "dataSyncField": "The field is read only and part of the table's data sync.",
     "dataSyncFieldTwoWaySync": "The field is synchronized with the table's data sync.",

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldType.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldType.spec.js
@@ -1,0 +1,162 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import GridViewFieldType from '@baserow/modules/database/components/view/grid/GridViewFieldType'
+import { MAX_GROUP_BYS } from '@baserow/modules/database/constants'
+
+describe('GridViewFieldType group by menu item', () => {
+  let testApp = null
+  let mockServer = null
+  let store = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+    store = testApp.store
+    store.$config = { public: { baserowRowPageSizeLimit: 200 } }
+    mockServer = testApp.mockServer
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const primary = {
+    id: 1,
+    name: 'Name',
+    order: 0,
+    type: 'text',
+    primary: true,
+    text_default: '',
+    _: { loading: false, type: { iconClass: 'iconoir-text', name: 'text' } },
+  }
+
+  const textField = {
+    id: 2,
+    name: 'Surname',
+    order: 1,
+    type: 'text',
+    primary: false,
+    text_default: '',
+    _: { loading: false, type: { iconClass: 'iconoir-text', name: 'text' } },
+  }
+
+  const richTextField = {
+    id: 3,
+    name: 'Notes',
+    order: 2,
+    type: 'long_text',
+    primary: false,
+    long_text_enable_rich_text: true,
+    _: {
+      loading: false,
+      type: { iconClass: 'iconoir-text', name: 'long_text' },
+    },
+  }
+
+  const allFields = [textField, richTextField]
+
+  const groupBy = (fieldId) => ({
+    id: `gb-${fieldId}`,
+    field: fieldId,
+    order: 'ASC',
+    type: 'default',
+    width: 200,
+    _: { loading: false },
+  })
+
+  const populateStore = async (groupBys = []) => {
+    const table = mockServer.createTable()
+    const { application } = await mockServer.createAppAndWorkspace(table)
+    const view = mockServer.createGridView(application, table, { groupBys })
+    const fields = mockServer.createFields(application, table, allFields)
+    mockServer.createGridRows(view, fields, [])
+    await store.dispatch('page/view/grid/fetchInitial', {
+      gridId: 1,
+      fields,
+      primary,
+    })
+    await store.dispatch('view/fetchAll', { id: 1 })
+    return { table, application, view }
+  }
+
+  const mountFieldType = async ({ table, application, view }, field) => {
+    const wrapper = await testApp.mount(GridViewFieldType, {
+      props: {
+        database: application,
+        table,
+        view,
+        field,
+        readOnly: false,
+        allFieldsInTable: allFields,
+        storePrefix: 'page/',
+      },
+    })
+    await wrapper.vm.$refs.context.toggle(wrapper.vm.$refs.contextLink)
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  const findGroupByItem = (wrapper) =>
+    wrapper
+      .findAll('.context__menu-item-link')
+      .find((item) => item.find('.iconoir-book-stack').exists())
+
+  test('shows "Group by this field" and creates a group by on click', async () => {
+    const context = await populateStore([])
+    const wrapper = await mountFieldType(context, textField)
+
+    const item = findGroupByItem(wrapper)
+    expect(item).toBeTruthy()
+    expect(item.text()).toContain('gridViewFieldType.groupByField')
+    expect(item.classes()).not.toContain('context__menu-item-link--active')
+    expect(item.find('.context__menu-active-icon').exists()).toBe(false)
+
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue()
+    await item.trigger('click')
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'view/createGroupBy',
+      expect.objectContaining({
+        view: context.view,
+        values: expect.objectContaining({ field: textField.id, order: 'ASC' }),
+      })
+    )
+  })
+
+  test('shows "Don\'t group by this field" as selected and removes it on click', async () => {
+    const context = await populateStore([groupBy(textField.id)])
+    const wrapper = await mountFieldType(context, textField)
+
+    const item = findGroupByItem(wrapper)
+    expect(item).toBeTruthy()
+    expect(item.text()).toContain('gridViewFieldType.ungroupByField')
+    expect(item.classes()).toContain('context__menu-item-link--active')
+    expect(item.find('.context__menu-active-icon').exists()).toBe(true)
+
+    const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue()
+    await item.trigger('click')
+
+    expect(dispatch).toHaveBeenCalledWith(
+      'view/deleteGroupBy',
+      expect.objectContaining({
+        view: context.view,
+        groupBy: expect.objectContaining({ field: textField.id }),
+      })
+    )
+  })
+
+  test('is hidden for a field type that cannot be grouped by', async () => {
+    const context = await populateStore([])
+    const wrapper = await mountFieldType(context, richTextField)
+
+    expect(findGroupByItem(wrapper)).toBeFalsy()
+  })
+
+  test('is hidden when the group by limit is reached and the field is not grouped', async () => {
+    const groupBys = Array.from({ length: MAX_GROUP_BYS }, (_, i) =>
+      groupBy(100 + i)
+    )
+    const context = await populateStore(groupBys)
+    const wrapper = await mountFieldType(context, textField)
+
+    expect(findGroupByItem(wrapper)).toBeFalsy()
+  })
+})

--- a/web-frontend/test/unit/database/components/view/grid/gridViewFieldType.spec.js
+++ b/web-frontend/test/unit/database/components/view/grid/gridViewFieldType.spec.js
@@ -121,15 +121,15 @@ describe('GridViewFieldType group by menu item', () => {
     )
   })
 
-  test('shows "Don\'t group by this field" as selected and removes it on click', async () => {
+  test('shows "Don\'t group by this field" and removes it on click', async () => {
     const context = await populateStore([groupBy(textField.id)])
     const wrapper = await mountFieldType(context, textField)
 
     const item = findGroupByItem(wrapper)
     expect(item).toBeTruthy()
     expect(item.text()).toContain('gridViewFieldType.ungroupByField')
-    expect(item.classes()).toContain('context__menu-item-link--active')
-    expect(item.find('.context__menu-active-icon').exists()).toBe(true)
+    expect(item.classes()).not.toContain('context__menu-item-link--active')
+    expect(item.find('.context__menu-active-icon').exists()).toBe(false)
 
     const dispatch = vi.spyOn(store, 'dispatch').mockResolvedValue()
     await item.trigger('click')


### PR DESCRIPTION
## Summary

Adds a **Group by** toggle to the grid view's field header context menu, alongside the existing Sort / Create filter items.

- **Not grouped:** "Group by" (book-stack icon) → creates a group-by on the field.
<img width="239" height="506" alt="image" src="https://github.com/user-attachments/assets/82eb6169-1e80-46bb-b08a-a4ebb999c1cd" />


- **Already grouped:** shown "Don't group by" → removes that field's group-by.
<img width="239" height="506" alt="image" src="https://github.com/user-attachments/assets/d01c53e0-d6ca-477b-ad65-bb813a8d237f" />


- **Hidden** when the field type can't be grouped (e.g. rich-text long text), when the user lacks the `create_group_by` permission, or when the view is at the 5-group cap and this field isn't already grouped.


## Permissions

Gated on `database.table.view.create_group_by`, matching the toolbar's persisting gate and the sibling menu items' pattern. Group-by create/update/delete are granted together (BUILDER role and up), so the toggle's remove side can't strand a user who could add but not remove. The menu only renders in editable (`!readOnly`) contexts; the backend enforces create/delete independently.


