### PR TITLE
feat: rich content in form view descriptions (#1851)

### DIFF
--- a/changelog/entries/unreleased/feature/add_links_and_rich_formatting_to_form_and_field_descriptions.json
+++ b/changelog/entries/unreleased/feature/add_links_and_rich_formatting_to_form_and_field_descriptions.json
@@ -1,0 +1,9 @@
+{
+    "type": "feature",
+    "message": "Add links and rich formatting to form and field descriptions",
+    "issue_origin": "github",
+    "issue_number": 1851,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-12"
+}

--- a/e2e-tests/tests/database/form_view_description_richtext.spec.ts
+++ b/e2e-tests/tests/database/form_view_description_richtext.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "../baserowTest";
+import { createDatabase } from "../../fixtures/database/database";
+import { createTable } from "../../fixtures/database/table";
+import { createField } from "../../fixtures/database/field";
+import {
+  createFormView,
+  updateFormFieldOptions,
+  patchView,
+} from "../../fixtures/database/view";
+import { FormPage } from "../../pages/database/formPage";
+import { User } from "../../fixtures/user";
+import { Workspace } from "../../fixtures/workspace";
+
+// Form view descriptions (field-level and form-level) are authored as markdown
+// and rendered rich to respondents. These tests lock in the two things that
+// matter on the public page: markdown becomes real formatting, and unsafe
+// markdown (raw HTML / javascript: links) is rendered inert by the shared
+// editor config (Markdown html:false + Link protocol allowlist).
+test.describe("Form view rich-text descriptions", () => {
+  test.describe.configure({ timeout: 60_000 });
+
+  let user: User;
+  let workspace: Workspace;
+
+  test.beforeEach(async ({ workspacePage }) => {
+    user = workspacePage.user;
+    workspace = workspacePage.workspace;
+  });
+
+  test("renders markdown descriptions as formatting", async ({ page, goto }) => {
+    const database = await createDatabase(user, "Rich Form DB", workspace);
+    const table = await createTable(user, "Entries", database, [
+      ["Name"],
+      ["Alice"],
+    ]);
+    const bio = await createField(user, "Bio", "long_text", {}, table);
+    const view = await createFormView(user, table);
+    await patchView(user, view, {
+      description: "Welcome — read the **instructions** and visit our [site](https://baserow.io).",
+    });
+    await updateFormFieldOptions(user, view, {
+      [bio.id]: {
+        enabled: true,
+        required: false,
+        order: 1,
+        description:
+          "Fill in your **bio**. See the [guide](https://baserow.io).\n\n- Be concise\n- Be honest",
+      },
+    });
+
+    const formPage = new FormPage({ page, goto });
+    await formPage.gotoPublic(view.slug);
+
+    const fieldDesc = page.locator(".form-view__field-description").first();
+    await fieldDesc.waitFor({ state: "visible" });
+    await expect(fieldDesc.locator("strong")).toHaveCount(1);
+    await expect(
+      fieldDesc.locator('a[href="https://baserow.io"]'),
+    ).toHaveCount(1);
+    expect(await fieldDesc.locator("ul li").count()).toBeGreaterThanOrEqual(2);
+
+    const formDesc = page.locator(".form-view__description").first();
+    await expect(formDesc.locator("strong")).toHaveCount(1);
+    await expect(
+      formDesc.locator('a[href="https://baserow.io"]'),
+    ).toHaveCount(1);
+  });
+
+  test("renders unsafe markdown inert (no script, no javascript: link)", async ({
+    page,
+    goto,
+  }) => {
+    const database = await createDatabase(user, "XSS Form DB", workspace);
+    const table = await createTable(user, "Entries", database, [
+      ["Name"],
+      ["Bob"],
+    ]);
+    const bio = await createField(user, "Bio", "long_text", {}, table);
+    const view = await createFormView(user, table);
+    await updateFormFieldOptions(user, view, {
+      [bio.id]: {
+        enabled: true,
+        required: false,
+        order: 1,
+        description:
+          "<script>window.__xss = 1</script> **safe** [bad](javascript:alert(1)) [good](https://baserow.io)",
+      },
+    });
+
+    let dialogFired = false;
+    page.on("dialog", async (d) => {
+      dialogFired = true;
+      await d.dismiss();
+    });
+
+    const formPage = new FormPage({ page, goto });
+    await formPage.gotoPublic(view.slug);
+
+    const fieldDesc = page.locator(".form-view__field-description").first();
+    await fieldDesc.waitFor({ state: "visible" });
+
+    // The injected script neither executed nor was rendered as an element.
+    expect(await page.evaluate(() => (window as any).__xss)).toBeUndefined();
+    expect(dialogFired).toBe(false);
+    await expect(fieldDesc.locator("script")).toHaveCount(0);
+    // The javascript: link was dropped, not rendered as a clickable anchor.
+    await expect(fieldDesc.locator('a[href^="javascript:"]')).toHaveCount(0);
+    // Safe markdown still renders (bold + the https link survive).
+    await expect(fieldDesc.locator("strong")).toHaveCount(1);
+    await expect(
+      fieldDesc.locator('a[href="https://baserow.io"]'),
+    ).toHaveCount(1);
+  });
+});

--- a/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModePreviewSurvey.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/form/FormViewModePreviewSurvey.vue
@@ -41,6 +41,7 @@
                 :field-options="fieldOptions[field.id]"
                 :fields="fields"
                 :read-only="readOnly"
+                :get-scroll-area-element="getScrollAreaElement"
                 :add-order-buttons="true"
                 :add-handle="false"
                 @hide="hideField(view, field)"
@@ -202,6 +203,12 @@ export default {
     readOnly: {
       type: Boolean,
       required: true,
+    },
+    // Resolves the scrollable preview container owned by FormViewPreview.
+    getScrollAreaElement: {
+      type: Function,
+      required: false,
+      default: null,
     },
   },
   data() {

--- a/web-frontend/modules/core/assets/scss/components/views/form.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/form.scss
@@ -315,6 +315,7 @@
   display: flex;
   align-items: flex-start;
   gap: 5px;
+  min-width: 0;
 }
 
 .form-view__description-rendered {
@@ -324,7 +325,7 @@
 
 .form-view__description-placeholder {
   flex: 1 1 auto;
-  color: $color-neutral-500;
+  color: $palette-neutral-700;
   cursor: text;
 }
 
@@ -369,6 +370,9 @@
   margin: 0;
   display: inline-block;
   line-height: 20px;
+
+  // Wrap long unbroken words instead of overflowing horizontally.
+  overflow-wrap: anywhere;
 
   @include flex-align-items(5px);
 }
@@ -529,6 +533,9 @@
   margin-bottom: 20px;
   color: $color-neutral-500;
   display: inline-block;
+
+  // Wrap long unbroken words instead of overflowing horizontally.
+  overflow-wrap: anywhere;
 }
 
 .form-view-field-edit {

--- a/web-frontend/modules/core/assets/scss/components/views/form.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/form.scss
@@ -311,6 +311,23 @@
   }
 }
 
+.form-view__description-editor {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.form-view__description-rendered {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.form-view__description-placeholder {
+  flex: 1 1 auto;
+  color: $color-neutral-500;
+  cursor: text;
+}
+
 .form-view__cover {
   position: relative;
   display: flex;

--- a/web-frontend/modules/core/assets/scss/components/views/form.scss
+++ b/web-frontend/modules/core/assets/scss/components/views/form.scss
@@ -371,8 +371,11 @@
   display: inline-block;
   line-height: 20px;
 
-  // Wrap long unbroken words instead of overflowing horizontally.
+  // Wrap long unbroken words instead of overflowing horizontally. The
+  // max-width keeps the inline-block clamped to the form column; without it
+  // the flex editor wrapper inside makes it shrink-to-fit its max-content.
   overflow-wrap: anywhere;
+  max-width: 100%;
 
   @include flex-align-items(5px);
 }
@@ -534,8 +537,11 @@
   color: $color-neutral-500;
   display: inline-block;
 
-  // Wrap long unbroken words instead of overflowing horizontally.
+  // Wrap long unbroken words instead of overflowing horizontally. The
+  // max-width keeps the inline-block clamped to the form column; without it
+  // the flex editor wrapper inside makes it shrink-to-fit its max-content.
   overflow-wrap: anywhere;
+  max-width: 100%;
 }
 
 .form-view-field-edit {

--- a/web-frontend/modules/database/components/view/form/FormPageField.vue
+++ b/web-frontend/modules/database/components/view/form/FormPageField.vue
@@ -6,8 +6,14 @@
           {{ field.name }}
           <span v-if="field.required" class="form-view__field-required">*</span>
         </div>
-        <!-- prettier-ignore -->
-        <div v-if="field.description" class="form-view__field-description whitespace-pre-wrap">{{ field.description }}</div>
+        <div v-if="field.description" class="form-view__field-description">
+          <RichTextEditor
+            :model-value="field.description"
+            :editable="false"
+            :enable-rich-text-formatting="true"
+            editor-class="form-view__field-description-editor"
+          ></RichTextEditor>
+        </div>
         <component
           :is="selectedFieldComponent.component"
           :key="field.field.id"
@@ -30,11 +36,12 @@
 
 <script>
 import FieldContext from '@baserow/modules/database/components/field/FieldContext'
+import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
 import { DEFAULT_FORM_VIEW_FIELD_COMPONENT_KEY } from '@baserow/modules/database/constants'
 
 export default {
   name: 'FormPageField',
-  components: { FieldContext },
+  components: { FieldContext, RichTextEditor },
   props: {
     slug: {
       type: String,

--- a/web-frontend/modules/database/components/view/form/FormPageField.vue
+++ b/web-frontend/modules/database/components/view/form/FormPageField.vue
@@ -7,11 +7,10 @@
           <span v-if="field.required" class="form-view__field-required">*</span>
         </div>
         <div v-if="field.description" class="form-view__field-description">
-          <RichTextEditor
-            :model-value="field.description"
-            :editable="false"
-            :enable-rich-text-formatting="true"
-          ></RichTextEditor>
+          <FormViewDescription
+            :value="field.description"
+            read-only
+          ></FormViewDescription>
         </div>
         <component
           :is="selectedFieldComponent.component"
@@ -35,12 +34,12 @@
 
 <script>
 import FieldContext from '@baserow/modules/database/components/field/FieldContext'
-import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
+import FormViewDescription from '@baserow/modules/database/components/view/form/FormViewDescription'
 import { DEFAULT_FORM_VIEW_FIELD_COMPONENT_KEY } from '@baserow/modules/database/constants'
 
 export default {
   name: 'FormPageField',
-  components: { FieldContext, RichTextEditor },
+  components: { FieldContext, FormViewDescription },
   props: {
     slug: {
       type: String,

--- a/web-frontend/modules/database/components/view/form/FormPageField.vue
+++ b/web-frontend/modules/database/components/view/form/FormPageField.vue
@@ -11,7 +11,6 @@
             :model-value="field.description"
             :editable="false"
             :enable-rich-text-formatting="true"
-            editor-class="form-view__field-description-editor"
           ></RichTextEditor>
         </div>
         <component

--- a/web-frontend/modules/database/components/view/form/FormViewDescription.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewDescription.vue
@@ -14,6 +14,7 @@
       :editable="true"
       :enable-rich-text-formatting="true"
       :placeholder="placeholder"
+      :scrollable-area-element="scrollAreaElement"
       @update:model-value="dirty = true"
       @blur="stopEditing"
     ></RichTextEditor>
@@ -68,6 +69,9 @@ export default {
       dirty: false,
       // Initial content handed to the editor when entering edit mode.
       buffer: '',
+      // Scrolling ancestor of the form preview, so the editor's floating/bubble
+      // menu sticks to the cursor line while the page scrolls.
+      scrollAreaElement: null,
     }
   },
   computed: {
@@ -80,6 +84,9 @@ export default {
       if (this.readOnly) {
         return
       }
+      // Resolve the form preview's scroll container so the editor menus track
+      // it. Falls back to the editor's own root when not found.
+      this.scrollAreaElement = this.$el.closest('.form-view__preview')
       this.buffer = this.value || ''
       this.dirty = false
       this.editing = true

--- a/web-frontend/modules/database/components/view/form/FormViewDescription.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewDescription.vue
@@ -61,6 +61,13 @@ export default {
       required: false,
       default: '',
     },
+    // Resolver returning the scrollable preview container, provided by the
+    // component that owns it (FormViewPreview) instead of a DOM lookup here.
+    getScrollAreaElement: {
+      type: Function,
+      required: false,
+      default: null,
+    },
   },
   emits: ['change'],
   data() {
@@ -69,8 +76,8 @@ export default {
       dirty: false,
       // Initial content handed to the editor when entering edit mode.
       buffer: '',
-      // Scrolling ancestor of the form preview, so the editor's floating/bubble
-      // menu sticks to the cursor line while the page scrolls.
+      // Scrolling container of the form preview, so the editor's floating/
+      // bubble menu sticks to the cursor line while the page scrolls.
       scrollAreaElement: null,
     }
   },
@@ -85,8 +92,8 @@ export default {
         return
       }
       // Resolve the form preview's scroll container so the editor menus track
-      // it. Falls back to the editor's own root when not found.
-      this.scrollAreaElement = this.$el.closest('.form-view__preview')
+      // it. When no resolver is provided the editor falls back to its own root.
+      this.scrollAreaElement = this.getScrollAreaElement?.() || null
       this.buffer = this.value || ''
       this.dirty = false
       this.editing = true

--- a/web-frontend/modules/database/components/view/form/FormViewDescription.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewDescription.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="form-view__description-editor">
+    <!--
+      Edit mode. The editor is only mounted while editing, so unselected fields
+      don't pay the rich-text instantiation cost and no floating menu lingers on
+      the form. `model-value` is passed one-way as the initial content; the saved
+      value is always read back with serializeToMarkdown() on blur, which avoids
+      round-tripping tiptap JSON through the parent and resetting the cursor.
+    -->
+    <RichTextEditor
+      v-if="editing"
+      ref="editor"
+      :model-value="buffer"
+      :editable="true"
+      :enable-rich-text-formatting="true"
+      :placeholder="placeholder"
+      @update:model-value="dirty = true"
+      @blur="stopEditing"
+    ></RichTextEditor>
+    <template v-else>
+      <RichTextEditor
+        v-if="hasValue"
+        class="form-view__description-rendered"
+        :model-value="value"
+        :editable="false"
+        :enable-rich-text-formatting="true"
+      ></RichTextEditor>
+      <span
+        v-else-if="!readOnly"
+        class="form-view__description-placeholder"
+        @click="edit"
+        >{{ placeholder }}</span
+      >
+      <a v-if="!readOnly" class="form-view__edit" @click="edit">
+        <i class="form-view__edit-icon iconoir-edit-pencil"></i>
+      </a>
+    </template>
+  </div>
+</template>
+
+<script>
+import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
+
+export default {
+  name: 'FormViewDescription',
+  components: { RichTextEditor },
+  props: {
+    value: {
+      type: String,
+      required: false,
+      default: '',
+    },
+    readOnly: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    placeholder: {
+      type: String,
+      required: false,
+      default: '',
+    },
+  },
+  emits: ['change'],
+  data() {
+    return {
+      editing: false,
+      dirty: false,
+      // Initial content handed to the editor when entering edit mode.
+      buffer: '',
+    }
+  },
+  computed: {
+    hasValue() {
+      return (this.value || '').trim().length > 0
+    },
+  },
+  methods: {
+    edit() {
+      if (this.readOnly) {
+        return
+      }
+      this.buffer = this.value || ''
+      this.dirty = false
+      this.editing = true
+      this.$nextTick(() => {
+        this.$refs.editor.focus()
+      })
+    },
+    stopEditing() {
+      // Read the markdown before unmounting the editor. Only save when the
+      // content actually changed, so opening and closing a legacy description
+      // doesn't rewrite it (markdown serialization can escape stray characters).
+      if (this.dirty) {
+        const markdown = this.$refs.editor.serializeToMarkdown()
+        if (markdown !== (this.value || '')) {
+          this.$emit('change', markdown)
+        }
+      }
+      this.editing = false
+      this.dirty = false
+    },
+  },
+}
+</script>

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -58,7 +58,7 @@
             :editable="!readOnly"
             :enable-rich-text-formatting="true"
             :placeholder="$t('formViewField.descriptionPlaceholder')"
-            editor-class="form-view__field-description-editor"
+            @update:model-value="descriptionDirty = true"
             @blur="saveDescription"
           ></RichTextEditor>
         </div>
@@ -239,7 +239,11 @@ export default {
       editingName: false,
       value: null,
       children: [],
+      // Display buffer for the editor: a markdown string initially, tiptap
+      // JSON after edits. Not the source of truth, saved value always comes
+      // from serializeToMarkdown().
       descriptionCopy: this.fieldOptions.description || '',
+      descriptionDirty: false,
     }
   },
   computed: {
@@ -301,6 +305,8 @@ export default {
     'fieldOptions.description': {
       handler(value) {
         this.descriptionCopy = value || ''
+        // Stored value changed externally, the buffer is back in sync.
+        this.descriptionDirty = false
       },
     },
   },
@@ -336,10 +342,14 @@ export default {
       this.value = value
     },
     saveDescription() {
+      if (!this.descriptionDirty) {
+        return
+      }
       const markdown = this.$refs.description.serializeToMarkdown()
       if (markdown !== (this.fieldOptions.description || '')) {
         this.$emit('updated-field-options', { description: markdown })
       }
+      this.descriptionDirty = false
     },
     getFieldType() {
       return this.$registry.get('field', this.field.type)

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -49,7 +49,7 @@
           </a>
         </div>
         <div
-          v-show="selected || fieldOptions.description"
+          v-if="selected || fieldOptions.description"
           class="form-view__field-description"
         >
           <RichTextEditor

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -52,15 +52,12 @@
           v-if="selected || fieldOptions.description"
           class="form-view__field-description"
         >
-          <RichTextEditor
-            ref="description"
-            v-model="descriptionCopy"
-            :editable="!readOnly"
-            :enable-rich-text-formatting="true"
+          <FormViewDescription
+            :value="fieldOptions.description || ''"
+            :read-only="readOnly"
             :placeholder="$t('formViewField.descriptionPlaceholder')"
-            @update:model-value="descriptionDirty = true"
-            @blur="saveDescription"
-          ></RichTextEditor>
+            @change="$emit('updated-field-options', { description: $event })"
+          ></FormViewDescription>
         </div>
         <p
           v-if="!readOnly && cannotSubmitValues"
@@ -187,11 +184,11 @@ import { clone } from '@baserow/modules/core/utils/object'
 import { DEFAULT_FORM_VIEW_FIELD_COMPONENT_KEY } from '@baserow/modules/database/constants'
 import ViewFieldConditionsForm from '@baserow/modules/database/components/view/ViewFieldConditionsForm'
 import { createFiltersTree } from '@baserow/modules/database/utils/view'
-import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
+import FormViewDescription from '@baserow/modules/database/components/view/form/FormViewDescription'
 
 export default {
   name: 'FormViewField',
-  components: { ViewFieldConditionsForm, RichTextEditor },
+  components: { ViewFieldConditionsForm, FormViewDescription },
   provide() {
     return {
       registerChild: this.registerChild,
@@ -239,11 +236,6 @@ export default {
       editingName: false,
       value: null,
       children: [],
-      // Display buffer for the editor: a markdown string initially, tiptap
-      // JSON after edits. Not the source of truth, saved value always comes
-      // from serializeToMarkdown().
-      descriptionCopy: this.fieldOptions.description || '',
-      descriptionDirty: false,
     }
   },
   computed: {
@@ -302,16 +294,6 @@ export default {
         })
       },
     },
-    'fieldOptions.description': {
-      handler(value) {
-        // Don't clobber an in-progress edit if the stored value changes
-        // externally (e.g. a realtime update from another editor).
-        if (this.descriptionDirty) {
-          return
-        }
-        this.descriptionCopy = value || ''
-      },
-    },
   },
   created() {
     this.resetValue()
@@ -343,16 +325,6 @@ export default {
     },
     updateValue(value) {
       this.value = value
-    },
-    saveDescription() {
-      if (!this.descriptionDirty) {
-        return
-      }
-      const markdown = this.$refs.description.serializeToMarkdown()
-      if (markdown !== (this.fieldOptions.description || '')) {
-        this.$emit('updated-field-options', { description: markdown })
-      }
-      this.descriptionDirty = false
     },
     getFieldType() {
       return this.$registry.get('field', this.field.type)

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -52,24 +52,15 @@
           v-show="selected || fieldOptions.description"
           class="form-view__field-description"
         >
-          <Editable
+          <RichTextEditor
             ref="description"
-            :value="fieldOptions.description"
+            v-model="descriptionCopy"
+            :editable="!readOnly"
+            :enable-rich-text-formatting="true"
             :placeholder="$t('formViewField.descriptionPlaceholder')"
-            :multiline="true"
-            @change="
-              $emit('updated-field-options', { description: $event.value })
-            "
-            @editing="editingDescription = $event"
-          ></Editable>
-          <a
-            v-if="!readOnly"
-            class="form-view__edit form-view-field-edit"
-            :class="{ 'form-view__edit--hidden': editingDescription }"
-            @click="$refs.description.edit()"
-          >
-            <i class="form-view__edit-icon iconoir-edit-pencil"></i
-          ></a>
+            editor-class="form-view__field-description-editor"
+            @blur="saveDescription"
+          ></RichTextEditor>
         </div>
         <p
           v-if="!readOnly && cannotSubmitValues"
@@ -196,10 +187,11 @@ import { clone } from '@baserow/modules/core/utils/object'
 import { DEFAULT_FORM_VIEW_FIELD_COMPONENT_KEY } from '@baserow/modules/database/constants'
 import ViewFieldConditionsForm from '@baserow/modules/database/components/view/ViewFieldConditionsForm'
 import { createFiltersTree } from '@baserow/modules/database/utils/view'
+import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
 
 export default {
   name: 'FormViewField',
-  components: { ViewFieldConditionsForm },
+  components: { ViewFieldConditionsForm, RichTextEditor },
   provide() {
     return {
       registerChild: this.registerChild,
@@ -245,9 +237,9 @@ export default {
     return {
       selected: false,
       editingName: false,
-      editingDescription: false,
       value: null,
       children: [],
+      descriptionCopy: this.fieldOptions.description || '',
     }
   },
   computed: {
@@ -306,6 +298,11 @@ export default {
         })
       },
     },
+    'fieldOptions.description': {
+      handler(value) {
+        this.descriptionCopy = value || ''
+      },
+    },
   },
   created() {
     this.resetValue()
@@ -337,6 +334,12 @@ export default {
     },
     updateValue(value) {
       this.value = value
+    },
+    saveDescription() {
+      const markdown = this.$refs.description.serializeToMarkdown()
+      if (markdown !== (this.fieldOptions.description || '')) {
+        this.$emit('updated-field-options', { description: markdown })
+      }
     },
     getFieldType() {
       return this.$registry.get('field', this.field.type)

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -56,6 +56,7 @@
             :value="fieldOptions.description || ''"
             :read-only="readOnly"
             :placeholder="$t('formViewField.descriptionPlaceholder')"
+            :get-scroll-area-element="getScrollAreaElement"
             @change="$emit('updated-field-options', { description: $event })"
           ></FormViewDescription>
         </div>
@@ -227,6 +228,12 @@ export default {
       type: Boolean,
       required: false,
       default: true,
+    },
+    // Resolves the scrollable preview container owned by FormViewPreview.
+    getScrollAreaElement: {
+      type: Function,
+      required: false,
+      default: null,
     },
   },
   emits: ['updated-field-options', 'hide'],

--- a/web-frontend/modules/database/components/view/form/FormViewField.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewField.vue
@@ -304,9 +304,12 @@ export default {
     },
     'fieldOptions.description': {
       handler(value) {
+        // Don't clobber an in-progress edit if the stored value changes
+        // externally (e.g. a realtime update from another editor).
+        if (this.descriptionDirty) {
+          return
+        }
         this.descriptionCopy = value || ''
-        // Stored value changed externally, the buffer is back in sync.
-        this.descriptionDirty = false
       },
     },
   },

--- a/web-frontend/modules/database/components/view/form/FormViewModeForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModeForm.vue
@@ -15,11 +15,13 @@
       <div class="form-view__heading">
         <Thumbnail v-if="logoImage !== null" :src="logoImage.url" width="200" />
         <h1 v-if="title !== ''" class="form-view__title">{{ title }}</h1>
-        <!-- prettier-ignore -->
-        <p
-          v-if="description !== ''"
-          class="form-view__description whitespace-pre-wrap"
-        >{{ description }}</p>
+        <div v-if="description !== ''" class="form-view__description">
+          <RichTextEditor
+            :model-value="description"
+            :editable="false"
+            :enable-rich-text-formatting="true"
+          ></RichTextEditor>
+        </div>
       </div>
       <FormPageField
         v-for="field in visibleFields"
@@ -63,6 +65,7 @@ import baseFormViewMode from '@baserow/modules/database/mixins/baseFormViewMode'
 import FormPageField from '@baserow/modules/database/components/view/form/FormPageField'
 import FormViewPoweredBy from '@baserow/modules/database/components/view/form/FormViewPoweredBy'
 import FormViewSubmitted from '@baserow/modules/database/components/view/form/FormViewSubmitted'
+import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
 
 export default {
   name: 'FormViewModeForm',
@@ -70,6 +73,7 @@ export default {
     FormViewSubmitted,
     FormPageField,
     FormViewPoweredBy,
+    RichTextEditor,
   },
   mixins: [baseFormViewMode],
   emits: ['submit'],

--- a/web-frontend/modules/database/components/view/form/FormViewModeForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModeForm.vue
@@ -16,11 +16,10 @@
         <Thumbnail v-if="logoImage !== null" :src="logoImage.url" width="200" />
         <h1 v-if="title !== ''" class="form-view__title">{{ title }}</h1>
         <div v-if="description !== ''" class="form-view__description">
-          <RichTextEditor
-            :model-value="description"
-            :editable="false"
-            :enable-rich-text-formatting="true"
-          ></RichTextEditor>
+          <FormViewDescription
+            :value="description"
+            read-only
+          ></FormViewDescription>
         </div>
       </div>
       <FormPageField
@@ -65,7 +64,7 @@ import baseFormViewMode from '@baserow/modules/database/mixins/baseFormViewMode'
 import FormPageField from '@baserow/modules/database/components/view/form/FormPageField'
 import FormViewPoweredBy from '@baserow/modules/database/components/view/form/FormViewPoweredBy'
 import FormViewSubmitted from '@baserow/modules/database/components/view/form/FormViewSubmitted'
-import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
+import FormViewDescription from '@baserow/modules/database/components/view/form/FormViewDescription'
 
 export default {
   name: 'FormViewModeForm',
@@ -73,7 +72,7 @@ export default {
     FormViewSubmitted,
     FormPageField,
     FormViewPoweredBy,
-    RichTextEditor,
+    FormViewDescription,
   },
   mixins: [baseFormViewMode],
   emits: ['submit'],

--- a/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
@@ -65,6 +65,7 @@
             :value="view.description || ''"
             :read-only="readOnly"
             :placeholder="$t('formViewModePreviewForm.descriptionPlaceholder')"
+            :get-scroll-area-element="getScrollAreaElement"
             @change="updateForm({ description: $event })"
           ></FormViewDescription>
         </div>
@@ -94,6 +95,7 @@
           :field-options="fieldOptions[field.id]"
           :fields="fields"
           :read-only="readOnly"
+          :get-scroll-area-element="getScrollAreaElement"
           @hide="updateFieldOptionsOfField(view, field, { enabled: false })"
           @updated-field-options="
             updateFieldOptionsOfField(view, field, $event)
@@ -178,6 +180,12 @@ export default {
     readOnly: {
       type: Boolean,
       required: true,
+    },
+    // Resolves the scrollable preview container owned by FormViewPreview.
+    getScrollAreaElement: {
+      type: Function,
+      required: false,
+      default: null,
     },
   },
   emits: ['ordered-fields'],

--- a/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
@@ -67,6 +67,7 @@
             :editable="!readOnly"
             :enable-rich-text-formatting="true"
             :placeholder="$t('formViewModePreviewForm.descriptionPlaceholder')"
+            @update:model-value="descriptionDirty = true"
             @blur="saveDescription"
           ></RichTextEditor>
         </div>
@@ -187,13 +188,19 @@ export default {
     return {
       editingTitle: false,
       editingSubmitText: false,
+      // Display buffer for the editor: a markdown string initially, tiptap
+      // JSON after edits. Not the source of truth, saved value always comes
+      // from serializeToMarkdown().
       descriptionCopy: this.view.description || '',
+      descriptionDirty: false,
     }
   },
   watch: {
     'view.description': {
       handler(value) {
         this.descriptionCopy = value || ''
+        // Stored value changed externally, the buffer is back in sync.
+        this.descriptionDirty = false
       },
     },
   },
@@ -202,10 +209,14 @@ export default {
       this.$emit('ordered-fields', order)
     },
     saveDescription() {
+      if (!this.descriptionDirty) {
+        return
+      }
       const markdown = this.$refs.description.serializeToMarkdown()
       if (markdown !== (this.view.description || '')) {
         this.updateForm({ description: markdown })
       }
+      this.descriptionDirty = false
     },
   },
 }

--- a/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
@@ -61,15 +61,12 @@
           v-if="!readOnly || view.description"
           class="form-view__description"
         >
-          <RichTextEditor
-            ref="description"
-            v-model="descriptionCopy"
-            :editable="!readOnly"
-            :enable-rich-text-formatting="true"
+          <FormViewDescription
+            :value="view.description || ''"
+            :read-only="readOnly"
             :placeholder="$t('formViewModePreviewForm.descriptionPlaceholder')"
-            @update:model-value="descriptionDirty = true"
-            @blur="saveDescription"
-          ></RichTextEditor>
+            @change="updateForm({ description: $event })"
+          ></FormViewDescription>
         </div>
         <div v-if="fields.length === 0" class="form-view__no-fields">
           <div class="form-view__no-fields-title">
@@ -149,7 +146,7 @@ import FormViewImageUpload from '@baserow/modules/database/components/view/form/
 import formViewHelpers from '@baserow/modules/database/mixins/formViewHelpers'
 import FormViewPoweredBy from '@baserow/modules/database/components/view/form/FormViewPoweredBy'
 import FormViewMetaControls from '@baserow/modules/database/components/view/form/FormViewMetaControls'
-import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
+import FormViewDescription from '@baserow/modules/database/components/view/form/FormViewDescription'
 
 export default {
   name: 'FormViewModePreviewForm',
@@ -158,7 +155,7 @@ export default {
     FormViewField,
     FormViewImageUpload,
     FormViewMetaControls,
-    RichTextEditor,
+    FormViewDescription,
   },
   mixins: [formViewHelpers],
   props: {
@@ -188,38 +185,11 @@ export default {
     return {
       editingTitle: false,
       editingSubmitText: false,
-      // Display buffer for the editor: a markdown string initially, tiptap
-      // JSON after edits. Not the source of truth, saved value always comes
-      // from serializeToMarkdown().
-      descriptionCopy: this.view.description || '',
-      descriptionDirty: false,
     }
-  },
-  watch: {
-    'view.description': {
-      handler(value) {
-        // Don't clobber an in-progress edit if the stored value changes
-        // externally (e.g. a realtime update from another editor).
-        if (this.descriptionDirty) {
-          return
-        }
-        this.descriptionCopy = value || ''
-      },
-    },
   },
   methods: {
     order(order) {
       this.$emit('ordered-fields', order)
-    },
-    saveDescription() {
-      if (!this.descriptionDirty) {
-        return
-      }
-      const markdown = this.$refs.description.serializeToMarkdown()
-      if (markdown !== (this.view.description || '')) {
-        this.updateForm({ description: markdown })
-      }
-      this.descriptionDirty = false
     },
   },
 }

--- a/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
@@ -57,24 +57,19 @@
             <i class="form-view__edit-icon iconoir-edit-pencil"></i
           ></a>
         </h1>
-        <p v-if="!readOnly || view.description" class="form-view__description">
-          <Editable
+        <div
+          v-if="!readOnly || view.description"
+          class="form-view__description"
+        >
+          <RichTextEditor
             ref="description"
-            :value="view.description"
+            v-model="descriptionCopy"
+            :editable="!readOnly"
+            :enable-rich-text-formatting="true"
             :placeholder="$t('formViewModePreviewForm.descriptionPlaceholder')"
-            :multiline="true"
-            @change="updateForm({ description: $event.value })"
-            @editing="editingDescription = $event"
-          ></Editable>
-          <a
-            v-if="!readOnly"
-            class="form-view__edit"
-            :class="{ 'form-view__edit--hidden': editingDescription }"
-            @click="$refs.description.edit()"
-          >
-            <i class="form-view__edit-icon iconoir-edit-pencil"></i
-          ></a>
-        </p>
+            @blur="saveDescription"
+          ></RichTextEditor>
+        </div>
         <div v-if="fields.length === 0" class="form-view__no-fields">
           <div class="form-view__no-fields-title">
             {{ $t('formViewModePreviewForm.noFieldsTitle') }}
@@ -153,6 +148,7 @@ import FormViewImageUpload from '@baserow/modules/database/components/view/form/
 import formViewHelpers from '@baserow/modules/database/mixins/formViewHelpers'
 import FormViewPoweredBy from '@baserow/modules/database/components/view/form/FormViewPoweredBy'
 import FormViewMetaControls from '@baserow/modules/database/components/view/form/FormViewMetaControls'
+import RichTextEditor from '@baserow/modules/core/components/editor/RichTextEditor.vue'
 
 export default {
   name: 'FormViewModePreviewForm',
@@ -161,6 +157,7 @@ export default {
     FormViewField,
     FormViewImageUpload,
     FormViewMetaControls,
+    RichTextEditor,
   },
   mixins: [formViewHelpers],
   props: {
@@ -190,12 +187,25 @@ export default {
     return {
       editingTitle: false,
       editingSubmitText: false,
-      editingDescription: false,
+      descriptionCopy: this.view.description || '',
     }
+  },
+  watch: {
+    'view.description': {
+      handler(value) {
+        this.descriptionCopy = value || ''
+      },
+    },
   },
   methods: {
     order(order) {
       this.$emit('ordered-fields', order)
+    },
+    saveDescription() {
+      const markdown = this.$refs.description.serializeToMarkdown()
+      if (markdown !== (this.view.description || '')) {
+        this.updateForm({ description: markdown })
+      }
     },
   },
 }

--- a/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewModePreviewForm.vue
@@ -198,9 +198,12 @@ export default {
   watch: {
     'view.description': {
       handler(value) {
+        // Don't clobber an in-progress edit if the stored value changes
+        // externally (e.g. a realtime update from another editor).
+        if (this.descriptionDirty) {
+          return
+        }
         this.descriptionCopy = value || ''
-        // Stored value changed externally, the buffer is back in sync.
-        this.descriptionDirty = false
       },
     },
   },

--- a/web-frontend/modules/database/components/view/form/FormViewPreview.vue
+++ b/web-frontend/modules/database/components/view/form/FormViewPreview.vue
@@ -9,6 +9,7 @@
         :fields="fields"
         :store-prefix="storePrefix"
         :read-only="readOnly"
+        :get-scroll-area-element="getScrollAreaElement"
         @ordered-fields="$emit('ordered-fields', $event)"
       ></component>
     </div>
@@ -49,6 +50,13 @@ export default {
       return this.$registry
         .get('formViewMode', this.view.mode)
         .getPreviewComponent()
+    },
+  },
+  methods: {
+    // This component owns the scrollable preview container; descendants use
+    // this resolver so rich text editor menus can stick to it while scrolling.
+    getScrollAreaElement() {
+      return this.$el
     },
   },
 }

--- a/web-frontend/test/unit/database/components/view/form/formPageFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formPageFieldDescription.spec.js
@@ -2,7 +2,9 @@ import { TestApp } from '@baserow/test/helpers/testApp'
 import FormPageField from '@baserow/modules/database/components/view/form/FormPageField'
 
 // Read-only stub: exposes the markdown handed to the editor so we can assert it is
-// forwarded for rendering (the real editor parses markdown; tiptap is out of scope here).
+// forwarded for rendering (the real editor parses markdown; tiptap is out of scope
+// here). FormPageField renders through FormViewDescription's read-only branch; the
+// stub is applied deeply, so it replaces the editor inside it.
 const RichTextEditorStub = {
   name: 'RichTextEditor',
   props: {

--- a/web-frontend/test/unit/database/components/view/form/formPageFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formPageFieldDescription.spec.js
@@ -1,0 +1,63 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import FormPageField from '@baserow/modules/database/components/view/form/FormPageField'
+
+// Read-only stub: exposes the markdown handed to the editor so we can assert it is
+// forwarded for rendering (the real editor parses markdown; tiptap is out of scope here).
+const RichTextEditorStub = {
+  name: 'RichTextEditor',
+  props: {
+    modelValue: { type: [String, Object], default: '' },
+    editable: { type: Boolean, default: true },
+  },
+  template:
+    '<div class="rich-text-editor-stub" :data-editable="editable">{{ modelValue }}</div>',
+}
+
+describe('FormPageField description render', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const baseField = {
+    field: { id: 1, name: 'Name', type: 'text' },
+    field_component: 'default',
+    required: false,
+    _: { touched: false },
+  }
+
+  const mountComponent = (description) =>
+    testApp.mount(FormPageField, {
+      props: {
+        slug: 'abc',
+        value: '',
+        field: { ...baseField, description },
+      },
+      global: { stubs: { RichTextEditor: RichTextEditorStub } },
+    })
+
+  test('renders the description read-only through the editor', async () => {
+    const wrapper = await mountComponent('**bold**')
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    expect(editor.exists()).toBe(true)
+    expect(editor.props('editable')).toBe(false)
+    expect(editor.props('modelValue')).toBe('**bold**')
+  })
+
+  test('renders nothing when there is no description', async () => {
+    const wrapper = await mountComponent('')
+    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(false)
+  })
+
+  test('forwards legacy plain-text descriptions unchanged (backward compat)', async () => {
+    const wrapper = await mountComponent('Just plain text')
+    expect(wrapper.findComponent(RichTextEditorStub).props('modelValue')).toBe(
+      'Just plain text'
+    )
+  })
+})

--- a/web-frontend/test/unit/database/components/view/form/formViewDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewDescription.spec.js
@@ -1,0 +1,151 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import FormViewDescription from '@baserow/modules/database/components/view/form/FormViewDescription'
+
+// Stub the tiptap editor: serialized output tracks live content, mirroring the
+// real component without pulling tiptap into the jsdom test.
+const RichTextEditorStub = {
+  name: 'RichTextEditor',
+  props: {
+    modelValue: { type: [String, Object], default: '' },
+    editable: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue', 'blur'],
+  data() {
+    return { content: this.modelValue || '' }
+  },
+  template: '<div class="rich-text-editor-stub"></div>',
+  methods: {
+    focus() {},
+    setContent(value) {
+      this.content = value
+      this.$emit('update:modelValue', value)
+    },
+    serializeToMarkdown() {
+      // Mirror tiptap-markdown, which escapes stray markdown-special chars
+      // (e.g. a lone "*") so serialized output can differ from the raw stored
+      // string even when the user never edited anything.
+      return (this.content || '').replace(/\*/g, '\\*')
+    },
+  },
+}
+
+describe('FormViewDescription', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const mountComponent = (props = {}) =>
+    testApp.mount(FormViewDescription, {
+      props: {
+        value: '',
+        readOnly: false,
+        placeholder: 'Add a description',
+        ...props,
+      },
+      global: { stubs: { RichTextEditor: RichTextEditorStub } },
+    })
+
+  const startEditing = async (wrapper) => {
+    await wrapper.find('.form-view__edit').trigger('click')
+    await wrapper.vm.$nextTick()
+    return wrapper.findComponent(RichTextEditorStub)
+  }
+
+  test('renders the stored description read-only in display mode', async () => {
+    const wrapper = await mountComponent({ value: '**bold**' })
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    expect(editor.exists()).toBe(true)
+    expect(editor.props('modelValue')).toBe('**bold**')
+    expect(editor.props('editable')).toBe(false)
+  })
+
+  test('shows an edit affordance when not read only and hides it when read only', async () => {
+    const editable = await mountComponent({
+      value: '**bold**',
+      readOnly: false,
+    })
+    expect(editable.find('.form-view__edit').exists()).toBe(true)
+
+    const readOnly = await mountComponent({ value: '**bold**', readOnly: true })
+    expect(readOnly.find('.form-view__edit').exists()).toBe(false)
+  })
+
+  test('mounts the editable editor only after entering edit mode', async () => {
+    const wrapper = await mountComponent({ value: '' })
+    // Nothing to render for an empty value: only the placeholder is shown.
+    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(false)
+    const editor = await startEditing(wrapper)
+    expect(editor.exists()).toBe(true)
+    expect(editor.props('editable')).toBe(true)
+  })
+
+  test('emits change with markdown after an edit and blur', async () => {
+    const wrapper = await mountComponent({ value: '' })
+    const editor = await startEditing(wrapper)
+    editor.vm.setContent('See [docs](https://baserow.io)')
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('change')
+    expect(events).toBeTruthy()
+    expect(events[events.length - 1][0]).toBe('See [docs](https://baserow.io)')
+  })
+
+  test('does not emit change on blur without an edit, even when markdown serialization differs from a legacy value', async () => {
+    const wrapper = await mountComponent({
+      value: 'Rate 1-5 and use * bullets',
+    })
+    const editor = await startEditing(wrapper)
+    // Focus in and out without changing anything (blur only, no update).
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('change')).toBeFalsy()
+  })
+
+  test('emits change after a real edit of a legacy plain-text value', async () => {
+    const wrapper = await mountComponent({
+      value: 'Rate 1-5 and use * bullets',
+    })
+    const editor = await startEditing(wrapper)
+    editor.vm.setContent('A whole new description')
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('change')
+    expect(events).toBeTruthy()
+    expect(events[events.length - 1][0]).toBe('A whole new description')
+  })
+
+  test('keeps the in-progress edit when the value prop changes externally', async () => {
+    const wrapper = await mountComponent({ value: 'original' })
+    const editor = await startEditing(wrapper)
+    editor.vm.setContent('unsaved edit in progress')
+    await wrapper.vm.$nextTick()
+
+    // A realtime update to the stored value arrives mid-edit.
+    await wrapper.setProps({ value: 'external change' })
+
+    // The unsaved edit is preserved: blur still serializes what was typed, not
+    // the external value.
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+    const events = wrapper.emitted('change')
+    expect(events[events.length - 1][0]).toBe('unsaved edit in progress')
+  })
+
+  test('read only mode does not enter edit mode', async () => {
+    const wrapper = await mountComponent({ value: 'read only', readOnly: true })
+    wrapper.vm.edit()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findComponent(RichTextEditorStub).props('editable')).toBe(
+      false
+    )
+  })
+})

--- a/web-frontend/test/unit/database/components/view/form/formViewDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewDescription.spec.js
@@ -8,6 +8,7 @@ const RichTextEditorStub = {
   props: {
     modelValue: { type: [String, Object], default: '' },
     editable: { type: Boolean, default: false },
+    scrollableAreaElement: { default: null },
   },
   emits: ['update:modelValue', 'blur'],
   data() {
@@ -83,6 +84,22 @@ describe('FormViewDescription', () => {
     const editor = await startEditing(wrapper)
     expect(editor.exists()).toBe(true)
     expect(editor.props('editable')).toBe(true)
+  })
+
+  test('hands the resolved scroll container to the editor when editing', async () => {
+    const container = document.createElement('div')
+    const wrapper = await mountComponent({
+      value: 'text',
+      getScrollAreaElement: () => container,
+    })
+    const editor = await startEditing(wrapper)
+    expect(editor.props('scrollableAreaElement')).toBe(container)
+  })
+
+  test('editor gets no scroll container when no resolver is provided', async () => {
+    const wrapper = await mountComponent({ value: 'text' })
+    const editor = await startEditing(wrapper)
+    expect(editor.props('scrollableAreaElement')).toBe(null)
   })
 
   test('emits change with markdown after an edit and blur', async () => {

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
@@ -1,36 +1,20 @@
 import { TestApp } from '@baserow/test/helpers/testApp'
 import FormViewField from '@baserow/modules/database/components/view/form/FormViewField'
 
-// Stub the tiptap editor: serialized output tracks live content, mirroring the real
-// component without pulling tiptap into the jsdom test.
-const RichTextEditorStub = {
-  name: 'RichTextEditor',
-  props: { modelValue: { type: [String, Object], default: '' } },
-  emits: ['update:modelValue', 'blur'],
-  data() {
-    return { content: this.modelValue || '' }
+// Stub the description editor: the toggle/save behavior is covered by
+// formViewDescription.spec.js, here we only check how FormViewField wires it up.
+const FormViewDescriptionStub = {
+  name: 'FormViewDescription',
+  props: {
+    value: { type: String, default: '' },
+    readOnly: { type: Boolean, default: false },
+    placeholder: { type: String, default: '' },
   },
-  watch: {
-    modelValue(value) {
-      this.content = value || ''
-    },
-  },
-  template: '<div class="rich-text-editor-stub"></div>',
-  methods: {
-    setContent(value) {
-      this.content = value
-      this.$emit('update:modelValue', value)
-    },
-    serializeToMarkdown() {
-      // Mirror tiptap-markdown, which escapes stray markdown-special chars
-      // (e.g. a lone "*") so serialized output can differ from the raw
-      // stored string even when the user never edited anything.
-      return (this.content || '').replace(/\*/g, '\\*')
-    },
-  },
+  emits: ['change'],
+  template: '<div class="form-view-description-stub"></div>',
 }
 
-describe('FormViewField description editor', () => {
+describe('FormViewField description', () => {
   let testApp = null
 
   beforeEach(() => {
@@ -64,31 +48,29 @@ describe('FormViewField description editor', () => {
         },
         readOnly: false,
       },
-      global: { stubs: { RichTextEditor: RichTextEditorStub } },
+      global: { stubs: { FormViewDescription: FormViewDescriptionStub } },
     })
 
-  test('seeds the editor from the stored markdown description', async () => {
+  test('forwards the stored markdown description to the editor', async () => {
     const wrapper = await mountComponent({ description: '**bold**' })
-    const editor = wrapper.findComponent(RichTextEditorStub)
-    expect(editor.exists()).toBe(true)
-    expect(editor.props('modelValue')).toBe('**bold**')
+    const description = wrapper.findComponent(FormViewDescriptionStub)
+    expect(description.exists()).toBe(true)
+    expect(description.props('value')).toBe('**bold**')
   })
 
-  test('does not mount an editor for an unselected field with no description', async () => {
+  test('does not render the description for an unselected field with no description', async () => {
     const wrapper = await mountComponent({ description: '' })
-    // v-if keeps the heavy rich-text editor out of the DOM until needed.
-    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(false)
+    // v-if keeps the description out of the DOM until the field is selected.
+    expect(wrapper.findComponent(FormViewDescriptionStub).exists()).toBe(false)
     await wrapper.find('.form-view__field').trigger('click')
-    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(true)
+    expect(wrapper.findComponent(FormViewDescriptionStub).exists()).toBe(true)
   })
 
-  test('emits updated-field-options with markdown on blur', async () => {
+  test('emits updated-field-options with markdown when the editor changes', async () => {
     const wrapper = await mountComponent({ description: '' })
-    // With no description the editor only mounts once the field is selected.
     await wrapper.find('.form-view__field').trigger('click')
-    const editor = wrapper.findComponent(RichTextEditorStub)
-    editor.vm.setContent('See [docs](https://baserow.io)')
-    editor.vm.$emit('blur')
+    const description = wrapper.findComponent(FormViewDescriptionStub)
+    description.vm.$emit('change', 'See [docs](https://baserow.io)')
     await wrapper.vm.$nextTick()
 
     const events = wrapper.emitted('updated-field-options')
@@ -96,59 +78,5 @@ describe('FormViewField description editor', () => {
     expect(events[events.length - 1][0]).toEqual({
       description: 'See [docs](https://baserow.io)',
     })
-  })
-
-  test(
-    'does not emit on blur without an edit, even if markdown serialization ' +
-      'differs from the stored legacy plain-text value',
-    async () => {
-      const wrapper = await mountComponent({
-        description: 'Rate 1-5 and use * bullets',
-      })
-      const editor = wrapper.findComponent(RichTextEditorStub)
-      // No edit happened, just focus in/out (blur only, no update:modelValue).
-      editor.vm.$emit('blur')
-      await wrapper.vm.$nextTick()
-
-      expect(wrapper.emitted('updated-field-options')).toBeFalsy()
-    }
-  )
-
-  test('emits on blur after a real edit even for a legacy plain-text description', async () => {
-    const wrapper = await mountComponent({
-      description: 'Rate 1-5 and use * bullets',
-    })
-    const editor = wrapper.findComponent(RichTextEditorStub)
-    editor.vm.setContent('A whole new description')
-    editor.vm.$emit('blur')
-    await wrapper.vm.$nextTick()
-
-    const events = wrapper.emitted('updated-field-options')
-    expect(events).toBeTruthy()
-    expect(events[events.length - 1][0]).toEqual({
-      description: 'A whole new description',
-    })
-  })
-
-  test('keeps an in-progress edit when the stored description changes externally', async () => {
-    const wrapper = await mountComponent({ description: 'original' })
-    const editor = wrapper.findComponent(RichTextEditorStub)
-    // User starts editing (this marks the buffer dirty).
-    editor.vm.setContent('unsaved edit in progress')
-    await wrapper.vm.$nextTick()
-
-    // A realtime update to the stored value arrives mid-edit.
-    await wrapper.setProps({
-      fieldOptions: {
-        description: 'external change',
-        conditions: [],
-        condition_groups: [],
-      },
-    })
-
-    // The unsaved edit is preserved, not clobbered by the external value.
-    expect(wrapper.findComponent(RichTextEditorStub).props('modelValue')).toBe(
-      'unsaved edit in progress'
-    )
   })
 })

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
@@ -22,7 +22,10 @@ const RichTextEditorStub = {
       this.$emit('update:modelValue', value)
     },
     serializeToMarkdown() {
-      return this.content || ''
+      // Mirror tiptap-markdown, which escapes stray markdown-special chars
+      // (e.g. a lone "*") so serialized output can differ from the raw
+      // stored string even when the user never edited anything.
+      return (this.content || '').replace(/\*/g, '\\*')
     },
   },
 }
@@ -82,6 +85,38 @@ describe('FormViewField description editor', () => {
     expect(events).toBeTruthy()
     expect(events[events.length - 1][0]).toEqual({
       description: 'See [docs](https://baserow.io)',
+    })
+  })
+
+  test(
+    'does not emit on blur without an edit, even if markdown serialization ' +
+      'differs from the stored legacy plain-text value',
+    async () => {
+      const wrapper = await mountComponent({
+        description: 'Rate 1-5 and use * bullets',
+      })
+      const editor = wrapper.findComponent(RichTextEditorStub)
+      // No edit happened, just focus in/out (blur only, no update:modelValue).
+      editor.vm.$emit('blur')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.emitted('updated-field-options')).toBeFalsy()
+    }
+  )
+
+  test('emits on blur after a real edit even for a legacy plain-text description', async () => {
+    const wrapper = await mountComponent({
+      description: 'Rate 1-5 and use * bullets',
+    })
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    editor.vm.setContent('A whole new description')
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('updated-field-options')
+    expect(events).toBeTruthy()
+    expect(events[events.length - 1][0]).toEqual({
+      description: 'A whole new description',
     })
   })
 })

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
@@ -129,4 +129,26 @@ describe('FormViewField description editor', () => {
       description: 'A whole new description',
     })
   })
+
+  test('keeps an in-progress edit when the stored description changes externally', async () => {
+    const wrapper = await mountComponent({ description: 'original' })
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    // User starts editing (this marks the buffer dirty).
+    editor.vm.setContent('unsaved edit in progress')
+    await wrapper.vm.$nextTick()
+
+    // A realtime update to the stored value arrives mid-edit.
+    await wrapper.setProps({
+      fieldOptions: {
+        description: 'external change',
+        conditions: [],
+        condition_groups: [],
+      },
+    })
+
+    // The unsaved edit is preserved, not clobbered by the external value.
+    expect(wrapper.findComponent(RichTextEditorStub).props('modelValue')).toBe(
+      'unsaved edit in progress'
+    )
+  })
 })

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
@@ -74,8 +74,18 @@ describe('FormViewField description editor', () => {
     expect(editor.props('modelValue')).toBe('**bold**')
   })
 
+  test('does not mount an editor for an unselected field with no description', async () => {
+    const wrapper = await mountComponent({ description: '' })
+    // v-if keeps the heavy rich-text editor out of the DOM until needed.
+    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(false)
+    await wrapper.find('.form-view__field').trigger('click')
+    expect(wrapper.findComponent(RichTextEditorStub).exists()).toBe(true)
+  })
+
   test('emits updated-field-options with markdown on blur', async () => {
     const wrapper = await mountComponent({ description: '' })
+    // With no description the editor only mounts once the field is selected.
+    await wrapper.find('.form-view__field').trigger('click')
     const editor = wrapper.findComponent(RichTextEditorStub)
     editor.vm.setContent('See [docs](https://baserow.io)')
     editor.vm.$emit('blur')

--- a/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
+++ b/web-frontend/test/unit/database/components/view/form/formViewFieldDescription.spec.js
@@ -1,0 +1,87 @@
+import { TestApp } from '@baserow/test/helpers/testApp'
+import FormViewField from '@baserow/modules/database/components/view/form/FormViewField'
+
+// Stub the tiptap editor: serialized output tracks live content, mirroring the real
+// component without pulling tiptap into the jsdom test.
+const RichTextEditorStub = {
+  name: 'RichTextEditor',
+  props: { modelValue: { type: [String, Object], default: '' } },
+  emits: ['update:modelValue', 'blur'],
+  data() {
+    return { content: this.modelValue || '' }
+  },
+  watch: {
+    modelValue(value) {
+      this.content = value || ''
+    },
+  },
+  template: '<div class="rich-text-editor-stub"></div>',
+  methods: {
+    setContent(value) {
+      this.content = value
+      this.$emit('update:modelValue', value)
+    },
+    serializeToMarkdown() {
+      return this.content || ''
+    },
+  },
+}
+
+describe('FormViewField description editor', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const field = {
+    id: 1,
+    name: 'Name',
+    type: 'text',
+    _: { type: { iconClass: '' } },
+  }
+
+  const mountComponent = (fieldOptions = {}) =>
+    testApp.mount(FormViewField, {
+      props: {
+        database: { workspace: { id: 1 } },
+        table: { id: 1 },
+        view: { slug: 'abc' },
+        field,
+        fields: [field],
+        fieldOptions: {
+          description: '**bold**',
+          conditions: [],
+          condition_groups: [],
+          ...fieldOptions,
+        },
+        readOnly: false,
+      },
+      global: { stubs: { RichTextEditor: RichTextEditorStub } },
+    })
+
+  test('seeds the editor from the stored markdown description', async () => {
+    const wrapper = await mountComponent({ description: '**bold**' })
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    expect(editor.exists()).toBe(true)
+    expect(editor.props('modelValue')).toBe('**bold**')
+  })
+
+  test('emits updated-field-options with markdown on blur', async () => {
+    const wrapper = await mountComponent({ description: '' })
+    const editor = wrapper.findComponent(RichTextEditorStub)
+    editor.vm.setContent('See [docs](https://baserow.io)')
+    editor.vm.$emit('blur')
+    await wrapper.vm.$nextTick()
+
+    const events = wrapper.emitted('updated-field-options')
+    expect(events).toBeTruthy()
+    expect(events[events.length - 1][0]).toEqual({
+      description: 'See [docs](https://baserow.io)',
+    })
+  })
+})


### PR DESCRIPTION
Closes #1851

Form descriptions used to be plain text. Now they can have links, bold, italic, lists, and headings. That covers both the description under each field and the intro at the top of the form, and it works while you're building the form and on the form people actually fill in (survey mode included).

It reuses the rich text editor we already have and saves everything as markdown in the same description field, so there's nothing to migrate and no backend changes.

## How editing works

On the form builder, a description shows its rendered text with an edit pencil next to it, the same as the title and submit button. Click the pencil to edit, and it saves when you click away. The editor is only mounted while you're actually editing, so unselected fields stay light and no formatting menu hangs around the form when you're not using it.

## Worth knowing

Existing descriptions are safe. Opening one and clicking away doesn't change what's stored; it only saves when you actually edit.

They can look a bit different, though. Descriptions are now read as markdown, so an old one that happens to contain markdown characters will show up formatted. A line starting with `# ` becomes a heading, `- ` becomes a bullet, and so on. Plain sentences render the same as before.

## How it was tested

Unit tests cover the toggle and the save behavior: showing the edit affordance, mounting the editor only when editing, saving markdown on blur, not rewriting an old description you never touched, and keeping your edit if the form updates while you're typing.

There's also an end-to-end test on the public form. It checks that formatting shows up correctly, and that anything dangerous in a description (a `<script>` tag, a `javascript:` link) gets stripped and can't run.

### Try it yourself

1. Open a table, add a form view.
2. Click a field in the preview and click the pencil next to its Description.
3. Type some markdown (`**bold**`, a `- ` list, a `[link](https://baserow.io)`). Move the cursor into the middle of the text with the arrow keys and keep typing; the cursor stays where you put it.
4. Click away. The description saves and renders formatted, with the pencil back for another edit.
5. Do the same for the form's own Description at the top.
6. Open the public form (Share form) and confirm the descriptions render with formatting.

## Follow-up

On the public form, every description still renders through the editor rather than as plain HTML. On very large forms that's a little heavier than it needs to be, so rendering the markdown as plain HTML there would be a good optimization later. Tracked in #5717.
