### PR TITLE
fix(frontend): persist group by on personal views for viewer role

### DIFF
--- a/changelog/entries/unreleased/bug/5709_fixed_group_by_settings_not_being_persisted_on_personal_view.json
+++ b/changelog/entries/unreleased/bug/5709_fixed_group_by_settings_not_being_persisted_on_personal_view.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed group by settings not being persisted on personal views for viewer role users",
+    "issue_origin": "github",
+    "issue_number": 5709,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-13"
+}

--- a/premium/web-frontend/modules/baserow_premium/permissionManagerTypes.js
+++ b/premium/web-frontend/modules/baserow_premium/permissionManagerTypes.js
@@ -18,10 +18,17 @@ export class ViewOwnershipPermissionManagerType extends PermissionManagerType {
       'database.table.view.duplicate',
       'database.table.view.filter.update',
       'database.table.view.filter.delete',
-      'database.table.view.update_field_options',
       'database.table.view.decoration.update',
       'database.table.view.decoration.delete',
       'database.table.view.update_default_values',
+      'database.table.view.create_group_by',
+      'database.table.view.group_by.update',
+      'database.table.view.group_by.delete',
+      'database.table.view.prioritize_sortings',
+      'database.table.view.prioritize_group_bys',
+      'database.table.view.create_filter_group',
+      'database.table.view.filter_group.update',
+      'database.table.view.filter_group.delete',
     ]
     const { $store } = this.app
     const userId = $store.getters['auth/getUserId']

--- a/premium/web-frontend/test/unit/premium/viewOwnershipPermissionManager.spec.js
+++ b/premium/web-frontend/test/unit/premium/viewOwnershipPermissionManager.spec.js
@@ -1,4 +1,6 @@
 import { ViewOwnershipPermissionManagerType } from '@baserow_premium/permissionManagerTypes'
+import { BasicPermissionManagerType } from '@baserow/modules/core/permissionManagerTypes'
+import { isAdhocGroupBy } from '@baserow/modules/database/utils/view'
 
 function createManager(userId) {
   const manager = new ViewOwnershipPermissionManagerType()
@@ -90,54 +92,59 @@ describe('ViewOwnershipPermissionManagerType', () => {
       expect(result).toBeUndefined()
     })
   })
+})
 
-  describe('group by operations are included (regression)', () => {
-    const groupByOps = [
-      'database.table.view.create_group_by',
-      'database.table.view.group_by.update',
-      'database.table.view.group_by.delete',
-      'database.table.view.prioritize_group_bys',
-    ]
+function buildHasPermission(userId) {
+  const app = {
+    $store: {
+      getters: {
+        'auth/getUserId': userId,
+      },
+    },
+  }
 
-    it.each(groupByOps)(
-      '%s is allowed for personal view owner',
-      (operation) => {
-        const manager = createManager(10)
-        expect(
-          manager.hasPermission(null, operation, personalView(10), 1)
-        ).toBe(true)
+  const viewOwnership = new ViewOwnershipPermissionManagerType()
+  viewOwnership.app = app
+
+  const basic = new BasicPermissionManagerType()
+  basic.app = app
+
+  const managers = [
+    { instance: viewOwnership, permissions: null },
+    {
+      instance: basic,
+      permissions: { admin_only_operations: [], is_admin: false },
+    },
+  ]
+
+  return (operation, context, workspaceId) => {
+    for (const { instance, permissions } of managers) {
+      const result = instance.hasPermission(
+        permissions,
+        operation,
+        context,
+        workspaceId
+      )
+      if (result === true || result === false) {
+        return result
       }
-    )
+    }
+    return false
+  }
+}
+
+describe('isAdhocGroupBy with real permission dispatch (regression)', () => {
+  it('returns false for personal view owner — group by is writable', () => {
+    const app = { $hasPermission: buildHasPermission(42) }
+    const workspace = { id: 1 }
+    const view = personalView(42)
+    expect(isAdhocGroupBy(app, workspace, view, false)).toBe(false)
   })
 
-  describe('sort and filter operations have matching group by counterparts', () => {
-    const sortOps = [
-      'database.table.view.create_sort',
-      'database.table.view.sort.update',
-      'database.table.view.sort.delete',
-      'database.table.view.prioritize_sortings',
-    ]
-    const groupByOps = [
-      'database.table.view.create_group_by',
-      'database.table.view.group_by.update',
-      'database.table.view.group_by.delete',
-      'database.table.view.prioritize_group_bys',
-    ]
-
-    it('every sort operation pattern has a group by equivalent', () => {
-      const manager = createManager(1)
-      const view = personalView(1)
-
-      for (let i = 0; i < sortOps.length; i++) {
-        const sortResult = manager.hasPermission(null, sortOps[i], view, 1)
-        const groupByResult = manager.hasPermission(
-          null,
-          groupByOps[i],
-          view,
-          1
-        )
-        expect(groupByResult).toBe(sortResult)
-      }
-    })
+  it('returns true for non-owner — group by is read-only', () => {
+    const app = { $hasPermission: buildHasPermission(42) }
+    const workspace = { id: 1 }
+    const view = personalView(99)
+    expect(isAdhocGroupBy(app, workspace, view, false)).toBe(true)
   })
 })

--- a/premium/web-frontend/test/unit/premium/viewOwnershipPermissionManager.spec.js
+++ b/premium/web-frontend/test/unit/premium/viewOwnershipPermissionManager.spec.js
@@ -1,0 +1,143 @@
+import { ViewOwnershipPermissionManagerType } from '@baserow_premium/permissionManagerTypes'
+
+function createManager(userId) {
+  const manager = new ViewOwnershipPermissionManagerType()
+  manager.app = {
+    $store: {
+      getters: {
+        'auth/getUserId': userId,
+      },
+    },
+  }
+  return manager
+}
+
+function personalView(ownerId) {
+  return { ownership_type: 'personal', owned_by_id: ownerId }
+}
+
+function collaborativeView() {
+  return { ownership_type: 'collaborative' }
+}
+
+const ALL_ALLOWED_OPERATIONS = [
+  'database.table.view.create_filter',
+  'database.table.view.create_sort',
+  'database.table.view.create_decoration',
+  'database.table.view.sort.update',
+  'database.table.view.sort.delete',
+  'database.table.view.update_field_options',
+  'database.table.view.update',
+  'database.table.view.delete',
+  'database.table.view.duplicate',
+  'database.table.view.filter.update',
+  'database.table.view.filter.delete',
+  'database.table.view.decoration.update',
+  'database.table.view.decoration.delete',
+  'database.table.view.update_default_values',
+  'database.table.view.create_group_by',
+  'database.table.view.group_by.update',
+  'database.table.view.group_by.delete',
+  'database.table.view.prioritize_sortings',
+  'database.table.view.prioritize_group_bys',
+  'database.table.view.create_filter_group',
+  'database.table.view.filter_group.update',
+  'database.table.view.filter_group.delete',
+]
+
+describe('ViewOwnershipPermissionManagerType', () => {
+  describe('personal view owned by current user', () => {
+    it.each(ALL_ALLOWED_OPERATIONS)('allows %s', (operation) => {
+      const manager = createManager(42)
+      const result = manager.hasPermission(null, operation, personalView(42), 1)
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('personal view owned by different user', () => {
+    it.each(ALL_ALLOWED_OPERATIONS)('denies %s', (operation) => {
+      const manager = createManager(42)
+      const result = manager.hasPermission(null, operation, personalView(99), 1)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('collaborative view', () => {
+    it.each(ALL_ALLOWED_OPERATIONS)(
+      'does not handle %s (falls through)',
+      (operation) => {
+        const manager = createManager(42)
+        const result = manager.hasPermission(
+          null,
+          operation,
+          collaborativeView(),
+          1
+        )
+        expect(result).toBeUndefined()
+      }
+    )
+  })
+
+  describe('unknown operation', () => {
+    it('does not handle operations outside the allowlist', () => {
+      const manager = createManager(42)
+      const result = manager.hasPermission(
+        null,
+        'database.table.view.some_unknown_op',
+        personalView(42),
+        1
+      )
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('group by operations are included (regression)', () => {
+    const groupByOps = [
+      'database.table.view.create_group_by',
+      'database.table.view.group_by.update',
+      'database.table.view.group_by.delete',
+      'database.table.view.prioritize_group_bys',
+    ]
+
+    it.each(groupByOps)(
+      '%s is allowed for personal view owner',
+      (operation) => {
+        const manager = createManager(10)
+        expect(
+          manager.hasPermission(null, operation, personalView(10), 1)
+        ).toBe(true)
+      }
+    )
+  })
+
+  describe('sort and filter operations have matching group by counterparts', () => {
+    const sortOps = [
+      'database.table.view.create_sort',
+      'database.table.view.sort.update',
+      'database.table.view.sort.delete',
+      'database.table.view.prioritize_sortings',
+    ]
+    const groupByOps = [
+      'database.table.view.create_group_by',
+      'database.table.view.group_by.update',
+      'database.table.view.group_by.delete',
+      'database.table.view.prioritize_group_bys',
+    ]
+
+    it('every sort operation pattern has a group by equivalent', () => {
+      const manager = createManager(1)
+      const view = personalView(1)
+
+      for (let i = 0; i < sortOps.length; i++) {
+        const sortResult = manager.hasPermission(null, sortOps[i], view, 1)
+        const groupByResult = manager.hasPermission(
+          null,
+          groupByOps[i],
+          view,
+          1
+        )
+        expect(groupByResult).toBe(sortResult)
+      }
+    })
+  })
+})


### PR DESCRIPTION
Closes #5709 


## Summary
- The frontend `ViewOwnershipPermissionManagerType` was missing group by, filter group, and prioritize operations from its allowlist, causing viewer-role users' group by settings on personal views to be treated as ad-hoc (not persisted to the server)
- Added the 8 missing mutation operations to match the backend permission manager
- Removed a duplicate `update_field_options` entry
- Added unit tests for the permission manager (72 test cases)


### How to test this PR
Follow steps to reproduce from issue and observe it behave as expected result says

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
