### PR TITLE
fix: data sync crash when syncing select field with default after source options change

### DIFF
--- a/changelog/entries/unreleased/bug/5147_fixed_data_sync_crash_when_syncing_a_single_select_field_wit.json
+++ b/changelog/entries/unreleased/bug/5147_fixed_data_sync_crash_when_syncing_a_single_select_field_wit.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed data sync crash when syncing a single select field with a default value after source options are modified.",
+    "issue_origin": "github",
+    "issue_number": 5147,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-14"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
@@ -122,16 +122,26 @@ class BaserowFieldDataSyncProperty(DataSyncProperty):
         model_class = self.field_types_override.get(
             field_type.type, field_type.model_class
         )
-        return model_class(
-            **{
-                allowed_field: getattr(self.field, allowed_field)
-                for allowed_field in allowed_fields
-                if hasattr(self.field, allowed_field)
-                and hasattr(model_class, allowed_field)
-                # Select options can't be set directly because that results in an error.
-                and allowed_field != "select_options"
-            }
-        )
+        excluded = {"select_options"}
+        mapping = getattr(self, "_select_options_mapping", None)
+        if not mapping:
+            excluded.add("single_select_default")
+
+        field_kwargs = {
+            allowed_field: getattr(self.field, allowed_field)
+            for allowed_field in allowed_fields
+            if hasattr(self.field, allowed_field)
+            and hasattr(model_class, allowed_field)
+            and allowed_field not in excluded
+        }
+
+        if mapping and "single_select_default" in field_kwargs:
+            source_default = field_kwargs["single_select_default"]
+            field_kwargs["single_select_default"] = (
+                mapping.get(str(source_default)) if source_default is not None else None
+            )
+
+        return model_class(**field_kwargs)
 
     def get_metadata(self, baserow_field, existing_metadata=None):
         new_metadata = super().get_metadata(baserow_field, existing_metadata)
@@ -158,7 +168,30 @@ class BaserowFieldDataSyncProperty(DataSyncProperty):
         )
         new_metadata["select_options_mapping"] = select_options_mapping
 
+        self._select_options_mapping = select_options_mapping
+        self._map_select_default_values(baserow_field, select_options_mapping)
+
         return new_metadata
+
+    def _map_select_default_values(self, baserow_field, select_options_mapping):
+        """
+        Maps the source field's select default option ID(s) to the corresponding
+        target option IDs on newly created fields (ADD path). For existing fields
+        (UPDATE path), the mapping flows through to_baserow_field() instead.
+        """
+
+        if not hasattr(baserow_field, "single_select_default"):
+            return
+
+        source_default = getattr(self.field, "single_select_default", None)
+        if source_default is not None:
+            mapped = select_options_mapping.get(str(source_default))
+        else:
+            mapped = None
+
+        if baserow_field.single_select_default != mapped:
+            baserow_field.single_select_default = mapped
+            baserow_field.save()
 
     def is_equal(self, baserow_row_value: Any, data_sync_row_value: Any) -> bool:
         # The CreatedOn and LastModified fields are always stored as datetime in the

--- a/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
@@ -175,9 +175,8 @@ class BaserowFieldDataSyncProperty(DataSyncProperty):
 
     def _map_select_default_values(self, baserow_field, select_options_mapping):
         """
-        Maps the source field's select default option ID(s) to the corresponding
-        target option IDs on newly created fields (ADD path). For existing fields
-        (UPDATE path), the mapping flows through to_baserow_field() instead.
+        Maps the source field's single-select default option ID to the corresponding
+        target option ID using the provided select_options_mapping.
         """
 
         if not hasattr(baserow_field, "single_select_default"):

--- a/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_local_baserow_table_data_sync_type.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/data_sync/test_local_baserow_table_data_sync_type.py
@@ -1135,6 +1135,152 @@ def test_sync_data_sync_table_single_select_field_and_making_changes(
     assert getattr(row_c, f"field_{single_select_field.id}_id") == options[1].id
 
 
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.data_sync
+@override_settings(DEBUG=True)
+def test_sync_data_sync_table_single_select_field_with_default_and_making_changes(
+    enterprise_data_fixture,
+):
+    enterprise_data_fixture.enable_enterprise()
+    user = enterprise_data_fixture.create_user()
+
+    source_table = enterprise_data_fixture.create_database_table(
+        user=user, name="Source"
+    )
+    source_single_select_field = enterprise_data_fixture.create_single_select_field(
+        table=source_table, name="Single select"
+    )
+    source_option_a = enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="A", color="blue"
+    )
+    source_option_b = enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="B", color="red"
+    )
+    source_option_c = enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="C", color="green"
+    )
+
+    source_single_select_field.single_select_default = source_option_a.id
+    source_single_select_field.save()
+
+    source_model = source_table.get_model()
+    source_model.objects.create(
+        **{f"field_{source_single_select_field.id}_id": source_option_a.id}
+    )
+    source_model.objects.create(
+        **{f"field_{source_single_select_field.id}_id": source_option_b.id}
+    )
+
+    database = enterprise_data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="local_baserow_table",
+        synced_properties=["id", f"field_{source_single_select_field.id}"],
+        source_table_id=source_table.id,
+    )
+    with transaction.atomic():
+        handler.sync_data_sync_table(user=user, data_sync=data_sync)
+
+    fields = specific_iterator(data_sync.table.field_set.all().order_by("id"))
+    single_select_field = fields[1]
+    options = list(single_select_field.select_options.all())
+    assert single_select_field.single_select_default is not None
+
+    target_default_option = next(
+        o for o in options if o.id == single_select_field.single_select_default
+    )
+    assert target_default_option.value == "A"
+
+    # Modify source options: remove B, add D, rename C -> E
+    source_option_b.delete()
+    source_option_c.value = "E"
+    source_option_c.save()
+    enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="D", color="orange"
+    )
+
+    with transaction.atomic():
+        handler.sync_data_sync_table(user=user, data_sync=data_sync)
+
+    single_select_field.refresh_from_db()
+    options = list(single_select_field.select_options.all())
+    option_values = {o.value for o in options}
+    assert option_values == {"A", "D", "E"}
+
+    target_default_option = next(
+        o for o in options if o.id == single_select_field.single_select_default
+    )
+    assert target_default_option.value == "A"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.data_sync
+@override_settings(DEBUG=True)
+def test_sync_data_sync_table_single_select_field_default_option_deleted(
+    enterprise_data_fixture,
+):
+    enterprise_data_fixture.enable_enterprise()
+    user = enterprise_data_fixture.create_user()
+
+    source_table = enterprise_data_fixture.create_database_table(
+        user=user, name="Source"
+    )
+    source_single_select_field = enterprise_data_fixture.create_single_select_field(
+        table=source_table, name="Single select"
+    )
+    source_option_a = enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="A", color="blue"
+    )
+    source_option_b = enterprise_data_fixture.create_select_option(
+        field=source_single_select_field, value="B", color="red"
+    )
+
+    source_single_select_field.single_select_default = source_option_a.id
+    source_single_select_field.save()
+
+    source_model = source_table.get_model()
+    source_model.objects.create(
+        **{f"field_{source_single_select_field.id}_id": source_option_b.id}
+    )
+
+    database = enterprise_data_fixture.create_database_application(user=user)
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="local_baserow_table",
+        synced_properties=["id", f"field_{source_single_select_field.id}"],
+        source_table_id=source_table.id,
+    )
+    with transaction.atomic():
+        handler.sync_data_sync_table(user=user, data_sync=data_sync)
+
+    fields = specific_iterator(data_sync.table.field_set.all().order_by("id"))
+    single_select_field = fields[1]
+    assert single_select_field.single_select_default is not None
+
+    # Delete the default option from source
+    source_option_a.delete()
+    source_single_select_field.single_select_default = None
+    source_single_select_field.save()
+
+    with transaction.atomic():
+        handler.sync_data_sync_table(user=user, data_sync=data_sync)
+
+    single_select_field.refresh_from_db()
+    assert single_select_field.single_select_default is None
+
+    options = list(single_select_field.select_options.all())
+    assert len(options) == 1
+    assert options[0].value == "B"
+
+
 @pytest.mark.django_db
 @pytest.mark.data_sync
 @override_settings(DEBUG=True)


### PR DESCRIPTION
## Summary
- Data sync crashes with `SelectOptionDoesNotBelongToField` when re-syncing a single select field that has a default value after source options are modified (add/remove/rename)
- Root cause: `to_baserow_field()` passed unmapped source option IDs to `update_field()`, where `before_update` correctly rejected them as not belonging to the target field
- Fix maps `single_select_default` through `select_options_mapping` before it reaches `update_field()`

Closes #5147

### Testing 

1. Create a table with a single select field, add options A, B, set default to A
2. Create a Local Baserow table data sync, sync — succeeds
3. Rename option A to AA in the source field
4. Sync again - succeeds, synced table shows updated option AA
5. Delete option B in the source field, add option C
6. Sync again - succeeds, synced table reflects changes, default still mapped correctly


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
