### PR TITLE
fix: allow advanced users to use code runner and xls service

### DIFF
--- a/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_advanced_license_customers_fr.json
+++ b/changelog/entries/unreleased/bug/resolved_a_bug_which_prevented_advanced_license_customers_fr.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Resolved a bug which prevented advanced license customers from being able to access the Code and XLS actions.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "integration",
+    "bullet_points": [],
+    "created_at": "2026-07-14"
+}

--- a/enterprise/backend/src/baserow_enterprise/license_types.py
+++ b/enterprise/backend/src/baserow_enterprise/license_types.py
@@ -39,11 +39,13 @@ COMMON_ADVANCED_FEATURES = [
     ADVANCED_WEBHOOKS,
     FIELD_LEVEL_PERMISSIONS,
     DATE_DEPENDENCY,
-    # application builder
+    # WAB
     BUILDER_SSO,
     BUILDER_NO_BRANDING,
     BUILDER_FILE_INPUT,
     BUILDER_CUSTOM_CODE,
+    CODE_RUNNER,
+    XLS_FILE_READER,
     # only self-hosted
     SSO,
 ]
@@ -106,8 +108,6 @@ class EnterpriseWithoutSupportLicenseType(AdvancedLicenseType):
         ENTERPRISE_SETTINGS,
         SECURE_FILE_SERVE,
         DATA_SCANNER,
-        CODE_RUNNER,
-        XLS_FILE_READER,
     ]
 
     def handle_seat_overflow(self, seats_taken: int, license_object: License):

--- a/enterprise/backend/tests/baserow_enterprise_tests/integrations/core/test_core_xls_file_reader_license.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/integrations/core/test_core_xls_file_reader_license.py
@@ -33,8 +33,8 @@ from baserow_enterprise.license_types import (
 from baserow_premium.license.exceptions import FeaturesNotAvailableError
 
 
-def test_core_xls_file_reader_feature_is_enterprise_only():
-    assert XLS_FILE_READER not in AdvancedLicenseType.features
+def test_core_xls_file_reader_feature():
+    assert XLS_FILE_READER in AdvancedLicenseType.features
     assert XLS_FILE_READER in EnterpriseWithoutSupportLicenseType.features
     assert XLS_FILE_READER in EnterpriseLicenseType.features
 

--- a/enterprise/web-frontend/modules/baserow_enterprise/licenseTypes.js
+++ b/enterprise/web-frontend/modules/baserow_enterprise/licenseTypes.js
@@ -13,11 +13,13 @@ const commonAdvancedFeatures = [
   EnterpriseFeaturesObject.ADVANCED_WEBHOOKS,
   EnterpriseFeaturesObject.FIELD_LEVEL_PERMISSIONS,
   EnterpriseFeaturesObject.DATE_DEPENDENCY,
-  // application builder
+  // WAB
   EnterpriseFeaturesObject.BUILDER_SSO,
   EnterpriseFeaturesObject.BUILDER_NO_BRANDING,
   EnterpriseFeaturesObject.BUILDER_FILE_INPUT,
   EnterpriseFeaturesObject.BUILDER_CUSTOM_CODE,
+  EnterpriseFeaturesObject.CODE_RUNNER,
+  EnterpriseFeaturesObject.XLS_FILE_READER,
   // Only self-hosted
   EnterpriseFeaturesObject.SSO,
 ]
@@ -112,8 +114,6 @@ export class EnterpriseWithoutSupportLicenseType extends AdvancedLicenseType {
       ...commonAdvancedFeatures,
       EnterpriseFeaturesObject.ENTERPRISE_SETTINGS,
       EnterpriseFeaturesObject.DATA_SCANNER,
-      EnterpriseFeaturesObject.CODE_RUNNER,
-      EnterpriseFeaturesObject.XLS_FILE_READER,
     ]
   }
 


### PR DESCRIPTION
### What is in this PR

Advanced license customers should be able to use the code runner and xls services.

### How to test this PR
- E.g. a short series of steps on how to test the features/bug fixes in this PR.

### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
