### PR TITLE
fix: audit WAB OTEL tracing

### DIFF
--- a/backend/src/baserow/contrib/automation/nodes/handler.py
+++ b/backend/src/baserow/contrib/automation/nodes/handler.py
@@ -52,13 +52,13 @@ from baserow.core.services.exceptions import (
 from baserow.core.services.handler import ServiceHandler
 from baserow.core.services.models import Service
 from baserow.core.storage import ExportZipFile
-from baserow.core.telemetry.utils import baserow_trace_methods
+from baserow.core.telemetry.utils import baserow_trace
 from baserow.core.utils import ChildProgressBuilder, MirrorDict, extract_allowed
 
 tracer = trace.get_tracer(__name__)
 
 
-class AutomationNodeHandler(metaclass=baserow_trace_methods(tracer)):
+class AutomationNodeHandler:
     allowed_fields = [
         "label",
         "service",
@@ -441,6 +441,7 @@ class AutomationNodeHandler(metaclass=baserow_trace_methods(tracer)):
             node_history=node_history,
         )
 
+    @baserow_trace(tracer)
     def dispatch_node(
         self,
         node_id: int,

--- a/backend/src/baserow/contrib/automation/workflows/handler.py
+++ b/backend/src/baserow/contrib/automation/workflows/handler.py
@@ -60,7 +60,7 @@ from baserow.core.cache import global_cache, local_cache
 from baserow.core.exceptions import IdDoesNotExist
 from baserow.core.registries import ImportExportConfig
 from baserow.core.storage import ExportZipFile, get_default_storage
-from baserow.core.telemetry.utils import baserow_trace_methods
+from baserow.core.telemetry.utils import baserow_trace
 from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import (
     ChildProgressBuilder,
@@ -78,7 +78,7 @@ AUTOMATION_WORKFLOW_CACHE_LOCK_SECONDS = 5
 tracer = trace.get_tracer(__name__)
 
 
-class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
+class AutomationWorkflowHandler:
     allowed_fields = [
         "name",
         "allow_test_run_until",
@@ -696,6 +696,7 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
 
         return cloned_automation, id_mapping
 
+    @baserow_trace(tracer)
     def publish(
         self,
         workflow: AutomationWorkflow,
@@ -1230,6 +1231,7 @@ class AutomationWorkflowHandler(metaclass=baserow_trace_methods(tracer)):
             lambda: start_workflow_celery_task.delay(workflow.id, history.id)
         )
 
+    @baserow_trace(tracer)
     def start_workflow(
         self,
         workflow: AutomationWorkflow,

--- a/backend/src/baserow/contrib/builder/domains/handler.py
+++ b/backend/src/baserow/contrib/builder/domains/handler.py
@@ -4,6 +4,8 @@ from typing import Iterable, List, Optional, cast
 from django.db.models import QuerySet
 from django.db.utils import IntegrityError
 
+from opentelemetry import trace
+
 from baserow.contrib.builder.domains.exceptions import (
     DomainDoesNotExist,
     DomainNameNotUniqueError,
@@ -20,8 +22,11 @@ from baserow.core.models import Workspace
 from baserow.core.psycopg import is_unique_violation_error
 from baserow.core.registries import ImportExportConfig, application_type_registry
 from baserow.core.storage import get_default_storage
+from baserow.core.telemetry.utils import baserow_trace
 from baserow.core.trash.handler import TrashHandler
 from baserow.core.utils import Progress, extract_allowed
+
+tracer = trace.get_tracer(__name__)
 
 
 class DomainHandler:
@@ -230,6 +235,7 @@ class DomainHandler:
             else applications
         )
 
+    @baserow_trace(tracer)
     def publish(self, domain: Domain, progress: Progress | None = None):
         """
         Publishes a builder for the given domain object. If the builder was

--- a/backend/src/baserow/contrib/builder/workflow_actions/handler.py
+++ b/backend/src/baserow/contrib/builder/workflow_actions/handler.py
@@ -4,6 +4,8 @@ from zipfile import ZipFile
 from django.core.files.storage import Storage
 from django.db.models import QuerySet
 
+from opentelemetry import trace
+
 from baserow.contrib.builder.data_providers.registries import (
     builder_data_provider_type_registry,
 )
@@ -25,12 +27,16 @@ from baserow.contrib.builder.workflow_actions.registries import (
 )
 from baserow.core.exceptions import IdDoesNotExist
 from baserow.core.services.types import DispatchResult
+from baserow.core.telemetry.utils import baserow_trace
 from baserow.core.workflow_actions.handler import WorkflowActionHandler
 from baserow.core.workflow_actions.models import WorkflowAction
 from baserow.core.workflow_actions.registries import WorkflowActionType
 
 if TYPE_CHECKING:
     from baserow.contrib.builder.models import Builder
+
+
+tracer = trace.get_tracer(__name__)
 
 
 class BuilderWorkflowActionHandler(WorkflowActionHandler):
@@ -170,6 +176,7 @@ class BuilderWorkflowActionHandler(WorkflowActionHandler):
 
         return super().create_workflow_action(workflow_action_type, **kwargs).specific
 
+    @baserow_trace(tracer)
     def dispatch_workflow_action(
         self,
         workflow_action: BuilderWorkflowServiceAction,


### PR DESCRIPTION
### What is in this PR

1. Stop tracing all methods in the automation node and workflow handlers.
2. Instead, trace specific locations:
    - `AutomationNodeHandler` node dispatching.
    - `AutomationWorkflowHandler` publishing and starting a run.
    - `DomainHandler` publishing.
    - `BuilderWorkflowActionHandler` action dispatching
 
### How to test this PR

You could setup OTEL and test this locally, but it's a pretty safe change.

### Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
