### PR TITLE
Show an error and disable generation for AI fields with a broken prompt

### DIFF
--- a/changelog/entries/unreleased/bug/show_an_error_on_ai_fields_with_a_broken_prompt_and_block_ge.json
+++ b/changelog/entries/unreleased/bug/show_an_error_on_ai_fields_with_a_broken_prompt_and_block_ge.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Show an error on AI fields with a broken prompt and block generating until fixed",
+    "issue_origin": "github",
+    "issue_number": 3088,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-13"
+}

--- a/premium/backend/src/baserow_premium/api/fields/errors.py
+++ b/premium/backend/src/baserow_premium/api/fields/errors.py
@@ -1,0 +1,7 @@
+from rest_framework.status import HTTP_400_BAD_REQUEST
+
+ERROR_AI_FIELD_PROMPT_INVALID = (
+    "ERROR_AI_FIELD_PROMPT_INVALID",
+    HTTP_400_BAD_REQUEST,
+    "The AI field's prompt is broken: {e}",
+)

--- a/premium/backend/src/baserow_premium/api/fields/views.py
+++ b/premium/backend/src/baserow_premium/api/fields/views.py
@@ -47,7 +47,6 @@ from baserow_premium.fields.actions import GenerateFormulaWithAIActionType
 from baserow_premium.fields.exceptions import AIFieldPromptInvalidError
 from baserow_premium.fields.job_types import GenerateAIValuesJobType
 from baserow_premium.fields.models import AIField
-from baserow_premium.fields.visitors import get_ai_prompt_error
 from baserow_premium.license.features import PREMIUM
 from baserow_premium.license.handler import LicenseHandler
 
@@ -132,10 +131,8 @@ class AsyncGenerateAIFieldValuesView(APIView):
             context=ai_field.table,
         )
 
-        prompt_error = get_ai_prompt_error(ai_field.ai_prompt, ai_field.table_id)
-        if prompt_error:
-            raise AIFieldPromptInvalidError(prompt_error)
-
+        # An invalid prompt raises `AIFieldPromptInvalidError` from the job type's
+        # `prepare_values`, mapped to a 400 by `map_exceptions` above.
         job = JobHandler().create_and_start_job(
             request.user,
             GenerateAIValuesJobType.type,

--- a/premium/backend/src/baserow_premium/api/fields/views.py
+++ b/premium/backend/src/baserow_premium/api/fields/views.py
@@ -42,9 +42,12 @@ from baserow.core.generative_ai.exceptions import (
 from baserow.core.handler import CoreHandler
 from baserow.core.jobs.handler import JobHandler
 from baserow.core.jobs.registries import job_type_registry
+from baserow_premium.api.fields.errors import ERROR_AI_FIELD_PROMPT_INVALID
 from baserow_premium.fields.actions import GenerateFormulaWithAIActionType
+from baserow_premium.fields.exceptions import AIFieldPromptInvalidError
 from baserow_premium.fields.job_types import GenerateAIValuesJobType
 from baserow_premium.fields.models import AIField
+from baserow_premium.fields.visitors import get_ai_prompt_error
 from baserow_premium.license.features import PREMIUM
 from baserow_premium.license.handler import LicenseHandler
 
@@ -84,6 +87,7 @@ class AsyncGenerateAIFieldValuesView(APIView):
                 [
                     "ERROR_GENERATIVE_AI_DOES_NOT_EXIST",
                     "ERROR_MODEL_DOES_NOT_BELONG_TO_TYPE",
+                    "ERROR_AI_FIELD_PROMPT_INVALID",
                 ]
             ),
             404: get_error_schema(
@@ -103,6 +107,7 @@ class AsyncGenerateAIFieldValuesView(APIView):
             GenerativeAITypeDoesNotExist: ERROR_GENERATIVE_AI_DOES_NOT_EXIST,
             ModelDoesNotBelongToType: ERROR_MODEL_DOES_NOT_BELONG_TO_TYPE,
             ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
+            AIFieldPromptInvalidError: ERROR_AI_FIELD_PROMPT_INVALID,
         }
     )
     @validate_body(GenerateAIFieldValueViewSerializer, return_validated=True)
@@ -126,6 +131,10 @@ class AsyncGenerateAIFieldValuesView(APIView):
             workspace=workspace,
             context=ai_field.table,
         )
+
+        prompt_error = get_ai_prompt_error(ai_field.ai_prompt, ai_field.table)
+        if prompt_error:
+            raise AIFieldPromptInvalidError(prompt_error)
 
         job = JobHandler().create_and_start_job(
             request.user,

--- a/premium/backend/src/baserow_premium/api/fields/views.py
+++ b/premium/backend/src/baserow_premium/api/fields/views.py
@@ -132,7 +132,7 @@ class AsyncGenerateAIFieldValuesView(APIView):
             context=ai_field.table,
         )
 
-        prompt_error = get_ai_prompt_error(ai_field.ai_prompt, ai_field.table)
+        prompt_error = get_ai_prompt_error(ai_field.ai_prompt, ai_field.table_id)
         if prompt_error:
             raise AIFieldPromptInvalidError(prompt_error)
 

--- a/premium/backend/src/baserow_premium/apps.py
+++ b/premium/backend/src/baserow_premium/apps.py
@@ -8,6 +8,7 @@ class BaserowPremiumConfig(AppConfig):
 
     def ready(self):
         # noinspection PyUnresolvedReferences
+        import baserow_premium.fields.receivers  # noqa: F401
         import baserow_premium.license.receivers  # noqa: F401
         import baserow_premium.row_comments.receivers  # noqa: F401
         from baserow.core.registries import application_type_registry

--- a/premium/backend/src/baserow_premium/fields/exceptions.py
+++ b/premium/backend/src/baserow_premium/fields/exceptions.py
@@ -10,3 +10,10 @@ class AIFieldEmptyPromptError(Exception):
     Raised when the resolved prompt for an AI field is empty, meaning there
     is nothing to send to the model.
     """
+
+
+class AIFieldPromptInvalidError(Exception):
+    """
+    Raised when an AI field's prompt formula is broken (unparseable or references a
+    field that no longer exists), so values cannot be generated.
+    """

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -373,6 +373,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         existing_field_ids = set(
             Field.objects.filter(id__in=field_ids).values_list("id", flat=True)
         )
+        # A trashed referenced field is declared as a broken reference (by name,
+        # like formula fields) so the edge survives and restoring the field
+        # re-links it and re-reports this field's error to the client.
+        trashed_names = Field.objects_and_trash.filter(
+            id__in=field_ids - existing_field_ids, trashed=True
+        ).values_list("name", flat=True)
         return [
             FieldDependency(
                 dependency_id=field_id,
@@ -381,6 +387,13 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             )
             for field_id in field_ids
             if field_id in existing_field_ids
+        ] + [
+            FieldDependency(
+                broken_reference_field_name=name,
+                dependant=field_instance,
+                via=None,
+            )
+            for name in trashed_names
         ]
 
     def field_dependency_updated(
@@ -395,8 +408,13 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         # When a referenced field is created, updated, deleted or restored, the
         # prompt's validity (and thus the computed `error`) can change. Mark the
         # field as changed so it is re-serialized and pushed to the client,
-        # without touching its stored cell values. (`field_dependency_created`
-        # and `field_dependency_deleted` both delegate here in the base type.)
+        # without touching its stored cell values (a None update statement is
+        # the collector's "changed without a cell update"). Not
+        # `add_field_which_has_changed`: that only reports via the
+        # additional-signals path, which skips the starting table, and the AI
+        # field usually lives in the same table as the changed dependency.
+        # (`field_dependency_created` and `field_dependency_deleted` both
+        # delegate here in the base type.)
         update_collector.add_field_with_pending_update_statement(
             field, None, via_path_to_starting_table
         )

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -82,6 +82,7 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         "ai_prompt",
         "ai_file_field_id",
         "ai_auto_update",
+        "error",
     ]
     serializer_field_overrides = {
         "ai_output_type": serializers.ChoiceField(
@@ -115,6 +116,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             allow_null=True,
             help_text="If set, AI field will be recalculated if a value of a "
             "referenced field has been changed.",
+        ),
+        "error": serializers.CharField(
+            required=False,
+            read_only=True,
+            allow_null=True,
+            help_text="The error message if the field's prompt is broken, else null.",
         ),
         **SelectOptionBaseFieldType.serializer_field_overrides,
     }

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -29,6 +29,7 @@ from baserow.contrib.database.fields.field_types import (
 from baserow.contrib.database.fields.models import Field, LinkRowField
 from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.formula import BaserowFormulaType
+from baserow.core.formula.parser.exceptions import BaserowFormulaException
 from baserow.core.formula.serializers import FormulaSerializerField
 from baserow.core.generative_ai.exceptions import (
     GenerativeAITypeDoesNotExist,
@@ -359,9 +360,14 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
     def get_field_dependencies(
         self, field_instance: AIField, field_cache: "FieldCache"
     ) -> FieldDependencies:
-        field_ids = set(
-            extract_field_id_dependencies(field_instance.ai_prompt["formula"])
-        )
+        try:
+            field_ids = set(
+                extract_field_id_dependencies(field_instance.ai_prompt["formula"])
+            )
+        except BaserowFormulaException:
+            # An unparseable prompt (e.g. from an import) is surfaced via the
+            # field's `error`; it simply has no field dependencies.
+            field_ids = set()
         if field_instance.ai_file_field_id is not None:
             field_ids.add(field_instance.ai_file_field_id)
         existing_field_ids = set(
@@ -605,10 +611,11 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
                     field.ai_prompt, id_mapping["database_fields"]
                 )
                 save = True
-            except KeyError:
-                # Raised when the field ID is not found in the mapping. If that's the
-                # case, we leave the field ID references broken so that the import
-                # can still succeed.
+            except (KeyError, BaserowFormulaException):
+                # KeyError: a referenced field ID isn't in the mapping.
+                # BaserowFormulaException: the prompt can't be parsed.
+                # In both cases we leave the prompt as-is so the import can still
+                # succeed; the broken state is surfaced via the field's `error`.
                 pass
 
         if save:

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -377,6 +377,32 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             if field_id in existing_field_ids
         ]
 
+    def field_dependency_updated(
+        self,
+        field,
+        updated_field,
+        updated_old_field,
+        update_collector,
+        field_cache,
+        via_path_to_starting_table=None,
+    ):
+        # When a referenced field is created, updated, deleted or restored, the
+        # prompt's validity (and thus the computed `error`) can change. Mark the
+        # field as changed so it is re-serialized and pushed to the client,
+        # without touching its stored cell values. (`field_dependency_created`
+        # and `field_dependency_deleted` both delegate here in the base type.)
+        update_collector.add_field_with_pending_update_statement(
+            field, None, via_path_to_starting_table
+        )
+        super().field_dependency_updated(
+            field,
+            updated_field,
+            updated_old_field,
+            update_collector,
+            field_cache,
+            via_path_to_starting_table,
+        )
+
     def _handle_dependent_rows_change(
         self,
         field: AIField,

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -377,7 +377,9 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
         # like formula fields) so the edge survives and restoring the field
         # re-links it and re-reports this field's error to the client.
         trashed_names = Field.objects_and_trash.filter(
-            id__in=field_ids - existing_field_ids, trashed=True
+            id__in=field_ids - existing_field_ids,
+            table_id=field_instance.table_id,
+            trashed=True,
         ).values_list("name", flat=True)
         return [
             FieldDependency(

--- a/premium/backend/src/baserow_premium/fields/field_types.py
+++ b/premium/backend/src/baserow_premium/fields/field_types.py
@@ -370,8 +370,12 @@ class AIFieldType(CollationSortMixin, SelectOptionBaseFieldType):
             field_ids = set()
         if field_instance.ai_file_field_id is not None:
             field_ids.add(field_instance.ai_file_field_id)
+        # Scoped to the field's table, matching `get_ai_prompt_error`; a prompt
+        # can only reference fields in the same table.
         existing_field_ids = set(
-            Field.objects.filter(id__in=field_ids).values_list("id", flat=True)
+            Field.objects.filter(
+                id__in=field_ids, table_id=field_instance.table_id
+            ).values_list("id", flat=True)
         )
         # A trashed referenced field is declared as a broken reference (by name,
         # like formula fields) so the edge survives and restoring the field

--- a/premium/backend/src/baserow_premium/fields/job_types.py
+++ b/premium/backend/src/baserow_premium/fields/job_types.py
@@ -34,10 +34,12 @@ from baserow.core.jobs.exceptions import MaxJobCountExceeded
 from baserow.core.jobs.models import JobQuerySet
 from baserow.core.jobs.registries import JobType
 from baserow.core.utils import ChildProgressBuilder
+from baserow_premium.api.fields.errors import ERROR_AI_FIELD_PROMPT_INVALID
 
-from .exceptions import AIFieldEmptyPromptError
+from .exceptions import AIFieldEmptyPromptError, AIFieldPromptInvalidError
 from .handler import AIFieldHandler
 from .models import AIField, AIFieldScheduledUpdate, GenerateAIValuesJob
+from .visitors import get_ai_prompt_error
 
 
 class AIValueUpdate(NamedTuple):
@@ -57,6 +59,7 @@ class GenerateAIValuesJobType(JobType):
         WorkspaceDoesNotExist: ERROR_GROUP_DOES_NOT_EXIST,
         ViewDoesNotExist: ERROR_VIEW_DOES_NOT_EXIST,
         FieldDoesNotExist: ERROR_FIELD_DOES_NOT_EXIST,
+        AIFieldPromptInvalidError: ERROR_AI_FIELD_PROMPT_INVALID,
     }
     serializer_field_names = [
         "field_id",
@@ -189,6 +192,12 @@ class GenerateAIValuesJobType(JobType):
         }
 
         AIFieldHandler.get_valid_model_type_or_raise(ai_field)
+
+        # Validate here rather than in the API views so every entry point
+        # (dedicated endpoint, generic /jobs/ endpoint) shares the invariant.
+        prompt_error = get_ai_prompt_error(ai_field.ai_prompt, ai_field.table_id)
+        if prompt_error:
+            raise AIFieldPromptInvalidError(prompt_error)
 
         if unsaved_job.mode == GenerateAIValuesJob.MODES.AUTO_UPDATE:
             if not AIFieldScheduledUpdate.objects.filter(field_id=ai_field.id).exists():

--- a/premium/backend/src/baserow_premium/fields/models.py
+++ b/premium/backend/src/baserow_premium/fields/models.py
@@ -14,6 +14,7 @@ from baserow.core.mixins import BigAutoFieldMixin
 
 from .ai_field_output_types import TextAIFieldOutputType
 from .registries import ai_field_output_registry
+from .visitors import get_ai_prompt_error
 
 User = get_user_model()
 
@@ -64,6 +65,14 @@ class AIField(Field):
         """
 
         return settings.BASEROW_AI_FIELD_MAX_CONCURRENT_GENERATIONS
+
+    @property
+    def error(self):
+        # Computed (not stored) prompt error so the field header can show it and
+        # generation can be blocked. Recomputed whenever the field is serialized.
+        if not self.table_id:
+            return None
+        return get_ai_prompt_error(self.ai_prompt, self.table)
 
 
 class GenerateAIValuesJob(JobWithUserIpAddress, JobWithUndoRedoIds, Job):

--- a/premium/backend/src/baserow_premium/fields/models.py
+++ b/premium/backend/src/baserow_premium/fields/models.py
@@ -72,7 +72,7 @@ class AIField(Field):
         # generation can be blocked. Recomputed whenever the field is serialized.
         if not self.table_id:
             return None
-        return get_ai_prompt_error(self.ai_prompt, self.table)
+        return get_ai_prompt_error(self.ai_prompt, self.table_id)
 
 
 class GenerateAIValuesJob(JobWithUserIpAddress, JobWithUndoRedoIds, Job):

--- a/premium/backend/src/baserow_premium/fields/receivers.py
+++ b/premium/backend/src/baserow_premium/fields/receivers.py
@@ -1,0 +1,11 @@
+from django.dispatch import receiver
+
+from baserow.contrib.database.table.signals import table_schema_changed
+from baserow.core.cache import local_cache
+
+
+@receiver(table_schema_changed)
+def invalidate_ai_prompt_field_ids_cache(sender, table_id, **kwargs):
+    # Invalidate the cached field ids used by AI prompt validation (see
+    # visitors.get_table_field_ids) when a field is added/updated/trashed/restored.
+    local_cache.delete(f"ai_prompt_table_field_ids_{table_id}")

--- a/premium/backend/src/baserow_premium/fields/tasks.py
+++ b/premium/backend/src/baserow_premium/fields/tasks.py
@@ -8,6 +8,7 @@ from celery_singleton import DuplicateTaskError, Singleton
 from baserow.celery_singleton_backend import SingletonAutoRescheduleFlag
 from baserow.config.celery import app
 from baserow.core.jobs.handler import JobHandler
+from baserow_premium.fields.exceptions import AIFieldPromptInvalidError
 from baserow_premium.fields.job_types import GenerateAIValuesJobType
 from baserow_premium.fields.models import AIField, AIFieldScheduledUpdate
 from baserow_premium.license.features import PREMIUM
@@ -90,13 +91,18 @@ def generate_scheduled_ai_field_generation(field_id: int):
 
     # Synchronously run the job while keeping the singleton lock, to avoid
     # multiple concurrent job runs for the same field.
-    jh.create_and_start_job(
-        user,
-        GenerateAIValuesJobType.type,
-        field_id=field_id,
-        is_auto_update=True,
-        sync=True,
-    )
+    try:
+        jh.create_and_start_job(
+            user,
+            GenerateAIValuesJobType.type,
+            field_id=field_id,
+            is_auto_update=True,
+            sync=True,
+        )
+    except AIFieldPromptInvalidError:
+        # The prompt is broken, so there's nothing to generate. The scheduled rows
+        # are kept so they can be processed once the prompt is fixed.
+        return
 
     if flag.is_set():
         _schedule_generate_ai_value_generation(field_id)

--- a/premium/backend/src/baserow_premium/fields/visitors.py
+++ b/premium/backend/src/baserow_premium/fields/visitors.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from baserow.contrib.database.fields.utils import get_field_id_from_field_key
 from baserow.core.formula import (
@@ -7,9 +7,15 @@ from baserow.core.formula import (
     BaserowFormulaObject,
     BaserowFormulaVisitor,
 )
-from baserow.core.formula.parser.exceptions import FieldByIdReferencesAreDeprecated
+from baserow.core.formula.parser.exceptions import (
+    BaserowFormulaException,
+    FieldByIdReferencesAreDeprecated,
+)
 from baserow.core.formula.parser.parser import get_parse_tree_for_formula
 from baserow.core.utils import to_path
+
+if TYPE_CHECKING:
+    from baserow.contrib.database.table.models import Table
 
 
 class BaserowFormulaReplaceFieldReferences(BaserowFormulaVisitor):
@@ -198,3 +204,35 @@ def extract_field_id_dependencies(
     visitor = AIFieldIDExtractingVisitor()
     visitor.visit(tree)
     return visitor.field_ids
+
+
+def get_ai_prompt_error(
+    prompt: Union[str, BaserowFormulaObject], table: "Table"
+) -> Optional[str]:
+    """
+    Validates an AI field prompt formula. Returns an error message when the prompt
+    cannot be parsed or references a field that does not exist (non-trashed) in the
+    given table. Returns None for an empty or valid prompt.
+    """
+
+    from baserow.contrib.database.fields.models import Field
+
+    formula_str = prompt if isinstance(prompt, str) else prompt["formula"]
+    if not formula_str:
+        return None
+
+    try:
+        referenced_ids = extract_field_id_dependencies(formula_str)
+    except BaserowFormulaException:
+        return "The prompt formula could not be parsed."
+
+    if referenced_ids:
+        existing_ids = set(
+            Field.objects.filter(
+                id__in=referenced_ids, table=table, trashed=False
+            ).values_list("id", flat=True)
+        )
+        if referenced_ids - existing_ids:
+            return "The prompt references a field that no longer exists."
+
+    return None

--- a/premium/backend/src/baserow_premium/fields/visitors.py
+++ b/premium/backend/src/baserow_premium/fields/visitors.py
@@ -2,6 +2,7 @@ import re
 from typing import Dict, Optional, Union
 
 from baserow.contrib.database.fields.utils import get_field_id_from_field_key
+from baserow.core.cache import local_cache
 from baserow.core.formula import (
     BaserowFormula,
     BaserowFormulaObject,
@@ -170,9 +171,10 @@ class AIFieldIDExtractingVisitor(BaserowFormulaVisitor):
 
         args = [expr.accept(self) for expr in function_argument_expressions]
 
-        # Detect get("'fields.field_XXX'") references
+        # Detect get('fields.field_XXX') references. The parser accepts both
+        # single and double quoted string literals, so strip either style.
         if function_name == "get" and args and args[0]:
-            if field_id_match := FIELD_ID_RE.match(args[0].strip("'")):
+            if field_id_match := FIELD_ID_RE.match(args[0].strip("'\"")):
                 self.field_ids.add(int(field_id_match.group(1)))
 
     def visitLeftWhitespaceOrComments(
@@ -203,6 +205,25 @@ def extract_field_id_dependencies(
     return visitor.field_ids
 
 
+def get_table_field_ids(table_id: int) -> set[int]:
+    """
+    Returns the ids of the non-trashed fields in the given table, cached per
+    request/task so validating many AI fields doesn't repeat the query. The cache
+    is invalidated by `table_schema_changed` (see receivers.py).
+    """
+
+    from baserow.contrib.database.fields.models import Field
+
+    return local_cache.get(
+        f"ai_prompt_table_field_ids_{table_id}",
+        lambda: set(
+            Field.objects.filter(table_id=table_id, trashed=False).values_list(
+                "id", flat=True
+            )
+        ),
+    )
+
+
 def get_ai_prompt_error(
     prompt: Union[str, BaserowFormulaObject], table_id: int
 ) -> Optional[str]:
@@ -211,8 +232,6 @@ def get_ai_prompt_error(
     cannot be parsed or references a field that does not exist (non-trashed) in the
     given table. Returns None for an empty or valid prompt.
     """
-
-    from baserow.contrib.database.fields.models import Field
 
     formula_str = prompt if isinstance(prompt, str) else prompt["formula"]
     if not formula_str:
@@ -223,13 +242,7 @@ def get_ai_prompt_error(
     except BaserowFormulaException:
         return "The prompt formula could not be parsed."
 
-    if referenced_ids:
-        existing_ids = set(
-            Field.objects.filter(
-                id__in=referenced_ids, table_id=table_id, trashed=False
-            ).values_list("id", flat=True)
-        )
-        if referenced_ids - existing_ids:
-            return "The prompt references a field that no longer exists."
+    if referenced_ids and referenced_ids - get_table_field_ids(table_id):
+        return "The prompt references a field that no longer exists."
 
     return None

--- a/premium/backend/src/baserow_premium/fields/visitors.py
+++ b/premium/backend/src/baserow_premium/fields/visitors.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import Dict, Optional, Union
 
 from baserow.contrib.database.fields.utils import get_field_id_from_field_key
 from baserow.core.formula import (
@@ -13,9 +13,6 @@ from baserow.core.formula.parser.exceptions import (
 )
 from baserow.core.formula.parser.parser import get_parse_tree_for_formula
 from baserow.core.utils import to_path
-
-if TYPE_CHECKING:
-    from baserow.contrib.database.table.models import Table
 
 
 class BaserowFormulaReplaceFieldReferences(BaserowFormulaVisitor):
@@ -207,7 +204,7 @@ def extract_field_id_dependencies(
 
 
 def get_ai_prompt_error(
-    prompt: Union[str, BaserowFormulaObject], table: "Table"
+    prompt: Union[str, BaserowFormulaObject], table_id: int
 ) -> Optional[str]:
     """
     Validates an AI field prompt formula. Returns an error message when the prompt
@@ -229,7 +226,7 @@ def get_ai_prompt_error(
     if referenced_ids:
         existing_ids = set(
             Field.objects.filter(
-                id__in=referenced_ids, table=table, trashed=False
+                id__in=referenced_ids, table_id=table_id, trashed=False
             ).values_list("id", flat=True)
         )
         if referenced_ids - existing_ids:

--- a/premium/backend/tests/baserow_premium_tests/api/fields/test_ai_field_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/fields/test_ai_field_views.py
@@ -479,3 +479,39 @@ def test_list_jobs_filter_by_type_and_field_id(premium_data_fixture, api_client)
     assert response_data["jobs"][0]["id"] == job_2_id
     assert response_data["jobs"][0]["type"] == "generate_ai_values"
     assert response_data["jobs"][0]["field_id"] == field_2.id
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+@override_settings(DEBUG=True)
+def test_generate_ai_field_value_rejected_when_prompt_broken(
+    premium_data_fixture, api_client
+):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+
+    database = premium_data_fixture.create_database_application(
+        user=user, name="database"
+    )
+    table = premium_data_fixture.create_database_table(name="table", database=database)
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="ai",
+        ai_prompt={"version": 1, "formula": "get('fields.field_999999')"},
+    )
+
+    rows = RowHandler().create_rows(user, table, rows_values=[{}]).created_rows
+
+    response = api_client.post(
+        reverse(
+            "api:premium:fields:async_generate_ai_field_values",
+            kwargs={"field_id": field.id},
+        ),
+        {"row_ids": [rows[0].id]},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_AI_FIELD_PROMPT_INVALID"

--- a/premium/backend/tests/baserow_premium_tests/api/fields/test_ai_field_views.py
+++ b/premium/backend/tests/baserow_premium_tests/api/fields/test_ai_field_views.py
@@ -515,3 +515,35 @@ def test_generate_ai_field_value_rejected_when_prompt_broken(
     )
     assert response.status_code == HTTP_400_BAD_REQUEST
     assert response.json()["error"] == "ERROR_AI_FIELD_PROMPT_INVALID"
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+@override_settings(DEBUG=True)
+def test_bulk_generate_ai_values_job_rejected_when_prompt_broken(
+    premium_data_fixture, api_client
+):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+
+    database = premium_data_fixture.create_database_application(
+        user=user, name="database"
+    )
+    table = premium_data_fixture.create_database_table(name="table", database=database)
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="ai",
+        ai_prompt={"version": 1, "formula": "get('fields.field_999999')"},
+    )
+
+    # The whole-view/table bulk modal posts directly to the generic jobs endpoint.
+    response = api_client.post(
+        reverse("api:jobs:list"),
+        {"type": "generate_ai_values", "field_id": field.id},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response.json()["error"] == "ERROR_AI_FIELD_PROMPT_INVALID"

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -23,6 +23,7 @@ from baserow.contrib.database.table.models import Table
 from baserow.core.cache import local_cache
 from baserow.core.db import specific_iterator
 from baserow.core.registries import ImportExportConfig
+from baserow.core.trash.handler import TrashHandler
 from baserow_premium.fields.field_types import AIFieldType
 from baserow_premium.fields.models import AIField
 
@@ -1892,6 +1893,49 @@ def test_deleting_referenced_field_marks_ai_field_as_updated(premium_data_fixtur
 
     ai_field.refresh_from_db()
     assert ai_field.error is not None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+@patch("baserow.contrib.database.fields.signals.field_restored.send")
+def test_restoring_referenced_field_clears_ai_field_error(
+    field_restored_mock, premium_data_fixture
+):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user = premium_data_fixture.create_user()
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table)
+    ai_field = FieldHandler().create_field(
+        user,
+        table,
+        "ai",
+        name="AI",
+        ai_generative_ai_type="test_generative_ai",
+        ai_generative_ai_model="test_1",
+        ai_prompt={
+            "version": 1,
+            "formula": f"get('fields.field_{text_field.id}')",
+        },
+    )
+    model = table.get_model()
+    row = model.objects.create(**{f"field_{ai_field.id}": "generated"})
+
+    FieldHandler().delete_field(user, text_field)
+    ai_field.refresh_from_db()
+    assert ai_field.error is not None
+
+    # Restoring the referenced field must report the AI field as updated so the
+    # client re-fetches it and sees the error is gone.
+    TrashHandler.restore_item(user, "field", text_field.id)
+    related = field_restored_mock.call_args[1]["related_fields"]
+    assert ai_field.id in [f.id for f in related]
+
+    ai_field.refresh_from_db()
+    assert ai_field.error is None
+
+    # The generated cell value must survive the delete/restore round trip.
+    row.refresh_from_db()
+    assert getattr(row, f"field_{ai_field.id}") == "generated"
 
     row.refresh_from_db()
     assert getattr(row, f"field_{ai_field.id}") == "generated"

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -1829,3 +1829,40 @@ def test_ai_field_import_with_broken_reference_records_error(premium_data_fixtur
 
     imported_field = AIField.objects.get(id=imported_field.id)
     assert imported_field.error is not None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_deleting_referenced_field_marks_ai_field_as_updated(premium_data_fixture):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user = premium_data_fixture.create_user()
+    table = premium_data_fixture.create_database_table(user=user)
+    text_field = premium_data_fixture.create_text_field(table=table)
+    ai_field = FieldHandler().create_field(
+        user,
+        table,
+        "ai",
+        name="AI",
+        ai_generative_ai_type="test_generative_ai",
+        ai_generative_ai_model="test_1",
+        ai_prompt={
+            "version": 1,
+            "formula": f"get('fields.field_{text_field.id}')",
+        },
+    )
+    assert ai_field.error is None
+
+    # A previously generated value must survive the dependency deletion.
+    model = table.get_model()
+    row = model.objects.create(**{f"field_{ai_field.id}": "generated"})
+
+    # Deleting the referenced field must report the AI field as updated so the
+    # client re-fetches it and sees the new broken state.
+    updated = FieldHandler().delete_field(user, text_field)
+    assert ai_field.id in [f.id for f in updated]
+
+    ai_field.refresh_from_db()
+    assert ai_field.error is not None
+
+    row.refresh_from_db()
+    assert getattr(row, f"field_{ai_field.id}") == "generated"

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -1894,6 +1894,9 @@ def test_deleting_referenced_field_marks_ai_field_as_updated(premium_data_fixtur
     ai_field.refresh_from_db()
     assert ai_field.error is not None
 
+    row.refresh_from_db()
+    assert getattr(row, f"field_{ai_field.id}") == "generated"
+
 
 @pytest.mark.field_ai
 @pytest.mark.django_db
@@ -1934,8 +1937,5 @@ def test_restoring_referenced_field_clears_ai_field_error(
     assert ai_field.error is None
 
     # The generated cell value must survive the delete/restore round trip.
-    row.refresh_from_db()
-    assert getattr(row, f"field_{ai_field.id}") == "generated"
-
     row.refresh_from_db()
     assert getattr(row, f"field_{ai_field.id}") == "generated"

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -10,6 +10,7 @@ from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NO
 
 from baserow.contrib.database.application_types import DatabaseApplicationType
 from baserow.contrib.database.fields.dependencies.models import FieldDependency
+from baserow.contrib.database.fields.field_cache import FieldCache
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import FileField
 from baserow.contrib.database.fields.registries import field_type_registry
@@ -1778,3 +1779,53 @@ def test_ai_field_api_serializes_error(api_client, premium_data_fixture):
     )
     assert response.status_code == HTTP_200_OK
     assert response.json()["error"] is not None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_ai_field_error_clears_when_prompt_fixed(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    text_field = premium_data_fixture.create_text_field(table=table)
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI",
+        ai_prompt={"version": 1, "formula": "get('fields.field_999999')"},
+    )
+    assert field.error is not None
+
+    field.ai_prompt = {
+        "version": 1,
+        "formula": f"get('fields.field_{text_field.id}')",
+    }
+    field.save()
+    field.refresh_from_db()
+
+    assert field.error is None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_ai_field_import_with_broken_reference_records_error(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI",
+        ai_prompt={"version": 1, "formula": "get('fields.field_424242')"},
+    )
+    field_type = field_type_registry.get_by_model(field)
+    exported = field_type.export_serialized(field)
+
+    # id_mapping without the referenced field id -> after_import_serialized swallows
+    # the KeyError and leaves the broken reference, so import must not raise.
+    id_mapping = {"database_fields": {}}
+    imported_field = field_type.import_serialized(
+        table,
+        exported,
+        ImportExportConfig(include_permission_data=False),
+        id_mapping,
+        deferred_fk_update_collector=DeferredForeignKeyUpdater(),
+    )
+    field_type.after_import_serialized(imported_field, FieldCache(), id_mapping)
+
+    imported_field = AIField.objects.get(id=imported_field.id)
+    assert imported_field.error is not None

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -426,6 +426,7 @@ def test_create_ai_field_type_via_api_invalid_formula(premium_data_fixture, api_
         format="json",
         HTTP_AUTHORIZATION=f"JWT {token}",
     )
+    # An unparseable prompt is rejected on save.
     assert response.status_code == HTTP_400_BAD_REQUEST
     response_json = response.json()
     assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
@@ -1817,6 +1818,34 @@ def test_ai_field_import_with_broken_reference_records_error(premium_data_fixtur
 
     # id_mapping without the referenced field id -> after_import_serialized swallows
     # the KeyError and leaves the broken reference, so import must not raise.
+    id_mapping = {"database_fields": {}}
+    imported_field = field_type.import_serialized(
+        table,
+        exported,
+        ImportExportConfig(include_permission_data=False),
+        id_mapping,
+        deferred_fk_update_collector=DeferredForeignKeyUpdater(),
+    )
+    field_type.after_import_serialized(imported_field, FieldCache(), id_mapping)
+
+    imported_field = AIField.objects.get(id=imported_field.id)
+    assert imported_field.error is not None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_ai_field_import_with_unparseable_prompt_records_error(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI",
+        ai_prompt={"version": 1, "formula": "get('fields.field_1') x hello"},
+    )
+    field_type = field_type_registry.get_by_model(field)
+    exported = field_type.export_serialized(field)
+
+    # An unparseable prompt (e.g. from an old or hand-edited export) must not
+    # break the import; the field simply ends up broken.
     id_mapping = {"database_fields": {}}
     imported_field = field_type.import_serialized(
         table,

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -1733,3 +1733,48 @@ def test_import_ai_field_disables_auto_update(premium_data_fixture):
     imported_field = AIField.objects.get(id=imported_field.id)
     assert imported_field.ai_auto_update is False
     assert imported_field.ai_auto_update_user_id is None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_ai_field_error_property_detects_broken_prompt(premium_data_fixture):
+    premium_data_fixture.register_fake_generate_ai_type()
+    table = premium_data_fixture.create_database_table()
+    broken = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI",
+        ai_prompt={"version": 1, "formula": "get('fields.field_999999')"},
+    )
+    assert broken.error is not None
+
+    text_field = premium_data_fixture.create_text_field(table=table)
+    valid = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI2",
+        ai_prompt={
+            "version": 1,
+            "formula": f"get('fields.field_{text_field.id}')",
+        },
+    )
+    assert valid.error is None
+
+
+@pytest.mark.field_ai
+@pytest.mark.django_db
+def test_ai_field_api_serializes_error(api_client, premium_data_fixture):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user, token = premium_data_fixture.create_user_and_token(
+        has_active_premium_license=True
+    )
+    table = premium_data_fixture.create_database_table(user=user)
+    field = premium_data_fixture.create_ai_field(
+        table=table,
+        name="AI",
+        ai_prompt={"version": 1, "formula": "get('fields.field_999999')"},
+    )
+    response = api_client.get(
+        reverse("api:database:fields:item", kwargs={"field_id": field.id}),
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["error"] is not None

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_type.py
@@ -1308,6 +1308,33 @@ def test_create_ai_field_with_references(premium_data_fixture):
 
 @pytest.mark.django_db
 @pytest.mark.field_ai
+def test_ai_field_ignores_cross_table_references_in_dependencies(
+    premium_data_fixture,
+):
+    premium_data_fixture.register_fake_generate_ai_type()
+    user = premium_data_fixture.create_user()
+    table = premium_data_fixture.create_database_table(user=user)
+    other_table = premium_data_fixture.create_database_table(user=user)
+    other_field = premium_data_fixture.create_text_field(table=other_table)
+
+    ai_field = FieldHandler().create_field(
+        user=user,
+        table=table,
+        type_name="ai",
+        name="ai",
+        ai_generative_ai_type="test_generative_ai",
+        ai_generative_ai_model="test_1",
+        ai_prompt=f"get('fields.field_{other_field.id}')",
+    )
+
+    # A reference to another table's field is invalid, so it must not create a
+    # dependency edge that would let that field's changes touch this one.
+    assert ai_field.error is not None
+    assert not FieldDependency.objects.filter(dependant_id=ai_field.id).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
 def test_create_ai_field_auto_update_user(premium_data_fixture):
     """
     Test if AI field type handler sets the user when auto-update flag is set.

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
@@ -1,7 +1,10 @@
 import pytest
 
 from baserow.core.formula import BaserowFormulaSyntaxError
-from baserow_premium.fields.visitors import replace_field_id_references
+from baserow_premium.fields.visitors import (
+    get_ai_prompt_error,
+    replace_field_id_references,
+)
 
 
 @pytest.mark.field_ai
@@ -32,3 +35,43 @@ def test_field_id_references_invalid_id():
 def test_field_id_references_invalid_formula():
     with pytest.raises(BaserowFormulaSyntaxError):
         replace_field_id_references("get('fields.field_1'))", {})
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_returns_none_for_empty_prompt(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    assert get_ai_prompt_error("", table) is None
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_returns_none_for_valid_reference(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    text_field = premium_data_fixture.create_text_field(table=table)
+    prompt = f"concat('Hi ', get('fields.field_{text_field.id}'))"
+    assert get_ai_prompt_error(prompt, table) is None
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_detects_unparseable_prompt(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    # Unbalanced parenthesis -> BaserowFormulaSyntaxError.
+    assert get_ai_prompt_error("concat('a', ", table) is not None
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_detects_missing_field_reference(premium_data_fixture):
+    table = premium_data_fixture.create_database_table()
+    # field_999999 does not exist in this table.
+    prompt = "get('fields.field_999999')"
+    assert get_ai_prompt_error(prompt, table) is not None
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_detects_reference_to_other_table_field(
+    premium_data_fixture,
+):
+    table = premium_data_fixture.create_database_table()
+    other_table = premium_data_fixture.create_database_table()
+    other_field = premium_data_fixture.create_text_field(table=other_table)
+    prompt = f"get('fields.field_{other_field.id}')"
+    assert get_ai_prompt_error(prompt, table) is not None

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
@@ -40,7 +40,7 @@ def test_field_id_references_invalid_formula():
 @pytest.mark.django_db
 def test_get_ai_prompt_error_returns_none_for_empty_prompt(premium_data_fixture):
     table = premium_data_fixture.create_database_table()
-    assert get_ai_prompt_error("", table) is None
+    assert get_ai_prompt_error("", table.id) is None
 
 
 @pytest.mark.django_db
@@ -48,14 +48,14 @@ def test_get_ai_prompt_error_returns_none_for_valid_reference(premium_data_fixtu
     table = premium_data_fixture.create_database_table()
     text_field = premium_data_fixture.create_text_field(table=table)
     prompt = f"concat('Hi ', get('fields.field_{text_field.id}'))"
-    assert get_ai_prompt_error(prompt, table) is None
+    assert get_ai_prompt_error(prompt, table.id) is None
 
 
 @pytest.mark.django_db
 def test_get_ai_prompt_error_detects_unparseable_prompt(premium_data_fixture):
     table = premium_data_fixture.create_database_table()
     # Unbalanced parenthesis -> BaserowFormulaSyntaxError.
-    assert get_ai_prompt_error("concat('a', ", table) is not None
+    assert get_ai_prompt_error("concat('a', ", table.id) is not None
 
 
 @pytest.mark.django_db
@@ -63,7 +63,7 @@ def test_get_ai_prompt_error_detects_missing_field_reference(premium_data_fixtur
     table = premium_data_fixture.create_database_table()
     # field_999999 does not exist in this table.
     prompt = "get('fields.field_999999')"
-    assert get_ai_prompt_error(prompt, table) is not None
+    assert get_ai_prompt_error(prompt, table.id) is not None
 
 
 @pytest.mark.django_db
@@ -74,4 +74,4 @@ def test_get_ai_prompt_error_detects_reference_to_other_table_field(
     other_table = premium_data_fixture.create_database_table()
     other_field = premium_data_fixture.create_text_field(table=other_table)
     prompt = f"get('fields.field_{other_field.id}')"
-    assert get_ai_prompt_error(prompt, table) is not None
+    assert get_ai_prompt_error(prompt, table.id) is not None

--- a/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_ai_field_visitors.py
@@ -1,7 +1,9 @@
 import pytest
 
+from baserow.core.cache import local_cache
 from baserow.core.formula import BaserowFormulaSyntaxError
 from baserow_premium.fields.visitors import (
+    extract_field_id_dependencies,
     get_ai_prompt_error,
     replace_field_id_references,
 )
@@ -64,6 +66,36 @@ def test_get_ai_prompt_error_detects_missing_field_reference(premium_data_fixtur
     # field_999999 does not exist in this table.
     prompt = "get('fields.field_999999')"
     assert get_ai_prompt_error(prompt, table.id) is not None
+
+
+@pytest.mark.field_ai
+def test_extract_field_id_dependencies_supports_both_quote_styles():
+    assert extract_field_id_dependencies("get('fields.field_1')") == {1}
+    assert extract_field_id_dependencies('get("fields.field_1")') == {1}
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_detects_double_quoted_missing_field_reference(
+    premium_data_fixture,
+):
+    table = premium_data_fixture.create_database_table()
+    prompt = 'get("fields.field_999999")'
+    assert get_ai_prompt_error(prompt, table.id) is not None
+
+
+@pytest.mark.django_db
+def test_get_ai_prompt_error_caches_field_ids_per_table(
+    premium_data_fixture, django_assert_num_queries
+):
+    table = premium_data_fixture.create_database_table()
+    text_field = premium_data_fixture.create_text_field(table=table)
+    prompt = f"get('fields.field_{text_field.id}')"
+
+    with local_cache.context():
+        # The second validation reuses the cached field ids.
+        with django_assert_num_queries(1):
+            assert get_ai_prompt_error(prompt, table.id) is None
+            assert get_ai_prompt_error(prompt, table.id) is None
 
 
 @pytest.mark.django_db

--- a/premium/backend/tests/baserow_premium_tests/fields/test_generate_ai_values_job_type.py
+++ b/premium/backend/tests/baserow_premium_tests/fields/test_generate_ai_values_job_type.py
@@ -21,6 +21,7 @@ from baserow.core.jobs.handler import JobHandler
 from baserow.core.storage import get_default_storage
 from baserow.core.user_files.handler import UserFileHandler
 from baserow_premium.fields.ai_field_output_types import ChoiceAIFieldOutputType
+from baserow_premium.fields.exceptions import AIFieldPromptInvalidError
 from baserow_premium.fields.models import GenerateAIValuesJob
 
 
@@ -50,6 +51,29 @@ def test_create_job_rows_mode(premium_data_fixture):
     assert job.view_id is None
     assert job.only_empty is False
     assert job.mode == GenerateAIValuesJob.MODES.ROWS
+
+
+@pytest.mark.django_db
+@pytest.mark.field_ai
+def test_create_job_rejected_when_prompt_broken(premium_data_fixture):
+    """A broken prompt must block job creation for every mode/entry point."""
+
+    premium_data_fixture.register_fake_generate_ai_type()
+    user = premium_data_fixture.create_user()
+    database = premium_data_fixture.create_database_application(user=user)
+    table = premium_data_fixture.create_database_table(database=database)
+    field = premium_data_fixture.create_ai_field(
+        table=table, ai_prompt="get('fields.field_999999')"
+    )
+
+    with pytest.raises(AIFieldPromptInvalidError):
+        JobHandler().create_and_start_job(
+            user,
+            "generate_ai_values",
+            field_id=field.id,
+        )
+
+    assert GenerateAIValuesJob.objects.count() == 0
 
 
 @pytest.mark.django_db
@@ -638,15 +662,17 @@ def test_generate_ai_field_value_view_generative_ai_invalid_field(
         .created_rows
     )
     assert patched_rows_updated.call_count == 0
-    JobHandler().create_and_start_job(
-        user, "generate_ai_values", sync=True, field_id=field.id, row_ids=[rows[0].id]
-    )
-    assert patched_rows_updated.call_count == 1
-    updated_row = patched_rows_updated.call_args[1]["rows"][0]
-    assert (
-        getattr(updated_row, field.db_column)
-        == "Generated with temperature None: Hello "
-    )
+    # A prompt referencing a missing field is rejected at job creation instead of
+    # silently generating with an empty reference value.
+    with pytest.raises(AIFieldPromptInvalidError):
+        JobHandler().create_and_start_job(
+            user,
+            "generate_ai_values",
+            sync=True,
+            field_id=field.id,
+            row_ids=[rows[0].id],
+        )
+    assert patched_rows_updated.call_count == 0
 
 
 @pytest.mark.django_db
@@ -666,7 +692,8 @@ def test_generate_ai_field_value_view_generative_ai_invalid_prompt(
     )
     table = premium_data_fixture.create_database_table(name="table", database=database)
     firstname = premium_data_fixture.create_text_field(table=table, name="firstname")
-    formula = "concat('Hello ', get('fields.field_0'))"
+    # The prompt must be valid; a broken one is rejected at job creation now.
+    formula = f"concat('Hello ', get('fields.field_{firstname.id}'))"
     field = premium_data_fixture.create_ai_field(
         table=table,
         name="ai",

--- a/premium/web-frontend/modules/baserow_premium/components/field/FieldAISubForm.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/field/FieldAISubForm.vue
@@ -80,7 +80,7 @@
     <FormGroup
       small-label
       :label="$t('fieldAISubForm.prompt')"
-      :error="v$.values.ai_prompt?.formula.$error"
+      :error="v$.values.ai_prompt?.formula.$error || promptInvalid"
       required
     >
       <div style="max-width: 366px">
@@ -92,9 +92,16 @@
           :validation-context="{ dataProviderRegistry: dataProviders }"
           @input="updatedFormulaStr"
           @update:mode="updateMode"
+          @update:invalid="promptInvalid = $event"
         />
       </div>
-      <template #error> {{ $t('error.requiredField') }}</template>
+      <template #error>
+        {{
+          promptInvalid
+            ? $t('fieldAISubForm.invalidPrompt')
+            : $t('error.requiredField')
+        }}
+      </template>
     </FormGroup>
 
     <component
@@ -147,6 +154,7 @@ export default {
       },
       fileFieldSupported: false,
       localMode: 'simple',
+      promptInvalid: false,
     }
   },
   computed: {
@@ -239,6 +247,14 @@ export default {
     },
   },
   methods: {
+    /**
+     * The prompt input only emits parseable formulas, so `values.ai_prompt`
+     * would silently keep the last valid one. Block submission while the
+     * editor content is invalid instead of saving a stale prompt.
+     */
+    isFormValid(deep = false) {
+      return !this.promptInvalid && form.methods.isFormValid.call(this, deep)
+    },
     /**
      * When `FormulaInputField` emits a new formula string, we need to emit the
      * entire value object with the updated formula string.

--- a/premium/web-frontend/modules/baserow_premium/components/field/GenerateAIValuesContextItem.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/field/GenerateAIValuesContextItem.vue
@@ -1,9 +1,10 @@
 <template>
   <li v-if="isAIField" class="context__menu-item">
     <a
+      v-tooltip="promptBroken ? $t('gridView.promptBroken') : null"
       class="context__menu-item-link"
       :class="{
-        disabled: !modelAvailable,
+        disabled: !modelAvailable || promptBroken,
       }"
       @click.prevent.stop="openModal()"
     >
@@ -88,12 +89,16 @@ export default {
     hasPremium() {
       return this.$hasFeature(PremiumFeatures.PREMIUM, this.workspace.id)
     },
+    // Indicates if the field's prompt is broken and can't be used to generate values.
+    promptBroken() {
+      return !!this.field.error
+    },
   },
   methods: {
     openModal() {
       if (!this.hasPremium) {
         this.$refs.paidFeaturesModal.show()
-      } else if (this.modelAvailable) {
+      } else if (this.modelAvailable && !this.promptBroken) {
         this.$emit('hide-context')
         this.$refs.generateAIValuesModal.show()
       }

--- a/premium/web-frontend/modules/baserow_premium/components/row/RowEditFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/row/RowEditFieldAI.vue
@@ -17,7 +17,9 @@
       </Button>
       <Button
         v-else-if="rowIsCreated"
+        v-tooltip="promptBroken ? $t('rowEditFieldAI.promptBroken') : null"
         type="secondary"
+        :disabled="promptBroken"
         :loading="generating"
         @click="generate()"
         >{{ $t('rowEditFieldAI.generate') }}</Button

--- a/premium/web-frontend/modules/baserow_premium/components/row/RowEditFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/row/RowEditFieldAI.vue
@@ -15,15 +15,18 @@
       >
         {{ $t('rowEditFieldAI.generate') }}
       </Button>
-      <Button
+      <span
         v-else-if="rowIsCreated"
         v-tooltip="promptBroken ? $t('rowEditFieldAI.promptBroken') : null"
-        type="secondary"
-        :disabled="promptBroken"
-        :loading="generating"
-        @click="generate()"
-        >{{ $t('rowEditFieldAI.generate') }}</Button
       >
+        <Button
+          type="secondary"
+          :disabled="promptBroken"
+          :loading="generating"
+          @click="generate()"
+          >{{ $t('rowEditFieldAI.generate') }}</Button
+        >
+      </span>
       <div v-else>{{ $t('rowEditFieldAI.createRowBefore') }}</div>
       <component
         :is="deactivatedClickComponent[0]"

--- a/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/FunctionalGridViewFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/FunctionalGridViewFieldAI.vue
@@ -6,7 +6,7 @@
         size="tiny"
         type="secondary"
         :loading="generating"
-        :disabled="!modelAvailable"
+        :disabled="!modelAvailable || promptBroken"
         :icon="isDeactivatedFunctional ? 'iconoir-lock' : ''"
       >
         <i18n-t keypath="functionalGridViewFieldAI.generate" tag="span" />

--- a/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/FunctionalGridViewFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/FunctionalGridViewFieldAI.vue
@@ -1,8 +1,10 @@
 <template>
   <div v-if="shouldShowGenerateButton" class="grid-view__cell">
-    <div class="grid-field-button">
+    <div
+      v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
+      class="grid-field-button"
+    >
       <Button
-        tag="a"
         size="tiny"
         type="secondary"
         :loading="generating"

--- a/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAI.vue
@@ -7,9 +7,10 @@
     >
       <div class="grid-field-button">
         <Button
+          v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
           type="secondary"
           size="tiny"
-          :disabled="!modelAvailable || generating"
+          :disabled="!modelAvailable || generating || promptBroken"
           :loading="generating"
           :icon="isDeactivated ? 'iconoir-lock' : ''"
           @click="generate()"
@@ -40,8 +41,9 @@
         <div style="background-color: #fff; padding: 8px">
           <ButtonText
             v-if="!isDeactivated"
+            v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
             icon="iconoir-magic-wand"
-            :disabled="!modelAvailable || generating"
+            :disabled="!modelAvailable || generating || promptBroken"
             :loading="generating"
             @mousedown.prevent.stop="generate()"
           >

--- a/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAI.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAI.vue
@@ -5,9 +5,11 @@
       ref="cell"
       class="grid-view__cell active"
     >
-      <div class="grid-field-button">
+      <div
+        v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
+        class="grid-field-button"
+      >
         <Button
-          v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
           type="secondary"
           size="tiny"
           :disabled="!modelAvailable || generating || promptBroken"
@@ -38,10 +40,12 @@
       @add-row-after="(...args) => $emit('add-row-after', ...args)"
     >
       <template v-if="!readOnly && editing" #default>
-        <div style="background-color: #fff; padding: 8px">
+        <div
+          v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
+          style="background-color: #fff; padding: 8px"
+        >
           <ButtonText
             v-if="!isDeactivated"
-            v-tooltip="promptBroken ? $t('gridViewFieldAI.promptBroken') : null"
             icon="iconoir-magic-wand"
             :disabled="!modelAvailable || generating || promptBroken"
             :loading="generating"

--- a/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAIGenerateValuesContextItem.vue
+++ b/premium/web-frontend/modules/baserow_premium/components/views/grid/fields/GridViewFieldAIGenerateValuesContextItem.vue
@@ -1,9 +1,10 @@
 <template>
   <li class="context__menu-item">
     <a
+      v-tooltip="promptBroken ? $t('gridView.promptBroken') : null"
       class="context__menu-item-link"
       :class="{
-        disabled: !modelAvailable || !hasPremium,
+        disabled: !modelAvailable || !hasPremium || promptBroken,
         'context__menu-item-link--loading': loading,
       }"
       @click.prevent.stop="generateAIFieldValues()"
@@ -64,10 +65,14 @@ export default {
     hasPremium() {
       return this.$hasFeature(PremiumFeatures.PREMIUM, this.workspace.id)
     },
+    // Indicates if the field's prompt is broken and can't be used to generate values.
+    promptBroken() {
+      return !!this.field.error
+    },
   },
   methods: {
     async generateAIFieldValues($event) {
-      if (!this.modelAvailable || !this.hasPremium) {
+      if (!this.modelAvailable || !this.hasPremium || this.promptBroken) {
         return
       }
 

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -345,7 +345,8 @@
   },
   "rowEditFieldAI": {
     "generate": "Generate",
-    "createRowBefore": "The AI value can be generated after the row has been created."
+    "createRowBefore": "The AI value can be generated after the row has been created.",
+    "promptBroken": "The prompt is broken and must be fixed before values can be generated."
   },
   "aiFormulaModal": {
     "title": "Generate formula using AI",

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -341,7 +341,8 @@
     "outputTypeChangedWarning": "Clears the generated cell values.",
     "autoUpdate": "Auto update",
     "autoUpdateHelp": "When enabled, the AI field value will be automatically regenerated when any of the referenced fields in the prompt are updated.",
-    "autoUpdateDescription": "Regenerate when referenced fields change"
+    "autoUpdateDescription": "Regenerate when referenced fields change",
+    "invalidPrompt": "The prompt formula is invalid."
   },
   "rowEditFieldAI": {
     "generate": "Generate",

--- a/premium/web-frontend/modules/baserow_premium/locales/en.json
+++ b/premium/web-frontend/modules/baserow_premium/locales/en.json
@@ -327,7 +327,8 @@
   },
   "gridViewFieldAI": {
     "generate": "Generate",
-    "regenerate": "Regenerate"
+    "regenerate": "Regenerate",
+    "promptBroken": "The prompt is broken and must be fixed before values can be generated."
   },
   "fieldAISubForm": {
     "prompt": "Prompt",

--- a/premium/web-frontend/modules/baserow_premium/mixins/fieldAI.js
+++ b/premium/web-frontend/modules/baserow_premium/mixins/fieldAI.js
@@ -29,6 +29,10 @@ export default {
         .get('field', this.field.type)
         .isDeactivated(this.workspaceId)
     },
+    // Indicates if the field's prompt is broken and can't be used to generate values.
+    promptBroken() {
+      return !!this.field.error
+    },
     deactivatedClickComponent() {
       return this.$registry
         .get('field', this.field.type)

--- a/premium/web-frontend/modules/baserow_premium/mixins/fieldAI.js
+++ b/premium/web-frontend/modules/baserow_premium/mixins/fieldAI.js
@@ -46,6 +46,11 @@ export default {
   },
   methods: {
     async generate() {
+      // Guard every caller and not just the disabled button.
+      if (!this.modelAvailable || this.generating || this.promptBroken) {
+        return
+      }
+
       this.generating = true
       try {
         await FieldService(this.$client).generateAIFieldValues(this.field.id, [

--- a/premium/web-frontend/modules/baserow_premium/mixins/gridFieldAI.js
+++ b/premium/web-frontend/modules/baserow_premium/mixins/gridFieldAI.js
@@ -63,6 +63,11 @@ export default {
         return
       }
 
+      // Guard every caller (button, Enter key) and not just the disabled button.
+      if (!this.modelAvailable || this.generating || this.promptBroken) {
+        return
+      }
+
       const rowId = this.$parent.row.id
       this.$store.dispatch(
         this.storePrefix + 'view/grid/setPendingFieldOperations',

--- a/premium/web-frontend/modules/baserow_premium/mixins/gridFieldAI.js
+++ b/premium/web-frontend/modules/baserow_premium/mixins/gridFieldAI.js
@@ -12,6 +12,10 @@ export default {
     modelAvailable() {
       return this.isModelAvailable(this.$parent, this.$props)
     },
+    // Indicates if the field's prompt is broken and can't be used to generate values.
+    promptBroken() {
+      return !!this.field.error
+    },
     isDeactivated() {
       return this.$registry
         .get('field', this.field.type)

--- a/premium/web-frontend/test/unit/premium/components/field/fieldAISubForm.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/field/fieldAISubForm.spec.js
@@ -1,0 +1,65 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import FieldAISubForm from '@baserow_premium/components/field/FieldAISubForm'
+
+describe('FieldAISubForm component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const mountComponent = async (aiPrompt) => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+    const wrapper = await testApp.mount(FieldAISubForm, {
+      props: {
+        table: { id: 10 },
+        view: {},
+        allFieldsInTable: [],
+        database: { id: 100, workspace: { id: workspace.id } },
+        fieldType: 'ai',
+        defaultValues: {
+          name: 'AI field',
+          type: 'ai',
+          ai_generative_ai_type: 'openai',
+          ai_generative_ai_model: 'gpt-4',
+          ai_output_type: 'text',
+          ai_prompt: aiPrompt,
+        },
+      },
+    })
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  test('a stored invalid prompt shows an error and blocks the form', async () => {
+    const wrapper = await mountComponent({
+      formula: "get('fields.field_1') x hello",
+      mode: 'advanced',
+    })
+
+    expect(wrapper.find('.control__messages--error').exists()).toBe(true)
+    // The parent FieldForm consults this to decide whether it may submit.
+    expect(wrapper.vm.isFormValid()).toBe(false)
+  })
+
+  test('a valid prompt shows no error and the form can submit', async () => {
+    const wrapper = await mountComponent({
+      formula: "'hello'",
+      mode: 'advanced',
+    })
+
+    expect(wrapper.find('.control__messages--error').exists()).toBe(false)
+    expect(wrapper.vm.isFormValid()).toBe(true)
+  })
+})

--- a/premium/web-frontend/test/unit/premium/components/field/generateAIValuesContextItem.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/field/generateAIValuesContextItem.spec.js
@@ -1,0 +1,67 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import GenerateAIValuesContextItem from '@baserow_premium/components/field/GenerateAIValuesContextItem'
+
+describe('GenerateAIValuesContextItem component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const aiField = {
+    id: 1,
+    name: 'AI field',
+    order: 0,
+    type: 'ai',
+    primary: false,
+    ai_generative_ai_type: 'openai',
+    ai_generative_ai_model: 'gpt-4',
+    ai_output_type: 'text',
+    error: null,
+  }
+
+  const mountComponent = (field) =>
+    testApp.mount(GenerateAIValuesContextItem, {
+      props: {
+        field,
+        table: { id: 1 },
+        database: { id: 1, workspace },
+      },
+      global: {
+        stubs: {
+          GenerateAIValuesModal: true,
+          PaidFeaturesModal: true,
+        },
+      },
+    })
+
+  test('item is disabled and does not open the modal when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' })
+
+    expect(wrapper.find('a').classes()).toContain('disabled')
+
+    await wrapper.find('a').trigger('click')
+    expect(wrapper.emitted('hide-context')).toBeUndefined()
+  })
+
+  test('item is enabled when the prompt is not broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent(aiField)
+
+    expect(wrapper.find('a').classes()).not.toContain('disabled')
+  })
+})

--- a/premium/web-frontend/test/unit/premium/components/row/rowEditFieldAI.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/row/rowEditFieldAI.spec.js
@@ -1,0 +1,59 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import RowEditFieldAI from '@baserow_premium/components/row/RowEditFieldAI'
+
+describe('RowEditFieldAI component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const aiField = {
+    id: 1,
+    name: 'AI field',
+    order: 0,
+    type: 'ai',
+    primary: false,
+    ai_generative_ai_type: 'openai',
+    ai_generative_ai_model: 'gpt-4',
+    ai_output_type: 'text',
+    error: null,
+  }
+
+  const mountComponent = (field) =>
+    testApp.mount(RowEditFieldAI, {
+      props: {
+        field,
+        value: null,
+        readOnly: false,
+        workspaceId: workspace.id,
+      },
+    })
+
+  test('Generate button is disabled when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' })
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+  })
+
+  test('Generate button is enabled when the prompt is not broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent(aiField)
+
+    expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+  })
+})

--- a/premium/web-frontend/test/unit/premium/components/views/grid/fields/functionalGridViewFieldAI.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/grid/fields/functionalGridViewFieldAI.spec.js
@@ -1,0 +1,63 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import FunctionalGridViewFieldAI from '@baserow_premium/components/views/grid/fields/FunctionalGridViewFieldAI'
+
+describe('FunctionalGridViewFieldAI component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const aiField = {
+    id: 1,
+    name: 'AI field',
+    order: 0,
+    type: 'ai',
+    primary: false,
+    ai_generative_ai_type: 'openai',
+    ai_generative_ai_model: 'gpt-4',
+    ai_output_type: 'text',
+    error: null,
+  }
+
+  const mountComponent = (field) =>
+    testApp.mount(FunctionalGridViewFieldAI, {
+      props: {
+        field,
+        row: { id: 1 },
+        value: null,
+        state: {},
+        readOnly: false,
+        storePrefix: '',
+        workspaceId: workspace.id,
+      },
+    })
+
+  test('Generate button is disabled when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' })
+
+    // A real <button> (not an anchor) so the disabled attribute takes effect.
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+  })
+
+  test('Generate button is enabled when the prompt is not broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent(aiField)
+
+    expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+  })
+})

--- a/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAI.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAI.spec.js
@@ -58,4 +58,19 @@ describe('GridViewFieldAI component', () => {
 
     expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
   })
+
+  test('Enter key does not trigger generation when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' })
+
+    // Selecting an empty cell and pressing Enter triggers `generate()`; the
+    // broken prompt guard must stop it before any request is made.
+    wrapper.vm.select()
+    document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))
+    await wrapper.vm.$nextTick()
+
+    expect(testApp.mock.history.post).toHaveLength(0)
+    wrapper.vm.beforeUnSelect()
+  })
 })

--- a/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAI.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAI.spec.js
@@ -1,0 +1,61 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import GridViewFieldAI from '@baserow_premium/components/views/grid/fields/GridViewFieldAI'
+
+describe('GridViewFieldAI component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const aiField = {
+    id: 1,
+    name: 'AI field',
+    order: 0,
+    type: 'ai',
+    primary: false,
+    ai_generative_ai_type: 'openai',
+    ai_generative_ai_model: 'gpt-4',
+    ai_output_type: 'text',
+    error: null,
+  }
+
+  const mountComponent = (field) =>
+    testApp.mount(GridViewFieldAI, {
+      props: {
+        field,
+        value: null,
+        selected: false,
+        readOnly: false,
+        storePrefix: '',
+        workspaceId: workspace.id,
+      },
+    })
+
+  test('Generate button is disabled when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' })
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined()
+  })
+
+  test('Generate button is enabled when the prompt is not broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent(aiField)
+
+    expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
+  })
+})

--- a/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAIGenerateValuesContextItem.spec.js
+++ b/premium/web-frontend/test/unit/premium/components/views/grid/fields/gridViewFieldAIGenerateValuesContextItem.spec.js
@@ -1,0 +1,64 @@
+import { PremiumTestApp } from '@baserow_premium_test/helpers/premiumTestApp'
+import GridViewFieldAIGenerateValuesContextItem from '@baserow_premium/components/views/grid/fields/GridViewFieldAIGenerateValuesContextItem'
+
+describe('GridViewFieldAIGenerateValuesContextItem component', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new PremiumTestApp()
+    testApp.giveCurrentUserGlobalPremiumFeatures()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+  })
+
+  const workspace = {
+    id: 1,
+    name: 'testWorkspace',
+    generative_ai_models_enabled: { openai: ['gpt-4'] },
+  }
+
+  const aiField = {
+    id: 1,
+    name: 'AI field',
+    order: 0,
+    type: 'ai',
+    primary: false,
+    ai_generative_ai_type: 'openai',
+    ai_generative_ai_model: 'gpt-4',
+    ai_output_type: 'text',
+    error: null,
+  }
+
+  const mountComponent = (field, getRows) =>
+    testApp.mount(GridViewFieldAIGenerateValuesContextItem, {
+      props: {
+        field,
+        getRows,
+        storePrefix: '',
+        database: { workspace },
+      },
+    })
+
+  test('item is disabled and does not fetch rows when the prompt is broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+    const getRows = vi.fn()
+
+    const wrapper = await mountComponent({ ...aiField, error: 'boom' }, getRows)
+
+    expect(wrapper.find('a').classes()).toContain('disabled')
+
+    await wrapper.find('a').trigger('click')
+    expect(getRows).not.toHaveBeenCalled()
+    expect(testApp.mock.history.post).toHaveLength(0)
+  })
+
+  test('item is enabled when the prompt is not broken', async () => {
+    await testApp.getStore().dispatch('workspace/forceCreate', workspace)
+
+    const wrapper = await mountComponent(aiField, vi.fn())
+
+    expect(wrapper.find('a').classes()).not.toContain('disabled')
+  })
+})

--- a/web-frontend/modules/core/components/formula/FormulaInputField.vue
+++ b/web-frontend/modules/core/components/formula/FormulaInputField.vue
@@ -223,7 +223,7 @@ export default {
       default: () => ({}),
     },
   },
-  emits: ['input', 'update:mode'],
+  emits: ['input', 'update:mode', 'update:invalid'],
   data() {
     return {
       editor: null,
@@ -387,6 +387,11 @@ export default {
     },
   },
   watch: {
+    // The `input` event only fires for valid formulas, so parents that must
+    // block submission on an invalid one need this signal too.
+    isFormulaInvalid(newValue) {
+      this.$emit('update:invalid', newValue)
+    },
     disabled(newValue) {
       this.editor.setOptions({ editable: !newValue && !this.readOnly })
     },

--- a/web-frontend/modules/database/locales/en.json
+++ b/web-frontend/modules/database/locales/en.json
@@ -726,6 +726,7 @@
     "copyCellsWithHeader": "Copy cells with header",
     "generateCellsValues": "Generate values with AI",
     "generateAllAiValues": "Generate all AI values",
+    "promptBroken": "The prompt is broken and must be fixed before values can be generated.",
     "rowCount": "No rows | 1 row | {count} rows",
     "hiddenRowsInsertedTitle": "Rows added",
     "hiddenRowsInsertedMessage": "{number} newly added rows have been added, but are not visible because of the active filters.",

--- a/web-frontend/test/unit/core/formula/FormulaInputField.spec.js
+++ b/web-frontend/test/unit/core/formula/FormulaInputField.spec.js
@@ -180,4 +180,22 @@ describe('FormulaInputField validates on display', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.vm.isFormulaInvalid).toBe(true)
   })
+
+  it('emits update:invalid when validity changes', async () => {
+    const wrapper = await mountField('now()')
+    expect(wrapper.emitted('update:invalid')).toBeUndefined()
+
+    await wrapper.setProps({ value: '$formula: now()' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('update:invalid').at(-1)).toEqual([true])
+
+    await wrapper.setProps({ value: 'today()' })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.emitted('update:invalid').at(-1)).toEqual([false])
+  })
+
+  it('emits update:invalid for an invalid initial value', async () => {
+    const wrapper = await mountField('$formula: now()')
+    expect(wrapper.emitted('update:invalid').at(-1)).toEqual([true])
+  })
 })


### PR DESCRIPTION
Closes #3088

### The problem

An AI field's prompt can break, for example when a field it references gets deleted, or a bad import brings in a formula that can't be parsed. Before this change nothing told you about it: the field looked fine, the Generate button was clickable, and generation just failed row by row with no explanation.

On top of that, if you typed an invalid formula into the prompt and hit Save, the modal closed as if everything was fine but your edit was silently thrown away and the old prompt was kept.

### The fix

When a prompt is broken:

- The field header shows a warning icon with a tooltip, like formula fields do.
- The Generate buttons (grid and row edit) are disabled.
- The generate API refuses with a clear error, so the disabled button can't be bypassed.
- Everything updates live, delete a referenced field and the icon appears right away; fix the prompt and it clears.

When you try to save an invalid prompt, the form now says "The prompt formula is invalid." and won't save until you fix it. The API rejects it too.

### Notes

- The broken state is computed when the field is read, so no new column and no migration.
- Empty prompts are not treated as broken.

### How to test

1. Make an AI field whose prompt references another field, then delete that field → warning icon shows and Generate is disabled, without a reload.
2. Edit the prompt and type some garbage after the reference, hit Save → the form shows an error and doesn't save.
3. Fix the prompt (or restore the deleted field) → the icon clears and Generate works again.

### Screencast


https://github.com/user-attachments/assets/1ac867f6-f1f2-4e29-9d6f-8dc2c136ac2a

