### PR TITLE
fix: Repeat element with long record content can overflow

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_a_repeat_element_bug_that_caused_overflow_when_a_recor.json
+++ b/changelog/entries/unreleased/bug/fixed_a_repeat_element_bug_that_caused_overflow_when_a_recor.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a Repeat element bug that caused overflow when a record contains long unbroken text.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-07-15"
+}

--- a/web-frontend/modules/builder/components/elements/components/RepeatElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/RepeatElement.vue
@@ -19,7 +19,11 @@
           :style="repeatedElementsStyles"
         >
           <!-- Iterate over each content -->
-          <div v-for="(content, index) in elementContent" :key="content.id">
+          <div
+            v-for="(content, index) in elementContent"
+            :key="content.id"
+            class="repeat-element__repeated-element"
+          >
             <!-- If the container has any children -->
             <template v-if="children.length > 0">
               <!-- Iterate over each child -->
@@ -253,7 +257,7 @@ export default {
           display: 'grid',
           'grid-template-columns': `repeat(${
             this.element.items_per_row[this.deviceTypeSelected]
-          }, 1fr)`,
+          }, minmax(0, 1fr))`,
           gap: `${this.element.vertical_gap}px ${this.element.horizontal_gap}px`,
         }
       }

--- a/web-frontend/modules/core/assets/scss/components/builder/elements/repeat_element.scss
+++ b/web-frontend/modules/core/assets/scss/components/builder/elements/repeat_element.scss
@@ -4,6 +4,11 @@
   }
 }
 
+.repeat-element__repeated-element {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
 .repeat-element__preview {
   opacity: 0.4;
   pointer-events: none;


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug with the Repeat element. When a specific record has a very long unbroken content, the text can overflow outside of the parent container.

### How to test this PR
In Database, create a long text field with a very long piece of unbroken text. I just used a URL.

In Builder, create a Repeat element in horizontal orientation, with only 1 item per row. Add a Text element that points to the long text field:
> <img width="3342" height="1188" alt="image" src="https://github.com/user-attachments/assets/cdd63b5f-2d0a-4912-9371-673b2560fd6f" />

Preview the app and view it in mobile mode (Chrome dev tools).

In `develop`, you'll notice that the URL causes an overflow. But in this branch it is fixed:
| Before | After |
| - | - |
| <img width="844" height="1424" alt="image" src="https://github.com/user-attachments/assets/1fd3e65f-c588-4de8-b4b2-340534f8304d" /> | <img width="830" height="1422" alt="image" src="https://github.com/user-attachments/assets/9f4034b7-ced8-4de3-ada1-9629f5ff2ba4" /> |

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
