### PR TITLE
fix: Resolve current_record from the correct element ancestry

### DIFF
--- a/backend/src/baserow/contrib/builder/elements/handler.py
+++ b/backend/src/baserow/contrib/builder/elements/handler.py
@@ -186,11 +186,11 @@ class ElementHandler:
 
         elements = self.get_elements(page, use_cache=use_element_cache)
         grouped_elements = {}
-        for element in elements:
+        for el in elements:
             # Pre-populate the page relation so that parent_element_id lookups
             # (which call _get_graph() → self.page) don't trigger extra queries.
-            element.page = page
-            grouped_elements[element.id] = element
+            el.page = page
+            grouped_elements[el.id] = el
         element = grouped_elements[element.id]
 
         ancestry = []

--- a/backend/tests/baserow/contrib/builder/data_providers/test_data_provider_types.py
+++ b/backend/tests/baserow/contrib/builder/data_providers/test_data_provider_types.py
@@ -1542,6 +1542,58 @@ def test_current_record_provider_get_data_chunk(data_fixture):
 
 
 @pytest.mark.django_db
+def test_current_record_provider_with_element_created_after_it(data_fixture):
+    user, token = data_fixture.create_user_and_token()
+
+    table, fields, rows = data_fixture.build_table(
+        user=user,
+        columns=[("Fruit", "text")],
+        rows=[["Apple"], ["Banana"], ["Cherry"]],
+    )
+    field = table.field_set.get(name="Fruit")
+    builder = data_fixture.create_builder_application(user=user)
+    page = data_fixture.create_builder_page(user=user, builder=builder)
+
+    data_source = data_fixture.create_builder_local_baserow_list_rows_data_source(
+        page=page, table=table, integration_args={"authorized_user": user}
+    )
+    repeat_element = data_fixture.create_builder_repeat_element(
+        page=page, data_source=data_source
+    )
+    button_element = data_fixture.create_builder_button_element(
+        page=page,
+        reference_element=repeat_element,
+        position=GraphPointPosition.CHILD,
+    )
+    # A root-level element created after the button. This button
+    # will be the highest-id element.
+    data_fixture.create_builder_heading_element(page=page)
+
+    workflow_action = data_fixture.create_local_baserow_create_row_workflow_action(
+        page=page, element=button_element, event=EventTypes.CLICK, user=user
+    )
+
+    fake_request = HttpRequest()
+    fake_request.user = user
+    fake_request.data = {
+        "metadata": json.dumps(
+            {"current_record": {"index": 0, "record_id": rows[0].id}}
+        )
+    }
+
+    dispatch_context = BuilderDispatchContext(
+        fake_request, page, workflow_action, only_expose_public_allowed_properties=False
+    )
+
+    current_record_provider = CurrentRecordDataProviderType()
+
+    assert (
+        current_record_provider.get_data_chunk(dispatch_context, [field.db_column])
+        == "Apple"
+    )
+
+
+@pytest.mark.django_db
 def test_current_record_provider_type_import_path(data_fixture):
     # When a `current_record` provider is imported, and the path only contains the
     # current record index (`__idx__`), then there is no need to update the path.

--- a/backend/tests/baserow/contrib/builder/elements/test_element_handler.py
+++ b/backend/tests/baserow/contrib/builder/elements/test_element_handler.py
@@ -510,6 +510,20 @@ def test_get_ancestors(data_fixture, django_assert_num_queries):
 
 
 @pytest.mark.django_db
+def test_get_ancestors_of_non_last_element(data_fixture):
+    page = data_fixture.create_builder_page()
+    parent = data_fixture.create_builder_column_element(column_amount=1, page=page)
+    child = data_fixture.create_builder_heading_element(
+        page=page, reference_element=parent, position=GraphPointPosition.CHILD
+    )
+    # An unrelated root-level element created afterwards (highest id on page).
+    data_fixture.create_builder_heading_element(page=page)
+
+    ancestors = ElementHandler().get_ancestors(child, page)
+    assert [a.id for a in ancestors] == [parent.id]
+
+
+@pytest.mark.django_db
 def test_get_first_ancestor_of_type(data_fixture, django_assert_num_queries):
     page = data_fixture.create_builder_page()
     grandparent = data_fixture.create_builder_column_element(column_amount=1, page=page)

--- a/changelog/entries/unreleased/bug/fixed_workflow_actions_inside_collection_elements_failing_to.json
+++ b/changelog/entries/unreleased/bug/fixed_workflow_actions_inside_collection_elements_failing_to.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed workflow actions inside collection elements failing to resolve the current_record.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-07-16"
+}


### PR DESCRIPTION
### What is in this PR
This PR fixes a bug with `get_ancestors()`.

The current record data provider uses `get_ancestors()` to figure out which data source to fetch the record from. It basically walks up from the workflow action's element to find the nearest collection element ancestor.

The bug is that the `element` loop variable is overwritten so the walk started from the wrong element. Instead of the element that is passed in, it starts with the highest id element on the page. In the case of the example below, when the element has no collection element ancestor (root level Heading), the lookup returns `None` and crashes.

### How to test this PR
Create a Record element and point it to a data source. Then create a Button element inside it with an Update Row workflow action. In the workflow action's row ID field, use the current record ID from the Repeat element's data source:
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/cdcb3af1-146e-4ee1-9c8c-aeda660390af" />

Then after the Repeat element, add a Heading element.

Preview the app and click the Repeat's button. You should see an error:
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/6657373c-09bf-4bf6-8eb8-7fb8404091b2" />

The bug is fixed in this branch (the workflow action should succeed).

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
