### PR TITLE
bug: ensure the HTTP trigger service's uid is immutable

### DIFF
--- a/backend/src/baserow/contrib/integrations/core/service_types.py
+++ b/backend/src/baserow/contrib/integrations/core/service_types.py
@@ -1604,9 +1604,9 @@ class CoreHTTPTriggerServiceType(TriggerServiceTypeMixin, ServiceType):
     type = "http_trigger"
     model_class = CoreHTTPTriggerService
 
-    allowed_fields = ["uid", "exclude_get", "is_public"]
+    allowed_fields = ["exclude_get", "is_public"]
     serializer_field_names = ["uid", "exclude_get", "is_public"]
-    request_serializer_field_names = ["uid", "exclude_get"]
+    request_serializer_field_names = ["exclude_get"]
 
     class SerializedDict(ServiceDict):
         uid: str
@@ -1796,15 +1796,6 @@ class CoreHTTPTriggerServiceType(TriggerServiceTypeMixin, ServiceType):
             import_export_config=import_export_config,
             **kwargs,
         )
-
-    def export_prepared_values(
-        self, instance: CoreHTTPTriggerService
-    ) -> dict[str, Any]:
-        values = super().export_prepared_values(instance)
-
-        values["uid"] = str(values["uid"])
-
-        return values
 
 
 class CoreManualTriggerServiceType(TriggerServiceTypeMixin, CoreServiceType):

--- a/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
+++ b/backend/tests/baserow/contrib/automation/api/nodes/test_nodes_views.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from uuid import uuid4
 
 from django.urls import reverse
 
@@ -423,6 +424,34 @@ def test_updating_node_with_invalid_formula_arguments_throws_error(
             }
         },
     }
+
+
+@pytest.mark.django_db
+def test_update_http_trigger_node_ignores_uid(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    workflow = data_fixture.create_automation_workflow(user, create_trigger=False)
+    node = data_fixture.create_http_trigger_node(user=user, workflow=workflow)
+    service = node.service
+    original_uid = service.uid
+
+    api_kwargs = get_api_kwargs(token)
+    update_url = reverse(API_URL_ITEM, kwargs={"node_id": node.id})
+    payload = {
+        "service": {
+            "type": service.get_type().type,
+            "uid": str(uuid4()),
+            "exclude_get": True,
+        }
+    }
+    response = api_client.patch(update_url, payload, **api_kwargs)
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["service"]["uid"] == str(original_uid)
+
+    service.refresh_from_db()
+    assert service.uid == original_uid
+    # A field which is allowed to be updated is still applied.
+    assert service.exclude_get is True
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/integrations/core/test_core_http_trigger_service_type.py
+++ b/backend/tests/baserow/contrib/integrations/core/test_core_http_trigger_service_type.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 
@@ -177,15 +177,3 @@ def test_import_serialized_sets_is_public(data_fixture, is_publishing):
     )
 
     assert instance.is_public is is_publishing
-
-
-@pytest.mark.django_db
-def test_export_prepared_values_casts_uid_to_str(data_fixture):
-    trigger_node = data_fixture.create_http_trigger_node()
-    service = trigger_node.service
-
-    assert isinstance(service.uid, UUID)
-
-    values = CoreHTTPTriggerServiceType().export_prepared_values(service)
-
-    assert values["uid"] == str(service.uid)

--- a/changelog/entries/unreleased/bug/prevents_the_webhook_address_of_an_http_trigger_from_being_c.json
+++ b/changelog/entries/unreleased/bug/prevents_the_webhook_address_of_an_http_trigger_from_being_c.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Prevents the webhook address of an HTTP trigger from being changed after it is created",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "automation",
+    "bullet_points": [],
+    "created_at": "2026-07-16"
+}


### PR DESCRIPTION
### What is in this PR

This can't be replicated in the UI, but API consumers can PATCH a new `uid` to an HTTP trigger service.

### How to test this PR

Either run the automated tests, or fire off a PATCH using your REST API client of choice.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
