### PR TITLE
fix: reduce backend memory usage by releasing each API response memory after request is sent

### DIFF
--- a/backend/src/baserow/api/renderers.py
+++ b/backend/src/baserow/api/renderers.py
@@ -1,12 +1,37 @@
+from typing import Any, Iterator
+
 from rest_framework.renderers import JSONRenderer
+from rest_framework.serializers import BaseSerializer
 
 
-def _release_serializer_references(serializer):
+def _iter_serializer_outputs(data: Any) -> Iterator[BaseSerializer]:
+    """
+    Yields the serializer of every `ReturnList`/`ReturnDict` anywhere in the response
+    data tree. Serializer outputs can sit at the top level, inside plain lists (e.g.
+    the job and application APIs), or in deeper mappings (e.g. the kanban and calendar
+    grouped-row responses).
+    """
+
+    stack = [data]
+    seen = set()
+    while stack:
+        node = stack.pop()
+        if not isinstance(node, (dict, list, tuple)) or id(node) in seen:
+            continue
+        seen.add(id(node))
+        serializer = getattr(node, "serializer", None)
+        if serializer is not None:
+            yield serializer
+        stack.extend(node.values() if isinstance(node, dict) else node)
+
+
+def _release_serializer_references(serializer: BaseSerializer) -> None:
     """
     Severs the references a DRF serializer graph keeps to the serialized payload. The
     serializer skeleton itself stays cyclic (that is inherent to DRF and small), but
-    `instance`, `_args`, `_kwargs`, and `_data` pin the fetched model instances and the
-    serialized output, which is where the actual memory sits.
+    `instance`, `_args`, `_kwargs`, `_data`, and `_context` pin the fetched model
+    instances, the serialized output, the request, and arbitrary context payloads,
+    which is where the actual memory sits.
     """
 
     current = serializer
@@ -21,8 +46,9 @@ def _release_serializer_references(serializer):
                 instance_dict[attribute] = None
         if "_args" in instance_dict:
             instance_dict["_args"] = ()
-        if "_kwargs" in instance_dict:
-            instance_dict["_kwargs"] = {}
+        for attribute in ("_kwargs", "_context"):
+            if attribute in instance_dict:
+                instance_dict[attribute] = {}
         current = instance_dict.get("child")
 
 
@@ -50,41 +76,34 @@ class BaserowJSONRenderer(JSONRenderer):
     a memory leak.
 
     The `serializer` backreference and the renderer context exist purely so that
-    renderers, in practice only the browsable API's `HTMLFormRenderer`, can inspect
-    them while rendering. The JSON renderer is the last consumer of both, so after
-    producing the bytes it can sever these references. That makes the whole payload
-    reference-count collectable the moment the handler drops the response, leaving only
-    the small serializer/view skeleton for the regular garbage collector.
-
-    A `JSONRenderer` that, after rendering, breaks the DRF reference cycles described
-    in this module's docstring so the per-request payload is freed by reference
-    counting instead of lingering as cyclic garbage. The browsable API and any other
-    renderer are unaffected because they use their own renderer classes.
+    renderers can inspect them while rendering. When this renderer produces the final
+    response it is their last consumer, so after producing the bytes it severs these
+    references, making the payload reference-count collectable the moment the handler
+    drops the response. The cleanup is skipped when another renderer (e.g. the
+    browsable API) delegates to this render and still needs the context afterwards.
     """
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         rendered = super().render(data, accepted_media_type, renderer_context)
 
-        # The serializer output is either the data itself or, for paginated and
-        # composite responses, one of the top level values (e.g. under `results`).
-        candidates = [data]
-        if isinstance(data, dict):
-            candidates += list(data.values())
-        for candidate in candidates:
-            serializer = getattr(candidate, "serializer", None)
-            if serializer is not None:
-                _release_serializer_references(serializer)
+        response = (
+            renderer_context.get("response")
+            if isinstance(renderer_context, dict)
+            else None
+        )
+        if response is None or getattr(response, "accepted_renderer", None) is not self:
+            return rendered
 
-        if isinstance(renderer_context, dict):
-            view = renderer_context.get("view")
-            if view is not None:
-                view.response = None
-                view.request = None
-                view.args = ()
-                view.kwargs = {}
-            response = renderer_context.get("response")
-            renderer_context.clear()
-            if response is not None:
-                response.renderer_context = None
+        for serializer in _iter_serializer_outputs(data):
+            _release_serializer_references(serializer)
+
+        view = renderer_context.get("view")
+        if view is not None:
+            view.response = None
+            view.request = None
+            view.args = ()
+            view.kwargs = {}
+        renderer_context.clear()
+        response.renderer_context = None
 
         return rendered

--- a/backend/src/baserow/api/renderers.py
+++ b/backend/src/baserow/api/renderers.py
@@ -1,0 +1,90 @@
+from rest_framework.renderers import JSONRenderer
+
+
+def _release_serializer_references(serializer):
+    """
+    Severs the references a DRF serializer graph keeps to the serialized payload. The
+    serializer skeleton itself stays cyclic (that is inherent to DRF and small), but
+    `instance`, `_args`, `_kwargs`, and `_data` pin the fetched model instances and the
+    serialized output, which is where the actual memory sits.
+    """
+
+    current = serializer
+    seen = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        instance_dict = getattr(current, "__dict__", None)
+        if not isinstance(instance_dict, dict):
+            break
+        for attribute in ("instance", "initial_data", "_data", "_validated_data"):
+            if attribute in instance_dict:
+                instance_dict[attribute] = None
+        if "_args" in instance_dict:
+            instance_dict["_args"] = ()
+        if "_kwargs" in instance_dict:
+            instance_dict["_kwargs"] = {}
+        current = instance_dict.get("child")
+
+
+class BaserowJSONRenderer(JSONRenderer):
+    """
+    DRF creates several reference cycles for every request (see
+    https://github.com/encode/django-rest-framework/issues/7250, acknowledged
+    upstream but never fixed):
+
+    - `Serializer.data` returns a `ReturnList`/`ReturnDict` with a `serializer`
+      backreference, while the serializer keeps the same object in `_data`.
+    - `Field.bind` sets `field.parent`, and `BindingDict` keeps a `serializer`
+      backreference, so a serializer and its fields always form cycles, pinning
+      `serializer.instance` and the `_args`/`_kwargs` stashed by `Field.__new__`
+      (which contain the full page of fetched model instances).
+    - `APIView.dispatch` sets `view.response`, and `finalize_response` puts the
+      view, request, and the response itself into `response.renderer_context`,
+      so the response, the rendered content in `response._container`, and the
+      request always form cycles.
+
+    Because of those cycles, the per-request object graph (fetched rows, serialized
+    data, rendered bytes) can never be freed by reference counting; it lingers until
+    Python's cyclic garbage collector runs a full pass, which is allocation-triggered
+    and therefore never happens on an idle worker. For large responses that looks like
+    a memory leak.
+
+    The `serializer` backreference and the renderer context exist purely so that
+    renderers, in practice only the browsable API's `HTMLFormRenderer`, can inspect
+    them while rendering. The JSON renderer is the last consumer of both, so after
+    producing the bytes it can sever these references. That makes the whole payload
+    reference-count collectable the moment the handler drops the response, leaving only
+    the small serializer/view skeleton for the regular garbage collector.
+
+    A `JSONRenderer` that, after rendering, breaks the DRF reference cycles described
+    in this module's docstring so the per-request payload is freed by reference
+    counting instead of lingering as cyclic garbage. The browsable API and any other
+    renderer are unaffected because they use their own renderer classes.
+    """
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        rendered = super().render(data, accepted_media_type, renderer_context)
+
+        # The serializer output is either the data itself or, for paginated and
+        # composite responses, one of the top level values (e.g. under `results`).
+        candidates = [data]
+        if isinstance(data, dict):
+            candidates += list(data.values())
+        for candidate in candidates:
+            serializer = getattr(candidate, "serializer", None)
+            if serializer is not None:
+                _release_serializer_references(serializer)
+
+        if isinstance(renderer_context, dict):
+            view = renderer_context.get("view")
+            if view is not None:
+                view.response = None
+                view.request = None
+                view.args = ()
+                view.kwargs = {}
+            response = renderer_context.get("response")
+            renderer_context.clear()
+            if response is not None:
+                response.renderer_context = None
+
+        return rendered

--- a/backend/src/baserow/config/asgi.py
+++ b/backend/src/baserow/config/asgi.py
@@ -1,10 +1,11 @@
+import django
 from django.conf import settings
-from django.core.asgi import get_asgi_application
 from django.urls import re_path
 
 from channels.routing import ProtocolTypeRouter, URLRouter
 
 from baserow.config.helpers import (
+    BaserowASGIHandler,
     ConcurrencyLimiterASGI,
     check_lazy_loaded_libraries,
     log_env_warnings,
@@ -16,7 +17,10 @@ from baserow.ws.routers import websocket_router
 # The telemetry instrumentation library setup needs to run prior to django's setup.
 setup_telemetry(add_django_instrumentation=True)
 
-django_asgi_app = get_asgi_application()
+# Same as django.core.asgi.get_asgi_application, but with Baserow's ASGI handler that
+# doesn't keep per-request memory alive in reference cycles.
+django.setup(set_prefix=False)
+django_asgi_app = BaserowASGIHandler()
 
 # Check that libraries meant to be lazy-loaded haven't been imported at startup.
 # This runs after Django is fully loaded, so it catches imports from all apps.

--- a/backend/src/baserow/config/helpers.py
+++ b/backend/src/baserow/config/helpers.py
@@ -61,22 +61,18 @@ class dummy_context:
 
 class BaserowASGIHandler(ASGIHandler):
     """
-    Django's `ASGIHandler.handle` keeps every request's response, rendered content, and
-    serialized rows in memory long after the response has been sent. Its disconnect
-    watcher raises `RequestAborted`, and when `handle` calls `task.result()` the
-    re-raise grafts the `handle` frame onto the exception's traceback. The exception
-    stays stored on the completed task, the task sits in the `tasks` list in that same
-    frame's locals, so exception -> traceback -> frame -> tasks -> task -> exception
-    forms a reference cycle that pins the frame's `request` and `response` locals until
-    a full cyclic garbage collection pass happens to run.
+    Django's disconnect watcher raises `RequestAborted`, whose traceback ends up in a
+    reference cycle with the `handle` frame that pins the request and response in
+    memory until a full garbage collection pass. On Django 5.2 completing the watcher
+    normally is behavior-identical (`handle` ignores the result and cancels the
+    in-flight request via `asyncio.wait`), and no cycle is created.
 
-    On Django, `handle` treats a disconnect watcher that completed normally exactly the
-    same as one that raised `RequestAborted` (the exception is caught and ignored, and
-    `process_request` is cancelled purely based on `asyncio.wait(FIRST_COMPLETED)`), so
-    returning instead of raising is behavior-identical and never creates the exception,
-    the traceback, or the cycle. Combined with `BaserowJSONRenderer`, this makes the
-    whole per-request object graph reference-count collectable as soon as the response
-    has been sent.
+    Streaming responses are not covered: on mid-stream disconnect an iterator that
+    references the view can still keep the response in a cycle.
+
+    TODO: re-evaluate before Django >= 6.1, where only a raising watcher aborts the
+    in-flight request. `test_handle_cancels_in_flight_request_on_disconnect` fails
+    loudly in that case.
     """
 
     async def listen_for_disconnect(self, receive):

--- a/backend/src/baserow/config/helpers.py
+++ b/backend/src/baserow/config/helpers.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from django.conf import settings
+from django.core.handlers.asgi import ASGIHandler
 
 from loguru import logger
 
@@ -56,6 +57,34 @@ class dummy_context:
 
     async def __aexit__(self, exc_type, exc, traceback):
         pass
+
+
+class BaserowASGIHandler(ASGIHandler):
+    """
+    Django's `ASGIHandler.handle` keeps every request's response, rendered content, and
+    serialized rows in memory long after the response has been sent. Its disconnect
+    watcher raises `RequestAborted`, and when `handle` calls `task.result()` the
+    re-raise grafts the `handle` frame onto the exception's traceback. The exception
+    stays stored on the completed task, the task sits in the `tasks` list in that same
+    frame's locals, so exception -> traceback -> frame -> tasks -> task -> exception
+    forms a reference cycle that pins the frame's `request` and `response` locals until
+    a full cyclic garbage collection pass happens to run.
+
+    On Django, `handle` treats a disconnect watcher that completed normally exactly the
+    same as one that raised `RequestAborted` (the exception is caught and ignored, and
+    `process_request` is cancelled purely based on `asyncio.wait(FIRST_COMPLETED)`), so
+    returning instead of raising is behavior-identical and never creates the exception,
+    the traceback, or the cycle. Combined with `BaserowJSONRenderer`, this makes the
+    whole per-request object graph reference-count collectable as soon as the response
+    has been sent.
+    """
+
+    async def listen_for_disconnect(self, receive):
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            return
+        # This should never happen.
+        assert False, "Invalid ASGI message after request body: %s" % message["type"]
 
 
 class ConcurrencyLimiterASGI:

--- a/backend/src/baserow/config/settings/base.py
+++ b/backend/src/baserow/config/settings/base.py
@@ -404,7 +404,7 @@ REST_FRAMEWORK = {
         "baserow.api.user_sources.authentication.UserSourceJSONWebTokenAuthentication",
         "baserow.api.authentication.JSONWebTokenAuthentication",
     ),
-    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
+    "DEFAULT_RENDERER_CLASSES": ("baserow.api.renderers.BaserowJSONRenderer",),
     "DEFAULT_SCHEMA_CLASS": "baserow.api.openapi.AutoSchema",
 }
 

--- a/backend/tests/baserow/api/test_renderers.py
+++ b/backend/tests/baserow/api/test_renderers.py
@@ -1,0 +1,66 @@
+import gc
+import weakref
+
+from django.shortcuts import reverse
+
+import pytest
+from rest_framework.status import HTTP_200_OK
+
+from baserow.contrib.database.fields.handler import FieldHandler
+
+
+@pytest.mark.django_db
+def test_rendered_response_graph_is_reference_count_collectable(
+    api_client, data_fixture
+):
+    """
+    The BaserowJSONRenderer must sever the DRF reference cycles after rendering,
+    so that the whole per-request payload (fetched rows, serialized data, rendered
+    content) is freed by reference counting alone, without depending on a cyclic
+    garbage collection pass. This is what keeps the worker memory flat when large
+    values are listed.
+    """
+
+    user, jwt_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    field = FieldHandler().create_field(
+        user=user, table=table, type_name="text", name="Notes"
+    )
+    table.get_model().objects.create(**{field.db_column: "value"})
+
+    url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
+
+    gc.collect()
+    gc.disable()
+    try:
+        response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {jwt_token}")
+        assert response.status_code == HTTP_200_OK
+
+        # The renderer must have cleared the cyclic renderer context, while the
+        # public response API stays usable.
+        assert response.renderer_context is None
+        results = response.data["results"]
+        assert results[0][f"field_{field.id}"] == "value"
+
+        # The serializer graph must no longer pin the fetched rows or the
+        # serialized output.
+        serializer = results.serializer
+        assert serializer.instance is None
+        assert serializer._data is None
+        assert serializer.child._args == ()
+
+        # The Django test client attaches `response.json = partial(...,
+        # response)`, a self-cycle that only exists in tests, not in the real
+        # request path, and would mask the behavior being verified here.
+        response.__dict__.pop("json", None)
+
+        response_ref = weakref.ref(response)
+        results_ref = weakref.ref(results)
+        del response, results, serializer
+
+        # The garbage collector is disabled, so these can only be dead if the
+        # object graph was freed by pure reference counting.
+        assert response_ref() is None
+        assert results_ref() is None
+    finally:
+        gc.enable()

--- a/backend/tests/baserow/api/test_renderers.py
+++ b/backend/tests/baserow/api/test_renderers.py
@@ -4,9 +4,11 @@ import weakref
 from django.shortcuts import reverse
 
 import pytest
+from rest_framework import serializers
+from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.status import HTTP_200_OK
 
-from baserow.contrib.database.fields.handler import FieldHandler
+from baserow.api.renderers import BaserowJSONRenderer
 
 
 @pytest.mark.django_db
@@ -23,9 +25,7 @@ def test_rendered_response_graph_is_reference_count_collectable(
 
     user, jwt_token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)
-    field = FieldHandler().create_field(
-        user=user, table=table, type_name="text", name="Notes"
-    )
+    field = data_fixture.create_text_field(table=table, name="Notes")
     table.get_model().objects.create(**{field.db_column: "value"})
 
     url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
@@ -62,5 +62,85 @@ def test_rendered_response_graph_is_reference_count_collectable(
         # object graph was freed by pure reference counting.
         assert response_ref() is None
         assert results_ref() is None
+    finally:
+        gc.enable()
+
+
+def test_renderer_skips_cleanup_when_another_renderer_delegates_to_it():
+    class FakeView:
+        response = "sentinel-response"
+        request = "sentinel-request"
+
+    class FakeResponse:
+        accepted_renderer = BrowsableAPIRenderer()
+
+    view = FakeView()
+    response = FakeResponse()
+    renderer_context = {"view": view, "request": "request", "response": response}
+
+    BaserowJSONRenderer().render({"a": 1}, "application/json", renderer_context)
+
+    assert renderer_context["request"] == "request"
+    assert view.response == "sentinel-response"
+    assert view.request == "sentinel-request"
+
+
+class _NameSerializer(serializers.Serializer):
+    name = serializers.CharField()
+
+
+@pytest.mark.parametrize(
+    "wrap_data",
+    [
+        # Serializer output inside an ordinary list, e.g. the job and
+        # application APIs.
+        lambda data: [data],
+        # The kanban/calendar grouped-row shape.
+        lambda data: {"rows": {"1": {"count": 1, "results": data}}},
+    ],
+)
+def test_renderer_releases_nested_serializer_outputs(wrap_data):
+    serializer = _NameSerializer(instance=[{"name": "a"}], many=True)
+    data = serializer.data
+
+    renderer = BaserowJSONRenderer()
+
+    class FakeResponse:
+        accepted_renderer = renderer
+
+    renderer.render(
+        wrap_data(data),
+        "application/json",
+        {"response": FakeResponse()},
+    )
+
+    assert serializer.instance is None
+    assert serializer._data is None
+    assert serializer.child._args == ()
+
+
+def test_renderer_releases_serializer_context():
+    class Marker:
+        pass
+
+    marker = Marker()
+    serializer = _NameSerializer(
+        instance=[{"name": "a"}], many=True, context={"marker": marker}
+    )
+    data = serializer.data
+
+    renderer = BaserowJSONRenderer()
+
+    class FakeResponse:
+        accepted_renderer = renderer
+
+    renderer.render(data, "application/json", {"response": FakeResponse()})
+
+    marker_ref = weakref.ref(marker)
+    gc.disable()
+    try:
+        del marker
+        # Only dead without gc if the serializer no longer holds the context.
+        assert marker_ref() is None
     finally:
         gc.enable()

--- a/backend/tests/baserow/config/test_asgi_handler.py
+++ b/backend/tests/baserow/config/test_asgi_handler.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from baserow.config.helpers import BaserowASGIHandler
@@ -22,3 +24,64 @@ async def test_listen_for_disconnect_still_asserts_on_invalid_message():
 
     with pytest.raises(AssertionError):
         await handler.listen_for_disconnect(receive)
+
+
+@pytest.mark.asyncio
+async def test_handle_cancels_in_flight_request_on_disconnect():
+    """
+    With a disconnect listener that completes normally instead of raising, `handle()`
+    must still cancel the in-flight request on disconnect. This holds on Django 5.2 but
+    not on Django >= 6.1 (TaskGroup based), where only a raising listener aborts the
+    request. If this test fails after a Django upgrade, the `listen_for_disconnect`
+    override must be reworked.
+    """
+
+    handler = BaserowASGIHandler()
+
+    request_started = asyncio.Event()
+    request_cancelled = False
+
+    async def fake_run_get_response(request):
+        nonlocal request_cancelled
+        request_started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            request_cancelled = True
+            raise
+
+    handler.run_get_response = fake_run_get_response
+
+    body_messages = [{"type": "http.request", "body": b"", "more_body": False}]
+
+    async def receive():
+        if body_messages:
+            return body_messages.pop(0)
+        # Only disconnect once the request is actually in flight, so the cancellation
+        # path is deterministically exercised.
+        await request_started.wait()
+        return {"type": "http.disconnect"}
+
+    sent_messages = []
+
+    async def send(message):
+        sent_messages.append(message)
+
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [],
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1000),
+        "scheme": "http",
+    }
+
+    await asyncio.wait_for(handler(scope, receive, send), timeout=10)
+
+    assert request_cancelled is True
+    # The request never completed, so nothing must have been sent.
+    assert sent_messages == []

--- a/backend/tests/baserow/config/test_asgi_handler.py
+++ b/backend/tests/baserow/config/test_asgi_handler.py
@@ -1,0 +1,24 @@
+import pytest
+
+from baserow.config.helpers import BaserowASGIHandler
+
+
+@pytest.mark.asyncio
+async def test_listen_for_disconnect_returns_instead_of_raising():
+    handler = BaserowASGIHandler.__new__(BaserowASGIHandler)
+
+    async def receive():
+        return {"type": "http.disconnect"}
+
+    assert await handler.listen_for_disconnect(receive) is None
+
+
+@pytest.mark.asyncio
+async def test_listen_for_disconnect_still_asserts_on_invalid_message():
+    handler = BaserowASGIHandler.__new__(BaserowASGIHandler)
+
+    async def receive():
+        return {"type": "http.unexpected"}
+
+    with pytest.raises(AssertionError):
+        await handler.listen_for_disconnect(receive)

--- a/changelog/entries/unreleased/bug/reduces_backend_memory_usage_by_releasing_each_api_responses.json
+++ b/changelog/entries/unreleased/bug/reduces_backend_memory_usage_by_releasing_each_api_responses.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Reduce backend memory usage by releasing each API response's memory right after it is sent",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-16"
+}


### PR DESCRIPTION
### What is in this PR

Django Rest Framework creates several references cycles for every request (see https://github.com/encode/django-rest-framework/issues/7250, acknowledged upstream but never fixed). Because of thos ecycles, the per-request object graph can never be freed by reference counting. It lingers until Python's cyclic garbage collector runs a full pass.

If a table has a cell with a lot of data, and read API requests are being made to that row, then the memory increase becomes apparent. In some cases, it can even result in huge memory spikes. This is currently happening on baserow.io, which causes the pods to automatically restart.

This PR is an attempt to fix this problem. It still requires high memory to serve the API response containing a cell with a lot of data, but it immediately returns the memory when the request is complete. This should mitigate the problem that we have on production.

This is not a 100% for the memory spike because it does spike when loading the data. However, it does significantly mitigate the problem because it's only for a brief moment that it spikes.

### How to test this PR

- Import this workspace export: [export_0763477a-2a6d-4e7b-86e3-512102c206a6.zip](https://github.com/user-attachments/files/30089027/export_0763477a-2a6d-4e7b-86e3-512102c206a6.zip)
- Checkout the develop branch and run the backend server like: `gunicorn -w 1 -b 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker baserow.config.asgi:application`.
- Run `docker stats` to monitor the memory usage of the `baserow-backend-1` container.
- Open the only table of the workspace and observe that memory increases significantly.
- Open the table a couple of times and observe that memory keeps growing. At some point it might decrease.
- Checkout this branch and repeat the process. Observe that memory only increases while the request is being served and immediately decreases after.
- Repeat the process with the wsgi worker `gunicorn -w 1 -b 0.0.0.0:8000 baserow.config.wsgi:application` and confirm the same behavior.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
