### PR TITLE
refactor: truncate text field values at fetch

### DIFF
--- a/backend/src/baserow/contrib/database/fields/field_types.py
+++ b/backend/src/baserow/contrib/database/fields/field_types.py
@@ -215,6 +215,7 @@ from .fields import (
     MultipleSelectManyToManyField,
     SingleSelectForeignKey,
     SyncedUserForeignKeyField,
+    TruncatingTextField,
 )
 from .fields import DurationField as DurationModelField
 from .handler import FieldHandler
@@ -355,7 +356,7 @@ class TextFieldMatchingRegexFieldType(FieldType, ABC):
         )
 
     def get_model_field(self, instance, **kwargs):
-        return models.TextField(
+        return TruncatingTextField(
             default="",
             blank=True,
             null=True,
@@ -421,7 +422,7 @@ class CharFieldMatchingRegexFieldType(TextFieldMatchingRegexFieldType):
         return super().get_serializer_field(instance, **kwargs)
 
     def get_model_field(self, instance, **kwargs):
-        return models.CharField(
+        return TruncatingTextField(
             default="",
             blank=True,
             null=True,
@@ -467,7 +468,7 @@ class TextFieldType(CollationSortMixin, FieldType):
         )
 
     def get_model_field(self, instance, **kwargs):
-        return models.TextField(
+        return TruncatingTextField(
             default=instance.text_default or None,
             blank=True,
             null=True,
@@ -545,7 +546,7 @@ class LongTextFieldType(CollationSortMixin, FieldType):
         }
 
     def get_model_field(self, instance, **kwargs):
-        return models.TextField(
+        return TruncatingTextField(
             blank=True, null=True, db_index=instance.db_index, **kwargs
         )
 

--- a/backend/src/baserow/contrib/database/fields/fields.py
+++ b/backend/src/baserow/contrib/database/fields/fields.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 from uuid import UUID
 
+from django.conf import settings
 from django.db import models
 from django.db.models import Field
 from django.db.models.expressions import RawSQL
@@ -20,6 +21,15 @@ from baserow.core.fields import SyncedDateTimeField
 
 class BaserowLastModifiedField(SyncedDateTimeField):
     requires_refresh_after_update = True
+
+
+class TruncatingTextField(models.TextField):
+    def select_format(self, compiler, sql, params):
+        sql, params = super().select_format(compiler, sql, params)
+        max_length = settings.MAX_FIELD_TEXT_LENGTH
+        if max_length is not None:
+            sql = f"LEFT(({sql})::text, {int(max_length)})"
+        return sql, params
 
 
 class IgnoreMissingForwardManyToOneDescriptor(ForwardManyToOneDescriptor):

--- a/backend/tests/baserow/contrib/database/field/test_autonumber_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_autonumber_field_type.py
@@ -299,6 +299,7 @@ def test_undo_redo_update_autonumber_field(data_fixture):
     assert_undo_redo_actions_are_valid(actions, [UpdateFieldActionType])
 
     assert does_field_sequence_exist(autonumber_field.id) is True
+    model = table.get_model()
     row_values = model.objects.values_list(f"field_{autonumber_field.id}", flat=True)
     assert list(row_values) == [1, 2, 3]
 

--- a/backend/tests/baserow/contrib/database/field/test_field_handler.py
+++ b/backend/tests/baserow/contrib/database/field/test_field_handler.py
@@ -1563,7 +1563,7 @@ def test_can_convert_formula_to_numeric_field(data_fixture):
         number_negative=True,
     )
 
-    row.refresh_from_db()
+    row = table.get_model().objects.get(pk=row.id)
     assert getattr(row, field_name) == 1
     assert Field.objects.all().count() == 1
     assert NumberField.objects.all().count() == 1

--- a/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_formula_field_type.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import TextField
 from django.urls import reverse
 
 import pytest
@@ -18,7 +17,10 @@ from baserow.contrib.database.fields.dependencies.update_collector import (
 )
 from baserow.contrib.database.fields.field_cache import FieldCache
 from baserow.contrib.database.fields.field_types import FormulaFieldType
-from baserow.contrib.database.fields.fields import BaserowExpressionField
+from baserow.contrib.database.fields.fields import (
+    BaserowExpressionField,
+    TruncatingTextField,
+)
 from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.contrib.database.fields.models import FormulaField
 from baserow.contrib.database.fields.registries import field_type_registry
@@ -1106,7 +1108,7 @@ def test_can_cache_and_uncache_formula_model_field(
     uncached = generated_models_cache.get("test_formula_key")
     assert uncached == formula_model_field
     assert isinstance(uncached, BaserowExpressionField)
-    assert uncached.__class__ == TextField
+    assert uncached.__class__ == TruncatingTextField
     assert str(uncached.expression) == str(formula_model_field.expression)
 
 

--- a/backend/tests/baserow/contrib/database/field/test_max_field_text_length.py
+++ b/backend/tests/baserow/contrib/database/field/test_max_field_text_length.py
@@ -44,7 +44,7 @@ def test_text_field_serializer_enforces_length_limit(
 @pytest.mark.django_db
 @pytest.mark.parametrize("field_type", ["text", "long_text"])
 @override_settings(MAX_FIELD_TEXT_LENGTH=10)
-def test_text_field_returns_existing_values_over_the_limit(
+def test_text_field_truncates_existing_values_over_the_limit(
     api_client, data_fixture, field_type
 ):
     user, jwt_token = data_fixture.create_user_and_token()
@@ -62,7 +62,53 @@ def test_text_field_returns_existing_values_over_the_limit(
     )
     response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {jwt_token}")
     assert response.status_code == HTTP_200_OK
-    assert response.json()[f"field_{field.id}"] == existing
+    assert response.json()[f"field_{field.id}"] == "x" * 10
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_type", ["text", "long_text"])
+@override_settings(MAX_FIELD_TEXT_LENGTH=10)
+def test_text_field_values_are_truncated_at_the_database_level(
+    api_client, data_fixture, field_type
+):
+    user, jwt_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    field = FieldHandler().create_field(
+        user=user, table=table, type_name=field_type, name="Notes"
+    )
+
+    existing = "x" * 20 + "Z"
+    model = table.get_model()
+    row = model.objects.create(**{field.db_column: existing})
+
+    assert getattr(model.objects.get(pk=row.id), field.db_column) == "x" * 10
+
+    assert model.objects.filter(**{f"{field.db_column}__contains": "Z"}).exists()
+
+    url = reverse("api:database:rows:list", kwargs={"table_id": table.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {jwt_token}")
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["results"][0][f"field_{field.id}"] == "x" * 10
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("field_type", ["text", "long_text"])
+@override_settings(MAX_FIELD_TEXT_LENGTH=10)
+def test_grid_view_returns_truncated_text_field_values(
+    api_client, data_fixture, field_type
+):
+    user, jwt_token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    field = FieldHandler().create_field(
+        user=user, table=table, type_name=field_type, name="Notes"
+    )
+    grid = data_fixture.create_grid_view(table=table)
+    table.get_model().objects.create(**{field.db_column: "x" * 25})
+
+    url = reverse("api:database:views:grid:list", kwargs={"view_id": grid.id})
+    response = api_client.get(url, HTTP_AUTHORIZATION=f"JWT {jwt_token}")
+    assert response.status_code == HTTP_200_OK
+    assert response.json()["results"][0][f"field_{field.id}"] == "x" * 10
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/field/test_rating_field_type.py
+++ b/backend/tests/baserow/contrib/database/field/test_rating_field_type.py
@@ -237,6 +237,7 @@ def test_rating_field_modification(data_fixture):
         max_value=3,
     )
 
+    model = table.get_model(attribute_names=True)
     # Check value clamping on max_value modification
     assert [
         (f.id, f.text, f.rating, f.integer, f.decimal, f.boolean)

--- a/changelog/entries/unreleased/bug/applies_the_text_field_character_limit_when_reading_rows.json
+++ b/changelog/entries/unreleased/bug/applies_the_text_field_character_limit_when_reading_rows.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Applies the text field character limit when reading rows",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-16"
+}


### PR DESCRIPTION
### What is in this PR

This PR truncates the fetched value of the text based field types. If a the cell value contains more than the 1m characters, then it will be fetched truncated. We recently implemented a limit that prevents settings more than 1m characters. However, this is not solving the memory problems if there is 50MB of data in a single cell on read requests.

The goal of this PR is to avoid memory spikes when there is a lot of data in the cell. Baserow can't be used with that much data anyway, so there is not need to expose it.

This is not an ideal solution because it slows things down a tiny bit (see table below). And it will truncate existing values that are over the limit. The downside is that if you export a table to CSV, it will also be merged. The reason I'm truncating the value is that I don't want to delete user data. I'm actually doubting if we should merge it. 🤔 

```
Measured on your Postgres (500k rows via EXPLAIN ANALYZE, so pure executor cost, no network):

┌───────────────────────────────┬──────────────────┬────────────────────────────┬────────────────┐
│       Value in the cell       │ plain SELECT col │ LEFT((col)::text, 1000000) │ Extra per cell │
├───────────────────────────────┼──────────────────┼────────────────────────────┼────────────────┤
│ 100 chars ASCII               │ 35ms             │ 120ms                      │ ~0.17µs        │
├───────────────────────────────┼──────────────────┼────────────────────────────┼────────────────┤
│ ~100 chars multibyte (é/漢字) │ 68ms             │ 175ms                      │ ~0.21µs        │
├───────────────────────────────┼──────────────────┼────────────────────────────┼────────────────┤
│ 1000 chars ASCII              │ 119ms            │ 972ms                      │ ~1.7µs         │
└───────────────────────────────┴──────────────────┴────────────────────────────┴────────────────┘
```

### How to test this PR

- Import this workspace export: [export_0763477a-2a6d-4e7b-86e3-512102c206a6.zip](https://github.com/user-attachments/files/30089027/export_0763477a-2a6d-4e7b-86e3-512102c206a6.zip)
- Open the table and confirm that only 1m characters are in the response of the API.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
