### PR TITLE
fix: prevent link row modal from unlinking newly created rows

### DIFF
--- a/changelog/entries/unreleased/bug/5735_fix_link_row_field_modal_unselecting_newly_created_rows_due_.json
+++ b/changelog/entries/unreleased/bug/5735_fix_link_row_field_modal_unselecting_newly_created_rows_due_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix link row field modal unselecting newly created rows due to a race condition with real-time updates",
+    "issue_origin": "github",
+    "issue_number": 5735,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-17"
+}

--- a/web-frontend/modules/database/components/row/SelectRowContent.vue
+++ b/web-frontend/modules/database/components/row/SelectRowContent.vue
@@ -473,7 +473,14 @@ export default {
           {},
           'page/'
         )
-        this.select(populateRow(rowCreated))
+        const populated = populateRow(rowCreated)
+        if (!this.selectedRows.includes(populated.id)) {
+          this.$emit('selected', {
+            row: populated,
+            primary: this.primary,
+            fields: this.fields,
+          })
+        }
       }
     },
     toggleFieldsContext() {

--- a/web-frontend/test/unit/database/components/row/selectRowContent.spec.js
+++ b/web-frontend/test/unit/database/components/row/selectRowContent.spec.js
@@ -5,7 +5,6 @@ import SelectRowContent from '@baserow/modules/database/components/row/SelectRow
 import RowService from '@baserow/modules/database/services/row'
 import FieldService from '@baserow/modules/database/services/field'
 import ViewService from '@baserow/modules/database/services/view'
-import { populateField } from '@baserow/modules/database/store/field'
 
 vi.mock('@baserow/modules/database/services/row', () => ({
   default: vi.fn(),
@@ -123,7 +122,7 @@ describe('SelectRowContent', () => {
 
   test('select() toggles existing row to unselected in multiple mode', async () => {
     setupStoreWithDatabase()
-    const { createFn } = setupServiceMocks()
+    setupServiceMocks()
 
     const wrapper = await mountContent([{ id: 42, value: 'Existing' }])
 

--- a/web-frontend/test/unit/database/components/row/selectRowContent.spec.js
+++ b/web-frontend/test/unit/database/components/row/selectRowContent.spec.js
@@ -1,0 +1,227 @@
+import { flushPromises } from '@vue/test-utils'
+
+import { TestApp } from '@baserow/test/helpers/testApp'
+import SelectRowContent from '@baserow/modules/database/components/row/SelectRowContent'
+import RowService from '@baserow/modules/database/services/row'
+import FieldService from '@baserow/modules/database/services/field'
+import ViewService from '@baserow/modules/database/services/view'
+import { populateField } from '@baserow/modules/database/store/field'
+
+vi.mock('@baserow/modules/database/services/row', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@baserow/modules/database/services/field', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@baserow/modules/database/services/view', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('@baserow/modules/core/utils/indexedDB', () => ({
+  getData: vi.fn().mockResolvedValue(null),
+  setData: vi.fn().mockResolvedValue(undefined),
+}))
+
+const TABLE_ID = 758
+const LINKED_TABLE_ID = 755
+const PRIMARY_FIELD = {
+  id: 100,
+  table_id: TABLE_ID,
+  name: 'Name',
+  type: 'text',
+  primary: true,
+  text_default: '',
+  _: { loading: false },
+}
+const SECONDARY_FIELD = {
+  id: 101,
+  table_id: TABLE_ID,
+  name: 'Email',
+  type: 'text',
+  primary: false,
+  text_default: '',
+  _: { loading: false },
+}
+
+function setupServiceMocks() {
+  const createFn = vi.fn()
+  const fetchAllRows = vi.fn().mockResolvedValue({
+    data: { count: 0, results: [], next: null, previous: null },
+  })
+  RowService.mockReturnValue({ create: createFn, fetchAll: fetchAllRows })
+
+  FieldService.mockReturnValue({
+    fetchAll: vi.fn().mockResolvedValue({
+      data: [{ ...PRIMARY_FIELD }, { ...SECONDARY_FIELD }],
+    }),
+  })
+
+  ViewService.mockReturnValue({
+    fetchAll: vi.fn().mockResolvedValue({ data: [] }),
+    fetchFieldOptions: vi
+      .fn()
+      .mockResolvedValue({ data: { field_options: {} } }),
+  })
+
+  return { createFn, fetchAllRows }
+}
+
+describe('SelectRowContent', () => {
+  let testApp = null
+
+  beforeEach(() => {
+    testApp = new TestApp()
+  })
+
+  afterEach(async () => {
+    await testApp.afterEach()
+    vi.restoreAllMocks()
+  })
+
+  function setupStoreWithDatabase({ withView = false } = {}) {
+    const store = testApp.getStore()
+    store.commit('application/SET_ITEMS', [
+      {
+        id: 1,
+        type: 'database',
+        workspace: { id: 1 },
+        tables: [{ id: TABLE_ID, name: 'Team members' }],
+      },
+    ])
+    if (withView) {
+      store.state.view.selected = {
+        id: 3387,
+        type: 'grid',
+        table_id: LINKED_TABLE_ID,
+      }
+    } else {
+      store.state.view.selected = { id: 0 }
+    }
+  }
+
+  async function mountContent(valueArray = []) {
+    const wrapper = await testApp.mount(SelectRowContent, {
+      props: {
+        tableId: TABLE_ID,
+        value: valueArray,
+        multiple: true,
+      },
+      global: {
+        stubs: {
+          RowCreateModal: true,
+          SimpleGrid: true,
+          ViewFieldsContext: true,
+          Paginator: true,
+        },
+      },
+    })
+    await flushPromises()
+    return wrapper
+  }
+
+  test('select() toggles existing row to unselected in multiple mode', async () => {
+    setupStoreWithDatabase()
+    const { createFn } = setupServiceMocks()
+
+    const wrapper = await mountContent([{ id: 42, value: 'Existing' }])
+
+    wrapper.vm.select({ id: 42 })
+
+    const events = wrapper.emitted()
+    expect(events.unselected).toHaveLength(1)
+    expect(events.unselected[0][0].row.id).toBe(42)
+    expect(events.selected).toBeUndefined()
+  })
+
+  test('select() emits selected for new row in multiple mode', async () => {
+    setupStoreWithDatabase()
+    setupServiceMocks()
+
+    const wrapper = await mountContent([])
+
+    wrapper.vm.select({ id: 42 })
+
+    const events = wrapper.emitted()
+    expect(events.selected).toHaveLength(1)
+    expect(events.selected[0][0].row.id).toBe(42)
+    expect(events.unselected).toBeUndefined()
+  })
+
+  test('createRow does not unselect when WebSocket already added row to value', async () => {
+    setupStoreWithDatabase({ withView: true })
+    const { createFn, fetchAllRows } = setupServiceMocks()
+
+    const createdRowId = 99
+    createFn.mockResolvedValue({
+      data: { id: createdRowId, field_100: 'New Member', field_101: '' },
+    })
+    fetchAllRows.mockResolvedValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: createdRowId, field_100: 'New Member', field_101: '' }],
+      },
+    })
+
+    // Mount with value already containing the new row — simulates WebSocket
+    // having delivered rows_updated before createRow finishes.
+    const wrapper = await mountContent([
+      { id: createdRowId, value: 'New Member' },
+    ])
+
+    const callback = vi.fn()
+    await wrapper.vm.createRow({
+      row: { field_100: 'New Member' },
+      callback,
+    })
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    const events = wrapper.emitted()
+    // Must NOT emit 'unselected' — that's the bug
+    expect(events.unselected).toBeUndefined()
+    // Should NOT emit 'selected' either — row is already linked via WebSocket
+    expect(events.selected).toBeUndefined()
+  })
+
+  test('createRow emits selected when WebSocket has not yet arrived', async () => {
+    setupStoreWithDatabase({ withView: true })
+    const { createFn, fetchAllRows } = setupServiceMocks()
+
+    const createdRowId = 99
+    createFn.mockResolvedValue({
+      data: { id: createdRowId, field_100: 'New Member', field_101: '' },
+    })
+    fetchAllRows.mockResolvedValue({
+      data: {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [{ id: createdRowId, field_100: 'New Member', field_101: '' }],
+      },
+    })
+
+    // Mount with empty value — WebSocket hasn't arrived yet
+    const wrapper = await mountContent([])
+
+    const callback = vi.fn()
+    await wrapper.vm.createRow({
+      row: { field_100: 'New Member' },
+      callback,
+    })
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    const events = wrapper.emitted()
+    // Must emit 'selected' to link the row
+    expect(events.selected).toHaveLength(1)
+    expect(events.selected[0][0].row.id).toBe(createdRowId)
+    // Must NOT emit 'unselected'
+    expect(events.unselected).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #5735 

## Summary
- Fix race condition where a WebSocket update arriving before the post-creation callback caused the selection modal to toggle the new row OFF instead of keeping it linked
- Replace toggle-based `select()` call in `createRow` with a direct `'selected'` emit that skips if the row is already linked
- Add unit tests for `SelectRowContent` covering both race condition outcomes

## Test plan
1. Open a row with a link row field, open the selection modal, create a new row via "+", verify it stays linked
2. Verify existing linked rows can still be toggled on/off by clicking in the modal
3. Run `just f yarn test:core test/unit/database/components/row/selectRowContent.spec.js`
4. If original code is restored `createRow does not unselect when WS arrived` test will fail.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
