### PR TITLE
Prevent impersonating deactivated users

### DIFF
--- a/backend/src/baserow/api/admin/users/serializers.py
+++ b/backend/src/baserow/api/admin/users/serializers.py
@@ -156,9 +156,9 @@ class BaserowImpersonateAuthTokenSerializer(serializers.Serializer):
     """
 
     User = get_user_model()
-    # It's not allowed to impersonate a superuser or staff.
+    # It's not allowed to impersonate a superuser, staff or deactivated user.
     user = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.filter(is_superuser=False, is_staff=False)
+        queryset=User.objects.filter(is_superuser=False, is_staff=False, is_active=True)
     )
 
     class Meta:

--- a/backend/src/baserow/api/admin/users/views.py
+++ b/backend/src/baserow/api/admin/users/views.py
@@ -299,7 +299,8 @@ class UserAdminImpersonateView(GenericAPIView):
         description=(
             "This endpoint allows staff to impersonate another user by requesting a "
             "JWT token and user object. The requesting user must have staff access in "
-            "order to do this. It's not possible to impersonate a superuser or staff."
+            "order to do this. It's not possible to impersonate a superuser, staff "
+            "or deactivated user."
         ),
         request=BaserowImpersonateAuthTokenSerializer,
         responses={

--- a/backend/tests/baserow/api/admin/users/test_users_admin_views.py
+++ b/backend/tests/baserow/api/admin/users/test_users_admin_views.py
@@ -1008,6 +1008,32 @@ def test_admin_impersonate_staff_or_superuser(api_client, data_fixture):
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_admin_impersonate_deactivated_user(api_client, data_fixture):
+    _, token = data_fixture.create_user_and_token(
+        email="test@test.nl",
+        password="password",
+        first_name="Test1",
+        is_staff=True,
+    )
+    user_to_impersonate = data_fixture.create_user(
+        email="specific_user@test.nl",
+        password="password",
+        first_name="Test1",
+        is_active=False,
+    )
+    response = api_client.post(
+        reverse("api:admin:users:impersonate"),
+        {"user": user_to_impersonate.id},
+        format="json",
+        HTTP_AUTHORIZATION=f"JWT {token}",
+    )
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    response_json = response.json()
+    assert response_json["user"][0].startswith("Invalid pk")
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_admin_users_endpoint_includes_two_factor_auth(api_client, data_fixture):
     staff_user, token = data_fixture.create_user_and_token(
         email="staff@test.nl",

--- a/changelog/entries/unreleased/bug/prevent_impersonating_deactivated_users_via_the_admin_impers.json
+++ b/changelog/entries/unreleased/bug/prevent_impersonating_deactivated_users_via_the_admin_impers.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Prevent impersonating deactivated users via the admin impersonate endpoint",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-20"
+}


### PR DESCRIPTION
### What is in this PR

Currently, it's possible to use the impersonate endpoint to obtain a token for a deactivate user. This token can't be used anywere. This PR prevents obtain that token.

### How to test this PR

- Deactivate a user.
- Use the `/api/admin/users/impersonate/`endpoint to confirm that it responds with a 400 error.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
