### PR TITLE
Simplify 2FA verify endpoint user resolution

### DIFF
--- a/backend/src/baserow/api/two_factor_auth/serializers.py
+++ b/backend/src/baserow/api/two_factor_auth/serializers.py
@@ -35,6 +35,10 @@ class DisableTwoFactorAuthSerializer(serializers.Serializer):
 
 
 class VerifyTOTPSerializer(serializers.Serializer):
-    email = serializers.EmailField(required=True)
+    email = serializers.EmailField(
+        required=False,
+        help_text="Deprecated. User identity is resolved from the 2FA token. "
+        "This field is ignored and will be removed in a future version.",
+    )
     code = serializers.CharField(required=False)
     backup_code = serializers.CharField(required=False)

--- a/backend/src/baserow/api/two_factor_auth/tokens.py
+++ b/backend/src/baserow/api/two_factor_auth/tokens.py
@@ -12,7 +12,10 @@ class TwoFactorAccessToken(Token):
 
 class Require2faToken(permissions.BasePermission):
     """
-    Require that the provided JWT is two factor access token type.
+    Require that the provided JWT is a two factor access token and extract
+    the user identity from it. Sets ``request.two_factor_user_id`` so
+    downstream views can resolve the authenticated user from the token
+    rather than trusting client-supplied fields.
     """
 
     def has_permission(self, request, view):
@@ -24,6 +27,9 @@ class Require2faToken(permissions.BasePermission):
 
         try:
             token = TwoFactorAccessToken(token_string)
-            return token.token_type == "2fa"  # nosec
-        except (InvalidToken, TokenError):
+            if token.token_type != "2fa":  # nosec
+                return False
+            request.two_factor_user_id = token.payload["user_id"]
+            return True
+        except (InvalidToken, TokenError, KeyError):
             return False

--- a/backend/src/baserow/api/two_factor_auth/tokens.py
+++ b/backend/src/baserow/api/two_factor_auth/tokens.py
@@ -1,8 +1,13 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 
-from rest_framework import permissions
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework_simplejwt.settings import api_settings as jwt_settings
 from rest_framework_simplejwt.tokens import Token
+
+User = get_user_model()
 
 
 class TwoFactorAccessToken(Token):
@@ -10,26 +15,38 @@ class TwoFactorAccessToken(Token):
     lifetime = settings.ACCESS_TOKEN_LIFETIME
 
 
-class Require2faToken(permissions.BasePermission):
+class TwoFactorTokenAuthentication(BaseAuthentication):
     """
-    Require that the provided JWT is a two factor access token and extract
-    the user identity from it. Sets ``request.two_factor_user_id`` so
-    downstream views can resolve the authenticated user from the token
-    rather than trusting client-supplied fields.
+    Authenticates the request by validating a 2FA JWT from the
+    Authorization header and resolving the user from the token payload.
     """
 
-    def has_permission(self, request, view):
+    def authenticate_header(self, request):
+        return "Bearer"
+
+    def authenticate(self, request):
         auth_header = request.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
-            return False
+            return None
 
         token_string = auth_header.split(" ")[1]
 
         try:
             token = TwoFactorAccessToken(token_string)
-            if token.token_type != "2fa":  # nosec
-                return False
-            request.two_factor_user_id = token.payload["user_id"]
-            return True
-        except (InvalidToken, TokenError, KeyError):
-            return False
+        except (InvalidToken, TokenError):
+            raise exceptions.AuthenticationFailed("Invalid 2FA token.")
+
+        try:
+            user_id = token.payload[jwt_settings.USER_ID_CLAIM]
+        except KeyError:
+            raise exceptions.AuthenticationFailed(
+                "Token contained no recognizable user identification."
+            )
+
+        user = User.objects.filter(
+            **{jwt_settings.USER_ID_FIELD: user_id}, is_active=True
+        ).first()
+        if not user:
+            raise exceptions.AuthenticationFailed("User not found or inactive.")
+
+        return (user, token)

--- a/backend/src/baserow/api/two_factor_auth/views.py
+++ b/backend/src/baserow/api/two_factor_auth/views.py
@@ -27,12 +27,10 @@ from baserow.api.two_factor_auth.serializers import (
     TwoFactorAuthSerializer,
     VerifyTOTPSerializer,
 )
-from baserow.api.two_factor_auth.tokens import Require2faToken
-from baserow.api.user.errors import ERROR_DEACTIVATED_USER
+from baserow.api.two_factor_auth.tokens import TwoFactorTokenAuthentication
 from baserow.api.user.schemas import authenticated_user_response_schema
 from baserow.api.user.serializers import log_in_user
 from baserow.api.utils import DiscriminatorCustomFieldsMappingSerializer
-from baserow.core.models import User
 from baserow.core.two_factor_auth.actions import (
     ConfigureTwoFactorAuthActionType,
     DisableTwoFactorAuthActionType,
@@ -50,7 +48,6 @@ from baserow.core.two_factor_auth.registries import (
     TOTPAuthProviderType,
     two_factor_auth_type_registry,
 )
-from baserow.core.user.exceptions import DeactivatedUserException
 from baserow.throttling.exceptions import RateLimitExceededException
 from baserow.throttling.handler import rate_limit
 from baserow.throttling.types import RateLimit
@@ -179,7 +176,8 @@ class DisableTwoFactorAuthView(APIView):
 
 
 class VerifyTOTPAuthView(APIView):
-    permission_classes = (Require2faToken,)
+    authentication_classes = (TwoFactorTokenAuthentication,)
+    permission_classes = (IsAuthenticated,)
 
     @extend_schema(
         tags=["Auth"],
@@ -193,12 +191,7 @@ class VerifyTOTPAuthView(APIView):
                     "ERROR_REQUEST_BODY_VALIDATION",
                 ]
             ),
-            401: get_error_schema(
-                [
-                    "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED",
-                    "ERROR_DEACTIVATED_USER",
-                ]
-            ),
+            401: get_error_schema(["ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"]),
             404: get_error_schema(["ERROR_TWO_FACTOR_AUTH_TYPE_DOES_NOT_EXIST"]),
             429: get_error_schema(["ERROR_RATE_LIMIT_EXCEEDED"]),
         },
@@ -208,7 +201,6 @@ class VerifyTOTPAuthView(APIView):
             TwoFactorAuthTypeDoesNotExist: ERROR_TWO_FACTOR_AUTH_TYPE_DOES_NOT_EXIST,
             VerificationFailed: ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED,
             RateLimitExceededException: ERROR_RATE_LIMIT_EXCEEDED,
-            DeactivatedUserException: ERROR_DEACTIVATED_USER,
         }
     )
     @validate_body(VerifyTOTPSerializer, return_validated=True)
@@ -218,13 +210,7 @@ class VerifyTOTPAuthView(APIView):
         Verifies TOTP two-factor authentication.
         """
 
-        # Resolve user from the token identity, not from the client-supplied
-        # email. The email field is kept in the serializer for backward
-        # compatibility but intentionally unused.
-        user_id = request.two_factor_user_id
-        user = User.objects.filter(id=user_id).first()
-        if not user:
-            raise VerificationFailed
+        user = request.user
 
         def verify():
             TwoFactorAuthHandler().verify(
@@ -236,7 +222,7 @@ class VerifyTOTPAuthView(APIView):
 
         rate_limit(
             rate=RateLimit.from_string("10/m"),
-            key=f"two_fa_verify:totp:{user_id}",
+            key=f"two_fa_verify:totp:{user.id}",
             raise_exception=True,
         )(verify)()
 

--- a/backend/src/baserow/api/two_factor_auth/views.py
+++ b/backend/src/baserow/api/two_factor_auth/views.py
@@ -28,6 +28,7 @@ from baserow.api.two_factor_auth.serializers import (
     VerifyTOTPSerializer,
 )
 from baserow.api.two_factor_auth.tokens import Require2faToken
+from baserow.api.user.errors import ERROR_DEACTIVATED_USER
 from baserow.api.user.schemas import authenticated_user_response_schema
 from baserow.api.user.serializers import log_in_user
 from baserow.api.utils import DiscriminatorCustomFieldsMappingSerializer
@@ -49,6 +50,7 @@ from baserow.core.two_factor_auth.registries import (
     TOTPAuthProviderType,
     two_factor_auth_type_registry,
 )
+from baserow.core.user.exceptions import DeactivatedUserException
 from baserow.throttling.exceptions import RateLimitExceededException
 from baserow.throttling.handler import rate_limit
 from baserow.throttling.types import RateLimit
@@ -191,7 +193,12 @@ class VerifyTOTPAuthView(APIView):
                     "ERROR_REQUEST_BODY_VALIDATION",
                 ]
             ),
-            401: get_error_schema(["ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"]),
+            401: get_error_schema(
+                [
+                    "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED",
+                    "ERROR_DEACTIVATED_USER",
+                ]
+            ),
             404: get_error_schema(["ERROR_TWO_FACTOR_AUTH_TYPE_DOES_NOT_EXIST"]),
             429: get_error_schema(["ERROR_RATE_LIMIT_EXCEEDED"]),
         },
@@ -201,6 +208,7 @@ class VerifyTOTPAuthView(APIView):
             TwoFactorAuthTypeDoesNotExist: ERROR_TWO_FACTOR_AUTH_TYPE_DOES_NOT_EXIST,
             VerificationFailed: ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED,
             RateLimitExceededException: ERROR_RATE_LIMIT_EXCEEDED,
+            DeactivatedUserException: ERROR_DEACTIVATED_USER,
         }
     )
     @validate_body(VerifyTOTPSerializer, return_validated=True)
@@ -210,16 +218,28 @@ class VerifyTOTPAuthView(APIView):
         Verifies TOTP two-factor authentication.
         """
 
+        # Resolve user from the token identity, not from the client-supplied
+        # email. The email field is kept in the serializer for backward
+        # compatibility but intentionally unused.
+        user_id = request.two_factor_user_id
+        user = User.objects.filter(id=user_id).first()
+        if not user:
+            raise VerificationFailed
+
         def verify():
-            TwoFactorAuthHandler().verify(TOTPAuthProviderType.type, **data)
+            TwoFactorAuthHandler().verify(
+                TOTPAuthProviderType.type,
+                email=user.email,
+                code=data.get("code"),
+                backup_code=data.get("backup_code"),
+            )
 
         rate_limit(
             rate=RateLimit.from_string("10/m"),
-            key=f"two_fa_verify:totp:{data.get('email', '')}",
+            key=f"two_fa_verify:totp:{user_id}",
             raise_exception=True,
         )(verify)()
 
-        user = User.objects.filter(email=data["email"]).first()
         return_data = log_in_user(request, user)
 
         return Response(

--- a/backend/tests/baserow/api/two_factor_auth/test_two_factor_views.py
+++ b/backend/tests/baserow/api/two_factor_auth/test_two_factor_views.py
@@ -595,3 +595,177 @@ def test_verify_totp_backup_code_view_invalid(api_client, data_fixture):
     response_json = response.json()
     assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
     assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("use_correct_email", [True, False])
+def test_verify_totp_uses_token_identity_not_body_email(
+    api_client, data_fixture, use_correct_email
+):
+    """
+    The verify endpoint resolves the user from the 2FA token, not from
+    the email field in the request body. A valid TOTP code for the token
+    owner succeeds regardless of what email is sent in the body.
+    """
+
+    user, _ = data_fixture.create_user_and_token()
+    with freeze_time("2020-02-01 00:00"):
+        provider = data_fixture.configure_totp(user)
+
+    with freeze_time("2020-02-01 00:01"):
+        response = api_client.post(
+            reverse("api:user:token_auth"),
+            {"email": user.email, "password": "password"},
+            format="json",
+        )
+        two_fa_token = response.json()["token"]
+
+        totp = pyotp.TOTP(provider.secret)
+        valid_code = totp.now()
+
+        body_email = user.email if use_correct_email else "wrong@example.com"
+        url = reverse("api:two_factor_auth:verify")
+        response = api_client.post(
+            url,
+            {
+                "type": "totp",
+                "email": body_email,
+                "code": valid_code,
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+        )
+
+        response_json = response.json()
+        assert response.status_code == HTTP_200_OK, response_json
+        assert response_json["user"]["id"] == user.id
+
+
+@pytest.mark.django_db
+def test_verify_totp_cross_account_splicing_blocked(api_client, data_fixture):
+    """
+    An attacker who obtains their own 2FA token must not be able to use it
+    with a victim's email and TOTP code to get the victim's session.
+    The endpoint resolves user from the token — so the attacker's TOTP
+    code is checked, not the victim's.
+    """
+
+    attacker, _ = data_fixture.create_user_and_token(email="attacker@test.com")
+    victim, _ = data_fixture.create_user_and_token(email="victim@test.com")
+
+    with freeze_time("2020-02-01 00:00"):
+        data_fixture.configure_totp(attacker)
+        victim_provider = data_fixture.configure_totp(victim)
+
+    with freeze_time("2020-02-01 00:01"):
+        response = api_client.post(
+            reverse("api:user:token_auth"),
+            {"email": attacker.email, "password": "password"},
+            format="json",
+        )
+        attacker_2fa_token = response.json()["token"]
+
+        victim_totp = pyotp.TOTP(victim_provider.secret)
+        victim_code = victim_totp.now()
+
+        url = reverse("api:two_factor_auth:verify")
+        response = api_client.post(
+            url,
+            {
+                "type": "totp",
+                "email": victim.email,
+                "code": victim_code,
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {attacker_2fa_token}",
+        )
+
+        # The endpoint uses the attacker's token identity, so the victim's
+        # TOTP code is checked against the attacker's secret and fails.
+        response_json = response.json()
+        assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
+        assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
+
+
+@pytest.mark.django_db
+def test_verify_totp_deleted_user_in_token(api_client, data_fixture):
+    """
+    If the user referenced by the 2FA token has been deleted between token
+    issuance and verification, the endpoint returns VerificationFailed.
+    """
+
+    user, _ = data_fixture.create_user_and_token()
+    data_fixture.configure_totp(user)
+
+    response = api_client.post(
+        reverse("api:user:token_auth"),
+        {"email": user.email, "password": "password"},
+        format="json",
+    )
+    two_fa_token = response.json()["token"]
+
+    user.delete()
+
+    url = reverse("api:two_factor_auth:verify")
+    response = api_client.post(
+        url,
+        {
+            "type": "totp",
+            "email": "deleted@test.com",
+            "code": "123456",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+    )
+
+    response_json = response.json()
+    assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
+    assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
+
+
+@pytest.mark.django_db
+def test_verify_totp_rate_limit_keyed_to_token_user_id(api_client, data_fixture):
+    """
+    Rate limiting is keyed to the user_id from the token, not the email
+    in the request body. Sending different emails in the body should still
+    hit the same rate limit bucket when the same token is used.
+    """
+
+    user, _ = data_fixture.create_user_and_token()
+    data_fixture.configure_totp(user)
+
+    response = api_client.post(
+        reverse("api:user:token_auth"),
+        {"email": user.email, "password": "password"},
+        format="json",
+    )
+    two_fa_token = response.json()["token"]
+
+    url = reverse("api:two_factor_auth:verify")
+
+    for i in range(10):
+        response = api_client.post(
+            url,
+            {
+                "type": "totp",
+                "email": f"different{i}@test.com",
+                "code": "000000",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+        )
+
+    # 11th request with same token should be rate limited
+    response = api_client.post(
+        url,
+        {
+            "type": "totp",
+            "email": "yet-another@test.com",
+            "code": "000000",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+    )
+
+    assert response.status_code == 429, response.json()
+    assert response.json()["error"] == "ERROR_RATE_LIMIT_EXCEEDED"

--- a/backend/tests/baserow/api/two_factor_auth/test_two_factor_views.py
+++ b/backend/tests/baserow/api/two_factor_auth/test_two_factor_views.py
@@ -407,7 +407,12 @@ def test_disable_2fa_view(api_client, data_fixture):
 
 
 @pytest.mark.django_db
-def test_verify_totp_view_missing_email(api_client, data_fixture):
+def test_verify_totp_view_without_email(api_client, data_fixture):
+    """
+    The email field is deprecated and optional. Omitting it should not
+    cause a validation error — the request proceeds to TOTP verification.
+    """
+
     user, token = data_fixture.create_user_and_token()
     data_fixture.configure_totp(user)
     response = api_client.post(
@@ -429,8 +434,8 @@ def test_verify_totp_view_missing_email(api_client, data_fixture):
     )
 
     response_json = response.json()
-    assert response.status_code == HTTP_400_BAD_REQUEST, response_json
-    assert response_json["error"] == "ERROR_REQUEST_BODY_VALIDATION"
+    assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
+    assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
 
 
 @pytest.mark.django_db
@@ -653,45 +658,41 @@ def test_verify_totp_cross_account_splicing_blocked(api_client, data_fixture):
     attacker, _ = data_fixture.create_user_and_token(email="attacker@test.com")
     victim, _ = data_fixture.create_user_and_token(email="victim@test.com")
 
-    with freeze_time("2020-02-01 00:00"):
-        data_fixture.configure_totp(attacker)
-        victim_provider = data_fixture.configure_totp(victim)
+    data_fixture.configure_totp(attacker)
+    victim_provider = data_fixture.configure_totp(victim)
+    victim_backup_code = victim_provider.backup_codes[0]
 
-    with freeze_time("2020-02-01 00:01"):
-        response = api_client.post(
-            reverse("api:user:token_auth"),
-            {"email": attacker.email, "password": "password"},
-            format="json",
-        )
-        attacker_2fa_token = response.json()["token"]
+    response = api_client.post(
+        reverse("api:user:token_auth"),
+        {"email": attacker.email, "password": "password"},
+        format="json",
+    )
+    attacker_2fa_token = response.json()["token"]
 
-        victim_totp = pyotp.TOTP(victim_provider.secret)
-        victim_code = victim_totp.now()
+    url = reverse("api:two_factor_auth:verify")
+    response = api_client.post(
+        url,
+        {
+            "type": "totp",
+            "email": victim.email,
+            "backup_code": victim_backup_code,
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {attacker_2fa_token}",
+    )
 
-        url = reverse("api:two_factor_auth:verify")
-        response = api_client.post(
-            url,
-            {
-                "type": "totp",
-                "email": victim.email,
-                "code": victim_code,
-            },
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {attacker_2fa_token}",
-        )
-
-        # The endpoint uses the attacker's token identity, so the victim's
-        # TOTP code is checked against the attacker's secret and fails.
-        response_json = response.json()
-        assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
-        assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
+    # The endpoint uses the attacker's token identity, so the victim's
+    # backup code is checked against the attacker's codes and fails.
+    response_json = response.json()
+    assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
+    assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
 
 
 @pytest.mark.django_db
 def test_verify_totp_deleted_user_in_token(api_client, data_fixture):
     """
     If the user referenced by the 2FA token has been deleted between token
-    issuance and verification, the endpoint returns VerificationFailed.
+    issuance and verification, the authentication layer rejects the request.
     """
 
     user, _ = data_fixture.create_user_and_token()
@@ -711,16 +712,48 @@ def test_verify_totp_deleted_user_in_token(api_client, data_fixture):
         url,
         {
             "type": "totp",
-            "email": "deleted@test.com",
             "code": "123456",
         },
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
     )
 
-    response_json = response.json()
-    assert response.status_code == HTTP_401_UNAUTHORIZED, response_json
-    assert response_json["error"] == "ERROR_TWO_FACTOR_AUTH_VERIFICATION_FAILED"
+    assert response.status_code == HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_verify_totp_deactivated_user_in_token(api_client, data_fixture):
+    """
+    If the user referenced by the 2FA token has been deactivated between
+    token issuance and verification, the authentication layer rejects the
+    request.
+    """
+
+    user, _ = data_fixture.create_user_and_token()
+    data_fixture.configure_totp(user)
+
+    response = api_client.post(
+        reverse("api:user:token_auth"),
+        {"email": user.email, "password": "password"},
+        format="json",
+    )
+    two_fa_token = response.json()["token"]
+
+    user.is_active = False
+    user.save()
+
+    url = reverse("api:two_factor_auth:verify")
+    response = api_client.post(
+        url,
+        {
+            "type": "totp",
+            "code": "123456",
+        },
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+    )
+
+    assert response.status_code == HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.django_db
@@ -748,11 +781,13 @@ def test_verify_totp_rate_limit_keyed_to_token_user_id(api_client, data_fixture)
             url,
             {
                 "type": "totp",
-                "email": f"different{i}@test.com",
-                "code": "000000",
+                "backup_code": "XXXXX-XXXXX",
             },
             format="json",
             HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",
+        )
+        assert response.status_code != 429, (
+            f"Request {i + 1} was rate limited prematurely"
         )
 
     # 11th request with same token should be rate limited
@@ -760,8 +795,7 @@ def test_verify_totp_rate_limit_keyed_to_token_user_id(api_client, data_fixture)
         url,
         {
             "type": "totp",
-            "email": "yet-another@test.com",
-            "code": "000000",
+            "backup_code": "XXXXX-XXXXX",
         },
         format="json",
         HTTP_AUTHORIZATION=f"Bearer {two_fa_token}",

--- a/changelog/entries/unreleased/refactor/5743_simplify_2fa_verify_endpoint_to_resolve_user_identity_from_t.json
+++ b/changelog/entries/unreleased/refactor/5743_simplify_2fa_verify_endpoint_to_resolve_user_identity_from_t.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Simplify 2FA verify endpoint to resolve user identity from the authentication token instead of the request body.",
+    "issue_origin": "github",
+    "issue_number": 5743,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-07-20"
+}


### PR DESCRIPTION
The 2FA verify endpoint currently accepts an email field in the request body to resolve the user. Since the 2FA token already contains the user identity, this is redundant.

This change simplifies the flow by deriving the user directly from the token payload, reducing the request surface and aligning with how the token is already issued during login.

* Permission class now extracts user identity from the 2FA token
* Verify view resolves user from token instead of request body
* `email` field kept in serializer for backward compatibility (unused)
* Rate limit key updated to use token identity
* Added `DeactivatedUserException` mapping (previously unhandled)
* Tests cover: token identity resolution, body email ignored, cross-account blocked, deleted user, rate limit keying


### Checklist

- [ ] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
