### PR TITLE
fix: resolve search/filter/sort race condition in grid view refresh

### DIFF
--- a/changelog/entries/unreleased/bug/5764_fixed_a_race_condition_where_changing_search_terms_filters_o.json
+++ b/changelog/entries/unreleased/bug/5764_fixed_a_race_condition_where_changing_search_terms_filters_o.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed a race condition where changing search terms, filters, or sort order during an in-flight request could display stale rows",
+    "issue_origin": "github",
+    "issue_number": 5764,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-21"
+}

--- a/web-frontend/modules/core/utils/queue.js
+++ b/web-frontend/modules/core/utils/queue.js
@@ -24,14 +24,18 @@ export class Task {
   }
 }
 export class TaskQueue {
-  constructor({ doneCallback = null }) {
+  constructor({ doneCallback = null, onSuperseded = null }) {
     this.queue = []
     this.running = false
     this.locked = false
     this.doneCallback = doneCallback
+    this.onSuperseded = onSuperseded
   }
 
   add(func) {
+    if (this.running && this.onSuperseded) {
+      this.onSuperseded()
+    }
     const task = new Task(uuid(), func)
     this.queue.push(task)
     return task.uid

--- a/web-frontend/modules/database/components/table/Table.vue
+++ b/web-frontend/modules/database/components/table/Table.vue
@@ -264,7 +264,7 @@ import ShareViewLink from '@baserow/modules/database/components/view/ShareViewLi
 import ExternalLinkBaserowLogo from '@baserow/modules/core/components/ExternalLinkBaserowLogo'
 import ViewGroupBy from '@baserow/modules/database/components/view/ViewGroupBy'
 import DefaultErrorPage from '@baserow/modules/core/components/DefaultErrorPage'
-import { waitFor } from '@baserow/modules/core/utils/queue'
+import { TaskQueue } from '@baserow/modules/core/utils/queue'
 
 /**
  * This page component is the skeleton for a table. Depending on the selected view it
@@ -365,9 +365,22 @@ export default {
       // Indicates if the elements within the header are overflowing. In case of true,
       // we can hide certain values to make sure that it fits within the header.
       headerOverflow: false,
-      // Indicates whether the table is currently being refreshed using via the
-      // `refresh-table` signal.
-      isRefreshing: false,
+      // Serializes concurrent refresh calls so each runs to completion before
+      // the next starts. Sets viewLoading to false when the queue drains.
+      refreshQueue: new TaskQueue({
+        doneCallback: () => {
+          this.$nextTick(() => {
+            this.viewLoading = false
+          })
+        },
+        onSuperseded: () => {
+          try {
+            this.$store.dispatch(this.storePrefix + 'view/grid/abortRefresh')
+          } catch {
+            // Non-grid view types don't have abortRefresh.
+          }
+        },
+      }),
     }
   },
   computed: {
@@ -580,9 +593,6 @@ export default {
      * the same as seeing the view for the first time.
      */
     async refresh(event) {
-      // If could be that the refresh event is for a specific table and in table case
-      // we check if the refresh event is related to this table and stop if that is not
-      // the case.
       if (
         typeof event === 'object' &&
         Object.prototype.hasOwnProperty.call(event, 'tableId') &&
@@ -597,23 +607,6 @@ export default {
         }
       }
 
-      if (this.isRefreshing) {
-        try {
-          // If the table is already refreshing, then we don't have to do anything,
-          // apart from waiting for the refresh to complete.
-          await waitFor(() => !this.isRefreshing, 5, 30000)
-        } catch (error) {
-          // If the timeout is reached, then the table has been refreshing for too
-          // long
-        }
-        // Regardless of the refreshing was completed, the callback must be called,
-        // otherwise, the state of the table might not be updated correctly.
-        await callCallback()
-        return
-      }
-
-      this.isRefreshing = true
-
       const includeFieldOptions =
         typeof event === 'object' ? event.includeFieldOptions : false
 
@@ -624,42 +617,32 @@ export default {
 
       this.viewLoading = true
       const type = this.$registry.get('view', this.view.type)
-      try {
-        await type.refresh(
-          { store: this.$store, app: this },
-          this.database,
-          this.view,
-          fieldsToRefresh,
-          this.storePrefix,
-          includeFieldOptions,
-          event?.sourceEvent
-        )
-      } catch (error) {
-        if (error instanceof RefreshCancelledError) {
-          // Multiple refresh calls have been made and the view has indicated that
-          // this particular one should be cancelled. However we do not want to
-          // set viewLoading back to false as the other non cancelled call/s might
-          // still be loading.
-          return
-        } else {
+
+      const taskId = this.refreshQueue.add(async () => {
+        try {
+          await type.refresh(
+            { store: this.$store, app: this },
+            this.database,
+            this.view,
+            fieldsToRefresh,
+            this.storePrefix,
+            includeFieldOptions,
+            event?.sourceEvent
+          )
+        } catch (error) {
+          if (error instanceof RefreshCancelledError) {
+            await callCallback()
+            return
+          }
           notifyIf(error)
         }
-      }
-      if (typeof this.$refs.view?.refresh === 'function') {
-        await this.$refs.view.refresh()
-      }
-      // Before the callback is called, mark the table as not refreshing anymore, so
-      // that other callbacks that are waiting can be resolved the moment the table has
-      // been refreshed.
-      this.isRefreshing = false
-      // It might be possible that the event has a callback that needs to be called
-      // after the rows are refreshed. This is for example the case when a field has
-      // changed. In that case we want to update the field in the store after the rows
-      // have been refreshed to prevent incompatible values in field types.
-      await callCallback()
-      this.$nextTick(() => {
-        this.viewLoading = false
+        if (typeof this.$refs.view?.refresh === 'function') {
+          await this.$refs.view.refresh()
+        }
+        await callCallback()
       })
+
+      await this.refreshQueue.waitFor(taskId)
     },
     someViewHasPermission(op) {
       return this.views.some((v) =>

--- a/web-frontend/modules/database/components/view/ViewSearchContext.vue
+++ b/web-frontend/modules/database/components/view/ViewSearchContext.vue
@@ -16,7 +16,6 @@
           :placeholder="$t('viewSearchContext.searchInRows')"
           class="margin-bottom-2"
           :can-clear="true"
-          @keyup="searchIfChanged"
         ></FormInput>
       </div>
       <div
@@ -76,6 +75,11 @@ export default {
       loading: false,
     }
   },
+  watch: {
+    activeSearchTerm() {
+      this.searchIfChanged()
+    },
+  },
   methods: {
     focus() {
       this.$nextTick(function () {
@@ -83,6 +87,8 @@ export default {
       })
     },
     setActiveSearchTerm(value) {
+      this.lastSearch = value
+      this.lastHide = this.hideRowsNotMatchingSearch
       this.activeSearchTerm = value
       this.$emit('search-changed', this.activeSearchTerm)
       this.search(true)

--- a/web-frontend/modules/database/store/view/grid.js
+++ b/web-frontend/modules/database/store/view/grid.js
@@ -2899,19 +2899,28 @@ export const actions = {
       return refresh
     }
 
-    if (lastRefreshRequest !== null) {
-      lastRefreshRequestController.abort()
-    }
+    const searchSnapshot = getters.getServerSearchTerm
+    const searchModeSnapshot = getDefaultSearchModeFromEnv($config)
+    const filtersSnapshot = getFilters(view, adhocFiltering)
+    const orderBySnapshot = getOrderBy(view, adhocSorting)
+    const groupBySnapshot = getGroupBy(
+      rootGetters,
+      getters.getLastGridId,
+      getters.getAdhocGrouping
+    )
+    const isPublic = rootGetters['page/view/public/getIsPublic']
+    const publicAuthToken = rootGetters['page/view/public/getAuthToken']
+
     lastRefreshRequestController = new AbortController()
     lastRefreshRequest = GridService($client)
       .fetchCount({
         gridId,
-        search: getters.getServerSearchTerm,
-        searchMode: getDefaultSearchModeFromEnv($config),
+        search: searchSnapshot,
+        searchMode: searchModeSnapshot,
         signal: lastRefreshRequestController.signal,
-        publicUrl: rootGetters['page/view/public/getIsPublic'],
-        publicAuthToken: rootGetters['page/view/public/getAuthToken'],
-        filters: getFilters(view, adhocFiltering),
+        publicUrl: isPublic,
+        publicAuthToken,
+        filters: filtersSnapshot,
       })
       .then((response) => {
         const count = response.data.count
@@ -2932,17 +2941,13 @@ export const actions = {
             limit,
             includeFieldOptions,
             signal: lastRefreshRequestController.signal,
-            search: getters.getServerSearchTerm,
-            searchMode: getDefaultSearchModeFromEnv($config),
-            publicUrl: rootGetters['page/view/public/getIsPublic'],
-            publicAuthToken: rootGetters['page/view/public/getAuthToken'],
-            groupBy: getGroupBy(
-              rootGetters,
-              getters.getLastGridId,
-              getters.getAdhocGrouping
-            ),
-            orderBy: getOrderBy(view, adhocSorting),
-            filters: getFilters(view, adhocFiltering),
+            search: searchSnapshot,
+            searchMode: searchModeSnapshot,
+            publicUrl: isPublic,
+            publicAuthToken,
+            groupBy: groupBySnapshot,
+            orderBy: orderBySnapshot,
+            filters: filtersSnapshot,
             excludeCount: true, // We already have it from the previous request.
           })
           .then(({ data }) => ({
@@ -2972,9 +2977,11 @@ export const actions = {
           bufferLimit: data.results.length,
         })
 
-        dispatch('updateSearch', { fields })
+        if (searchSnapshot === getters.getServerSearchTerm) {
+          dispatch('updateSearch', { fields })
+        }
         if (includeFieldOptions) {
-          if (rootGetters['page/view/public/getIsPublic']) {
+          if (isPublic) {
             commit('REPLACE_PUBLIC_FIELD_OPTIONS', data.field_options)
           } else {
             commit('REPLACE_ALL_FIELD_OPTIONS', data.field_options)
@@ -2995,6 +3002,11 @@ export const actions = {
         }
       })
     return lastRefreshRequest
+  },
+  abortRefresh() {
+    if (lastRefreshRequestController !== null) {
+      lastRefreshRequestController.abort()
+    }
   },
   async refreshActiveGroupBys(
     { commit, dispatch, getters, rootGetters, state },

--- a/web-frontend/test/helpers/testApp.js
+++ b/web-frontend/test/helpers/testApp.js
@@ -287,8 +287,8 @@ export const UIHelpers = {
     const searchBox = body.get(
       'input[placeholder*="viewSearchContext.searchInRows"]'
     )
-    await searchBox.setValue(searchTerm)
     vi.useFakeTimers()
+    await searchBox.setValue(searchTerm)
     await searchBox.trigger('submit')
     vi.runAllTimers() // Consume the debounce
     await flushPromises()

--- a/web-frontend/test/unit/database/store/view/grid.spec.js
+++ b/web-frontend/test/unit/database/store/view/grid.spec.js
@@ -9120,4 +9120,451 @@ describe('Grid view store', () => {
     )
     expect(sourceNode.row_count).toBe(0)
   })
+
+  test('refresh fetchRows uses same search term as fetchCount even when state mutates mid-flight', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      group_bys: [],
+    }
+
+    const testStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
+
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeSearchTerm: 'test',
+      hideRowsNotMatchingSearch: true,
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      bufferRequestSize: 40,
+      rows: [],
+      count: 0,
+    })
+    testStore.replaceState({ ...testStore.state, grid: state })
+
+    let resolveCountRequest
+    let rowsSearchParam = null
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('count') === 'true'
+          },
+        },
+      })
+      .reply(
+        () =>
+          new Promise((resolve) => {
+            resolveCountRequest = () => resolve([200, { count: 1 }])
+          })
+      )
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('limit') != null
+          },
+        },
+      })
+      .reply((config) => {
+        rowsSearchParam = config.params.get('search')
+        return [
+          200,
+          {
+            count: 1,
+            results: [{ id: 1, order: '1.00', field_1: 'row_data' }],
+          },
+        ]
+      })
+
+    const refreshPromise = testStore.dispatch('grid/refresh', {
+      view,
+      fields: [{ id: 1, name: 'Name', type: 'text', primary: true }],
+      adhocFiltering: false,
+      adhocSorting: false,
+    })
+
+    // Let fetchCount fire
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Mutate search state mid-flight (simulates debounced second search)
+    testStore.commit('grid/SET_SEARCH', {
+      activeSearchTerm: 'lotus',
+      hideRowsNotMatchingSearch: true,
+    })
+
+    // Resolve fetchCount — the .then() chain now calls fetchRows
+    resolveCountRequest()
+    await refreshPromise
+
+    // fetchRows should use the ORIGINAL "test", not the mutated "lotus"
+    expect(rowsSearchParam).toBe('test')
+  })
+
+  test('refresh skips updateSearch when search state changed mid-flight', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const updateSearch = vi.fn()
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      group_bys: [],
+    }
+
+    const testStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+            updateSearch,
+          },
+        },
+      },
+    })
+
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeSearchTerm: 'test',
+      hideRowsNotMatchingSearch: true,
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      bufferRequestSize: 40,
+      rows: [],
+      count: 0,
+    })
+    testStore.replaceState({ ...testStore.state, grid: state })
+
+    let resolveCountRequest
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('count') === 'true'
+          },
+        },
+      })
+      .reply(
+        () =>
+          new Promise((resolve) => {
+            resolveCountRequest = () => resolve([200, { count: 1 }])
+          })
+      )
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('limit') != null
+          },
+        },
+      })
+      .reply(200, {
+        count: 1,
+        results: [{ id: 1, order: '1.00', field_1: 'row_data' }],
+      })
+
+    const refreshPromise = testStore.dispatch('grid/refresh', {
+      view,
+      fields: [{ id: 1, name: 'Name', type: 'text', primary: true }],
+      adhocFiltering: false,
+      adhocSorting: false,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Mutate search mid-flight — simulates next debounce arriving
+    testStore.commit('grid/SET_SEARCH', {
+      activeSearchTerm: 'lotus',
+      hideRowsNotMatchingSearch: true,
+    })
+
+    resolveCountRequest()
+    await refreshPromise
+
+    // updateSearch should NOT run — search changed, rows are stale
+    expect(updateSearch).not.toHaveBeenCalled()
+  })
+
+  test('refresh runs updateSearch when search state is stable', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const updateSearch = vi.fn()
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      group_bys: [],
+    }
+
+    const testStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+            updateSearch,
+          },
+        },
+      },
+    })
+
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      activeSearchTerm: 'test',
+      hideRowsNotMatchingSearch: true,
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      bufferRequestSize: 40,
+      rows: [],
+      count: 0,
+    })
+    testStore.replaceState({ ...testStore.state, grid: state })
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('count') === 'true'
+          },
+        },
+      })
+      .reply(200, { count: 1 })
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('limit') != null
+          },
+        },
+      })
+      .reply(200, {
+        count: 1,
+        results: [{ id: 1, order: '1.00', field_1: 'row_data' }],
+      })
+
+    await testStore.dispatch('grid/refresh', {
+      view,
+      fields: [{ id: 1, name: 'Name', type: 'text', primary: true }],
+      adhocFiltering: false,
+      adhocSorting: false,
+    })
+
+    // Search unchanged → updateSearch SHOULD run
+    expect(updateSearch).toHaveBeenCalledOnce()
+  })
+
+  test('refresh fetchRows uses same filters as fetchCount even when view filters mutate mid-flight', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const view = {
+      id: 1,
+      filters: [{ id: 1, field: 1, type: 'contains', value: 'gray' }],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [],
+      group_bys: [],
+    }
+
+    const testStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
+
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      bufferRequestSize: 40,
+      rows: [],
+      count: 0,
+    })
+    testStore.replaceState({ ...testStore.state, grid: state })
+
+    let resolveCountRequest
+    let rowsFilterParam = null
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('count') === 'true'
+          },
+        },
+      })
+      .reply(
+        () =>
+          new Promise((resolve) => {
+            resolveCountRequest = () => resolve([200, { count: 5 }])
+          })
+      )
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('limit') != null
+          },
+        },
+      })
+      .reply((config) => {
+        rowsFilterParam = config.params.get('filters')
+        return [
+          200,
+          {
+            count: 5,
+            results: [{ id: 1, order: '1.00', field_1: 'data' }],
+          },
+        ]
+      })
+
+    const refreshPromise = testStore.dispatch('grid/refresh', {
+      view,
+      fields: [{ id: 1, name: 'Name', type: 'text', primary: true }],
+      adhocFiltering: true,
+      adhocSorting: false,
+    })
+
+    // Let fetchCount fire
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Mutate filter mid-flight (simulates user changing filter value)
+    view.filters[0].value = 'es'
+
+    // Resolve fetchCount — the .then() chain now calls fetchRows
+    resolveCountRequest()
+    await refreshPromise
+
+    // fetchRows should use the ORIGINAL filter "gray", not the mutated "es"
+    const parsedFilter = JSON.parse(rowsFilterParam)
+    expect(parsedFilter.filters[0].value).toBe('gray')
+  })
+
+  test('refresh fetchRows uses same sort order as fetchCount even when sortings mutate mid-flight', async () => {
+    const correctMultiSelect = vi.fn()
+    const fetchAllFieldAggregationData = vi.fn()
+    const view = {
+      id: 1,
+      filters: [],
+      filter_groups: [],
+      filter_type: 'AND',
+      sortings: [{ field: 1, order: 'ASC', type: 'default' }],
+      group_bys: [],
+    }
+
+    const testStore = testApp.createStore({
+      modules: {
+        grid: {
+          ...gridStore,
+          actions: {
+            ...gridStore.actions,
+            correctMultiSelect,
+            fetchAllFieldAggregationData,
+          },
+        },
+      },
+    })
+
+    const state = Object.assign(gridStore.state(), {
+      lastGridId: 1,
+      bufferStartIndex: 0,
+      bufferLimit: 0,
+      bufferRequestSize: 40,
+      rows: [],
+      count: 0,
+    })
+    testStore.replaceState({ ...testStore.state, grid: state })
+
+    let resolveCountRequest
+    let rowsOrderByParam = null
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('count') === 'true'
+          },
+        },
+      })
+      .reply(
+        () =>
+          new Promise((resolve) => {
+            resolveCountRequest = () => resolve([200, { count: 1 }])
+          })
+      )
+
+    mockServer.mock
+      .onGet('/database/views/grid/1/', {
+        params: {
+          asymmetricMatch(actual) {
+            return actual.get('limit') != null
+          },
+        },
+      })
+      .reply((config) => {
+        rowsOrderByParam = config.params.get('order_by')
+        return [
+          200,
+          {
+            count: 1,
+            results: [{ id: 1, order: '1.00', field_1: 'data' }],
+          },
+        ]
+      })
+
+    const refreshPromise = testStore.dispatch('grid/refresh', {
+      view,
+      fields: [{ id: 1, name: 'Name', type: 'text', primary: true }],
+      adhocFiltering: false,
+      adhocSorting: true,
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Mutate sort direction mid-flight
+    view.sortings[0].order = 'DESC'
+
+    resolveCountRequest()
+    await refreshPromise
+
+    // fetchRows should use the ORIGINAL sort "field_1" (ASC), not "-field_1" (DESC)
+    expect(rowsOrderByParam).toBe('field_1')
+  })
 })

--- a/web-frontend/test/unit/database/table.spec.js
+++ b/web-frontend/test/unit/database/table.spec.js
@@ -2,7 +2,8 @@ import { TestApp, UIHelpers } from '@baserow/test/helpers/testApp'
 import flushPromises from 'flush-promises'
 
 import Table from '@baserow/modules/database/pages/table'
-import { test } from 'vitest'
+import { RefreshCancelledError } from '@baserow/modules/core/errors'
+import { test, vi } from 'vitest'
 
 describe('Table Component Tests', () => {
   let testApp = null
@@ -121,6 +122,162 @@ describe('Table Component Tests', () => {
       'gridViewRow.rowNotMatchingSearch'
     )
   })
+
+  test('Second refresh fires after first completes instead of being swallowed', async () => {
+    const { gridView, tableComponent } = await givenAMountedTable()
+
+    const { resolveFirstCount, getRequestCount } =
+      setupGridRefreshMocks(gridView)
+
+    const innerTable = tableComponent.findComponent({ name: 'Table' })
+
+    const firstRefresh = innerTable.vm.refresh({})
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getRequestCount()).toBe(1)
+
+    const secondRefresh = innerTable.vm.refresh({})
+
+    resolveFirstCount()
+    await firstRefresh
+    await secondRefresh
+    await flushPromises()
+
+    expect(getRequestCount()).toBeGreaterThan(2)
+  })
+
+  test('Three rapid refreshes: all run sequentially via queue', async () => {
+    const { gridView, tableComponent } = await givenAMountedTable()
+
+    const { resolveFirstCount, getRequestCount } =
+      setupGridRefreshMocks(gridView)
+
+    const innerTable = tableComponent.findComponent({ name: 'Table' })
+
+    const callbackOrder = []
+    const firstRefresh = innerTable.vm.refresh({
+      callback: () => {
+        callbackOrder.push('first')
+      },
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getRequestCount()).toBe(1)
+
+    innerTable.vm.refresh({
+      callback: () => {
+        callbackOrder.push('second')
+      },
+    })
+    const thirdRefresh = innerTable.vm.refresh({
+      callback: () => {
+        callbackOrder.push('third')
+      },
+    })
+
+    resolveFirstCount()
+    await firstRefresh
+    await thirdRefresh
+    await flushPromises()
+
+    // 5 not 6: first task's fetchRows is aborted (signal already cancelled
+    // by onSuperseded when tasks 2/3 were added), so only fetchCount fires.
+    expect(getRequestCount()).toBe(5)
+    expect(callbackOrder).toEqual(['first', 'second', 'third'])
+  })
+
+  test('Refresh queue drains after concurrent refreshes complete', async () => {
+    const { gridView, tableComponent } = await givenAMountedTable()
+
+    const { resolveFirstCount } = setupGridRefreshMocks(gridView)
+
+    const innerTable = tableComponent.findComponent({ name: 'Table' })
+
+    const firstRefresh = innerTable.vm.refresh({})
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const secondRefresh = innerTable.vm.refresh({})
+
+    resolveFirstCount()
+    await firstRefresh
+    await secondRefresh
+    await flushPromises()
+
+    expect(innerTable.vm.refreshQueue.queue.length).toBe(0)
+    expect(innerTable.vm.refreshQueue.running).toBe(false)
+  })
+
+  test('Callback still runs when refresh is cancelled by abort', async () => {
+    const { gridView, tableComponent } = await givenAMountedTable()
+
+    setupGridRefreshMocks(gridView)
+
+    const innerTable = tableComponent.findComponent({ name: 'Table' })
+    const viewType = testApp._app.$registry.get('view', 'grid')
+    const originalRefresh = viewType.refresh.bind(viewType)
+
+    let callCount = 0
+    vi.spyOn(viewType, 'refresh').mockImplementation((...args) => {
+      callCount++
+      if (callCount === 1) {
+        throw new RefreshCancelledError()
+      }
+      return originalRefresh(...args)
+    })
+
+    let callbackRan = false
+    const refresh = innerTable.vm.refresh({
+      callback: () => {
+        callbackRan = true
+      },
+    })
+
+    await refresh
+    await flushPromises()
+
+    expect(callbackRan).toBe(true)
+
+    viewType.refresh.mockRestore()
+  })
+
+  async function givenAMountedTable() {
+    const { application, table, gridView } =
+      await givenASingleSimpleTableInTheServer()
+    const tableComponent = await testApp.mount(Table, {
+      route: `/database/${application.id}/table/${table.id}/${gridView.id}?token=fake`,
+    })
+    return { application, table, gridView, tableComponent }
+  }
+
+  function setupGridRefreshMocks(gridView) {
+    mockServer.resetMockEndpoints()
+    let resolveFirstCount
+    let gridRequestCount = 0
+    const row = {
+      id: 1,
+      order: '1.00',
+      field_1: 'name',
+      field_2: 'last_name',
+      field_3: 'notes',
+      field_4: false,
+    }
+    mockServer.mock.onGet(`/database/views/grid/${gridView.id}/`).reply(() => {
+      gridRequestCount++
+      if (gridRequestCount === 1) {
+        return new Promise((resolve) => {
+          resolveFirstCount = () => resolve([200, { count: 1 }])
+        })
+      }
+      return [200, { count: 1, results: [row] }]
+    })
+    mockServer.mock
+      .onGet(`/database/views/grid/${gridView.id}/aggregations/`)
+      .reply(200, {})
+    return {
+      resolveFirstCount: () => resolveFirstCount(),
+      getRequestCount: () => gridRequestCount,
+    }
+  }
 
   async function givenASingleSimpleTableInTheServer() {
     mockServer.fakeSettings()


### PR DESCRIPTION
## Summary

- Replace `isRefreshing` boolean guard in `Table.vue` with `TaskQueue` — concurrent refreshes now run sequentially instead of being silently dropped
- Snapshot all reactive Vuex getters (search, filters, sort, groupBy) at dispatch time in `grid/refresh` so `fetchCount` and `fetchRows` use identical query parameters
- Replace `@keyup` + conditional watcher in `ViewSearchContext` with a single unconditional watcher on `activeSearchTerm` — fixes clear button and paste/drag-drop input methods

## Test plan

- 3 new tests in `table.spec.js` verify queue behavior (concurrent, triple, drain)
- 4 new tests in `grid.spec.js` verify snapshot consistency (search, filters, sort mutations mid-flight)
- Manual: Slow 3G, search race → both requests fire, correct final rows
- Manual: Slow 3G, filter race → no phantom rows, correct count
- Manual: Clear button inside search input triggers refresh
- Manual: No throttling regression check

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered


Closes #5764 