### PR TITLE
bug: improve e2e CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
+      e2e: ${{ steps.filter.outputs.e2e }}
       mjml: ${{ steps.filter.outputs.mjml }}
       zapier: ${{ steps.filter.outputs.zapier }}
       helm: ${{ steps.filter.outputs.helm }}
@@ -235,6 +236,9 @@ jobs:
               - '.github/workflows/ci.yml'
             dockerfiles:
               - '**/Dockerfile'
+              - '.github/workflows/ci.yml'
+            e2e:
+              - 'e2e-tests/**'
               - '.github/workflows/ci.yml'
             mjml:
               - '**/*.eta'
@@ -673,7 +677,7 @@ jobs:
       - detect-changes
       - build-backend
       - build-frontend
-    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.dockerfiles == 'true' || github.ref_name == 'develop' || github.ref_name == 'master'
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.dockerfiles == 'true' || needs.detect-changes.outputs.e2e == 'true' || github.ref_name == 'develop' || github.ref_name == 'master'
     permissions:
       contents: read
       packages: read
@@ -866,6 +870,10 @@ jobs:
           PUBLIC_BACKEND_URL: http://localhost:8000
           PUBLIC_WEB_FRONTEND_URL: http://localhost:3000
           PRIVATE_BACKEND_URL: http://backend:8000
+          # The CI web-frontend runs with the default (empty) cookie prefix, so
+          # tests that read/set cookies (e.g. the user_source_token) must use the
+          # same empty prefix rather than playwright.config's baserow_e2e_ default.
+          BASEROW_FRONTEND_COOKIE_PREFIX: ""
           CI: 1
         run: |
           cd e2e-tests


### PR DESCRIPTION
## Fix `elementVisibility` e2e test in CI                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                
The `elementVisibility` e2e test passed locally but failed on `develop` after merge. Two fixes:                                                                                                                                                               
                                                                                                                                                                                                                                                                
### 1. Cookie prefix mismatch in CI                                                                                                                                                                                                                           

The test authenticates via a `` `${prefix}user_source_token` `` cookie. The prefix comes from `BASEROW_FRONTEND_COOKIE_PREFIX`, which defaults differently on each side: the frontend defaults to `""`, but `playwright.config.ts` defaults to `baserow_e2e_`.
 
In CI neither set it, so the test wrote `baserow_e2e_user_source_token` while the frontend read `user_source_token` — the token was never found, the logged-in visitor rendered as anonymous, and `E2_LOGGED` was missing.                                    
                                                                                                                                                                                                                                                                
Fix: set `BASEROW_FRONTEND_COOKIE_PREFIX: ""` on the Playwright step so it matches the CI frontend. (`just e2e` already pins both sides to `baserow_e2e_` locally, so that path is unchanged — the sides just have to agree.)                                 
                                                                                                                                                                                                                                                                
### 2. e2e-only PRs never ran the e2e suite                                                                                                                                                                                                                   

`test-e2e` is gated by `detect-changes`, whose filters only cover `backend/**`, `web-frontend/**`, and Dockerfiles. A PR touching only `e2e-tests/**` matched none, so the suite was skipped on the PR and first ran on `develop`.                            
                                                                                                                                                                                                                                                                
Fix: added an `e2e` filter for `e2e-tests/**` and OR'd it into the `test-e2e` condition.

## Checklist

- [ ] ~A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`~
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
