### PR TITLE
fix(database): validate ad-hoc filter fields when public view has empty visible field set

### DIFF
--- a/backend/src/baserow/contrib/database/views/view_filter_groups.py
+++ b/backend/src/baserow/contrib/database/views/view_filter_groups.py
@@ -206,7 +206,7 @@ class APIGroupedFiltersAdapter(GroupedFiltersAdapter):
                     field_id = filter["field"]
 
                 if (
-                    only_filter_by_field_ids
+                    only_filter_by_field_ids is not None
                     and field_id not in only_filter_by_field_ids
                 ):
                     raise FilterFieldNotFound(

--- a/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/gallery/test_gallery_view_views.py
@@ -1249,6 +1249,45 @@ def test_list_rows_public_with_query_param_advanced_filters(api_client, data_fix
         assert response_json["error"] == "ERROR_FILTERS_PARAM_VALIDATION_ERROR"
 
 
+@pytest.mark.django_db
+def test_list_rows_public_all_fields_hidden_rejects_adhoc_filter(
+    api_client, data_fixture
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    hidden_field = data_fixture.create_text_field(table=table, name="hidden")
+    gallery_view = data_fixture.create_gallery_view(
+        table=table, user=user, public=True, create_options=False
+    )
+    data_fixture.create_gallery_view_field_option(
+        gallery_view, hidden_field, hidden=True
+    )
+
+    RowHandler().create_row(
+        user, table, values={"hidden": "secret"}, user_field_names=True
+    )
+
+    url = reverse(
+        "api:database:views:gallery:public_rows",
+        kwargs={"slug": gallery_view.slug},
+    )
+    advanced_filters = {
+        "filter_type": "AND",
+        "filters": [
+            {
+                "field": hidden_field.id,
+                "type": "contains",
+                "value": "secret",
+            }
+        ],
+    }
+    get_params = ["filters=" + json.dumps(advanced_filters)]
+    response = api_client.get(f"{url}?{'&'.join(get_params)}")
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_FILTER_FIELD_NOT_FOUND"
+
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("search_mode", ALL_SEARCH_MODES)
 @pytest.mark.enable_signals(

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
@@ -3721,6 +3721,83 @@ def test_list_rows_public_with_query_param_advanced_filters(api_client, data_fix
 
 
 @pytest.mark.django_db
+def test_list_rows_public_all_fields_hidden_rejects_adhoc_filter(
+    api_client, data_fixture
+):
+    user = data_fixture.create_user()
+    table = data_fixture.create_database_table(user=user)
+    hidden_field = data_fixture.create_text_field(table=table, name="hidden")
+    grid_view = data_fixture.create_grid_view(
+        table=table, user=user, public=True, create_options=False
+    )
+    data_fixture.create_grid_view_field_option(grid_view, hidden_field, hidden=True)
+
+    RowHandler().create_row(
+        user, table, values={"hidden": "secret"}, user_field_names=True
+    )
+
+    url = reverse(
+        "api:database:views:grid:public_rows", kwargs={"slug": grid_view.slug}
+    )
+    advanced_filters = {
+        "filter_type": "AND",
+        "filters": [
+            {
+                "field": hidden_field.id,
+                "type": "contains",
+                "value": "secret",
+            }
+        ],
+    }
+    get_params = ["filters=" + json.dumps(advanced_filters)]
+    response = api_client.get(f"{url}?{'&'.join(get_params)}")
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_FILTER_FIELD_NOT_FOUND"
+
+
+@pytest.mark.django_db
+def test_public_view_aggregations_all_fields_hidden_rejects_adhoc_filter(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    hidden_field = data_fixture.create_text_field(table=table, name="hidden")
+    grid = data_fixture.create_grid_view(
+        table=table, user=user, public=True, create_options=False
+    )
+    data_fixture.create_grid_view_field_option(grid, hidden_field, hidden=True)
+    data_fixture.create_grid_view_field_option(
+        grid_view=grid,
+        field=hidden_field,
+        aggregation_type="whatever",
+        aggregation_raw_type="empty_count",
+    )
+
+    advanced_filters = {
+        "filter_type": "AND",
+        "filters": [
+            {
+                "field": hidden_field.id,
+                "type": "equal",
+                "value": "secret",
+            }
+        ],
+    }
+    get_params = [f"filters={json.dumps(advanced_filters)}", "include=total"]
+    response = api_client.get(
+        reverse(
+            "api:database:views:grid:public-field-aggregations",
+            kwargs={"slug": grid.slug},
+        )
+        + f"?{'&'.join(get_params)}"
+    )
+    response_json = response.json()
+    assert response.status_code == HTTP_400_BAD_REQUEST
+    assert response_json["error"] == "ERROR_FILTER_FIELD_NOT_FOUND"
+
+
+@pytest.mark.django_db
 def test_list_rows_with_query_param_order(api_client, data_fixture):
     user, token = data_fixture.create_user_and_token()
     table = data_fixture.create_database_table(user=user)

--- a/changelog/entries/unreleased/bug/5778_fixed_adhoc_filter_field_validation_not_raising_an_error_whe.json
+++ b/changelog/entries/unreleased/bug/5778_fixed_adhoc_filter_field_validation_not_raising_an_error_whe.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed ad-hoc filter field validation not raising an error when all view fields are hidden in public views.",
+    "issue_origin": "github",
+    "issue_number": 5778,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-24"
+}


### PR DESCRIPTION
Closes #5778 

## Summary
- Fixed a field-scope bypass in `view_filter_groups.py` where an empty
  `only_filter_by_field_ids` set (falsy) skipped the guard instead of
  rejecting all filters. Changed truthiness check to `is not None` to
  match the three sibling patterns in `table/models.py`.
- Added regression tests for public grid rows, public grid aggregations,
  and public gallery rows endpoints with all fields hidden.


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
