### PR TITLE
bug: Fix grid scrolling blocked when hover scrollable cells

### DIFF
--- a/changelog/entries/unreleased/bug/fix_grid_scrolling_blocked_when_hover_scrollable_cells.json
+++ b/changelog/entries/unreleased/bug/fix_grid_scrolling_blocked_when_hover_scrollable_cells.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixes grid scrolling being blocked when hovering a scrollable cell.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-27"
+}

--- a/web-frontend/modules/core/directives/preventParentScroll.js
+++ b/web-frontend/modules/core/directives/preventParentScroll.js
@@ -3,10 +3,28 @@
  * being able to scroll. This directive can be used on a child element that supports
  * scrolling, it makes sure that scrolling works and so that it doesn't scroll the
  * parent.
+ *
+ * The binding value controls the behavior:
+ * - `true` or no value: always stop propagation.
+ * - `false`: directive is disabled.
+ * - `WHEN_SCROLLABLE`: only stop propagation if the element actually overflows.
+ *   This must be checked at event time because the overflow state changes with the
+ *   content. Use this when the parent should still scroll while the element has
+ *   nothing to scroll itself, for example the selected link row cell in the grid
+ *   view.
  */
 
-const addEventListeners = (el) => {
+export const WHEN_SCROLLABLE = 'when-scrollable'
+
+const addEventListeners = (el, mode) => {
   el.preventParentScrollDirectiveEvent = (event) => {
+    if (
+      mode === WHEN_SCROLLABLE &&
+      el.scrollHeight <= el.clientHeight &&
+      el.scrollWidth <= el.clientWidth
+    ) {
+      return
+    }
     event.stopPropagation()
   }
   el.addEventListener('wheel', el.preventParentScrollDirectiveEvent)
@@ -24,17 +42,17 @@ const removeEventListeners = (el) => {
 
 export default {
   beforeMount(el, binding) {
-    const active = binding.value !== undefined ? binding.value : true
-    if (active) {
-      addEventListeners(el)
+    const value = binding.value !== undefined ? binding.value : true
+    if (value !== false) {
+      addEventListeners(el, value)
     }
   },
   updated(el, binding) {
     if (binding.value !== binding.oldValue) {
-      if (binding.value) {
-        addEventListeners(el)
-      } else {
-        removeEventListeners(el)
+      removeEventListeners(el)
+      const value = binding.value !== undefined ? binding.value : true
+      if (value !== false) {
+        addEventListeners(el, value)
       }
     }
   },

--- a/web-frontend/modules/core/directives/preventParentScroll.js
+++ b/web-frontend/modules/core/directives/preventParentScroll.js
@@ -4,22 +4,17 @@
  * scrolling, it makes sure that scrolling works and so that it doesn't scroll the
  * parent.
  *
- * The binding value controls the behavior:
- * - `true` or no value: always stop propagation.
- * - `false`: directive is disabled.
- * - `WHEN_SCROLLABLE`: only stop propagation if the element actually overflows.
- *   This must be checked at event time because the overflow state changes with the
- *   content. Use this when the parent should still scroll while the element has
- *   nothing to scroll itself, for example the selected link row cell in the grid
- *   view.
+ * The `whenScrollable` modifier makes stopping the propagation conditional: the
+ * event only stops if the element actually overflows. This must be checked at
+ * event time because the overflow state changes with the content. Use this when
+ * the parent should still scroll while the element has nothing to scroll itself,
+ * for example the selected link row cell in the grid view.
  */
 
-export const WHEN_SCROLLABLE = 'when-scrollable'
-
-const addEventListeners = (el, mode) => {
+const addEventListeners = (el, whenScrollable) => {
   el.preventParentScrollDirectiveEvent = (event) => {
     if (
-      mode === WHEN_SCROLLABLE &&
+      whenScrollable &&
       el.scrollHeight <= el.clientHeight &&
       el.scrollWidth <= el.clientWidth
     ) {
@@ -42,17 +37,17 @@ const removeEventListeners = (el) => {
 
 export default {
   beforeMount(el, binding) {
-    const value = binding.value !== undefined ? binding.value : true
-    if (value !== false) {
-      addEventListeners(el, value)
+    const active = binding.value !== undefined ? binding.value : true
+    if (active) {
+      addEventListeners(el, !!binding.modifiers.whenScrollable)
     }
   },
   updated(el, binding) {
     if (binding.value !== binding.oldValue) {
-      removeEventListeners(el)
-      const value = binding.value !== undefined ? binding.value : true
-      if (value !== false) {
-        addEventListeners(el, value)
+      if (binding.value) {
+        addEventListeners(el, !!binding.modifiers.whenScrollable)
+      } else {
+        removeEventListeners(el)
       }
     }
   },

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkRow.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkRow.vue
@@ -5,7 +5,7 @@
     :class="{ invalid: removingRelationships }"
   >
     <div
-      v-prevent-parent-scroll="WHEN_SCROLLABLE"
+      v-prevent-parent-scroll.whenScrollable
       class="grid-field-many-to-many__list"
     >
       <component
@@ -100,7 +100,6 @@ import ForeignRowEditModal from '@baserow/modules/database/components/row/Foreig
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import { DatabaseApplicationType } from '@baserow/modules/database/applicationTypes'
 import { isPrintableUnicodeCharacterKeyPress } from '@baserow/modules/core/utils/events'
-import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   name: 'GridViewFieldLinkRow',
@@ -116,9 +115,6 @@ export default {
     }
   },
   computed: {
-    WHEN_SCROLLABLE() {
-      return WHEN_SCROLLABLE
-    },
     publicGrid() {
       return this.$store.getters['page/view/public/getIsPublic']
     },

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkRow.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLinkRow.vue
@@ -1,11 +1,13 @@
 <template>
   <div
     ref="cell"
-    v-prevent-parent-scroll
     class="grid-view__cell grid-field-many-to-many__cell active"
     :class="{ invalid: removingRelationships }"
   >
-    <div class="grid-field-many-to-many__list">
+    <div
+      v-prevent-parent-scroll="WHEN_SCROLLABLE"
+      class="grid-field-many-to-many__list"
+    >
       <component
         :is="publicGrid || !canAccessLinkedTable ? 'span' : 'a'"
         v-for="item in visibleValues"
@@ -98,6 +100,7 @@ import ForeignRowEditModal from '@baserow/modules/database/components/row/Foreig
 import { notifyIf } from '@baserow/modules/core/utils/error'
 import { DatabaseApplicationType } from '@baserow/modules/database/applicationTypes'
 import { isPrintableUnicodeCharacterKeyPress } from '@baserow/modules/core/utils/events'
+import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   name: 'GridViewFieldLinkRow',
@@ -113,6 +116,9 @@ export default {
     }
   },
   computed: {
+    WHEN_SCROLLABLE() {
+      return WHEN_SCROLLABLE
+    },
     publicGrid() {
       return this.$store.getters['page/view/public/getIsPublic']
     },

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLongText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLongText.vue
@@ -10,7 +10,7 @@
       <textarea
         ref="input"
         v-model="copy"
-        v-prevent-parent-scroll="WHEN_SCROLLABLE"
+        v-prevent-parent-scroll.whenScrollable
         :disabled="readOnly"
         type="text"
         class="grid-field-long-text__textarea"
@@ -27,15 +27,9 @@
 <script>
 import gridField from '@baserow/modules/database/mixins/gridField'
 import gridFieldInput from '@baserow/modules/database/mixins/gridFieldInput'
-import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   mixins: [gridField, gridFieldInput],
-  computed: {
-    WHEN_SCROLLABLE() {
-      return WHEN_SCROLLABLE
-    },
-  },
   methods: {
     afterEdit(event) {
       // If the enter key is pressed we do not want to add a new line to the textarea.

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLongText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldLongText.vue
@@ -10,7 +10,7 @@
       <textarea
         ref="input"
         v-model="copy"
-        v-prevent-parent-scroll
+        v-prevent-parent-scroll="WHEN_SCROLLABLE"
         :disabled="readOnly"
         type="text"
         class="grid-field-long-text__textarea"
@@ -27,9 +27,15 @@
 <script>
 import gridField from '@baserow/modules/database/mixins/gridField'
 import gridFieldInput from '@baserow/modules/database/mixins/gridFieldInput'
+import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   mixins: [gridField, gridFieldInput],
+  computed: {
+    WHEN_SCROLLABLE() {
+      return WHEN_SCROLLABLE
+    },
+  },
   methods: {
     afterEdit(event) {
       // If the enter key is pressed we do not want to add a new line to the textarea.

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
@@ -22,7 +22,7 @@
       v-else
       ref="input"
       v-model="richCopy"
-      v-prevent-parent-scroll="editing ? WHEN_SCROLLABLE : false"
+      v-prevent-parent-scroll.whenScrollable="editing"
       class="grid-field-rich-text__textarea"
       :class="{ 'grid-field-rich-text__textarea--resizable': editing }"
       :editable="editing && !isModalOpen()"
@@ -62,7 +62,6 @@ import gridFieldInput from '@baserow/modules/database/mixins/gridFieldInput'
 import FieldRichTextModal from '@baserow/modules/database/components/view/FieldRichTextModal'
 import { parseMarkdown } from '@baserow/modules/core/editor/markdown'
 import { getRichTextClipboardContent } from '@baserow/modules/database/utils/clipboard'
-import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   components: { RichTextEditor, FieldRichTextModal },
@@ -75,9 +74,6 @@ export default {
     }
   },
   computed: {
-    WHEN_SCROLLABLE() {
-      return WHEN_SCROLLABLE
-    },
     formattedValue() {
       return parseMarkdown(this.value, {
         openLinkOnClick: true,

--- a/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
+++ b/web-frontend/modules/database/components/view/grid/fields/GridViewFieldRichText.vue
@@ -22,7 +22,7 @@
       v-else
       ref="input"
       v-model="richCopy"
-      v-prevent-parent-scroll="editing"
+      v-prevent-parent-scroll="editing ? WHEN_SCROLLABLE : false"
       class="grid-field-rich-text__textarea"
       :class="{ 'grid-field-rich-text__textarea--resizable': editing }"
       :editable="editing && !isModalOpen()"
@@ -62,6 +62,7 @@ import gridFieldInput from '@baserow/modules/database/mixins/gridFieldInput'
 import FieldRichTextModal from '@baserow/modules/database/components/view/FieldRichTextModal'
 import { parseMarkdown } from '@baserow/modules/core/editor/markdown'
 import { getRichTextClipboardContent } from '@baserow/modules/database/utils/clipboard'
+import { WHEN_SCROLLABLE } from '@baserow/modules/core/directives/preventParentScroll'
 
 export default {
   components: { RichTextEditor, FieldRichTextModal },
@@ -74,6 +75,9 @@ export default {
     }
   },
   computed: {
+    WHEN_SCROLLABLE() {
+      return WHEN_SCROLLABLE
+    },
     formattedValue() {
       return parseMarkdown(this.value, {
         openLinkOnClick: true,

--- a/web-frontend/test/unit/core/directives/preventParentScroll.spec.js
+++ b/web-frontend/test/unit/core/directives/preventParentScroll.spec.js
@@ -1,0 +1,94 @@
+import preventParentScroll, {
+  WHEN_SCROLLABLE,
+} from '@baserow/modules/core/directives/preventParentScroll'
+
+describe('preventParentScroll directive', () => {
+  let parent
+  let child
+  let parentListener
+
+  beforeEach(() => {
+    parent = document.createElement('div')
+    child = document.createElement('div')
+    parent.appendChild(child)
+    parentListener = vi.fn()
+    parent.addEventListener('wheel', parentListener)
+  })
+
+  const dispatchWheel = () => {
+    child.dispatchEvent(new Event('wheel', { bubbles: true }))
+  }
+
+  const makeOverflowing = () => {
+    Object.defineProperties(child, {
+      scrollHeight: { value: 200, configurable: true },
+      clientHeight: { value: 100, configurable: true },
+    })
+  }
+
+  test('stops propagation to the parent by default', () => {
+    preventParentScroll.beforeMount(child, { value: undefined })
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+  })
+
+  test('does not stop propagation when the binding value is false', () => {
+    preventParentScroll.beforeMount(child, { value: false })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('when-scrollable lets the event propagate if the element does not overflow', () => {
+    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('when-scrollable stops propagation if the element overflows', () => {
+    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+  })
+
+  test('when-scrollable reacts to overflow changes after mount', () => {
+    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('updated hook switches between modes', () => {
+    preventParentScroll.beforeMount(child, { value: true })
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+
+    preventParentScroll.updated(child, {
+      value: WHEN_SCROLLABLE,
+      oldValue: true,
+    })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('updated hook can enable when-scrollable from a disabled state', () => {
+    preventParentScroll.beforeMount(child, { value: false })
+    preventParentScroll.updated(child, {
+      value: WHEN_SCROLLABLE,
+      oldValue: false,
+    })
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+  })
+
+  test('unmounted removes the listeners', () => {
+    preventParentScroll.beforeMount(child, { value: true })
+    preventParentScroll.unmounted(child)
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web-frontend/test/unit/core/directives/preventParentScroll.spec.js
+++ b/web-frontend/test/unit/core/directives/preventParentScroll.spec.js
@@ -1,6 +1,4 @@
-import preventParentScroll, {
-  WHEN_SCROLLABLE,
-} from '@baserow/modules/core/directives/preventParentScroll'
+import preventParentScroll from '@baserow/modules/core/directives/preventParentScroll'
 
 describe('preventParentScroll directive', () => {
   let parent
@@ -27,66 +25,90 @@ describe('preventParentScroll directive', () => {
   }
 
   test('stops propagation to the parent by default', () => {
-    preventParentScroll.beforeMount(child, { value: undefined })
+    preventParentScroll.beforeMount(child, { value: undefined, modifiers: {} })
     dispatchWheel()
     expect(parentListener).not.toHaveBeenCalled()
   })
 
   test('does not stop propagation when the binding value is false', () => {
-    preventParentScroll.beforeMount(child, { value: false })
+    preventParentScroll.beforeMount(child, { value: false, modifiers: {} })
     dispatchWheel()
     expect(parentListener).toHaveBeenCalledTimes(1)
   })
 
-  test('when-scrollable lets the event propagate if the element does not overflow', () => {
-    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
-    dispatchWheel()
-    expect(parentListener).toHaveBeenCalledTimes(1)
-  })
-
-  test('when-scrollable stops propagation if the element overflows', () => {
-    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
-    makeOverflowing()
-    dispatchWheel()
-    expect(parentListener).not.toHaveBeenCalled()
-  })
-
-  test('when-scrollable reacts to overflow changes after mount', () => {
-    preventParentScroll.beforeMount(child, { value: WHEN_SCROLLABLE })
-    dispatchWheel()
-    expect(parentListener).toHaveBeenCalledTimes(1)
-
-    makeOverflowing()
-    dispatchWheel()
-    expect(parentListener).toHaveBeenCalledTimes(1)
-  })
-
-  test('updated hook switches between modes', () => {
-    preventParentScroll.beforeMount(child, { value: true })
-    dispatchWheel()
-    expect(parentListener).not.toHaveBeenCalled()
-
-    preventParentScroll.updated(child, {
-      value: WHEN_SCROLLABLE,
-      oldValue: true,
+  test('whenScrollable lets the event propagate if the element does not overflow', () => {
+    preventParentScroll.beforeMount(child, {
+      value: undefined,
+      modifiers: { whenScrollable: true },
     })
     dispatchWheel()
     expect(parentListener).toHaveBeenCalledTimes(1)
   })
 
-  test('updated hook can enable when-scrollable from a disabled state', () => {
-    preventParentScroll.beforeMount(child, { value: false })
+  test('whenScrollable stops propagation if the element overflows', () => {
+    preventParentScroll.beforeMount(child, {
+      value: undefined,
+      modifiers: { whenScrollable: true },
+    })
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+  })
+
+  test('whenScrollable reacts to overflow changes after mount', () => {
+    preventParentScroll.beforeMount(child, {
+      value: undefined,
+      modifiers: { whenScrollable: true },
+    })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('whenScrollable respects a false binding value', () => {
+    preventParentScroll.beforeMount(child, {
+      value: false,
+      modifiers: { whenScrollable: true },
+    })
+    makeOverflowing()
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
+  })
+
+  test('updated hook can enable whenScrollable from a disabled state', () => {
+    preventParentScroll.beforeMount(child, {
+      value: false,
+      modifiers: { whenScrollable: true },
+    })
     preventParentScroll.updated(child, {
-      value: WHEN_SCROLLABLE,
+      value: true,
       oldValue: false,
+      modifiers: { whenScrollable: true },
     })
     makeOverflowing()
     dispatchWheel()
     expect(parentListener).not.toHaveBeenCalled()
+  })
+
+  test('updated hook can disable the directive', () => {
+    preventParentScroll.beforeMount(child, { value: true, modifiers: {} })
+    dispatchWheel()
+    expect(parentListener).not.toHaveBeenCalled()
+
+    preventParentScroll.updated(child, {
+      value: false,
+      oldValue: true,
+      modifiers: {},
+    })
+    dispatchWheel()
+    expect(parentListener).toHaveBeenCalledTimes(1)
   })
 
   test('unmounted removes the listeners', () => {
-    preventParentScroll.beforeMount(child, { value: true })
+    preventParentScroll.beforeMount(child, { value: true, modifiers: {} })
     preventParentScroll.unmounted(child)
     dispatchWheel()
     expect(parentListener).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
### What is in this PR

Before, in the grid view, if you a link row field cell is selected and the mouse of hovering over the field, then it's not possible to scroll in the grid view. The problem is related to the GridViewFieldLinkRow always having `v-prevent-parent-scroll`. However, this should only be the case if there the cell is scrollable because there are many relations. This fix introduces a `when-scrollable` argument for the directive to only prevent scroll if there is a scrollbar. While looking into this I noticed that the long text has the same problem. I've also fixed it there.

https://github.com/user-attachments/assets/f4cdabca-72b7-41ac-ab1b-5e993bdbe23f

### How to test this PR

- Create a link row field, long text field, and long text with rich text field.
- Confirm that if the cell is selected and there is no scrollbar, that you can use the trackpad/scrollwheel to scroll in the grid view.
- Fill some of the cells with relations or text so that a scrollbar appears. Confirm that if the cell is selected, it scrolls within the cell instead of in the grid view.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered