### PR TITLE
fix: fall back to attachment endpoint for unmapped file URLs during import

### DIFF
--- a/backend/src/baserow/contrib/database/airtable/handler.py
+++ b/backend/src/baserow/contrib/database/airtable/handler.py
@@ -14,6 +14,7 @@ from django.core.files.storage import Storage
 
 import requests
 from requests import Response
+from requests.exceptions import RequestException
 
 from baserow.contrib.database.airtable.constants import (
     AIRTABLE_API_BASE_URL,
@@ -109,21 +110,26 @@ def download_airtable_file(
     :raises FileDownloadFailed: When the file could not be downloaded.
     """
 
-    if download_file.type == AIRTABLE_DOWNLOAD_FILE_TYPE_FETCH:
-        response = requests.get(download_file.url, headers=headers)  # noqa: S113
-    elif download_file.type == AIRTABLE_DOWNLOAD_FILE_TYPE_ATTACHMENT_ENDPOINT:
-        response = AirtableHandler.fetch_attachment(
-            row_id=download_file.row_id,
-            column_id=download_file.column_id,
-            attachment_id=download_file.attachment_id,
-            init_data=init_data,
-            request_id=request_id,
-            cookies=cookies,
-            headers=headers,
-        )
-    else:
+    try:
+        if download_file.type == AIRTABLE_DOWNLOAD_FILE_TYPE_FETCH:
+            response = requests.get(download_file.url, headers=headers)  # noqa: S113
+        elif download_file.type == AIRTABLE_DOWNLOAD_FILE_TYPE_ATTACHMENT_ENDPOINT:
+            response = AirtableHandler.fetch_attachment(
+                row_id=download_file.row_id,
+                column_id=download_file.column_id,
+                attachment_id=download_file.attachment_id,
+                init_data=init_data,
+                request_id=request_id,
+                cookies=cookies,
+                headers=headers,
+            )
+        else:
+            raise FileDownloadFailed(
+                f"Unknown download file type: {download_file.type}",
+            )
+    except RequestException as e:
         raise FileDownloadFailed(
-            f"Unknown download file type: {download_file.type}",
+            f"File {name} could not be downloaded: {e}",
         )
     if response.status_code not in [HTTPStatus.OK, HTTPStatus.PARTIAL_CONTENT]:
         raise FileDownloadFailed(
@@ -966,7 +972,7 @@ class AirtableHandler:
                     and url in signed_user_content_urls
                 ):
                     download_file.url = signed_user_content_urls[url]
-                elif signed_user_content_urls is None:
+                else:
                     download_file.type = AIRTABLE_DOWNLOAD_FILE_TYPE_ATTACHMENT_ENDPOINT
 
                 files_to_download[file_name] = download_file

--- a/backend/tests/baserow/contrib/database/airtable/test_airtable_handler.py
+++ b/backend/tests/baserow/contrib/database/airtable/test_airtable_handler.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 
 import pytest
+import requests
 import responses
 from rest_framework import serializers
 
@@ -217,7 +218,7 @@ def test_to_baserow_database_export():
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -229,7 +230,7 @@ def test_to_baserow_database_export():
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -590,7 +591,7 @@ def test_config_skip_files(tmpdir, data_fixture):
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -602,7 +603,7 @@ def test_config_skip_files(tmpdir, data_fixture):
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -698,7 +699,7 @@ def test_to_baserow_database_export_without_primary_value():
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -710,7 +711,7 @@ def test_to_baserow_database_export_without_primary_value():
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -860,7 +861,7 @@ def test_import_from_airtable_to_workspace(
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -872,7 +873,7 @@ def test_import_from_airtable_to_workspace(
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -1007,7 +1008,7 @@ def test_import_from_airtable_to_workspace_file_size_over_limit(
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -1019,7 +1020,7 @@ def test_import_from_airtable_to_workspace_file_size_over_limit(
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -1125,7 +1126,7 @@ def test_import_from_airtable_to_workspace_with_report_table(data_fixture, tmpdi
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/e93dc201ce27080d9ad9df5775527d09/93e85b28/file-sample_500kB.doc",
+            "https://airtable.com/v0.3/row/rec9Imz1INvNXgRIXn1/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -1137,7 +1138,7 @@ def test_import_from_airtable_to_workspace_with_report_table(data_fixture, tmpdi
         body = file_handler.read()
         responses.add(
             responses.GET,
-            "https://dl.airtable.com/.attachments/025730a04991a764bb3ace6d524b45e5/bd61798a/file_example_JPG_100kB.jpg",
+            "https://airtable.com/v0.3/row/recyANUudYjDqIXdq9Z/downloadAttachment",
             status=206,
             body=body,
             headers={"Content-Range": f"bytes 0-{len(body) - 1}/{len(body)}"},
@@ -1578,3 +1579,21 @@ def test_airtable_file_import_open_download_failure_raises_key_error():
     with pytest.raises(KeyError, match="could not be downloaded"):
         with file_import.open("broken.pdf"):
             pass
+
+
+@responses.activate
+def test_download_airtable_file_request_exception_wraps_to_file_download_failed():
+    responses.add(
+        responses.GET,
+        STUB_AIRTABLE_FETCH_DOWNLOAD_FILE.url,
+        body=requests.exceptions.ConnectionError("Connection refused"),
+    )
+
+    with pytest.raises(FileDownloadFailed, match="could not be downloaded"):
+        download_airtable_file(
+            name="unreachable.pdf",
+            download_file=STUB_AIRTABLE_FETCH_DOWNLOAD_FILE,
+            init_data={},
+            request_id="req1",
+            cookies={},
+        )

--- a/changelog/entries/unreleased/bug/5799_fixed_file_attachments_not_being_imported_when_their_urls_we.json
+++ b/changelog/entries/unreleased/bug/5799_fixed_file_attachments_not_being_imported_when_their_urls_we.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed file attachments not being imported when their URLs were not included in the external system's signed URL mapping",
+    "issue_origin": "github",
+    "issue_number": 5799,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-07-30"
+}


### PR DESCRIPTION
## Summary
- When importing from an external system, files whose URLs are absent from the
  signed URL mapping now correctly fall back to the attachment download endpoint
  instead of silently failing.
- Network errors during file downloads are now caught and reported per-file in
  the import report instead of crashing the entire import job.

## Test plan
Import an Airtable base that contains directly uploaded file attachments (`.directUploadAttachment` files)  and observe it works


### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
