### PR TITLE
fix: set user.id on the HTTP server span so per-user metrics work

### DIFF
--- a/backend/src/baserow/core/telemetry/utils.py
+++ b/backend/src/baserow/core/telemetry/utils.py
@@ -76,12 +76,35 @@ class BatchBaggageSpanProcessor(BatchSpanProcessor):
             span.set_attribute(name, value)
 
 
+def _django_server_span(request) -> typing.Optional[Span]:
+    """
+    Return the Django server span the OpenTelemetry middleware stored on this request.
+
+    Authentication runs inside the `DRF.initial` span, so the current span during
+    authentication is an internal child, not the server span. Attributes set only on
+    that child are invisible to anything selecting on `SpanKind.SERVER`, such as the
+    Collector's per-user request metric connector.
+    """
+
+    # Imported lazily: this module is loaded by setup_telemetry() before django.setup(),
+    # and otel_middleware imports django.http at module scope.
+    from opentelemetry.instrumentation.django.middleware.otel_middleware import (
+        _DjangoMiddleware,
+    )
+
+    key = getattr(_DjangoMiddleware, "_environ_span_key", None)
+    meta = getattr(request, "META", None)
+    if not key or not meta:
+        return None
+    return meta.get(key)
+
+
 @contextmanager
 def setup_user_in_baggage_and_spans(user, request=None):
     """
-    Context manager that sets user-related attributes in the current span and adds
-    selected attributes as OpenTelemetry baggage. Automatically handles context
-    attach/detach safely for ASGI.
+    Context manager that sets user-related attributes on the request's server span,
+    falling back to the current span, and adds selected attributes as OpenTelemetry
+    baggage. Automatically handles context attach/detach safely for ASGI.
     """
 
     if not otel_is_enabled():
@@ -89,6 +112,10 @@ def setup_user_in_baggage_and_spans(user, request=None):
         return
 
     span = get_current_span()
+    if request is not None:
+        server_span = _django_server_span(request)
+        if server_span is not None:
+            span = server_span
     ctx = context.get_current()
 
     def _set(name, attr, source, set_baggage=False):

--- a/backend/tests/baserow/core/telemetry/test_utils.py
+++ b/backend/tests/baserow/core/telemetry/test_utils.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from opentelemetry import baggage
+from opentelemetry.instrumentation.django.middleware.otel_middleware import (
+    _DjangoMiddleware,
+)
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -14,9 +17,11 @@ from baserow.core.telemetry.sampling import OTEL_FORCE_FULL_TRACE_ATTRIBUTE
 from baserow.core.telemetry.utils import (
     BaserowTraceMeta,
     BatchBaggageSpanProcessor,
+    _django_server_span,
     baserow_trace,
     baserow_trace_entrypoint,
     baserow_trace_handler,
+    setup_user_in_baggage_and_spans,
 )
 
 
@@ -380,3 +385,51 @@ def test_baserow_trace_meta_rejects_non_method_override_of_traced_contract():
             operation = property(lambda self: "implementation")
 
     provider.shutdown()
+
+
+def test_user_attributes_land_on_the_django_server_span_not_the_current_span():
+    server_span = MagicMock()
+    current_span = MagicMock()
+    request = MagicMock()
+    request.META = {_DjangoMiddleware._environ_span_key: server_span}
+    request.user_token = None
+    user = MagicMock(id=42, untrusted_client_session_id=None)
+
+    with (
+        patch("baserow.core.telemetry.utils.otel_is_enabled", return_value=True),
+        patch(
+            "baserow.core.telemetry.utils.get_current_span", return_value=current_span
+        ),
+        setup_user_in_baggage_and_spans(user, request),
+    ):
+        assert baggage.get_baggage("user.id") == "42"
+
+    server_span.set_attribute.assert_any_call("user.id", 42)
+    current_span.set_attribute.assert_not_called()
+
+
+def test_user_attributes_fall_back_to_current_span_without_a_request():
+    current_span = MagicMock()
+    user = MagicMock(id=7, untrusted_client_session_id=None)
+
+    with (
+        patch("baserow.core.telemetry.utils.otel_is_enabled", return_value=True),
+        patch(
+            "baserow.core.telemetry.utils.get_current_span", return_value=current_span
+        ),
+        setup_user_in_baggage_and_spans(user),
+    ):
+        pass
+
+    current_span.set_attribute.assert_any_call("user.id", 7)
+
+
+def test_django_server_span_returns_none_when_request_has_no_span():
+    assert _django_server_span(MagicMock(META={})) is None
+    assert _django_server_span(object()) is None
+
+
+def test_upstream_still_exposes_the_environ_span_key_contract():
+    """Guards the private upstream attribute `_django_server_span` depends on."""
+
+    assert isinstance(_DjangoMiddleware._environ_span_key, str)


### PR DESCRIPTION
## The bug

`baserow.http.server.user.request.duration` has had **no datapoints in production since #5726 rolled out**. The per-user Honeycomb board renders "No results in this time range" and `user.id` groups as `(No value)`. It never worked in production — it did not "stop".

## Root cause

`setup_user_in_baggage_and_spans` picked its target span with `get_current_span()`. Its only HTTP callers are the DRF authentication classes (`baserow/api/authentication.py`, `contrib/database/api/tokens/authentications.py`), and DRF runs authentication inside `initial()` — which #5726 wrapped in a new `DRF.initial` span.

So `user.id`, `user.untrusted_client_session_id` and `user.token_id` were being set on an **internal child span**, never on the HTTP server span.

The Collector's `span_metrics/user_requests` connector keeps only spans satisfying all of:

```
span.kind == SPAN_KIND_SERVER
span.attributes["user.id"]    != nil
span.attributes["http.route"] != nil
```

No span satisfied both `SERVER` and `user.id`, so the connector received zero input.

Baggage does not paper over this: `BatchBaggageSpanProcessor` stamps attributes in `on_start`, and the server span starts *before* authentication runs. That is also why descendants of the auth point do carry `user.id` while the server span does not — which made the failure look like a Collector problem.

Confirmed against production: the other two `span_metrics` connectors (`baserow.dependency.duration`, `baserow.workspace.invitation.created.calls`) were writing normally at the same moment, so this is specific to the SERVER-scoped filter rather than shared Collector pressure.

## The fix

Resolve the server span from `request.META`, where the OpenTelemetry Django middleware stores it, and fall back to `get_current_span()` when there is no request — the `core.jobs.tasks` caller.

The META key is read off `_DjangoMiddleware` rather than hardcoded, and a test pins that contract so an upstream rename fails CI loudly instead of silently emptying the metric again. That failure mode is exactly what this PR is fixing, so it seemed worth guarding.

## Tests

Four new tests in `tests/baserow/core/telemetry/test_utils.py`:

- attributes land on the server span and **not** on the current span, and baggage is still set
- fall back to the current span when called without a request
- `_django_server_span` returns `None` for a request with no span, and for an object with no `META`
- the upstream `_environ_span_key` contract still holds

`just b test tests/baserow/core/telemetry/` → 54 passed. `pre-commit` clean.

## Impact

Once deployed, the per-user board fills in and the "single user making too many requests" alert becomes viable — that migration was deliberately held because moving it onto a dead metric would have made it permanently silent.

No changelog entry, matching #5726 which also shipped without one; this is internal observability with no user-visible behaviour change.