### PR TITLE
fix(database): exclude trashed fields from data sync export and guard import

### DIFF
--- a/backend/src/baserow/contrib/database/data_sync/registries.py
+++ b/backend/src/baserow/contrib/database/data_sync/registries.py
@@ -238,7 +238,7 @@ class DataSyncType(
         format.
         """
 
-        properties = instance.synced_properties.all()
+        properties = instance.synced_properties.filter(field__trashed=False)
         type_specific = {
             field: getattr(instance, field)
             for field in BASE_DATA_SYNC_ALLOWED_FIELDS + self.allowed_fields
@@ -290,10 +290,13 @@ class DataSyncType(
 
         properties_to_be_created = []
         for property in properties:
+            mapped_field_id = id_mapping["database_fields"].get(property["field_id"])
+            if mapped_field_id is None:
+                continue
             properties_to_be_created.append(
                 DataSyncSyncedProperty(
                     data_sync=data_sync,
-                    field_id=id_mapping["database_fields"][property["field_id"]],
+                    field_id=mapped_field_id,
                     key=property["key"],
                 )
             )

--- a/backend/src/baserow/contrib/database/data_sync/registries.py
+++ b/backend/src/baserow/contrib/database/data_sync/registries.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AbstractUser
 
 from celery.app.task import Context
+from loguru import logger
 
 from baserow.contrib.database.data_sync.constants import (
     BASE_DATA_SYNC_ALLOWED_FIELDS,
@@ -292,6 +293,12 @@ class DataSyncType(
         for property in properties:
             mapped_field_id = id_mapping["database_fields"].get(property["field_id"])
             if mapped_field_id is None:
+                logger.warning(
+                    "Skipping data sync property with key {key} for unmapped "
+                    "field {field_id} during import.",
+                    key=property["key"],
+                    field_id=property["field_id"],
+                )
                 continue
             properties_to_be_created.append(
                 DataSyncSyncedProperty(

--- a/backend/tests/baserow/contrib/database/data_sync/test_data_sync_registries.py
+++ b/backend/tests/baserow/contrib/database/data_sync/test_data_sync_registries.py
@@ -3,6 +3,7 @@ import responses
 
 from baserow.contrib.database.data_sync.handler import DataSyncHandler
 from baserow.contrib.database.data_sync.models import ICalCalendarDataSync
+from baserow.contrib.database.fields.handler import FieldHandler
 from baserow.core.registries import ImportExportConfig, application_type_registry
 
 ICAL_FEED_WITH_ONE_ITEMS = """BEGIN:VCALENDAR
@@ -172,3 +173,55 @@ def test_base_data_sync_settings_are_preserved_on_import_export(data_fixture):
     assert imported_data_sync.auto_add_new_properties is True
     assert imported_data_sync.delete_unmatched_rows is False
     assert imported_data_sync.two_way_sync is True
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_import_export_data_sync_with_trashed_property_field(data_fixture):
+    responses.add(
+        responses.GET,
+        "https://baserow.io/ical.ics",
+        status=200,
+        body=ICAL_FEED_WITH_ONE_ITEMS,
+    )
+
+    user = data_fixture.create_user()
+    workspace = data_fixture.create_workspace(user=user)
+    database = data_fixture.create_database_application(workspace=workspace)
+
+    handler = DataSyncHandler()
+
+    data_sync = handler.create_data_sync_table(
+        user=user,
+        database=database,
+        table_name="Test",
+        type_name="ical_calendar",
+        synced_properties=["uid", "dtstart", "dtend", "summary"],
+        ical_url="https://baserow.io/ical.ics",
+    )
+    handler.sync_data_sync_table(user=user, data_sync=data_sync)
+
+    fields = list(data_sync.table.field_set.all().order_by("id"))
+    FieldHandler().delete_field(user, fields[1].specific)
+
+    database_type = application_type_registry.get("database")
+    config = ImportExportConfig(include_permission_data=True)
+    serialized = database_type.export_serialized(database, config)
+
+    imported_workspace = data_fixture.create_workspace()
+    data_fixture.create_user_workspace(workspace=imported_workspace, user=user)
+
+    imported_database = database_type.import_serialized(
+        imported_workspace,
+        serialized,
+        config,
+        {},
+        None,
+        None,
+    )
+
+    imported_table = imported_database.table_set.all().first()
+    imported_data_sync = imported_table.data_sync.specific
+    imported_properties = imported_data_sync.synced_properties.all()
+    non_trashed_fields = data_sync.table.field_set.all()
+    assert imported_properties.count() == non_trashed_fields.count()

--- a/changelog/entries/unreleased/bug/5825_filter_trashed_fields_from_data_sync_export_and_guard_import.json
+++ b/changelog/entries/unreleased/bug/5825_filter_trashed_fields_from_data_sync_export_and_guard_import.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Filter trashed fields from data sync export and guard import against missing field mappings.",
+    "issue_origin": "github",
+    "issue_number": 5825,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-03"
+}

--- a/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
+++ b/enterprise/backend/src/baserow_enterprise/data_sync/baserow_table_data_sync.py
@@ -398,7 +398,9 @@ class LocalBaserowTableDataSyncType(DataSyncType):
             for data_sync_property in data_sync.synced_properties.all():
                 key_field_id = get_field_id_from_field_key(data_sync_property.key)
                 if key_field_id:
-                    new_field_id = id_mapping["database_fields"][key_field_id]
+                    new_field_id = id_mapping["database_fields"].get(key_field_id)
+                    if new_field_id is None:
+                        continue
                     data_sync_property.key = f"field_{new_field_id}"
                     properties_to_update.append(data_sync_property)
             DataSyncSyncedProperty.objects.bulk_update(properties_to_update, ["key"])


### PR DESCRIPTION
### What is in this PR

Snapshot/export/duplicate of a database containing a data sync table with trashed fields crashes with `KeyError` in the Celery export worker.

**Root cause:** `DataSyncSyncedProperty` is not a `TrashableModelMixin`, so `synced_properties.all()` includes properties referencing trashed fields, but the field export excludes trashed fields via `NoTrashManager` — creating a mismatch that causes a `KeyError` during import.

**Fix:**
- Filter `synced_properties` by `field__trashed=False` at export time to exclude trashed-field properties from serialized output
- Replace bare `id_mapping["database_fields"][...]` with `.get()` + `continue` at both import sites (core `registries.py` and enterprise `baserow_table_data_sync.py`) to handle legacy snapshots that contain trashed-field properties

**Not in scope:** Making `DataSyncSyncedProperty` a `TrashableModelMixin` — would require migration, cascading trash logic, and broader audit for a model that doesn't need independent trash semantics.

**Sentry:** Fixes BASEROW-SAAS-BACKEND-16N

### How to test this PR

1. Create a data sync table (e.g. iCal), sync it, trash one field, then snapshot/export the database — should succeed without error
2. Run tests from: `tests/baserow/contrib/database/data_sync/test_data_sync_registries.py`

Closes #5825

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
