### PR TITLE
fix(database): stringify field_options dict keys for msgpack-safe ws payloads

### DIFF
--- a/backend/src/baserow/contrib/database/api/views/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/serializers.py
@@ -137,7 +137,7 @@ class FieldOptionsField(serializers.Field):
                     fo for fo in field_options if fo.field_id in allowed_field_ids
                 ]
             return {
-                field_options.field_id: self.serializer_class(field_options).data
+                str(field_options.field_id): self.serializer_class(field_options).data
                 for field_options in field_options
             }
         else:

--- a/backend/src/baserow/contrib/database/api/views/serializers.py
+++ b/backend/src/baserow/contrib/database/api/views/serializers.py
@@ -136,6 +136,8 @@ class FieldOptionsField(serializers.Field):
                 field_options = [
                     fo for fo in field_options if fo.field_id in allowed_field_ids
                 ]
+            # Keys must be strings: channels_redis unpacks msgpack with
+            # strict_map_key=True and rejects integer map keys.
             return {
                 str(field_options.field_id): self.serializer_class(field_options).data
                 for field_options in field_options

--- a/backend/src/baserow/contrib/database/rows/registries.py
+++ b/backend/src/baserow/contrib/database/rows/registries.py
@@ -30,21 +30,21 @@ class RowMetadataRegistry(Registry):
 
         return self.generate_and_merge_metadata_for_rows(
             user, table, (i for i in [row_id])
-        ).get(row_id, {})
+        ).get(str(row_id), {})
 
     def generate_and_merge_metadata_for_rows(
         self, user, table, row_ids: Generator[int, None, None]
-    ) -> Dict[int, Dict[str, Any]]:
+    ) -> Dict[str, Dict[str, Any]]:
         """
         For every type of row metadata will generate that type of metadata for each
         provided row in the row_ids generator. Then returns a dictionary keyed by the
-        row id with the value being a dictionary of metadata. The dictionary of metadata
-        is keyed by the particular instance's RowMetadataType.type with the value being
-        whatever was returned by that instances generate_metadata_for_rows for that
-        row id.
+        stringified row id with the value being a dictionary of metadata. The dictionary
+        of metadata is keyed by the particular instance's RowMetadataType.type with the
+        value being whatever was returned by that instances generate_metadata_for_rows
+        for that row id.
 
         For example if two different RowMetadata types 'A' and 'B" were registered,
-        and they returned {'1': 10, '2': 2} and {'1': False, '2': True} from their
+        and they returned {1: 10, 2: 2} and {1: False, 2: True} from their
         respective generate_metadata_for_rows methods. This function would then return
         a dict which looked like: {'1': {'A':10, 'B':False}, '2': {'A':2, 'B':True}}.
 
@@ -53,8 +53,8 @@ class RowMetadataRegistry(Registry):
         :param row_ids: A generator which should return the row ids generate metadata
             for. If no RowMetadataTypes are registered then this generator will not be
             invoked.
-        :return: A dictionary of Row Id -> RowMetadataType -> Metadata Value if
-            metadata types are registered, otherwise an empty dict.
+        :return: A dictionary of stringified Row Id -> RowMetadataType -> Metadata
+            Value if metadata types are registered, otherwise an empty dict.
         """
 
         metadata_types = self.get_all()
@@ -66,7 +66,10 @@ class RowMetadataRegistry(Registry):
                     user, table, row_ids
                 )
                 for row_id, metadata in per_row_metadata.items():
-                    single_row_metadata = row_metadata.setdefault(row_id, {})
+                    # Keys must be strings: channels_redis unpacks msgpack with
+                    # strict_map_key=True and rejects integer map keys.
+                    str_row_id = str(row_id)
+                    single_row_metadata = row_metadata.setdefault(str_row_id, {})
                     single_row_metadata[metadata_type.type] = metadata
             return row_metadata
         else:

--- a/backend/src/baserow/contrib/database/ws/rows/messages.py
+++ b/backend/src/baserow/contrib/database/ws/rows/messages.py
@@ -40,7 +40,7 @@ class RealtimeRowMessages:
         table_id: int,
         serialized_rows_before_update: List[Dict[str, Any]],
         serialized_rows: List[Dict[str, Any]],
-        metadata: Dict[int, Dict[str, Any]],
+        metadata: Dict[str, Dict[str, Any]],
         updated_field_ids: List[int],
     ) -> Dict[str, Any]:
         return {

--- a/backend/tests/baserow/contrib/database/api/views/test_view_serializers.py
+++ b/backend/tests/baserow/contrib/database/api/views/test_view_serializers.py
@@ -1,3 +1,4 @@
+import msgpack
 import pytest
 from pytest_unordered import unordered
 
@@ -6,7 +7,24 @@ from baserow.contrib.database.fields.models import Field
 from baserow.contrib.database.fields.registries import field_type_registry
 from baserow.contrib.database.views.handler import ViewHandler
 from baserow.contrib.database.views.models import DEFAULT_SORT_TYPE_KEY
+from baserow.contrib.database.views.registries import view_type_registry
 from baserow.test_utils.helpers import setup_interesting_test_table
+
+
+@pytest.mark.django_db
+def test_field_options_field_to_representation_keys_are_msgpack_safe(data_fixture):
+    grid_view = data_fixture.create_grid_view()
+    data_fixture.create_text_field(table=grid_view.table)
+
+    view_type = view_type_registry.get_by_model(grid_view.specific_class)
+    serializer_class = view_type.get_field_options_serializer_class(
+        create_if_missing=True
+    )
+    payload = serializer_class(grid_view).data["field_options"]
+
+    assert payload, "expected at least one field option in the payload"
+    packed = msgpack.packb(payload, use_bin_type=True)
+    msgpack.unpackb(packed, strict_map_key=True, raw=False)
 
 
 @pytest.mark.django_db

--- a/backend/tests/baserow/contrib/database/rows/test_row_metadata_registry.py
+++ b/backend/tests/baserow/contrib/database/rows/test_row_metadata_registry.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List
 
+import msgpack
 from rest_framework import serializers
 from rest_framework.fields import Field
 
@@ -49,9 +50,36 @@ def test_merges_together_row_metadata_by_type_and_row_id():
         None, None, (i for i in range(3))
     )
     assert result == {
-        0: {"is_even": True, "row_id": 0},
-        1: {"row_id": 1},
-        2: {"is_even": True, "row_id": 2},
+        "0": {"is_even": True, "row_id": 0},
+        "1": {"row_id": 1},
+        "2": {"is_even": True, "row_id": 2},
     }
     result = registry.generate_and_merge_metadata_for_row(None, None, 0)
     assert result == {"is_even": True, "row_id": 0}
+
+
+def test_row_metadata_keys_are_msgpack_safe():
+    registry = RowMetadataRegistry()
+
+    class RowIdMetadata(RowMetadataType):
+        type = "row_id"
+
+        def generate_metadata_for_rows(
+            self, user, table, row_ids: List[int]
+        ) -> Dict[int, Any]:
+            return {row_id: row_id for row_id in row_ids}
+
+        def get_example_serializer_field(self) -> Field:
+            return serializers.CharField()
+
+    registry.register(RowIdMetadata())
+
+    result = registry.generate_and_merge_metadata_for_rows(
+        None, None, (i for i in range(3))
+    )
+
+    for key in result:
+        assert isinstance(key, str), f"metadata key {key!r} must be a string"
+
+    packed = msgpack.packb(result, use_bin_type=True)
+    msgpack.unpackb(packed, strict_map_key=True, raw=False)

--- a/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/test_ws_rows_signals.py
@@ -90,7 +90,7 @@ def test_row_created_with_metadata(mock_broadcast_to_channel_group, data_fixture
     assert args[0][1]["rows"][0]["id"] == row.id
     assert args[0][1]["before_row_id"] is None
     assert args[0][1]["rows"][0][f"field_{field.id}"] == "Test"
-    assert args[0][1]["metadata"] == {1: {"row_id": row.id}}
+    assert args[0][1]["metadata"] == {"1": {"row_id": row.id}}
 
 
 def test_populates_with_row_id_metadata():
@@ -199,7 +199,7 @@ def test_row_updated_with_metadata(mock_broadcast_to_channel_group, data_fixture
     assert args[0][1]["rows"][0]["id"] == row.id
     assert args[0][1]["rows"][0][f"field_{field.id}"] == "Test"
     assert args[0][1]["rows"][0][f"field_{field_2.id}"] is None
-    assert args[0][1]["metadata"] == {1: {"row_id": row.id}}
+    assert args[0][1]["metadata"] == {"1": {"row_id": row.id}}
 
 
 @pytest.mark.django_db(transaction=True)

--- a/backend/tests/baserow/contrib/database/ws/test_ws_view_signals.py
+++ b/backend/tests/baserow/contrib/database/ws/test_ws_view_signals.py
@@ -261,7 +261,7 @@ def test_view_field_options_updated(mock_broadcast_to_channel_group, data_fixtur
     assert args[0][0] == f"table-{table.id}"
     assert args[0][1]["type"] == "view_field_options_updated"
     assert args[0][1]["view_id"] == grid_view.id
-    assert args[0][1]["field_options"][text_field.id]["width"] == 150
+    assert args[0][1]["field_options"][str(text_field.id)]["width"] == 150
 
 
 @pytest.mark.django_db(transaction=True)

--- a/changelog/entries/unreleased/bug/5827_stringify_field_options_dict_keys_in_view_serializer_to_prev.json
+++ b/changelog/entries/unreleased/bug/5827_stringify_field_options_dict_keys_in_view_serializer_to_prev.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Stringify field_options dict keys in view serializer to prevent msgpack rejection on WebSocket broadcast",
+    "issue_origin": "github",
+    "issue_number": 5827,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-03"
+}

--- a/changelog/entries/unreleased/bug/5827_stringify_field_options_dict_keys_in_view_serializer_to_prev.json
+++ b/changelog/entries/unreleased/bug/5827_stringify_field_options_dict_keys_in_view_serializer_to_prev.json
@@ -1,6 +1,6 @@
 {
     "type": "bug",
-    "message": "Stringify field_options dict keys in view serializer to prevent msgpack rejection on WebSocket broadcast",
+    "message": "Fixed a bug where column resizes and other field option changes weren't shown to other users in real time",
     "issue_origin": "github",
     "issue_number": 5827,
     "domain": "database",


### PR DESCRIPTION
### What is in this PR

**Two related fixes for integer dict keys breaking WebSocket broadcasts via msgpack `strict_map_key=True` rejection.**

#### 1. `FieldOptionsField.to_representation` (original fix)

Keyed `field_options` dict by raw integer `field_id`. While `msgpack.packb` accepts int keys, `channels_redis` unpacks with `strict_map_key=True`, which rejects them — causing a `ValueError` that silently drops the WebSocket broadcast (1949 Sentry events).

**Root cause:** Integer dict keys in serializer output incompatible with `channels_redis` msgpack `strict_map_key=True` default.

**Fix:** `str(field_options.field_id)` at the single construction site in `FieldOptionsField.to_representation`.

#### 2. `RowMetadataRegistry.generate_and_merge_metadata_for_rows` (sibling fix)

Same root cause: `generate_and_merge_metadata_for_rows()` built dicts keyed by integer `row_id`, which flow into WS broadcasts via `rows_created`, `rows_updated`, and `broadcast_dependant_rows_updated` signals/tasks. This affects row metadata (e.g. comment counts) when premium row comments are active.

**Fix:** Stringify keys at the registry level — the single source for all row metadata — so all current and future metadata types produce msgpack-safe payloads. Frontend is unaffected since JS auto-coerces `obj[123]` to `obj["123"]`.

### How to test this PR

1. Open a grid view in two tabs, resize a column in tab 1 → tab 2 should reflect the change via WebSocket
2. (Premium) Add a row comment, verify comment count metadata propagates in real time to other tabs
3. Run tests:
   ```
   just pytest tests/baserow/contrib/database/rows/test_row_metadata_registry.py
   just pytest tests/baserow/contrib/database/ws/test_ws_rows_signals.py
   just pytest tests/baserow/contrib/database/api/views/test_view_serializers.py
   ```

Closes: #5827

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
