### PR TITLE
fix: strip XML-illegal control chars in Excel export

### DIFF
--- a/changelog/entries/unreleased/bug/5829_strip_xmlillegal_control_characters_from_cell_values_during_.json
+++ b/changelog/entries/unreleased/bug/5829_strip_xmlillegal_control_characters_from_cell_values_during_.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Strip XML-illegal control characters from cell values during Excel export instead of crashing.",
+    "issue_origin": "github",
+    "issue_number": 5829,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-03"
+}

--- a/premium/backend/src/baserow_premium/export/exporter_types.py
+++ b/premium/backend/src/baserow_premium/export/exporter_types.py
@@ -192,12 +192,14 @@ class ExcelQuerysetSerializer(QuerysetSerializer):
         """
 
         from openpyxl import Workbook
-        from openpyxl.cell.cell import WriteOnlyCell
+        from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE, WriteOnlyCell
 
         workbook = Workbook(write_only=True)
         worksheet = workbook.create_sheet()
 
         def text_cell(value):
+            # Strip XML-illegal control chars that crash openpyxl's check_string.
+            value = ILLEGAL_CHARACTERS_RE.sub("", value)
             # openpyxl types a string that starts with "=" as a live formula
             # cell, so a user defined field name or cell value could carry a
             # formula injection (CWE-1236). Force those to an explicit string

--- a/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
+++ b/premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py
@@ -1484,3 +1484,42 @@ def test_excel_export_does_not_write_formula_cells(
     assert value_cell.data_type == "s"
     assert header_cell.value == "=2+5+cmd"
     assert value_cell.value == "=3+4+cmd"
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
+@patch("baserow.core.storage.get_default_storage")
+def test_excel_export_strips_xml_illegal_control_characters(
+    get_storage_mock, premium_data_fixture
+):
+    storage_mock = MagicMock()
+    get_storage_mock.return_value = storage_mock
+    user = premium_data_fixture.create_user(has_active_premium_license=True)
+    table = premium_data_fixture.create_database_table(user=user)
+    field = premium_data_fixture.create_text_field(
+        table=table, name="Notes\x1f", primary=True
+    )
+    grid_view = premium_data_fixture.create_grid_view(table=table)
+    RowHandler().create_row(user, table, {f"field_{field.id}": "Hong Kong\x1f"})
+    RowHandler().create_row(user, table, {f"field_{field.id}": "keep\tme\nplease"})
+    RowHandler().create_row(user, table, {f"field_{field.id}": "=SUM\x1f(A1)"})
+
+    _, wb_bytes = run_export_job_with_mock_storage(
+        table,
+        grid_view,
+        storage_mock,
+        user,
+        {
+            "exporter_type": "excel",
+            "export_charset": None,
+            "excel_include_header": True,
+            "include_row_id": False,
+        },
+    )
+
+    worksheet = load_workbook(filename=BytesIO(wb_bytes)).active
+    assert worksheet.cell(row=1, column=1).value == "Notes"
+    assert worksheet.cell(row=2, column=1).value == "Hong Kong"
+    assert worksheet.cell(row=3, column=1).value == "keep\tme\nplease"
+    assert worksheet.cell(row=4, column=1).value == "=SUM(A1)"
+    assert worksheet.cell(row=4, column=1).data_type == "s"


### PR DESCRIPTION
### What is in this PR

Excel export jobs crash with `IllegalCharacterError` when any exported cell value or field name contains an XML-illegal control character (`0x00-0x08`, `0x0B-0C`, `0x0E-1F`). These invisible bytes typically arrive via copy-paste from external sources. One bad byte aborts the entire export, producing no file.

**Root cause:** `text_cell` in `ExcelQuerysetSerializer.write_to_file` passes raw strings to openpyxl without stripping XML-illegal control characters.

**Fix:**
- Import `ILLEGAL_CHARACTERS_RE` from `openpyxl.cell.cell` (reuses openpyxl's own regex — zero validation-class drift)
- Strip illegal chars as first step in `text_cell`, before formula-injection handling
- Allowed whitespace (`\t`, `\n`, `\r`) is preserved

**Not in scope:** CSV/JSON/XML exporters are unaffected (they don't run openpyxl's `check_string`).

**Sentry:** Fixes BASEROW-SAAS-BACKEND-1D, BASEROW-SAAS-BACKEND-194

### How to test this PR

1. Create a text field, insert a row with value containing `\x1f` (e.g. via API: `"Hong Kong\x1f"`). Export as Excel. Confirm export succeeds and value reads `"Hong Kong"`.
2. Insert a row with `"keep\tme\nplease"`. Export. Confirm tab and newline are preserved.
3. Insert a row with `"=SUM\x1f(A1)"`. Export. Confirm value is `"=SUM(A1)"` as plain string (not formula).
4. Run tests: `just pytest ../premium/backend/tests/baserow_premium_tests/export/test_premium_export_types.py`

Closes: #5829 

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
