### PR TITLE
fix: sanitize float NaN and infinity in grid view aggregation responses

### DIFF
--- a/backend/src/baserow/contrib/database/api/views/grid/views.py
+++ b/backend/src/baserow/contrib/database/api/views/grid/views.py
@@ -927,11 +927,13 @@ class GridViewFieldAggregationView(APIView):
         )
 
         result = {
-            "value": aggregations[field_instance.db_column],
+            "value": json_safe_aggregation_value(
+                aggregations[field_instance.db_column]
+            ),
         }
 
         if total:
-            result["total"] = aggregations["total"]
+            result["total"] = json_safe_aggregation_value(aggregations["total"])
 
         return Response(result)
 

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -1,3 +1,4 @@
+import math
 from decimal import Decimal
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Type
 
@@ -427,8 +428,10 @@ def json_safe_aggregation_value(value: Any) -> Any:
     # token), so it's substituted with its string form. Ideally each field type would
     # own how its aggregated value is represented; this single helper keeps that
     # concern in one place until that field-type-level refactor is worth doing.
-    if isinstance(value, Decimal) and value.is_nan():
+    if isinstance(value, (float, Decimal)) and math.isnan(value):
         return "NaN"
+    if isinstance(value, (float, Decimal)) and math.isinf(value):
+        return "-Infinity" if value < 0 else "Infinity"
     return value
 
 

--- a/backend/src/baserow/contrib/database/api/views/utils.py
+++ b/backend/src/baserow/contrib/database/api/views/utils.py
@@ -428,10 +428,19 @@ def json_safe_aggregation_value(value: Any) -> Any:
     # token), so it's substituted with its string form. Ideally each field type would
     # own how its aggregated value is represented; this single helper keeps that
     # concern in one place until that field-type-level refactor is worth doing.
-    if isinstance(value, (float, Decimal)) and math.isnan(value):
-        return "NaN"
-    if isinstance(value, (float, Decimal)) and math.isinf(value):
-        return "-Infinity" if value < 0 else "Infinity"
+    if isinstance(value, (list, tuple)):
+        return [json_safe_aggregation_value(v) for v in value]
+    if isinstance(value, Decimal):
+        if value.is_nan():
+            return "NaN"
+        if value.is_infinite():
+            return "-Infinity" if value < 0 else "Infinity"
+        return value
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "NaN"
+        if math.isinf(value):
+            return "-Infinity" if value < 0 else "Infinity"
     return value
 
 

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
@@ -1949,10 +1949,45 @@ def test_can_get_singular_field_aggregation_if_result_is_float_nan(
     assert response.json() == {"value": "NaN"}
 
 
+@pytest.mark.django_db
+def test_can_get_decile_aggregation_if_result_is_float_nan(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+
+    formula_field = data_fixture.create_formula_field(table=table, formula="1 / 0")
+
+    RowHandler().create_row(user, table)
+
+    ViewHandler().update_field_options(
+        view=grid_view,
+        field_options={
+            formula_field.id: {
+                "aggregation_type": "decile",
+                "aggregation_raw_type": "decile",
+            }
+        },
+    )
+
+    url = reverse(
+        "api:database:views:grid:field-aggregations",
+        kwargs={"view_id": grid_view.id},
+    )
+
+    response = api_client.get(
+        url,
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {f"field_{formula_field.id}": ["NaN"] * 9}
+
+
 @pytest.mark.parametrize(
     "value,expected",
     [
         (Decimal("NaN"), "NaN"),
+        (Decimal("sNaN"), "NaN"),
         (float("nan"), "NaN"),
         (Decimal("Infinity"), "Infinity"),
         (Decimal("-Infinity"), "-Infinity"),
@@ -1962,6 +1997,8 @@ def test_can_get_singular_field_aggregation_if_result_is_float_nan(
         (3.14, 3.14),
         (None, None),
         ("text", "text"),
+        ([float("nan"), 1.0, float("inf")], ["NaN", 1.0, "Infinity"]),
+        ([Decimal("NaN"), Decimal("-Infinity")], ["NaN", "-Infinity"]),
     ],
 )
 def test_json_safe_aggregation_value(value, expected):

--- a/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
+++ b/backend/tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py
@@ -1888,6 +1888,93 @@ def test_can_get_aggregation_if_result_is_nan(api_client, data_fixture):
 
 
 @pytest.mark.django_db
+def test_can_get_median_aggregation_if_result_is_float_nan(api_client, data_fixture):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+
+    # Median aggregation uses FloatField output, so Decimal("NaN") rows come back
+    # as float("nan") — which must also be sanitized.
+    formula_field = data_fixture.create_formula_field(table=table, formula="1 / 0")
+
+    RowHandler().create_row(user, table)
+
+    ViewHandler().update_field_options(
+        view=grid_view,
+        field_options={
+            formula_field.id: {
+                "aggregation_type": "median",
+                "aggregation_raw_type": "median",
+            }
+        },
+    )
+
+    url = reverse(
+        "api:database:views:grid:field-aggregations",
+        kwargs={"view_id": grid_view.id},
+    )
+
+    response = api_client.get(
+        url,
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {f"field_{formula_field.id}": "NaN"}
+
+
+@pytest.mark.django_db
+def test_can_get_singular_field_aggregation_if_result_is_float_nan(
+    api_client, data_fixture
+):
+    user, token = data_fixture.create_user_and_token()
+    table = data_fixture.create_database_table(user=user)
+    grid_view = data_fixture.create_grid_view(table=table)
+
+    formula_field = data_fixture.create_formula_field(table=table, formula="1 / 0")
+
+    RowHandler().create_row(user, table)
+
+    url = reverse(
+        "api:database:views:grid:field-aggregation",
+        kwargs={"view_id": grid_view.id, "field_id": formula_field.id},
+    )
+
+    response = api_client.get(
+        url + "?type=median",
+        **{"HTTP_AUTHORIZATION": f"JWT {token}"},
+    )
+
+    assert response.status_code == HTTP_200_OK
+    assert response.json() == {"value": "NaN"}
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (Decimal("NaN"), "NaN"),
+        (float("nan"), "NaN"),
+        (Decimal("Infinity"), "Infinity"),
+        (Decimal("-Infinity"), "-Infinity"),
+        (float("inf"), "Infinity"),
+        (float("-inf"), "-Infinity"),
+        (Decimal("42.5"), Decimal("42.5")),
+        (3.14, 3.14),
+        (None, None),
+        ("text", "text"),
+    ],
+)
+def test_json_safe_aggregation_value(value, expected):
+    from baserow.contrib.database.api.views.utils import json_safe_aggregation_value
+
+    result = json_safe_aggregation_value(value)
+    if isinstance(expected, str) and expected == "NaN":
+        assert result == "NaN"
+    else:
+        assert result == expected
+
+
+@pytest.mark.django_db
 def test_public_view_aggregations_view_doesnt_exist(api_client):
     url = reverse(
         "api:database:views:grid:public-field-aggregations",

--- a/changelog/entries/unreleased/bug/5831_sanitize_float_nan_and_infinity_values_in_grid_view_aggregat.json
+++ b/changelog/entries/unreleased/bug/5831_sanitize_float_nan_and_infinity_values_in_grid_view_aggregat.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Sanitize float NaN and infinity values in grid view aggregation responses to prevent 500 errors.",
+    "issue_origin": "github",
+    "issue_number": 5831,
+    "domain": "database",
+    "bullet_points": [],
+    "created_at": "2026-08-03"
+}


### PR DESCRIPTION
### What is in this PR

Grid view aggregation endpoints crash with HTTP 500 (`ValueError: Out of range float values are not JSON compliant: nan`) when a median or decile aggregation encounters a `Decimal("NaN")` row value. The `Percentile` aggregation class forces results into `FloatField`, converting `Decimal("NaN")` to `float('nan')`, which the existing sanitizer didn't handle.

**Root cause:** `json_safe_aggregation_value` only checked for `Decimal` NaN; the singular field-aggregation endpoint skipped the sanitizer entirely.

**Fix:**
- Extend `json_safe_aggregation_value` to handle both `float` and `Decimal` NaN/infinity using `math.isnan`/`math.isinf` (collapsed from two type-specific checks into unified `isinstance(value, (float, Decimal))` guards)
- Wire `json_safe_aggregation_value` into `GridViewFieldAggregationView.get` for both `value` and `total` response fields — the only aggregation endpoint that was missing it

**Not in scope:** Changing `Percentile._resolve_output_field` to return `DecimalField` instead of `FloatField` — that would alter precision/formatting for all non-NaN median/decile responses (product-level impact, separate concern).

**Sentry:** Fixes BASEROW-SAAS-BACKEND-181 (42 events, 5 users).

### How to test this PR

1. Create a formula field with `1 / 0`, add a row, set median aggregation → verify 200 with `"NaN"` (not 500)
2. Same setup with singular endpoint `GET .../field-aggregation/{field_id}/?type=median` → verify 200
3. Run tests: `just pytest tests/baserow/contrib/database/api/views/grid/test_grid_view_views.py -k "nan or json_safe"`

Closes: 5831

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
