### PR TITLE
fix: markdow parsing to avoid escaping

### DIFF
--- a/changelog/entries/unreleased/bug/fix_markdown_in_text_element_to_prevent_code_execution.json
+++ b/changelog/entries/unreleased/bug/fix_markdown_in_text_element_to_prevent_code_execution.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fix markdown parsing in Text element to prevent code execution",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/web-frontend/modules/builder/components/elements/components/TextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/TextElement.vue
@@ -37,7 +37,7 @@ import element from '@baserow/modules/builder/mixins/element'
 import { generateHash } from '@baserow/modules/core/utils/hashing'
 import { ensureString } from '@baserow/modules/core/utils/validator'
 import { TEXT_FORMAT_TYPES } from '@baserow/modules/builder/enums'
-import { prefixInternalResolvedUrl } from '@baserow/modules/builder/utils/urlResolution'
+import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/utils/markdown'
 
 /**
  * @typedef Text
@@ -85,103 +85,10 @@ export default {
     // The goal is to make the styling of the rendered markdown content
     // consistent with the rest of the application builder CSS classes
     rules() {
-      return {
-        heading_open: (tokens, idx, options, env, renderer) => {
-          const level = tokens[idx].markup.length
-          tokens[idx].attrJoin('class', `ab-heading ab-heading--h${level}`)
-          return renderer.renderToken(tokens, idx, options)
-        },
-        link_open: (tokens, idx, options, env, renderer) => {
-          const url = prefixInternalResolvedUrl(
-            tokens[idx].attrGet('href'),
-            this.builder,
-            'custom',
-            this.mode
-          )
-          tokens[idx].attrSet('href', url)
-          tokens[idx].attrJoin('class', 'ab-link')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        image: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-image')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        paragraph_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-text')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        blockquote_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-blockquote')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        fence: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-code')
-
-          return `${renderer.renderToken(tokens, idx, options)}<pre>${
-            tokens[idx].content
-          }</pre></code>`
-        },
-        code_inline: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-code ab-code--inline')
-          return `${renderer.renderToken(tokens, idx, options)}${
-            tokens[idx].content
-          }</code>`
-        },
-        hr: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-hr')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        table_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin(
-            'class',
-            'baserow-table baserow-table--horizontal'
-          )
-          return `<div class="ab-table">${renderer.renderToken(
-            tokens,
-            idx,
-            options
-          )}`
-        },
-        table_close: (tokens, idx, options, env, renderer) => {
-          return `${renderer.renderToken(tokens, idx, options)}</div>`
-        },
-        tr_open: (tokens, idx, options, env, renderer) => {
-          // Only apply this styling to the first row present in table header.
-          if (idx > 0 && tokens[idx - 1].type === 'thead_open') {
-            tokens[idx].attrJoin('class', 'baserow-table__row')
-          } else {
-            tokens[idx].attrJoin('class', 'baserow-table__row')
-          }
-          return renderer.renderToken(tokens, idx, options)
-        },
-        th_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-table__header-cell')
-          return `${renderer.renderToken(tokens, idx, options)}<div>`
-        },
-        td_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-table__cell')
-          return `${renderer.renderToken(
-            tokens,
-            idx,
-            options
-          )}<div class="ab-table__cell-content">`
-        },
-        td_close: (tokens, idx, options, env, renderer) => {
-          return `</div>${renderer.renderToken(tokens, idx, options)}`
-        },
-        ordered_list_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-list')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        list_item_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-list__item')
-          return renderer.renderToken(tokens, idx, options)
-        },
-        bullet_list_open: (tokens, idx, options, env, renderer) => {
-          tokens[idx].attrJoin('class', 'ab-list')
-          return renderer.renderToken(tokens, idx, options)
-        },
-      }
+      return createApplicationBuilderMarkdownRules({
+        builder: this.builder,
+        mode: this.mode,
+      })
     },
   },
   methods: {

--- a/web-frontend/modules/builder/utils/markdown.js
+++ b/web-frontend/modules/builder/utils/markdown.js
@@ -1,0 +1,93 @@
+import { escapeHtml } from '@baserow/modules/core/utils/string'
+import { prefixInternalResolvedUrl } from '@baserow/modules/builder/utils/urlResolution'
+
+/**
+ * Creates the Markdown-It renderer rules used by Application Builder content.
+ * These rules add the Application Builder CSS classes and safely render token
+ * content interpolated into HTML.
+ */
+export const createApplicationBuilderMarkdownRules = ({ builder, mode }) => ({
+  heading_open: (tokens, idx, options, env, renderer) => {
+    const level = tokens[idx].markup.length
+    tokens[idx].attrJoin('class', `ab-heading ab-heading--h${level}`)
+    return renderer.renderToken(tokens, idx, options)
+  },
+  link_open: (tokens, idx, options, env, renderer) => {
+    const url = prefixInternalResolvedUrl(
+      tokens[idx].attrGet('href'),
+      builder,
+      'custom',
+      mode
+    )
+    tokens[idx].attrSet('href', url)
+    tokens[idx].attrJoin('class', 'ab-link')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  image: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-image')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  paragraph_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-text')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  blockquote_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-blockquote')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  fence: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-code')
+
+    return `${renderer.renderToken(tokens, idx, options)}<pre>${escapeHtml(
+      tokens[idx].content
+    )}</pre></code>`
+  },
+  code_inline: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-code ab-code--inline')
+    return `${renderer.renderToken(tokens, idx, options)}${escapeHtml(
+      tokens[idx].content
+    )}</code>`
+  },
+  hr: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-hr')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  table_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'baserow-table baserow-table--horizontal')
+    return `<div class="ab-table">${renderer.renderToken(tokens, idx, options)}`
+  },
+  table_close: (tokens, idx, options, env, renderer) => {
+    return `${renderer.renderToken(tokens, idx, options)}</div>`
+  },
+  tr_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'baserow-table__row')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  th_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-table__header-cell')
+    return `${renderer.renderToken(tokens, idx, options)}<div>`
+  },
+  td_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-table__cell')
+    return `${renderer.renderToken(
+      tokens,
+      idx,
+      options
+    )}<div class="ab-table__cell-content">`
+  },
+  td_close: (tokens, idx, options, env, renderer) => {
+    return `</div>${renderer.renderToken(tokens, idx, options)}`
+  },
+  ordered_list_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-list')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  list_item_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-list__item')
+    return renderer.renderToken(tokens, idx, options)
+  },
+  bullet_list_open: (tokens, idx, options, env, renderer) => {
+    tokens[idx].attrJoin('class', 'ab-list')
+    return renderer.renderToken(tokens, idx, options)
+  },
+})

--- a/web-frontend/test/unit/builder/components/elements/components/TextElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/TextElement.spec.js
@@ -1,0 +1,34 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import TextElement from '@baserow/modules/builder/components/elements/components/TextElement.vue'
+
+describe('TextElement', () => {
+  test('renders Markdown with the Application Builder rules', async () => {
+    const page = {}
+    const builder = { id: 1, theme: {} }
+    const mode = 'public'
+    const element = {
+      id: 1,
+      type: 'text',
+      value: { mode: 'raw', formula: '# Heading\n\n`inline code`' },
+      format: 'markdown',
+      styles: {},
+    }
+
+    const wrapper = await mountSuspended(TextElement, {
+      props: { element },
+      global: {
+        provide: {
+          workspace: {},
+          builder,
+          currentPage: page,
+          elementPage: page,
+          mode,
+          applicationContext: { builder, page, mode },
+        },
+      },
+    })
+
+    expect(wrapper.find('.ab-heading').text()).toBe('Heading')
+    expect(wrapper.find('.ab-code--inline').text()).toBe('inline code')
+  })
+})

--- a/web-frontend/test/unit/builder/utils/markdown.spec.js
+++ b/web-frontend/test/unit/builder/utils/markdown.spec.js
@@ -1,0 +1,68 @@
+import MarkdownIt from 'markdown-it'
+import { createApplicationBuilderMarkdownRules } from '@baserow/modules/builder/utils/markdown'
+
+const renderMarkdown = (
+  content,
+  { builder = { id: 1 }, mode = 'public' } = {}
+) => {
+  const markdown = new MarkdownIt()
+  markdown.renderer.rules = {
+    ...markdown.renderer.rules,
+    ...createApplicationBuilderMarkdownRules({ builder, mode }),
+  }
+  return markdown.render(content)
+}
+
+describe('createApplicationBuilderMarkdownRules', () => {
+  test.each([
+    [
+      'inline',
+      '`</code><img src=x onerror=alert(document.domain)>`',
+      '&lt;/code&gt;&lt;img src=x onerror=alert(document.domain)&gt;',
+    ],
+    [
+      'fenced',
+      '```\n</pre></code><img src=x onerror=alert(document.domain)>\n```',
+      '&lt;/pre&gt;&lt;/code&gt;&lt;img src=x onerror=alert(document.domain)&gt;',
+    ],
+  ])('escapes HTML in %s code', (type, content, escapedContent) => {
+    const html = renderMarkdown(content)
+
+    expect(html).not.toContain('<img')
+    expect(html).toContain(escapedContent)
+  })
+
+  test('renders HTML-looking content as inline code', () => {
+    const html = renderMarkdown('`const template = "<div>hello</div>"`')
+
+    expect(html).toContain(
+      '<code class="ab-code ab-code--inline">' +
+        'const template = &quot;&lt;div&gt;hello&lt;/div&gt;&quot;</code>'
+    )
+    expect(html).not.toContain('<div>hello</div>')
+  })
+
+  test('adds Application Builder classes', () => {
+    const html = renderMarkdown(
+      '# Heading\n\nParagraph\n\n> Quote\n\n- List item\n\n---'
+    )
+
+    expect(html).toContain('class="ab-heading ab-heading--h1"')
+    expect(html).toContain('class="ab-text"')
+    expect(html).toContain('class="ab-blockquote"')
+    expect(html).toContain('class="ab-list"')
+    expect(html).toContain('class="ab-list__item"')
+    expect(html).toContain('class="ab-hr"')
+  })
+
+  test('prefixes internal links in preview mode', () => {
+    const html = renderMarkdown('[Link](/path)', {
+      builder: { id: 42 },
+      mode: 'preview',
+    })
+
+    expect(html).toContain(
+      '<a href="/builder/42/preview/path" class="ab-link">Link</a>'
+    )
+  })
+})


### PR DESCRIPTION
### What is in this PR

Fix Markdown parsing for Text element.

### How to test this PR

Ask me

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [ ] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [ ] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [ ] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [ ] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [ ] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [ ] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [ ] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [ ] Security impact of change has been considered
