### PR TITLE
Improve audit log performance

### DIFF
--- a/backend/src/baserow/core/db.py
+++ b/backend/src/baserow/core/db.py
@@ -44,24 +44,30 @@ ModelInstance = TypeVar("ModelInstance", bound=object)
 
 
 APPROXIMATE_COUNT_THRESHOLD = 50_000
+EXACT_COUNT_MAX_COST = 200_000
 
 
 def get_approximate_row_count(queryset: QuerySet) -> int:
     """
-    Uses Postgres EXPLAIN to estimate the row count for the given queryset.
-    If the estimate is below APPROXIMATE_COUNT_THRESHOLD, falls back to an
-    exact COUNT(*) since the cost is negligible for small result sets and
-    the planner estimate is unreliable at that scale.
+    Uses Postgres EXPLAIN to estimate the row count for the given queryset, falling
+    back to an exact COUNT(*) when the planner reports both a small result set,
+    because the estimate is unreliable at that scale, and a cheap plan to produce it.
 
     :param queryset: The queryset to estimate the row count for.
     :return: An estimate of the row count for the queryset.
     """
 
     queryset = queryset.order_by()
-    plan = json.loads(queryset.explain(format="json"))
-    estimate = int(plan[0]["Plan"]["Plan Rows"])
+    plan = json.loads(queryset.explain(format="json"))[0]["Plan"]
+    estimate = int(plan["Plan Rows"])
 
-    if estimate < APPROXIMATE_COUNT_THRESHOLD:
+    # A low row estimate does not mean the count is cheap. A selective filter with
+    # no index to support it still has to scan the whole table to prove how few rows
+    # match, so the cost has to be checked as well as the number of rows.
+    if (
+        estimate < APPROXIMATE_COUNT_THRESHOLD
+        and plan["Total Cost"] < EXACT_COUNT_MAX_COST
+    ):
         return queryset.count()
 
     return estimate

--- a/backend/tests/baserow/core/test_core_db.py
+++ b/backend/tests/baserow/core/test_core_db.py
@@ -837,3 +837,20 @@ def test_get_approximate_row_count_works_with_filtered_queryset(data_fixture):
     queryset = Workspace.objects.filter(name__startswith="test_ws_")
     count = get_approximate_row_count(queryset)
     assert count == 2
+
+
+@pytest.mark.django_db
+def test_get_approximate_row_count_skips_exact_count_for_expensive_plans():
+    """
+    A filter matching few rows can still be expensive to count when no index
+    supports it, so a low row estimate alone must not trigger the exact count.
+    """
+
+    queryset = Workspace.objects.all()
+
+    with patch("baserow.core.db.EXACT_COUNT_MAX_COST", 0):
+        with patch.object(type(queryset), "count") as mock_count:
+            count = get_approximate_row_count(queryset)
+
+    mock_count.assert_not_called()
+    assert isinstance(count, int)

--- a/changelog/entries/unreleased/breaking_change/the_audit_log_can_now_only_be_sorted_by_timestamp_and_can_no.json
+++ b/changelog/entries/unreleased/breaking_change/the_audit_log_can_now_only_be_sorted_by_timestamp_and_can_no.json
@@ -1,0 +1,9 @@
+{
+    "type": "breaking_change",
+    "message": "The audit log can now only be sorted by timestamp, and can no longer be filtered by IP address.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/changelog/entries/unreleased/refactor/made_filtering_the_audit_log_by_user_workspace_or_event_type.json
+++ b/changelog/entries/unreleased/refactor/made_filtering_the_audit_log_by_user_workspace_or_event_type.json
@@ -1,0 +1,9 @@
+{
+    "type": "refactor",
+    "message": "Made filtering the audit log by user, workspace or event type fast on large installations.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-04"
+}

--- a/enterprise/backend/src/baserow_enterprise/api/audit_log/serializers.py
+++ b/enterprise/backend/src/baserow_enterprise/api/audit_log/serializers.py
@@ -28,7 +28,6 @@ def render_action_type(action_type):
 
 class AuditLogQueryParamsSerializer(serializers.Serializer):
     page = serializers.IntegerField(required=False, default=1)
-    search = serializers.CharField(required=False, default=None)
     sorts = serializers.CharField(required=False, default=None)
     user_id = serializers.IntegerField(min_value=1, required=False, default=None)
     workspace_id = serializers.IntegerField(min_value=1, required=False, default=None)

--- a/enterprise/backend/src/baserow_enterprise/api/audit_log/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/audit_log/views.py
@@ -47,20 +47,17 @@ class AuditLogView(APIListingView):
     permission_classes = (IsAuthenticated,)
     pagination_class = PageNumberPaginationWithApproximateCount
     serializer_class = AuditLogSerializer
+    # Every filter here is backed by an index leading with that column, so that a
+    # filtered page stays a seek instead of a scan of the whole table.
     filters_field_mapping = {
         "user_id": "user_id",
         "workspace_id": "workspace_id",
         "action_type": "action_type",
         "from_timestamp": "action_timestamp__gte",
         "to_timestamp": "action_timestamp__lte",
-        "ip_address": "ip_address",
     }
     sort_field_mapping = {
-        "user": "user_email",
-        "workspace": "workspace_name",
-        "type": "action_type",
         "timestamp": "action_timestamp",
-        "ip_address": "ip_address",
     }
     default_order_by = "-action_timestamp"
 

--- a/enterprise/backend/src/baserow_enterprise/api/audit_log/views.py
+++ b/enterprise/backend/src/baserow_enterprise/api/audit_log/views.py
@@ -59,6 +59,7 @@ class AuditLogView(APIListingView):
     sort_field_mapping = {
         "timestamp": "action_timestamp",
     }
+    search_fields = []
     default_order_by = "-action_timestamp"
 
     def get_queryset(self, request):

--- a/enterprise/backend/src/baserow_enterprise/audit_log/models.py
+++ b/enterprise/backend/src/baserow_enterprise/audit_log/models.py
@@ -91,13 +91,31 @@ class AuditLogEntry(CreatedAndUpdatedOnMixin, models.Model):
 
     class Meta:
         ordering = ["-action_timestamp"]
-        # Note: the index name will be `baserow_ent_action__8db5d6_idx`
-        # (when `workspace_id` used to be called `group_id`), but its true name
-        # is `baserow_ent_action__ca13aa_idx`. See enterprise migration 0016.
+        # The audit log is only ever ordered by `action_timestamp`, so every index
+        # below leads with the column that can be filtered on and is followed by the
+        # timestamp. That way the filter is a seek instead of a scan, and the rows it
+        # finds are already in the requested order, which lets `LIMIT` stop early.
+        #
+        # A single leading equality column is enough to bound a query that combines
+        # several filters: the scan can never be larger than the number of entries
+        # for that user, workspace or action type.
         indexes = [
             models.Index(
-                fields=["-action_timestamp", "user_id", "workspace_id", "action_type"]
-            )
+                fields=["-action_timestamp"],
+                name="auditlogentry_ts_idx",
+            ),
+            models.Index(
+                fields=["user_id", "-action_timestamp"],
+                name="auditlogentry_user_ts_idx",
+            ),
+            models.Index(
+                fields=["workspace_id", "-action_timestamp"],
+                name="auditlogentry_ws_ts_idx",
+            ),
+            models.Index(
+                fields=["action_type", "-action_timestamp"],
+                name="auditlogentry_type_ts_idx",
+            ),
         ]
 
 

--- a/enterprise/backend/src/baserow_enterprise/migrations/0063_auditlogentry_filter_indexes.py
+++ b/enterprise/backend/src/baserow_enterprise/migrations/0063_auditlogentry_filter_indexes.py
@@ -12,12 +12,49 @@ OLD_INDEX_DB_NAME = "baserow_ent_action__8db5d6_idx"
 OLD_INDEX_STATE_NAME = "baserow_ent_action__ca13aa_idx"
 
 
+def is_unusable(cursor, name):
+    """
+    Whether an index exists but was left half-built, which is what an interrupted
+    `CREATE INDEX CONCURRENTLY` produces.
+    """
+
+    cursor.execute(
+        """
+        SELECT 1
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        JOIN pg_class t ON t.oid = i.indrelid
+        WHERE c.relname = %s AND t.relname = %s
+          AND NOT (i.indisvalid AND i.indisready)
+        """,
+        [name, TABLE],
+    )
+    return cursor.fetchone() is not None
+
+
 def add_index(name, fields, columns):
-    return migrations.RunSQL(
-        sql=(
-            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{name}" ON "{TABLE}" ({columns})'
-        ),
-        reverse_sql=f'DROP INDEX CONCURRENTLY IF EXISTS "{name}"',
+    def forwards(apps, schema_editor):
+        with schema_editor.connection.cursor() as cursor:
+            # An interrupted build leaves an unusable index behind that
+            # `IF NOT EXISTS` would silently skip on the next attempt, leaving the
+            # table paying to maintain an index no query can use. Clear it first so
+            # a retried migration rebuilds it instead of stepping over it.
+            if is_unusable(cursor, name):
+                cursor.execute(f'DROP INDEX CONCURRENTLY "{name}"')
+
+            cursor.execute(
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{name}" '
+                f'ON "{TABLE}" ({columns})'
+            )
+
+    def backwards(apps, schema_editor):
+        with schema_editor.connection.cursor() as cursor:
+            cursor.execute(f'DROP INDEX CONCURRENTLY IF EXISTS "{name}"')
+
+    return migrations.SeparateDatabaseAndState(
+        database_operations=[
+            migrations.RunPython(forwards, backwards, atomic=False),
+        ],
         state_operations=[
             migrations.AddIndex(
                 model_name="auditlogentry",
@@ -59,6 +96,7 @@ class Migration(migrations.Migration):
             '"action_type", "action_timestamp" DESC',
         ),
         # Dropped last so the listing is never left without an index to order by.
+        # `IF EXISTS` also removes a half-dropped index, so this is safe to retry.
         migrations.RunSQL(
             sql=f'DROP INDEX CONCURRENTLY IF EXISTS "{OLD_INDEX_DB_NAME}"',
             reverse_sql=(

--- a/enterprise/backend/src/baserow_enterprise/migrations/0063_auditlogentry_filter_indexes.py
+++ b/enterprise/backend/src/baserow_enterprise/migrations/0063_auditlogentry_filter_indexes.py
@@ -1,0 +1,76 @@
+from django.db import migrations, models
+
+TABLE = "baserow_enterprise_auditlogentry"
+
+# In Postgres this index is always called `baserow_ent_action__8db5d6_idx`, the name
+# migration 0011 created it with, while Django's migration state calls it
+# `baserow_ent_action__ca13aa_idx`: migration 0016 renamed `group_id` to
+# `workspace_id` in the state only and never renamed the index in the database, as
+# its own comment records. The `RunSQL` below therefore drops a different name than
+# the `RemoveIndex` it carries as its state operation.
+OLD_INDEX_DB_NAME = "baserow_ent_action__8db5d6_idx"
+OLD_INDEX_STATE_NAME = "baserow_ent_action__ca13aa_idx"
+
+
+def add_index(name, fields, columns):
+    return migrations.RunSQL(
+        sql=(
+            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{name}" ON "{TABLE}" ({columns})'
+        ),
+        reverse_sql=f'DROP INDEX CONCURRENTLY IF EXISTS "{name}"',
+        state_operations=[
+            migrations.AddIndex(
+                model_name="auditlogentry",
+                index=models.Index(fields=fields, name=name),
+            )
+        ],
+    )
+
+
+class Migration(migrations.Migration):
+    # `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. The audit log is
+    # large enough on existing installations that a plain `CREATE INDEX` would block
+    # inserts, and entries are written synchronously while users perform actions.
+    atomic = False
+
+    dependencies = [
+        ("baserow_enterprise", "0062_core_xls_file_reader"),
+    ]
+
+    operations = [
+        add_index(
+            "auditlogentry_ts_idx",
+            ["-action_timestamp"],
+            '"action_timestamp" DESC',
+        ),
+        add_index(
+            "auditlogentry_user_ts_idx",
+            ["user_id", "-action_timestamp"],
+            '"user_id", "action_timestamp" DESC',
+        ),
+        add_index(
+            "auditlogentry_ws_ts_idx",
+            ["workspace_id", "-action_timestamp"],
+            '"workspace_id", "action_timestamp" DESC',
+        ),
+        add_index(
+            "auditlogentry_type_ts_idx",
+            ["action_type", "-action_timestamp"],
+            '"action_type", "action_timestamp" DESC',
+        ),
+        # Dropped last so the listing is never left without an index to order by.
+        migrations.RunSQL(
+            sql=f'DROP INDEX CONCURRENTLY IF EXISTS "{OLD_INDEX_DB_NAME}"',
+            reverse_sql=(
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{OLD_INDEX_DB_NAME}" '
+                f'ON "{TABLE}" ("action_timestamp" DESC, "user_id", '
+                f'"workspace_id", "action_type")'
+            ),
+            state_operations=[
+                migrations.RemoveIndex(
+                    model_name="auditlogentry",
+                    name=OLD_INDEX_STATE_NAME,
+                ),
+            ],
+        ),
+    ]

--- a/enterprise/backend/tests/baserow_enterprise_tests/api/audit_log/test_audit_log_admin_views.py
+++ b/enterprise/backend/tests/baserow_enterprise_tests/api/audit_log/test_audit_log_admin_views.py
@@ -491,6 +491,35 @@ def test_audit_log_entries_return_400_for_invalid_values(
 
 @pytest.mark.django_db
 @override_settings(DEBUG=True)
+def test_audit_log_entries_can_only_be_sorted_by_timestamp(
+    api_client, enterprise_data_fixture
+):
+    (
+        admin_user,
+        admin_token,
+    ) = enterprise_data_fixture.create_enterprise_admin_user_and_token()
+
+    # `%2B` rather than a literal `+`, which a query string decodes as a space.
+    for direction in ["%2B", "-"]:
+        response = api_client.get(
+            reverse("api:enterprise:audit_log:list") + f"?sorts={direction}timestamp",
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {admin_token}",
+        )
+        assert response.status_code == HTTP_200_OK
+
+    for removed_sort in ["user", "workspace", "type", "ip_address"]:
+        response = api_client.get(
+            reverse("api:enterprise:audit_log:list") + f"?sorts=-{removed_sort}",
+            format="json",
+            HTTP_AUTHORIZATION=f"JWT {admin_token}",
+        )
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json()["error"] == "ERROR_INVALID_SORT_ATTRIBUTE"
+
+
+@pytest.mark.django_db
+@override_settings(DEBUG=True)
 def test_audit_log_can_export_to_csv_all_entries(
     api_client,
     enterprise_data_fixture,

--- a/enterprise/web-frontend/modules/baserow_enterprise/pages/auditLog.vue
+++ b/enterprise/web-frontend/modules/baserow_enterprise/pages/auditLog.vue
@@ -214,13 +214,14 @@ const toTimestampFilter = ref(null)
 const filters = ref(initFilters(workspaceId))
 const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZ'
 
-// Build columns
+// Build columns. Only the timestamp is sortable: the audit log is far too large to
+// order by anything the backend can't serve straight from an index.
 const columns = [
   new CrudTableColumn(
     'user',
     () => $t('auditLog.user'),
     SimpleField,
-    true,
+    false,
     false,
     false,
     {},
@@ -234,7 +235,7 @@ if (!workspaceId) {
       'workspace',
       () => $t('auditLog.workspace'),
       SimpleField,
-      true,
+      false,
       false,
       false,
       {},
@@ -248,7 +249,7 @@ columns.push(
     'type',
     () => $t('auditLog.actionType'),
     SimpleField,
-    true,
+    false,
     false,
     false,
     {},
@@ -278,7 +279,7 @@ columns.push(
     'ip_address',
     () => $t('auditLog.ip_address'),
     SimpleField,
-    true,
+    false,
     false,
     false,
     {},


### PR DESCRIPTION
### What is in this PR

The audit log was quite slow in our production environment (175m entries and 360GB of data) when filtering on a user, workspace, or action. Opening the audit log without filters was fast. This is because it was not actually using the related index and because it did a full count if there are less than 50k records in the estimated results.

The table had a single index leading with `action_timestamp`:

```
    (action_timestamp DESC, user_id, workspace_id, action_type)
```

Because `action_timestamp` is effectively unique, no other column in that index can be seeked on — Postgres had to walk the entire index and discard non-matching rows. Two things made this especially bad:

- `LIMIT 100` can only stop early once it has found 100 matching rows. Any user or workspace with fewer than 100 entries forced a scan to the end of the index.
- The paginator's approximate count falls back to an exact `COUNT(*)` when the planner estimates fewer than 50k rows — which is exactly the selective, unindexed case. So a filtered page paid for the full scan twice.

### Changes

- **Four indexes** on `AuditLogEntry`, each leading with a filterable column followed by the timestamp, replacing the old wide index: `(action_timestamp DESC)`, `(user_id, action_timestamp DESC)`, `(workspace_id, action_timestamp DESC)`, `(action_type, action_timestamp DESC)`. Built with `CREATE INDEX CONCURRENTLY` so inserts are never blocked — audit entries are written synchronously while users perform actions.
- **Sorting is limited to `timestamp`.** Supporting the other columns would need an index per combination of filter and sort column (~80 of them), and an audit log is only ever read in time order. The columns are no longer sortable in the
  web frontend either.
- **Dropped the `ip_address` filter.** It was never exposed in the API schema or the UI, and it was the one remaining unindexed filter.
- **The approximate count now also checks the plan's cost**, not just its row estimate. A low row estimate doesn't mean a count is cheap: a selective filter with no index still scans the whole table to prove how few rows match.

### Measured on production (~175M rows, 360 GB)

Filtering by a user with 20 entries:

| | Before | After |
|---|---|---|
| `COUNT(*)` | 98,339 ms | 4.6 ms |
| `ORDER BY action_timestamp DESC LIMIT 100` | 43,602 ms | 0.058 ms |
| Blocks read | 1,247,746 | 26 |

### Deployment

The four indexes were already created manually on production with `CREATE INDEX CONCURRENTLY`; the migration uses `IF NOT EXISTS` so those are no-ops there and it only runs the `DROP INDEX CONCURRENTLY` of the old index. On other installations the migration builds them concurrently — expect ~20-30 minutes per index on a large table, without blocking reads or writes. The only thing I'm a bit worried about is that the migration can take quite long for a self-hosted instance with many audit log entries.

### How to test this PR

- Go to the audit log page http://localhost:3000/admin/audit-log.
- Set the user filter, check the query in Silk, and confirm in the expain analyze that the index is used.
- Set the workspace filter, check the query in Silk, and confirm in the expain analyze that the index is used.
- Set the action filter, check the query in Silk, and confirm in the expain analyze that the index is used.
- Do the same with timestamp sorted ASC and DESC.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder
- [x] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide)
- [x] Security impact of change has been considered
