### PR TITLE
fix: display zero in numeric data inputs

### DIFF
--- a/changelog/entries/unreleased/bug/5835_fixed_data_input_fields_not_displaying_the_number_0_when_num.json
+++ b/changelog/entries/unreleased/bug/5835_fixed_data_input_fields_not_displaying_the_number_0_when_num.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed Data Input fields not displaying the number 0 when number validation is enabled.",
+    "issue_origin": "github",
+    "issue_number": 5835,
+    "domain": "builder",
+    "bullet_points": [],
+    "created_at": "2026-08-05"
+}

--- a/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
+++ b/web-frontend/modules/builder/components/elements/components/InputTextElement.vue
@@ -83,9 +83,13 @@ export default {
     },
   },
   methods: {
+    hasInputValue(value) {
+      return value !== null && value !== '' && value !== undefined
+    },
+
     toInternalValue(value) {
       if (this.isNumericField) {
-        if (value) {
+        if (this.hasInputValue(value)) {
           return new Intl.NumberFormat(this.localeLanguage, {
             useGrouping: false,
           }).format(value)
@@ -99,7 +103,7 @@ export default {
 
     fromInternalValue(value) {
       if (this.isNumericField) {
-        if (value) {
+        if (this.hasInputValue(value)) {
           try {
             return ensureNumeric(
               parseLocalizedNumber(value, this.localeLanguage),

--- a/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
+++ b/web-frontend/test/unit/builder/components/elements/components/InputTextElement.spec.js
@@ -1,0 +1,65 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import InputTextElement from '@baserow/modules/builder/components/elements/components/InputTextElement.vue'
+
+describe('InputTextElement', () => {
+  let store = null
+
+  beforeEach(() => {
+    store = useNuxtApp().$store
+  })
+
+  const mountComponent = ({ props = {}, provide = {} }) => {
+    return mountSuspended(InputTextElement, {
+      props,
+      global: { provide },
+    })
+  }
+
+  const mountNumericInput = async (defaultValue) => {
+    const page = { id: 1, elements: [] }
+    const builder = { id: 1, theme: { primary_color: '#ccc' }, pages: [page] }
+    const workspace = {}
+    const mode = 'public'
+    const element = {
+      id: 42,
+      type: 'input_text',
+      validation_type: 'integer',
+      default_value: { formula: defaultValue },
+      label: { formula: '' },
+      placeholder: { formula: '' },
+      required: false,
+      is_multiline: false,
+      rows: 1,
+      input_type: 'number',
+      page_id: page.id,
+      styles: {},
+    }
+
+    store.dispatch('element/forceCreate', { page, element })
+
+    return mountComponent({
+      props: { element },
+      provide: {
+        builder,
+        currentPage: page,
+        elementPage: page,
+        mode,
+        applicationContext: { builder, page, mode },
+        element,
+        workspace,
+      },
+    })
+  }
+
+  test.each([
+    ['0', '0'],
+    ['', ''],
+  ])(
+    'renders numeric default value %p as %p',
+    async (defaultValue, expected) => {
+      const wrapper = await mountNumericInput(defaultValue)
+
+      expect(wrapper.find('input').element.value).toBe(expected)
+    }
+  )
+})


### PR DESCRIPTION
### What is in this PR

- Fixes #5835, where Application Builder Data Input fields using number validation rendered a numeric `0` as empty.
- Preserves zero values during numeric input formatting and parsing.

### How to test this PR

1. Create a table with a number field and a row whose value is `0`.
2. Surface that value in an Application Builder Data Input element.
3. Set the Data Input validation type to **Number**.
4. Confirm that the input displays `0`, an empty numeric value should still render as blank.

### Checklist

- [x] A changelog entry has been added to `changelog/entries/unreleased` using `changelog/src/changelog.py`
- [x] New/updated **Premium/Enterprise features** are separated correctly in the premium or enterprise folder (not applicable)
- [ ] The latest **Chrome and Firefox** have been used to test any new frontend features
- [x] [Documentation](https://github.com/baserow/baserow/blob/master/docs/index.md) has been updated (not applicable)
- [x] [Quality Standards](https://github.com/baserow/baserow/blob/master/CONTRIBUTING.md#quality-standards) are met
- [x] **Performance**: tables are still fast with 100k+ rows, 100+ field tables (not applicable)
- [x] The [redoc API pages](https://api.baserow.io/api/redoc/) have been updated for any REST API changes (not applicable)
- [x] Our [custom API docs](https://github.com/baserow/baserow/blob/master/web-frontend/modules/database/pages/APIDocsDatabase.vue) are updated for changes to endpoints accessed via API tokens (not applicable)
- [x] The UI/UX has been updated following the [UI Style Guide](https://baserow.io/style-guide) (not applicable)
- [x] Security impact of change has been considered
