### PR TITLE
fix: prevent stale formula context click handlers

### DIFF
--- a/changelog/entries/unreleased/bug/fixed_an_error_that_could_occur_after_interacting_with_formu.json
+++ b/changelog/entries/unreleased/bug/fixed_an_error_that_could_occur_after_interacting_with_formu.json
@@ -1,0 +1,9 @@
+{
+    "type": "bug",
+    "message": "Fixed an error that could occur after interacting with formula inputs.",
+    "issue_origin": "github",
+    "issue_number": null,
+    "domain": "core",
+    "bullet_points": [],
+    "created_at": "2026-08-06"
+}

--- a/web-frontend/modules/core/components/formula/extensions/ContextManagementExtension.js
+++ b/web-frontend/modules/core/components/formula/extensions/ContextManagementExtension.js
@@ -67,6 +67,12 @@ export const ContextManagementExtension = Extension.create({
           editor.commands.unselectNode()
           this.options.showExplorerContextMenu()
 
+          // Focus and click can both show the context before it is hidden.
+          if (this.storage.clickOutsideEventCancel) {
+            this.storage.clickOutsideEventCancel()
+            this.storage.clickOutsideEventCancel = null
+          }
+
           const rootEl = this.options.getRootEl()
           if (rootEl) {
             this.storage.clickOutsideEventCancel = onClickOutside(

--- a/web-frontend/test/unit/core/formula/ContextManagementExtension.spec.js
+++ b/web-frontend/test/unit/core/formula/ContextManagementExtension.spec.js
@@ -1,0 +1,83 @@
+import { Editor } from '@tiptap/core'
+import { Document } from '@tiptap/extension-document'
+import { Paragraph } from '@tiptap/extension-paragraph'
+import { Text } from '@tiptap/extension-text'
+import { ContextManagementExtension } from '@baserow/modules/core/components/formula/extensions/ContextManagementExtension'
+import { NodeSelectionExtension } from '@baserow/modules/core/components/formula/extensions/NodeSelectionExtension'
+
+function createEditor(rootEl, contextEl, options = {}) {
+  return new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      NodeSelectionExtension,
+      ContextManagementExtension.configure({
+        getRootEl: () => rootEl,
+        getContextEl: () => contextEl,
+        hideContextMenu: options.hideContextMenu ?? (() => {}),
+      }),
+    ],
+    content: '<p></p>',
+  })
+}
+
+describe('ContextManagementExtension', () => {
+  let editor
+  let rootEl
+  let contextEl
+  let outsideEl
+
+  beforeEach(() => {
+    rootEl = document.createElement('div')
+    contextEl = document.createElement('div')
+    outsideEl = document.createElement('div')
+    rootEl.append(contextEl)
+    document.body.append(rootEl, outsideEl)
+  })
+
+  afterEach(() => {
+    editor?.destroy()
+    rootEl.remove()
+    outsideEl.remove()
+  })
+
+  it('removes every click-outside handler when the editor is destroyed', () => {
+    editor = createEditor(rootEl, contextEl)
+
+    // Focusing the editor and clicking its wrapper can each show the context.
+    editor.commands.showContext()
+    editor.commands.showContext()
+    editor.destroy()
+    editor = null
+
+    const errors = []
+    const onError = (event) => {
+      errors.push(event.error)
+      event.preventDefault()
+    }
+    window.addEventListener('error', onError)
+
+    try {
+      outsideEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+      outsideEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+      expect(errors).toEqual([])
+    } finally {
+      window.removeEventListener('error', onError)
+    }
+  })
+
+  it('keeps a click-outside handler active after showing context twice', () => {
+    const hideContextMenu = vi.fn()
+    editor = createEditor(rootEl, contextEl, { hideContextMenu })
+
+    editor.commands.showContext()
+    editor.commands.showContext()
+
+    outsideEl.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
+    outsideEl.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+
+    expect(hideContextMenu).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Baserow! Please ensure you have read the contribution guidelines before submitting this PR: https://baserow.io/docs/development/contributing
-->

### What is in this PR

- Prevents duplicate formula-context click-outside handlers from remaining active after the TipTap editor is destroyed.
- Adds regression coverage for repeated context activation and for a live editor's outside click behavior.

Sentry reference:
- [BASEROW-SAAS-WEB-FRONTEND-27E](https://baserow-eu.sentry.io/issues/137323827) 

### How to test

- Open a formula input field then click outside. 
- Verify that no `Editor.commands` null-reference error is reported.

### Checklist

- [x] I have added a changelog entry.
- [x] I have added tests.
- [x] I have run the relevant tests locally.
- [ ] I have manually tested this in Chrome and Firefox.
